### PR TITLE
Module wrappers for external projects.

### DIFF
--- a/module/interface_module_partitions/adolc.ccm
+++ b/module/interface_module_partitions/adolc.ccm
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from ADOL-C into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_ADOLC
+#  include <adolc/adolc_fatalerror.h>
+#  include <adolc/adouble.h> // Taped double
+#  include <adolc/adtl.h>    // Tapeless double
+#  include <adolc/drivers/drivers.h>
+#  include <adolc/internal/adolc_settings.h>
+#  include <adolc/internal/adubfunc.h> // Taped double math functions
+#  include <adolc/internal/usrparms.h>
+#  include <adolc/taping.h>
+#endif
+
+
+export module dealii:interface_partition_adolc;
+
+#ifdef DEAL_II_WITH_ADOLC
+
+export
+{
+  using ::adouble;
+  using ::adub;
+  using ::badouble;
+  using ::cachedTraceTags;
+  using ::FatalError;
+  using ::function;
+  using ::gradient;
+  using ::hessian;
+  using ::jacobian;
+  using ::removeTape;
+  using ::TapeRemovalType;
+  using ::tapestats;
+  using ::trace_off;
+  using ::trace_on;
+
+  namespace adtl
+  {
+    using ::adtl::adouble;
+    using ::adtl::fabs;
+    using ::adtl::getNumDir;
+    using ::adtl::setNumDir;
+  } // namespace adtl
+}
+
+
+// ADOL-C also defines symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace Adolc_Macros                                \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                              \
+    namespace dealii                                                   \
+    {                                                                  \
+      export const auto &sym = dealii::Adolc_Macros::exportable_##sym; \
+    }
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(TBUFNUM)
+#  undef TBUFNUM
+EXPORT_PREPROCESSOR_SYMBOL(TBUFNUM)
+
+#endif

--- a/module/interface_module_partitions/boost.ccm
+++ b/module/interface_module_partitions/boost.ccm
@@ -1,0 +1,365 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of
+// BOOST into one partition that we can 'import' wherever we need.
+// This is the file that wraps everything we need from BOOST into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/any.hpp>
+#include <boost/archive/basic_archive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/iterators/base64_from_binary.hpp>
+#include <boost/archive/iterators/binary_from_base64.hpp>
+#include <boost/archive/iterators/transform_width.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/config.hpp>
+#include <boost/container/small_vector.hpp>
+#include <boost/core/demangle.hpp>
+#include <boost/geometry.hpp>
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/core/coordinate_dimension.hpp>
+#include <boost/geometry/core/coordinate_system.hpp>
+#include <boost/geometry/core/coordinate_type.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/core/tag.hpp>
+#include <boost/geometry/geometries/point.hpp>
+#include <boost/geometry/geometries/segment.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/bandwidth.hpp>
+#include <boost/graph/cuthill_mckee_ordering.hpp>
+#include <boost/graph/king_ordering.hpp>
+#include <boost/graph/minimum_degree_ordering.hpp>
+#include <boost/graph/properties.hpp>
+#include <boost/hana.hpp>
+#include <boost/io/ios_state.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/math/special_functions/bessel.hpp>
+#include <boost/math/special_functions/binomial.hpp>
+#include <boost/math/special_functions/legendre.hpp>
+#include <boost/math/special_functions/relative_difference.hpp>
+#include <boost/math/special_functions/sign.hpp>
+#include <boost/math/tools/roots.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <boost/property_tree/ptree_serialization.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+#include <boost/random.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+#include <boost/range/irange.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/range/iterator_range_core.hpp>
+#include <boost/serialization/array.hpp>
+#include <boost/serialization/array_wrapper.hpp>
+#include <boost/serialization/complex.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/unique_ptr.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/signals2.hpp>
+#include <boost/signals2/connection.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/type_traits.hpp>
+#include <boost/variant.hpp>
+#include <boost/version.hpp>
+
+
+export module dealii:interface_partition_boost;
+export
+{
+  namespace boost
+  {
+    namespace algorithm
+    {
+      using boost::algorithm::join;
+      using boost::algorithm::to_lower;
+      using boost::algorithm::trim;
+    } // namespace algorithm
+
+    namespace archive
+    {
+      using boost::archive::binary_iarchive;
+      using boost::archive::binary_oarchive;
+      using boost::archive::text_iarchive;
+      using boost::archive::text_oarchive;
+
+      namespace iterators
+      {
+        using boost::archive::iterators::base64_from_binary;
+        using boost::archive::iterators::binary_from_base64;
+        using boost::archive::iterators::transform_width;
+      } // namespace iterators
+    }   // namespace archive
+
+    namespace container
+    {
+      using boost::container::small_vector;
+    }
+
+    namespace core
+    {
+      using boost::core::demangle;
+    }
+
+    namespace geometry
+    {
+      namespace cs
+      {
+        using boost::geometry::cs::cartesian;
+      }
+
+      namespace index
+      {
+        using boost::geometry::index::indexable;
+        using boost::geometry::index::intersects;
+        using boost::geometry::index::linear;
+        using boost::geometry::index::nearest;
+        using boost::geometry::index::query;
+        using boost::geometry::index::rtree;
+        using boost::geometry::index::satisfies;
+
+        namespace adaptors
+        {
+          using boost::geometry::index::adaptors::queried;
+
+          namespace detail
+          {
+            using boost::geometry::index::adaptors::detail::operator|;
+          }
+        } // namespace adaptors
+
+        namespace detail
+        {
+          namespace predicates
+          {
+            using boost::geometry::index::detail::predicates::operator!;
+            using boost::geometry::index::detail::predicates::operator&&;
+          } // namespace predicates
+
+          namespace rtree
+          {
+            using boost::geometry::index::detail::rtree::apply_visitor;
+            using boost::geometry::index::detail::rtree::elements;
+            using boost::geometry::index::detail::rtree::elements_type;
+            using boost::geometry::index::detail::rtree::internal_node;
+            using boost::geometry::index::detail::rtree::leaf;
+            using boost::geometry::index::detail::rtree::visitor;
+
+            namespace utilities
+            {
+              using boost::geometry::index::detail::rtree::utilities::view;
+            }
+          } // namespace rtree
+        }   // namespace detail
+      }     // namespace index
+
+      namespace model
+      {
+        using boost::geometry::model::point;
+        using boost::geometry::model::segment;
+      } // namespace model
+
+      namespace traits
+      {
+        using boost::geometry::traits::access;
+        using boost::geometry::traits::coordinate_system;
+        using boost::geometry::traits::coordinate_type;
+        using boost::geometry::traits::dimension;
+        using boost::geometry::traits::indexed_access;
+        using boost::geometry::traits::point_type;
+        using boost::geometry::traits::tag;
+      } // namespace traits
+
+      using boost::geometry::box_tag;
+      using boost::geometry::convert;
+      using boost::geometry::dimension;
+      using boost::geometry::get;
+      using boost::geometry::point_tag;
+
+      // The following two we would like to export, but can't: They have
+      // internal linkage until we fixed it after Boost 1.88.0.
+#if DEAL_II_BOOST_VERSION_GTE(1, 89, 0)
+      using boost::geometry::max_corner;
+      using boost::geometry::min_corner;
+#endif
+    } // namespace geometry
+
+
+    // Things from the boost graph library that end up in the boost namespace
+    using boost::add_edge;
+    using boost::adjacency_list;
+    using boost::cuthill_mckee_ordering;
+    using boost::default_color_type;
+    using boost::degree;
+    using boost::directedS;
+    using boost::get;
+    using boost::graph_traits;
+    using boost::king_ordering;
+    using boost::make_degree_map;
+    using boost::make_iterator_property_map;
+    using boost::minimum_degree_ordering;
+    using boost::num_vertices;
+    using boost::property;
+    using boost::property_map;
+    using boost::tie;
+    using boost::undirectedS;
+    using boost::vecS;
+    using boost::vertex_color;
+    using boost::vertex_color_t;
+    using boost::vertex_degree_t;
+    using boost::vertex_in_degree;
+    using boost::vertex_index_t;
+    using boost::vertices;
+
+    namespace hana
+    {
+      using boost::hana::is_valid;
+    }
+
+    namespace io
+    {
+      using boost::io::basic_ios_fill_saver;
+      using boost::io::ios_base_all_saver;
+      using boost::io::ios_flags_saver;
+    } // namespace io
+
+    namespace iostreams
+    {
+      using boost::iostreams::array_source;
+      using boost::iostreams::back_insert_device;
+      using boost::iostreams::back_inserter;
+      using boost::iostreams::basic_array_source;
+      using boost::iostreams::copy;
+      using boost::iostreams::filtering_istreambuf;
+      using boost::iostreams::filtering_ostream;
+      using boost::iostreams::filtering_ostreambuf;
+      using boost::iostreams::filtering_streambuf;
+      using boost::iostreams::gzip_compressor;
+      using boost::iostreams::gzip_decompressor;
+      using boost::iostreams::input;
+
+#ifdef DEAL_II_WITH_ZLIB
+      using boost::iostreams::zlib_compressor;
+      using boost::iostreams::zlib_decompressor;
+
+      namespace zlib
+      {
+        using boost::iostreams::zlib::best_compression;
+        using boost::iostreams::zlib::best_speed;
+        using boost::iostreams::zlib::default_compression;
+        using boost::iostreams::zlib::no_compression;
+      } // namespace zlib
+#endif
+    } // namespace iostreams
+
+    namespace iterators
+    {
+      using boost::iterators::operator==;
+      using boost::iterators::operator!=;
+    } // namespace iterators
+
+    namespace math
+    {
+      using boost::math::binomial_coefficient;
+      using boost::math::cyl_bessel_j;
+      using boost::math::epsilon_difference;
+      using boost::math::legendre_p;
+      using boost::math::sign;
+
+      namespace tools
+      {
+        using boost::math::tools::toms748_solve;
+      }
+    } // namespace math
+
+    namespace mpl
+    {
+      using boost::mpl::int_;
+    }
+
+    namespace property_tree
+    {
+      using boost::property_tree::ptree;
+      using boost::property_tree::read_json;
+      using boost::property_tree::read_xml;
+      using boost::property_tree::write_json;
+      using boost::property_tree::write_xml;
+    } // namespace property_tree
+
+    namespace random
+    {
+      using boost::random::mt19937;
+      using boost::random::normal_distribution;
+      using boost::random::uniform_int_distribution;
+      using boost::random::uniform_real_distribution;
+    } // namespace random
+
+    namespace serialization
+    {
+      using boost::serialization::array_wrapper;
+      using boost::serialization::base_object;
+      using boost::serialization::make_array;
+      using boost::serialization::split_member;
+    } // namespace serialization
+
+    namespace signals2
+    {
+      using boost::signals2::connection;
+      using boost::signals2::signal;
+    } // namespace signals2
+
+    using boost::apply_visitor;
+    using boost::is_complex;
+    using boost::iterator_range;
+    using boost::lexical_cast;
+    using boost::make_iterator_range;
+    using boost::mt19937;
+    using boost::normal_distribution;
+    using boost::optional;
+    using boost::static_visitor;
+    using boost::uintmax_t;
+    using boost::variant;
+  } // namespace boost
+}

--- a/module/interface_module_partitions/cgal.ccm
+++ b/module/interface_module_partitions/cgal.ccm
@@ -1,0 +1,205 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from ADOL-C into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_CGAL
+
+// This file does not compile with clang-19+ with CGAL versions
+// released prior to 5.6.2 because of this issue:
+// https://github.com/CGAL/cgal/issues/8313. This was fixed in 5.6.2,
+// as shown here:
+// https://github.com/CGAL/cgal/issues?q=sort%3Aupdated-desc+label%3AMerged_in_5.6.2+-label%3AMerged_in_5.6.1
+// But even then, CGAL has design issues that don't allow us to use it
+// via modules before version 6.1, see
+// https://github.com/CGAL/cgal/issues/8871 and
+// https://github.com/CGAL/cgal/issues/8874. Disallow things before
+// then.
+#  include <CGAL/version.h>
+#  if (CGAL_VERSION_NR < 1050602000)
+#    error \
+      "You can only use CGAL starting with version 6.1.0 when using the CLang compiler."
+#  endif
+
+#  include <CGAL/Boolean_set_operations_2.h>
+#  include <CGAL/Cartesian.h>
+#  include <CGAL/Circular_kernel_intersections.h>
+#  include <CGAL/Complex_2_in_triangulation_3.h>
+#  include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#  include <CGAL/Delaunay_mesh_face_base_2.h>
+#  include <CGAL/Delaunay_mesh_size_criteria_2.h>
+#  include <CGAL/Delaunay_mesher_2.h>
+#  include <CGAL/Delaunay_triangulation_2.h>
+#  include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#  include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
+#  include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#  include <CGAL/IO/facets_in_complex_2_to_triangle_mesh.h>
+#  include <CGAL/Implicit_surface_3.h>
+#  include <CGAL/Kernel_traits.h>
+#  include <CGAL/Labeled_mesh_domain_3.h>
+#  include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#  include <CGAL/Mesh_criteria_3.h>
+#  include <CGAL/Mesh_facet_topology.h>
+#  include <CGAL/Mesh_triangulation_3.h>
+#  include <CGAL/Polygon_2.h>
+#  include <CGAL/Polygon_mesh_processing/corefinement.h>
+#  include <CGAL/Polygon_mesh_processing/measure.h>
+#  include <CGAL/Polygon_mesh_processing/remesh.h>
+#  include <CGAL/Polygon_mesh_processing/stitch_borders.h>
+#  include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
+#  include <CGAL/Polygon_with_holes_2.h>
+#  include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
+#  include <CGAL/Polyhedron_3.h>
+#  include <CGAL/Projection_traits_xy_3.h>
+#  include <CGAL/Segment_3.h>
+#  include <CGAL/Simple_cartesian.h>
+#  include <CGAL/Surface_mesh.h>
+#  include <CGAL/Surface_mesh/Surface_mesh.h>
+#  include <CGAL/Surface_mesh_default_triangulation_3.h>
+#  include <CGAL/Tetrahedron_3.h>
+#  include <CGAL/Triangle_2.h>
+#  include <CGAL/Triangle_3.h>
+#  include <CGAL/Triangulation_2.h>
+#  include <CGAL/Triangulation_3.h>
+#  include <CGAL/Triangulation_face_base_with_id_2.h>
+#  include <CGAL/Triangulation_face_base_with_info_2.h>
+#  include <CGAL/boost/graph/copy_face_graph.h>
+#  include <CGAL/boost/graph/selection.h>
+#  include <CGAL/convex_hull_3.h>
+#  include <CGAL/make_mesh_3.h>
+#  include <CGAL/make_surface_mesh.h>
+#endif
+
+
+export module dealii:interface_partition_cgal;
+
+
+#ifdef DEAL_II_WITH_CGAL
+
+export
+{
+  namespace CGAL
+  {
+    using ::CGAL::Complex_2_in_triangulation_3;
+    using ::CGAL::Constrained_Delaunay_triangulation_2;
+    using ::CGAL::Constrained_triangulation_face_base_2;
+    using ::CGAL::Default;
+    using ::CGAL::Delaunay_mesh_face_base_2;
+    using ::CGAL::Delaunay_mesh_size_criteria_2;
+    using ::CGAL::Exact_predicates_exact_constructions_kernel;
+    using ::CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt;
+    using ::CGAL::Exact_predicates_inexact_constructions_kernel;
+    using ::CGAL::Exact_predicates_tag;
+    using ::CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH;
+    using ::CGAL::FACET_VERTICES_ON_SAME_SURFACE_PATCH_WITH_ADJACENCY_CHECK;
+    using ::CGAL::FACET_VERTICES_ON_SURFACE;
+    using ::CGAL::Implicit_surface_3;
+    using ::CGAL::Kernel_traits;
+    using ::CGAL::Labeled_mesh_domain_3;
+    using ::CGAL::Mesh_complex_3_in_triangulation_3;
+    using ::CGAL::Mesh_criteria_3;
+    using ::CGAL::Mesh_facet_topology;
+    using ::CGAL::Mesh_polyhedron_3;
+    using ::CGAL::Mesh_triangulation_3;
+    using ::CGAL::Non_manifold_tag;
+    using ::CGAL::Parallel_tag;
+    using ::CGAL::Point_3;
+    using ::CGAL::Polygon_2;
+    namespace Polygon_mesh_processing
+    {
+      using ::CGAL::Polygon_mesh_processing::stitch_borders;
+      using ::CGAL::Polygon_mesh_processing::triangulate_faces;
+    } // namespace Polygon_mesh_processing
+    using ::CGAL::circulator_size;
+    using ::CGAL::convex_hull_3;
+    using ::CGAL::copy_face_graph;
+    using ::CGAL::do_intersect;
+    using ::CGAL::facets_in_complex_2_to_triangle_mesh;
+    using ::CGAL::facets_in_complex_3_to_triangle_mesh;
+    using ::CGAL::intersection;
+    using ::CGAL::is_closed;
+    using ::CGAL::is_triangle_mesh;
+    using ::CGAL::make_mesh_3;
+    using ::CGAL::make_surface_mesh;
+    using ::CGAL::make_tetrahedron;
+    using ::CGAL::Polygon_with_holes_2;
+    using ::CGAL::Polyhedral_mesh_domain_with_features_3;
+    using ::CGAL::Polyhedron_3;
+    using ::CGAL::Sequential_tag;
+    using ::CGAL::Simple_cartesian;
+    using ::CGAL::Surface_mesh;
+    using ::CGAL::Surface_mesh_default_criteria_3;
+    using ::CGAL::Surface_mesh_default_triangulation_3;
+    using ::CGAL::to_double;
+    using ::CGAL::Triangulation_2;
+    using ::CGAL::Triangulation_3;
+    using ::CGAL::Triangulation_data_structure_2;
+    using ::CGAL::Triangulation_face_base_with_info_2;
+    using ::CGAL::Triangulation_vertex_base_2;
+    using ::CGAL::vertices_around_face;
+    using ::CGAL::operator==;
+    using ::CGAL::operator!=;
+
+    namespace Polygon_mesh_processing
+    {
+      using ::CGAL::Polygon_mesh_processing::corefine;
+      using ::CGAL::Polygon_mesh_processing::corefine_and_compute_difference;
+      using ::CGAL::Polygon_mesh_processing::corefine_and_compute_intersection;
+      using ::CGAL::Polygon_mesh_processing::corefine_and_compute_union;
+      using ::CGAL::Polygon_mesh_processing::volume;
+    } // namespace Polygon_mesh_processing
+  }   // namespace CGAL
+
+
+  // In CGAL 5.6.1, the following are variables of types such as 'const
+  // Boost_parameter_compatibility_wrapper<internal_np::facet_size_param_t>',
+  // all with internal linkage because they are marked as 'const' and not
+  // 'inline const'. These cannot be exported with
+#  if (CGAL_VERSION_NR >= 1050601000)
+  namespace CGAL
+  {
+    namespace parameters
+    {
+      // The following all have internal linkage:
+      using ::CGAL::parameters::cell_radius_edge_ratio;
+      using ::CGAL::parameters::cell_size;
+      using ::CGAL::parameters::edge_size;
+      using ::CGAL::parameters::facet_angle;
+      using ::CGAL::parameters::facet_distance;
+      using ::CGAL::parameters::facet_size;
+      using ::CGAL::parameters::facet_topology;
+      using ::CGAL::parameters::no_exude;
+      using ::CGAL::parameters::no_perturb;
+    } // namespace parameters
+  }   // namespace CGAL
+#  endif
+}
+
+#endif

--- a/module/interface_module_partitions/hdf5.ccm
+++ b/module/interface_module_partitions/hdf5.ccm
@@ -1,0 +1,217 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from VTK into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_HDF5
+#  include <hdf5.h>
+#endif
+
+
+export module dealii:interface_partition_hdf5;
+
+#ifdef DEAL_II_WITH_HDF5
+
+export
+{
+  using ::H5Aclose;
+  using ::H5Acreate2;
+  using ::H5Aopen;
+  using ::H5Aread;
+  using ::H5Awrite;
+  using ::H5D_mpio_actual_io_mode_t;
+  using ::H5Dclose;
+  using ::H5Dcreate2;
+  using ::H5Dget_space;
+  using ::H5Dget_type;
+  using ::H5Dopen2;
+  using ::H5Dread;
+  using ::H5Dwrite;
+  using ::H5Fclose;
+  using ::H5Fcreate;
+  using ::H5Fopen;
+  using ::H5Gclose;
+  using ::H5Gcreate2;
+  using ::H5Gopen2;
+  using ::H5Pclose;
+  using ::H5Pcreate;
+  using ::H5Pget_mpio_actual_io_mode;
+  using ::H5Pget_mpio_no_collective_cause;
+  using ::H5Pset_chunk;
+  using ::H5Pset_deflate;
+  using ::H5Pset_dxpl_mpio;
+  using ::H5Pset_fapl_mpio;
+  using ::H5Sclose;
+  using ::H5Screate;
+  using ::H5Screate_simple;
+  using ::H5Sget_simple_extent_dims;
+  using ::H5Sget_simple_extent_ndims;
+  using ::H5Sselect_hyperslab;
+  using ::H5Sselect_none;
+  using ::H5T_class_t;
+  using ::H5Tclose;
+  using ::H5Tcopy;
+  using ::H5Tcreate;
+  using ::H5Tenum_insert;
+  using ::H5Tget_class;
+  using ::H5Tinsert;
+  using ::H5Tset_cset;
+  using ::H5Tset_size;
+  using ::herr_t;
+  using ::hid_t;
+  using ::hsize_t;
+}
+
+
+// HDF5 also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export them (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace HDF5_Macros                                 \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                     \
+    namespace dealii                                          \
+    {                                                         \
+      export const auto &sym = HDF5_Macros::exportable_##sym; \
+    }
+
+// H5F symbols
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5F_ACC_RDWR)
+#  undef H5F_ACC_RDWR
+EXPORT_PREPROCESSOR_SYMBOL(H5F_ACC_RDWR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5F_ACC_RDONLY)
+#  undef H5F_ACC_RDONLY
+EXPORT_PREPROCESSOR_SYMBOL(H5F_ACC_RDONLY)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5F_ACC_TRUNC)
+#  undef H5F_ACC_TRUNC
+EXPORT_PREPROCESSOR_SYMBOL(H5F_ACC_TRUNC)
+
+// H5T symbols
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_NATIVE_DOUBLE)
+#  undef H5T_NATIVE_DOUBLE
+EXPORT_PREPROCESSOR_SYMBOL(H5T_NATIVE_DOUBLE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_NATIVE_FLOAT)
+#  undef H5T_NATIVE_FLOAT
+EXPORT_PREPROCESSOR_SYMBOL(H5T_NATIVE_FLOAT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_NATIVE_HBOOL)
+#  undef H5T_NATIVE_HBOOL
+EXPORT_PREPROCESSOR_SYMBOL(H5T_NATIVE_HBOOL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_NATIVE_CHAR)
+#  undef H5T_NATIVE_CHAR
+EXPORT_PREPROCESSOR_SYMBOL(H5T_NATIVE_CHAR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_NATIVE_INT)
+#  undef H5T_NATIVE_INT
+EXPORT_PREPROCESSOR_SYMBOL(H5T_NATIVE_INT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_NATIVE_UINT)
+#  undef H5T_NATIVE_UINT
+EXPORT_PREPROCESSOR_SYMBOL(H5T_NATIVE_UINT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_C_S1)
+#  undef H5T_C_S1
+EXPORT_PREPROCESSOR_SYMBOL(H5T_C_S1)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5T_VARIABLE)
+#  undef H5T_VARIABLE
+EXPORT_PREPROCESSOR_SYMBOL(H5T_VARIABLE)
+
+// H5S symbols
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5S_NULL)
+#  undef H5S_NULL
+EXPORT_PREPROCESSOR_SYMBOL(H5S_NULL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5S_ALL)
+#  undef H5S_ALL
+EXPORT_PREPROCESSOR_SYMBOL(H5S_ALL)
+
+// H5P symbols
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5P_DEFAULT)
+#  undef H5P_DEFAULT
+EXPORT_PREPROCESSOR_SYMBOL(H5P_DEFAULT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5P_DATASET_CREATE)
+#  undef H5P_DATASET_CREATE
+EXPORT_PREPROCESSOR_SYMBOL(H5P_DATASET_CREATE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5P_DATASET_XFER)
+#  undef H5P_DATASET_XFER
+EXPORT_PREPROCESSOR_SYMBOL(H5P_DATASET_XFER)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(H5P_FILE_ACCESS)
+#  undef H5P_FILE_ACCESS
+EXPORT_PREPROCESSOR_SYMBOL(H5P_FILE_ACCESS)
+
+
+// There is also the case that HDF5 has the following:
+//   #define H5Dcreate H5Dcreate2
+// We deal with this by exporting a symbol H5DCreate that simply
+// aliases H5DCreate2:
+#  undef H5Dcreate
+export
+{
+  auto H5Dcreate = &::H5Dcreate2;
+}
+
+
+#endif

--- a/module/interface_module_partitions/kokkos.ccm
+++ b/module/interface_module_partitions/kokkos.ccm
@@ -1,0 +1,126 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of
+// Kokkos into one partition that we can 'import' wherever we need.
+// This is the file that wraps everything we need from Kokkos into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#include <Kokkos_Macros.hpp>
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 2, 0)
+#  include <Kokkos_Abort.hpp>
+#else
+#  include <Kokkos_Core.hpp>
+#endif
+#include <Kokkos_Array.hpp>
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Core_fwd.hpp>
+#include <Kokkos_DualView.hpp>
+#include <Kokkos_Macros.hpp>
+
+export module dealii:interface_partition_kokkos;
+export
+{
+  namespace Kokkos
+  {
+    using ::Kokkos::abort;
+    using ::Kokkos::abs;
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::ALL;
+#endif
+    using ::Kokkos::Array;
+    using ::Kokkos::atomic_add;
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::AUTO;
+#endif
+    using ::Kokkos::finalize;
+
+    using ::Kokkos::MemoryTraits;
+
+    using ::Kokkos::complex;
+    using ::Kokkos::create_mirror;
+    using ::Kokkos::create_mirror_view;
+    using ::Kokkos::create_mirror_view_and_copy;
+    using ::Kokkos::deep_copy;
+    using ::Kokkos::DefaultExecutionSpace;
+    using ::Kokkos::DefaultHostExecutionSpace;
+    using ::Kokkos::DualView;
+
+    using ::Kokkos::fence;
+    using ::Kokkos::finalize;
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::fmax;
+#endif
+    using ::Kokkos::HostSpace;
+    using ::Kokkos::IndexType;
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::InitializationSettings;
+#endif
+    using ::Kokkos::initialize;
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::is_finalized;
+#endif
+    using ::Kokkos::is_initialized;
+    using ::Kokkos::make_pair;
+    using ::Kokkos::Max;
+    using ::Kokkos::MDRangePolicy;
+    //    using ::Kokkos::Nodes;
+    using ::Kokkos::pair;
+    using ::Kokkos::parallel_for;
+    using ::Kokkos::parallel_reduce;
+    using ::Kokkos::PerTeam;
+    using ::Kokkos::pow;
+    using ::Kokkos::push_finalize_hook;
+    using ::Kokkos::RangePolicy;
+    using ::Kokkos::Rank;
+    using ::Kokkos::realloc;
+    using ::Kokkos::resize;
+    using ::Kokkos::single;
+    using ::Kokkos::subview;
+    using ::Kokkos::TeamPolicy;
+    using ::Kokkos::TeamThreadRange;
+    using ::Kokkos::TeamVectorRange;
+    using ::Kokkos::Unmanaged;
+    using ::Kokkos::View;
+    using ::Kokkos::view_alloc;
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::WithoutInitializing;
+#endif
+
+#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
+    using ::Kokkos::SharedHostPinnedSpace;
+    using ::Kokkos::TeamThreadMDRange;
+#else
+    using ::Kokkos::InitArguments;
+
+    namespace Experimental
+    {
+      using ::Kokkos::Experimental::fabs;
+      using ::Kokkos::Experimental::fmax;
+      using ::Kokkos::Experimental::pow;
+    } // namespace Experimental
+#endif
+  } // namespace Kokkos
+}

--- a/module/interface_module_partitions/metis.ccm
+++ b/module/interface_module_partitions/metis.ccm
@@ -1,0 +1,100 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from METIS into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_METIS
+extern "C"
+{
+#  include <metis.h>
+}
+#endif
+
+
+export module dealii:interface_partition_metis;
+
+#ifdef DEAL_II_WITH_METIS
+
+export
+{
+  using ::idx_t;
+  using ::METIS_OPTION_SEED;
+  using ::METIS_PartGraphKway;
+  using ::METIS_PartGraphRecursive;
+  using ::METIS_SetDefaultOptions;
+}
+
+// METIS also defines symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace Metis_Macros                                \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                              \
+    namespace dealii                                                   \
+    {                                                                  \
+      export const auto &sym = dealii::Metis_Macros::exportable_##sym; \
+    }
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(METIS_NOPTIONS)
+#  undef METIS_NOPTIONS
+EXPORT_PREPROCESSOR_SYMBOL(METIS_NOPTIONS)
+
+
+#endif

--- a/module/interface_module_partitions/mpi.ccm
+++ b/module/interface_module_partitions/mpi.ccm
@@ -1,0 +1,393 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of
+// MPI into one partition that we can 'import' wherever we need.
+// This is the file that wraps everything we need from MPI into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_MPI
+#  include <mpi.h>
+#endif
+
+
+export module dealii:interface_partition_mpi;
+
+#ifdef DEAL_II_WITH_MPI
+
+// If we are using MPI, export some symbols. If we aren't, the
+// include/deal.II/base/mpi_stub.h file (or its transformed version)
+// exports some stubs.
+export
+{
+  using ::MPI_Abort;
+  using ::MPI_Aint;
+  using ::MPI_Allgather;
+  using ::MPI_Allgatherv;
+  using ::MPI_Allreduce;
+  using ::MPI_Barrier;
+  using ::MPI_Bcast;
+  using ::MPI_Comm;
+  using ::MPI_Comm_c2f;
+  using ::MPI_Comm_compare;
+  using ::MPI_Comm_create_group;
+  using ::MPI_Comm_dup;
+  using ::MPI_Comm_free;
+  using ::MPI_Comm_group;
+  using ::MPI_Comm_rank;
+  using ::MPI_Comm_size;
+  using ::MPI_Comm_split;
+  using ::MPI_Comm_split_type;
+  using ::MPI_Count;
+  using ::MPI_Datatype;
+  using ::MPI_Error_class;
+  using ::MPI_Error_string;
+  using ::MPI_Exscan;
+  using ::MPI_File;
+  using ::MPI_File_close;
+  using ::MPI_File_open;
+  using ::MPI_File_read_at;
+  using ::MPI_File_read_at_all;
+  using ::MPI_File_set_size;
+  using ::MPI_File_sync;
+  using ::MPI_File_write_at;
+  using ::MPI_File_write_at_all;
+  using ::MPI_File_write_ordered;
+  using ::MPI_Finalize;
+  using ::MPI_Gather;
+  using ::MPI_Gatherv;
+  using ::MPI_Get_count;
+  using ::MPI_Group;
+  using ::MPI_Group_free;
+  using ::MPI_Group_incl;
+  using ::MPI_Group_union;
+  using ::MPI_Ibarrier;
+  using ::MPI_Info;
+  using ::MPI_Info_create;
+  using ::MPI_Info_free;
+  using ::MPI_Info_set;
+  using ::MPI_Init_thread;
+  using ::MPI_Initialized;
+  using ::MPI_Iprobe;
+  using ::MPI_Irecv;
+  using ::MPI_Isend;
+  using ::MPI_Message;
+  using ::MPI_Mprobe;
+  using ::MPI_Mrecv;
+  using ::MPI_Offset;
+  using ::MPI_Op;
+  using ::MPI_Op_create;
+  using ::MPI_Op_free;
+  using ::MPI_Probe;
+  using ::MPI_Recv;
+  using ::MPI_Reduce;
+  using ::MPI_Reduce_scatter_block;
+  using ::MPI_Request;
+  using ::MPI_Request_free;
+  using ::MPI_Scan;
+  using ::MPI_Scatter;
+  using ::MPI_Scatterv;
+  using ::MPI_Send;
+  using ::MPI_Sendrecv;
+  using ::MPI_Status;
+  using ::MPI_Test;
+  using ::MPI_Testall;
+  using ::MPI_Type_commit;
+  using ::MPI_Type_contiguous;
+  using ::MPI_Type_create_struct;
+  using ::MPI_Type_free;
+  using ::MPI_Type_size_x;
+  using ::MPI_Type_vector;
+  using ::MPI_User_function;
+  using ::MPI_Wait;
+  using ::MPI_Waitall;
+  using ::MPI_Waitany;
+  using ::MPI_Win;
+  using ::MPI_Win_allocate_shared;
+  using ::MPI_Win_free;
+  using ::MPI_Win_shared_query;
+}
+
+
+// MPI also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export them (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace MPI_Macros                                  \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                    \
+    namespace dealii                                         \
+    {                                                        \
+      export const auto &sym = MPI_Macros::exportable_##sym; \
+    }
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_SUCCESS)
+#  undef MPI_SUCCESS
+EXPORT_PREPROCESSOR_SYMBOL(MPI_SUCCESS)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_INFO_NULL)
+#  undef MPI_INFO_NULL
+EXPORT_PREPROCESSOR_SYMBOL(MPI_INFO_NULL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_PROC_NULL)
+#  undef MPI_PROC_NULL
+EXPORT_PREPROCESSOR_SYMBOL(MPI_PROC_NULL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_COMM_NULL)
+#  undef MPI_COMM_NULL
+EXPORT_PREPROCESSOR_SYMBOL(MPI_COMM_NULL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_COMM_SELF)
+#  undef MPI_COMM_SELF
+EXPORT_PREPROCESSOR_SYMBOL(MPI_COMM_SELF)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_COMM_WORLD)
+#  undef MPI_COMM_WORLD
+EXPORT_PREPROCESSOR_SYMBOL(MPI_COMM_WORLD)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_BYTE)
+#  undef MPI_BYTE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_BYTE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_CXX_BOOL)
+#  undef MPI_CXX_BOOL
+EXPORT_PREPROCESSOR_SYMBOL(MPI_CXX_BOOL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_INT)
+#  undef MPI_INT
+EXPORT_PREPROCESSOR_SYMBOL(MPI_INT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_SHORT)
+#  undef MPI_SHORT
+EXPORT_PREPROCESSOR_SYMBOL(MPI_SHORT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_CHAR)
+#  undef MPI_CHAR
+EXPORT_PREPROCESSOR_SYMBOL(MPI_CHAR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_SIGNED_CHAR)
+#  undef MPI_SIGNED_CHAR
+EXPORT_PREPROCESSOR_SYMBOL(MPI_SIGNED_CHAR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_CHAR)
+#  undef MPI_UNSIGNED_CHAR
+EXPORT_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_CHAR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_WCHAR)
+#  undef MPI_WCHAR
+EXPORT_PREPROCESSOR_SYMBOL(MPI_WCHAR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_FLOAT)
+#  undef MPI_FLOAT
+EXPORT_PREPROCESSOR_SYMBOL(MPI_FLOAT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_DOUBLE)
+#  undef MPI_DOUBLE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_DOUBLE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_LONG_DOUBLE)
+#  undef MPI_LONG_DOUBLE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_LONG_DOUBLE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_UINT64_T)
+#  undef MPI_UINT64_T
+EXPORT_PREPROCESSOR_SYMBOL(MPI_UINT64_T)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_UNSIGNED)
+#  undef MPI_UNSIGNED
+EXPORT_PREPROCESSOR_SYMBOL(MPI_UNSIGNED)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_SHORT)
+#  undef MPI_UNSIGNED_SHORT
+EXPORT_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_SHORT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_LONG)
+#  undef MPI_UNSIGNED_LONG
+EXPORT_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_LONG)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_LONG_LONG)
+#  undef MPI_UNSIGNED_LONG_LONG
+EXPORT_PREPROCESSOR_SYMBOL(MPI_UNSIGNED_LONG_LONG)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_LONG)
+#  undef MPI_LONG
+EXPORT_PREPROCESSOR_SYMBOL(MPI_LONG)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_LONG_LONG)
+#  undef MPI_LONG_LONG
+EXPORT_PREPROCESSOR_SYMBOL(MPI_LONG_LONG)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_COMPLEX)
+#  undef MPI_COMPLEX
+EXPORT_PREPROCESSOR_SYMBOL(MPI_COMPLEX)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_DOUBLE_COMPLEX)
+#  undef MPI_DOUBLE_COMPLEX
+EXPORT_PREPROCESSOR_SYMBOL(MPI_DOUBLE_COMPLEX)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_SUM)
+#  undef MPI_SUM
+EXPORT_PREPROCESSOR_SYMBOL(MPI_SUM)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_MIN)
+#  undef MPI_MIN
+EXPORT_PREPROCESSOR_SYMBOL(MPI_MIN)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_MAX)
+#  undef MPI_MAX
+EXPORT_PREPROCESSOR_SYMBOL(MPI_MAX)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_LAND)
+#  undef MPI_LAND
+EXPORT_PREPROCESSOR_SYMBOL(MPI_LAND)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_LOR)
+#  undef MPI_LOR
+EXPORT_PREPROCESSOR_SYMBOL(MPI_LOR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_BOR)
+#  undef MPI_BOR
+EXPORT_PREPROCESSOR_SYMBOL(MPI_BOR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_HOST)
+#  undef MPI_HOST
+EXPORT_PREPROCESSOR_SYMBOL(MPI_HOST)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_STATUS_IGNORE)
+#  undef MPI_STATUS_IGNORE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_STATUS_IGNORE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_STATUSES_IGNORE)
+#  undef MPI_STATUSES_IGNORE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_STATUSES_IGNORE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_REQUEST_NULL)
+#  undef MPI_REQUEST_NULL
+EXPORT_PREPROCESSOR_SYMBOL(MPI_REQUEST_NULL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_IO)
+#  undef MPI_IO
+EXPORT_PREPROCESSOR_SYMBOL(MPI_IO)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_IN_PLACE)
+#  undef MPI_IN_PLACE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_IN_PLACE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_REPLACE)
+#  undef MPI_REPLACE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_REPLACE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_WIN_BASE)
+#  undef MPI_WIN_BASE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_WIN_BASE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_ANY_SOURCE)
+#  undef MPI_ANY_SOURCE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_ANY_SOURCE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_MODE_CREATE)
+#  undef MPI_MODE_CREATE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_MODE_CREATE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_MODE_RDONLY)
+#  undef MPI_MODE_RDONLY
+EXPORT_PREPROCESSOR_SYMBOL(MPI_MODE_RDONLY)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_MODE_WRONLY)
+#  undef MPI_MODE_WRONLY
+EXPORT_PREPROCESSOR_SYMBOL(MPI_MODE_WRONLY)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_ERR_INTERN)
+#  undef MPI_ERR_INTERN
+EXPORT_PREPROCESSOR_SYMBOL(MPI_ERR_INTERN)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_MAX_ERROR_STRING)
+#  undef MPI_MAX_ERROR_STRING
+EXPORT_PREPROCESSOR_SYMBOL(MPI_MAX_ERROR_STRING)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MPI_ERR_LASTCODE)
+#  undef MPI_ERR_LASTCODE
+EXPORT_PREPROCESSOR_SYMBOL(MPI_ERR_LASTCODE)
+
+
+// There is also the issue of MPI_Fint, the Fortran integer data
+// type. The MPI standard does not say how it is declared. If it a
+// typedef, we should export it, but at least OpenMPI simply #defines
+// it to int, which means we can't export it. The following allows for
+// both:
+#  ifdef MPI_Fint
+namespace dealii
+{
+  namespace MPI_Macros
+  {
+    using MPI_Fint_alias = MPI_Fint;
+  }
+} // namespace dealii
+#    undef MPI_Fint
+export
+{
+  using MPI_Fint = dealii::MPI_Macros::MPI_Fint_alias;
+}
+
+#  else
+
+// The implementation does not use the preprocessor to #define MPI_Fint
+export
+{
+  using ::MPI_Fint;
+}
+#  endif
+
+
+
+#endif

--- a/module/interface_module_partitions/mumps.ccm
+++ b/module/interface_module_partitions/mumps.ccm
@@ -1,0 +1,47 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from SLEPC into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_MUMPS
+#  include <dmumps_c.h>
+#endif
+
+
+export module dealii:interface_partition_mumps;
+
+#ifdef DEAL_II_WITH_MUMPS
+
+export
+{
+  using ::dmumps_c;
+}
+
+#endif

--- a/module/interface_module_partitions/muparser.ccm
+++ b/module/interface_module_partitions/muparser.ccm
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from VTK into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_MUPARSER
+#  include <muParser.h>
+#endif
+
+
+export module dealii:interface_partition_muparser;
+
+#ifdef DEAL_II_WITH_MUPARSER
+
+export
+{
+  namespace mu
+  {
+    using ::mu::Parser;
+    using ::mu::ParserError;
+  } // namespace mu
+}
+
+#endif

--- a/module/interface_module_partitions/opencascade.ccm
+++ b/module/interface_module_partitions/opencascade.ccm
@@ -1,0 +1,178 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from ADOL-C into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_OPENCASCADE
+// opencascade needs "HAVE_CONFIG_H" to be exported...
+#  define HAVE_CONFIG_H
+#  include <Adaptor3d_Curve.hxx>
+#  if !DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+#    include <Adaptor3d_HCurve.hxx>
+#  endif
+#  if !DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+#    include <BRepAdaptor_HCompCurve.hxx>
+#    include <BRepAdaptor_HCurve.hxx>
+#  endif
+#  if !DEAL_II_OPENCASCADE_VERSION_GTE(7, 0, 0)
+#    include <Handle_Adaptor3d_HCurve.hxx>
+#  endif
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 0, 0)
+#    include <Standard_Transient.hxx>
+#  else
+#    include <Handle_Standard_Transient.hxx>
+#  endif
+
+#  include <BRepAdaptor_Curve.hxx>
+#  if DEAL_II_OPENCASCADE_VERSION_GTE(7, 6, 0)
+#    include <BRepAlgoAPI_Section.hxx>
+#  else
+#    include <BRepAdaptor_HCompCurve.hxx>
+#    include <BRepAdaptor_HCurve.hxx>
+#    include <BRepAlgo_Section.hxx>
+#  endif
+#  include <BRepAdaptor_CompCurve.hxx>
+#  include <BRepAdaptor_Curve.hxx>
+#  include <BRepAdaptor_Surface.hxx>
+#  include <BRepBndLib.hxx>
+#  include <BRepBuilderAPI_MakeEdge.hxx>
+#  include <BRepBuilderAPI_Sewing.hxx>
+#  include <BRepBuilderAPI_Transform.hxx>
+#  include <BRepMesh_IncrementalMesh.hxx>
+#  include <BRepTools.hxx>
+#  include <BRep_Builder.hxx>
+#  include <BRep_Tool.hxx>
+#  include <GCPnts_AbscissaPoint.hxx>
+#  include <GeomAPI_Interpolate.hxx>
+#  include <GeomAPI_ProjectPointOnCurve.hxx>
+#  include <GeomAPI_ProjectPointOnSurf.hxx>
+#  include <GeomConvert_CompCurveToBSplineCurve.hxx>
+#  include <GeomLProp_SLProps.hxx>
+#  include <Geom_BoundedCurve.hxx>
+#  include <Geom_Plane.hxx>
+#  include <IFSelect_ReturnStatus.hxx>
+#  include <IGESControl_Controller.hxx>
+#  include <IGESControl_Reader.hxx>
+#  include <IGESControl_Writer.hxx>
+#  include <IntCurvesFace_ShapeIntersector.hxx>
+#  include <Poly_Triangulation.hxx>
+#  include <STEPControl_Controller.hxx>
+#  include <STEPControl_Reader.hxx>
+#  include <STEPControl_Writer.hxx>
+#  include <ShapeAnalysis_Curve.hxx>
+#  include <ShapeAnalysis_Surface.hxx>
+#  include <StlAPI_Reader.hxx>
+#  include <StlAPI_Writer.hxx>
+#  include <TColStd_HSequenceOfTransient.hxx>
+#  include <TColStd_SequenceOfTransient.hxx>
+#  include <TColgp_HArray1OfPnt.hxx>
+#  include <TopExp_Explorer.hxx>
+#  include <TopLoc_Location.hxx>
+#  include <TopoDS.hxx>
+#  include <TopoDS_CompSolid.hxx>
+#  include <TopoDS_Compound.hxx>
+#  include <TopoDS_Edge.hxx>
+#  include <TopoDS_Face.hxx>
+#  include <TopoDS_Shape.hxx>
+#  include <TopoDS_Shell.hxx>
+#  include <TopoDS_Solid.hxx>
+#  include <TopoDS_Vertex.hxx>
+#  include <TopoDS_Wire.hxx>
+#  include <gp_Lin.hxx>
+#  include <gp_Pnt.hxx>
+#  include <gp_Vec.hxx>
+#  undef HAVE_CONFIG_H
+#endif
+
+
+export module dealii:interface_partition_opencascade;
+
+#ifdef DEAL_II_WITH_OPENCASCADE
+
+export
+{
+  using ::BRep_Tool;
+  using ::BRepAdaptor_CompCurve;
+  using ::BRepAdaptor_Curve;
+  using ::BRepAdaptor_Surface;
+  using ::BRepAlgoAPI_Section;
+  using ::BRepBuilderAPI_MakeEdge;
+  using ::BRepBuilderAPI_Sewing;
+  using ::BRepBuilderAPI_Transform;
+  using ::BRepMesh_IncrementalMesh;
+  using ::BRepTools;
+  using ::Geom_BoundedCurve;
+  using ::Geom_BSplineCurve;
+  using ::Geom_Curve;
+  using ::Geom_Plane;
+  using ::Geom_Surface;
+  using ::GeomAPI_Interpolate;
+  using ::GeomAPI_ProjectPointOnCurve;
+  using ::GeomConvert_CompCurveToBSplineCurve;
+  using ::GeomLProp_SLProps;
+  using ::gp_Ax1;
+  using ::gp_Dir;
+  using ::gp_Lin;
+  using ::gp_Pnt;
+  using ::gp_Pnt2d;
+  using ::gp_Trsf;
+  using ::gp_Vec;
+  using ::Handle_Adaptor3d_Curve;
+  using ::Handle_Geom_BoundedCurve;
+  using ::IFSelect_PrintCount;
+  using ::IFSelect_ReturnStatus;
+  using ::IGESControl_Controller;
+  using ::IGESControl_Reader;
+  using ::IGESControl_Writer;
+  using ::IntCurvesFace_ShapeIntersector;
+  using ::Poly_Triangulation;
+  using ::ShapeAnalysis_Curve;
+  using ::ShapeAnalysis_Surface;
+  using ::STEPControl_Controller;
+  using ::STEPControl_Reader;
+  using ::STEPControl_Writer;
+  using ::StlAPI_Reader;
+  using ::StlAPI_Writer;
+  using ::TColgp_HArray1OfPnt;
+  using ::TopExp_Explorer;
+  using ::TopLoc_Location;
+  using ::TopoDS;
+  using ::TopoDS_Compound;
+  using ::TopoDS_CompSolid;
+  using ::TopoDS_Edge;
+  using ::TopoDS_Face;
+  using ::TopoDS_Shape;
+  using ::TopoDS_Shell;
+  using ::TopoDS_Solid;
+  using ::TopoDS_Vertex;
+  using ::TopoDS_Wire;
+}
+
+#endif

--- a/module/interface_module_partitions/p4est.ccm
+++ b/module/interface_module_partitions/p4est.ccm
@@ -1,0 +1,246 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of
+// PETSc into one partition that we can 'import' wherever we need.
+// This is the file that wraps everything we need from PETSc into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_P4EST
+#  include <p4est_bits.h>
+#  include <p4est_communication.h>
+#  include <p4est_extended.h>
+#  include <p4est_ghost.h>
+#  include <p4est_iterate.h>
+#  include <p4est_search.h>
+#  include <p4est_vtk.h>
+#  include <p8est_bits.h>
+#  include <p8est_communication.h>
+#  include <p8est_extended.h>
+#  include <p8est_ghost.h>
+#  include <p8est_iterate.h>
+#  include <p8est_search.h>
+#  include <p8est_vtk.h>
+#  include <sc_containers.h>
+#endif
+
+
+export module dealii:interface_partition_p4est;
+
+#ifdef DEAL_II_WITH_P4EST
+
+export
+{
+  using ::p4est_balance;
+  using ::p4est_checksum;
+  using ::p4est_coarsen;
+  using ::p4est_coarsen_t;
+  using ::p4est_comm_find_owner;
+  using ::p4est_connect_type_t;
+  using ::p4est_connectivity_destroy;
+  using ::p4est_connectivity_is_valid;
+  using ::p4est_connectivity_join_faces;
+  using ::p4est_connectivity_load;
+  using ::p4est_connectivity_memory_used;
+  using ::p4est_connectivity_new;
+  using ::p4est_connectivity_new_copy;
+  using ::p4est_connectivity_save;
+  using ::p4est_connectivity_t;
+  using ::p4est_copy;
+  using ::p4est_destroy;
+  using ::p4est_face_corners;
+  using ::p4est_geometry_t;
+  using ::p4est_ghost_destroy;
+  using ::p4est_ghost_new;
+  using ::p4est_ghost_t;
+  using ::p4est_gloidx_t;
+  using ::p4est_init;
+  using ::p4est_init_t;
+  using ::p4est_iter_corner_info_t;
+  using ::p4est_iter_corner_side_t;
+  using ::p4est_iter_corner_t;
+  using ::p4est_iter_face_info_t;
+  using ::p4est_iter_face_side_t;
+  using ::p4est_iter_face_t;
+  using ::p4est_iterate;
+  using ::p4est_load_ext;
+  using ::p4est_locidx_t;
+  using ::p4est_memory_used;
+  using ::p4est_new_ext;
+  using ::p4est_partition_ext;
+  using ::p4est_qcoord_t;
+  using ::p4est_qcoord_to_vertex;
+  using ::p4est_quadrant_ancestor_id;
+  using ::p4est_quadrant_childrenv;
+  using ::p4est_quadrant_compare;
+  using ::p4est_quadrant_is_ancestor;
+  using ::p4est_quadrant_is_equal;
+  using ::p4est_quadrant_is_sibling;
+  using ::p4est_quadrant_overlaps_tree;
+  using ::p4est_quadrant_set_morton;
+  using ::p4est_quadrant_t;
+  using ::p4est_refine;
+  using ::p4est_refine_t;
+  using ::p4est_reset_data;
+  using ::p4est_save;
+  using ::p4est_search_partition;
+  using ::p4est_search_partition_t;
+  using ::p4est_t;
+  using ::p4est_topidx_t;
+  using ::p4est_transfer_context_t;
+  using ::p4est_transfer_custom;
+  using ::p4est_transfer_custom_begin;
+  using ::p4est_transfer_custom_end;
+  using ::p4est_transfer_fixed;
+  using ::p4est_transfer_fixed_begin;
+  using ::p4est_transfer_fixed_end;
+  using ::p4est_tree_t;
+  using ::p4est_vtk_write_file;
+  using ::p4est_weight_t;
+  using ::p8est_balance;
+  using ::p8est_checksum;
+  using ::p8est_coarsen;
+  using ::p8est_coarsen_t;
+  using ::p8est_comm_find_owner;
+  using ::p8est_connect_type_t;
+  using ::p8est_connectivity_destroy;
+  using ::p8est_connectivity_is_valid;
+  using ::p8est_connectivity_join_faces;
+  using ::p8est_connectivity_load;
+  using ::p8est_connectivity_memory_used;
+  using ::p8est_connectivity_new;
+  using ::p8est_connectivity_new_copy;
+  using ::p8est_connectivity_save;
+  using ::p8est_connectivity_t;
+  using ::p8est_copy;
+  using ::p8est_corner_face_corners;
+  using ::p8est_destroy;
+  using ::p8est_edge_corners;
+  using ::p8est_face_corners;
+  using ::p8est_geometry_t;
+  using ::p8est_ghost_destroy;
+  using ::p8est_ghost_new;
+  using ::p8est_ghost_t;
+  using ::p8est_init_t;
+  using ::p8est_iter_corner_info_t;
+  using ::p8est_iter_corner_side_t;
+  using ::p8est_iter_corner_t;
+  using ::p8est_iter_edge_info_t;
+  using ::p8est_iter_edge_side_t;
+  using ::p8est_iter_edge_t;
+  using ::p8est_iter_face_info_t;
+  using ::p8est_iter_face_side_t;
+  using ::p8est_iter_face_t;
+  using ::p8est_load_ext;
+  using ::p8est_memory_used;
+  using ::p8est_new_ext;
+  using ::p8est_partition_ext;
+  using ::p8est_qcoord_to_vertex;
+  using ::p8est_quadrant_ancestor_id;
+  using ::p8est_quadrant_childrenv;
+  using ::p8est_quadrant_compare;
+  using ::p8est_quadrant_is_ancestor;
+  using ::p8est_quadrant_is_equal;
+  using ::p8est_quadrant_is_sibling;
+  using ::p8est_quadrant_overlaps_tree;
+  using ::p8est_quadrant_set_morton;
+  using ::p8est_quadrant_t;
+  using ::p8est_refine;
+  using ::p8est_refine_t;
+  using ::p8est_reset_data;
+  using ::p8est_save;
+  using ::p8est_search_partition;
+  using ::p8est_search_partition_t;
+  using ::p8est_t;
+  using ::p8est_transfer_context_t;
+  using ::p8est_transfer_custom;
+  using ::p8est_transfer_custom_begin;
+  using ::p8est_transfer_custom_end;
+  using ::p8est_transfer_fixed;
+  using ::p8est_transfer_fixed_begin;
+  using ::p8est_transfer_fixed_end;
+  using ::p8est_tree_t;
+  using ::p8est_vtk_write_file;
+  using ::p8est_weight_t;
+
+  using ::sc_array_bsearch;
+  using ::sc_array_destroy_null;
+  using ::sc_array_new_count;
+  using ::sc_array_t;
+  using ::sc_finalize;
+
+  // The following functions are declared as a 'static inline'
+  // function and so can't be exported. Wrap them via a function
+  // implemented in namespace dealii:
+  namespace dealii
+  {
+    inline void *
+    sc_array_index(sc_array_t *array, size_t iz)
+    {
+      return ::sc_array_index(array, iz);
+    }
+
+    inline void *
+    sc_array_index_ssize_t(sc_array_t *array, ssize_t iz)
+    {
+      return ::sc_array_index_ssize_t(array, iz);
+    }
+
+
+    inline void *
+    sc_array_push(::sc_array_t *array)
+    {
+      return ::sc_array_push(array);
+    }
+  } // namespace dealii
+}
+
+
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace p4est_Macros                                \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym) \
+    export const auto &sym = dealii::p4est_Macros::exportable_##sym;
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(P4EST_MAXLEVEL)
+#  undef P4EST_MAXLEVEL
+EXPORT_PREPROCESSOR_SYMBOL(P4EST_MAXLEVEL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(P8EST_MAXLEVEL)
+#  undef P8EST_MAXLEVEL
+EXPORT_PREPROCESSOR_SYMBOL(P8EST_MAXLEVEL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(SC_LP_SILENT)
+#  undef SC_LP_SILENT
+EXPORT_PREPROCESSOR_SYMBOL(SC_LP_SILENT)
+
+#endif

--- a/module/interface_module_partitions/petsc.ccm
+++ b/module/interface_module_partitions/petsc.ccm
@@ -1,0 +1,586 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from PETSc into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_PETSC
+#  include <petsc/private/pcimpl.h>
+#  include <petsc/private/petscimpl.h>
+#  include <petsc/private/snesimpl.h>
+#  include <petsc/private/tsimpl.h>
+#  include <petscconf.h>
+#  include <petscdm.h>
+#  include <petscis.h>
+#  include <petscistypes.h>
+#  include <petscksp.h>
+#  include <petscmat.h>
+#  include <petscpc.h>
+#  include <petscsf.h>
+#  include <petscsnes.h>
+#  include <petscsys.h>
+#  include <petscts.h>
+#  include <petscvec.h>
+#endif
+
+
+export module dealii:interface_partition_petsc;
+
+#ifdef DEAL_II_WITH_PETSC
+
+export
+{
+  using ::DM;
+  using ::DMDestroy;
+  using ::DMSetMatType;
+  using ::InsertMode;
+  using ::IS;
+  using ::ISCreateGeneral;
+  using ::ISDestroy;
+  using ::ISGetIndices;
+  using ::ISGetLocalSize;
+  using ::ISLocalToGlobalMapping;
+  using ::ISLocalToGlobalMappingCreateIS;
+  using ::ISLocalToGlobalMappingDestroy;
+  using ::ISLocalToGlobalMappingViewFromOptions;
+  using ::ISRestoreIndices;
+  using ::KSP;
+  using ::KSPConvergedReason;
+  using ::KSPCreate;
+  using ::KSPDestroy;
+  using ::KSPGetOperators;
+  using ::KSPGetPC;
+  using ::KSPGMRESSetRestart;
+  using ::KSPRichardsonSetScale;
+  using ::KSPSetConvergenceTest;
+  using ::KSPSetFromOptions;
+  using ::KSPSetInitialGuessNonzero;
+  using ::KSPSetOperators;
+  using ::KSPSetOptionsPrefix;
+  using ::KSPSetPC;
+  using ::KSPSetPCSide;
+  using ::KSPSetReusePreconditioner;
+  using ::KSPSetTolerances;
+  using ::KSPSetType;
+  using ::KSPSetUp;
+  using ::KSPSolve;
+  using ::Mat;
+  using ::MatAssemblyBegin;
+  using ::MatAssemblyEnd;
+  using ::MatAXPY;
+  using ::MatConvert;
+  using ::MatCopy;
+  using ::MatCreate;
+  using ::MatCreateIS;
+  using ::MatCreateNest;
+  using ::MatCreateSeqAIJ;
+  using ::MatCreateSeqDense;
+  using ::MatCreateShell;
+  using ::MatDestroy;
+  using ::MatDiagonalScale;
+  using ::MatDuplicate;
+  using ::MatGetInfo;
+  using ::MatGetLocalSize;
+  using ::MatGetOwnershipRange;
+  using ::MatGetOwnershipRangeColumn;
+  using ::MatGetRow;
+  using ::MatGetSize;
+  using ::MatGetTrace;
+  using ::MatGetType;
+  using ::MatGetValues;
+  using ::MatHasOperation;
+  using ::MatInfo;
+  using ::MatISGetLocalMat;
+  using ::MatIsHermitian;
+  using ::MatISRestoreLocalMat;
+  using ::MatIsSymmetric;
+  using ::MatMatMult;
+  using ::MatMPIAIJSetPreallocation;
+  using ::MatMPIAIJSetPreallocationCSR;
+  using ::MatMult;
+  using ::MatMultAdd;
+  using ::MatMultTranspose;
+  using ::MatMultTransposeAdd;
+  using ::MatMumpsSetIcntl;
+  using ::MatNestGetSize;
+  using ::MatNestGetSubMat;
+  using ::MatNestSetVecType;
+  using ::MatNorm;
+  using ::MatOption;
+  using ::MatRestoreRow;
+  using ::MatScale;
+  using ::MatSeqAIJSetPreallocation;
+  using ::MatSeqAIJSetPreallocationCSR;
+  using ::MatSetFromOptions;
+  using ::MatSetOption;
+  using ::MatSetSizes;
+  using ::MatSetType;
+  using ::MatSetUp;
+  using ::MatSetValues;
+  using ::MatShellGetContext;
+  using ::MatShellSetOperation;
+  using ::MatShift;
+  using ::MatTranspose;
+  using ::MatTransposeMatMult;
+  using ::MatType;
+  using ::MatView;
+  using ::MatZeroEntries;
+  using ::MatZeroRowsColumnsIS;
+  using ::MatZeroRowsIS;
+  using ::PC;
+  using ::PC_RIGHT;
+  using ::PCApply;
+  using ::PCApplyTranspose;
+  using ::PCCreate;
+  using ::PCDestroy;
+  using ::PCFactorGetMatrix;
+  using ::PCFactorSetColumnPivot;
+  using ::PCFactorSetLevels;
+#  if DEAL_II_PETSC_VERSION_LT(3, 9, 0)
+  using ::PCFactorSetMatSolverPackage;
+#  else
+  using ::PCFactorSetMatSolverType;
+#  endif
+  using ::PCFactorSetShiftAmount;
+#  if DEAL_II_PETSC_VERSION_LT(3, 9, 0)
+  using ::PCFactorSetUpMatSolverPackage;
+#  else
+  using ::PCFactorSetUpMatSolverType;
+#  endif
+  using ::PCFactorSetZeroPivot;
+  using ::PCFailedReason;
+  using ::PCGetOperators;
+  using ::PCGetUseAmat;
+  using ::PCHYPRESetType;
+  using ::PCSetCoordinates;
+  using ::PCSetFailedReason;
+  using ::PCSetFromOptions;
+  using ::PCSetOperators;
+  using ::PCSetType;
+  using ::PCSetUp;
+  using ::PCShellGetContext;
+  using ::PCShellSetApply;
+  using ::PCShellSetApplyTranspose;
+  using ::PCShellSetContext;
+  using ::PCShellSetName;
+  using ::PCShellSetSetUp;
+  using ::PCSORSetOmega;
+  using ::PCSORSetSymmetric;
+  using ::PETSC_COMM_WORLD;
+  using ::PETSC_VIEWER_STDOUT_;
+  using ::PetscBool;
+  using ::PetscError;
+  using ::PetscErrorCode;
+  using ::PetscErrorMessage;
+  using ::PetscFinalize;
+  using ::PetscFinalizeCalled;
+  using ::PetscInitialize;
+  using ::PetscInitializeCalled;
+  using ::PetscInt;
+  using ::PetscLayout;
+  using ::PetscLayoutCreate;
+  using ::PetscLayoutDestroy;
+  using ::PetscLayoutGetLocalSize;
+  using ::PetscLayoutGetRange;
+  using ::PetscLayoutGetRanges;
+  using ::PetscLayoutSetLocalSize;
+  using ::PetscLayoutSetSize;
+  using ::PetscLayoutSetUp;
+  using ::PetscMallocA;
+  using ::PetscMPIInt;
+  using ::PetscObject;
+  using ::PetscObjectComm;
+  using ::PetscObjectComposeFunction_Private;
+  using ::PetscObjectGetComm;
+  using ::PetscObjectQueryFunction_Private;
+  using ::PetscObjectReference;
+  using ::PetscObjectTypeCompare;
+  using ::PetscOptionsSetValue;
+  using ::PetscPopSignalHandler;
+  using ::PetscReal;
+  using ::PetscScalar;
+  using ::PetscSF;
+  using ::PetscSFBcastBegin;
+  using ::PetscSFBcastEnd;
+  using ::PetscSFCompose;
+  using ::PetscSFCreate;
+  using ::PetscSFCreateInverseSF;
+  using ::PetscSFDestroy;
+  using ::PetscSFNode;
+  using ::PetscSFReduceBegin;
+  using ::PetscSFReduceEnd;
+  using ::PetscSFSetGraph;
+  using ::PetscSFSetGraphLayout;
+  using ::PetscSFSetUp;
+  using ::PetscTrMalloc;
+  using ::PetscViewerPushFormat;
+
+#  if defined(PETSC_HAVE_SAWS)
+  using ::PetscStackSAWsGrantAccess;
+  using ::PetscStackSAWsTakeAccess;
+#  endif
+
+  using ::PetscViewerFormat;
+  using ::PetscViewerPopFormat;
+  using ::PetscVoidFunction;
+  using ::SNES;
+  using ::SNESConvergedReason;
+  using ::SNESConvergedReasons;
+  using ::SNESCreate;
+  using ::SNESDestroy;
+  using ::SNESGetConvergedReason;
+  using ::SNESGetDM;
+  using ::SNESGetIterationNumber;
+  using ::SNESGetKSP;
+  using ::SNESGetLineSearch;
+  using ::SNESGetSolution;
+  using ::SNESLineSearch;
+  using ::SNESLineSearchSetType;
+  using ::SNESMonitorSet;
+  using ::SNESReset;
+  using ::SNESSetApplicationContext;
+  using ::SNESSetCheckJacobianDomainError;
+  using ::SNESSetFromOptions;
+  using ::SNESSetFunction;
+  using ::SNESSetFunctionDomainError;
+  using ::SNESSetJacobian;
+  using ::SNESSetObjective;
+  using ::SNESSetOptionsPrefix;
+  using ::SNESSetSolution;
+  using ::SNESSetTolerances;
+  using ::SNESSetType;
+  using ::SNESSetUseMatrixFree;
+  using ::SNESSolve;
+  using ::TS;
+  using ::TSAdapt;
+  using ::TSAdaptSetOptionsPrefix;
+  using ::TSAdaptSetStepLimits;
+  using ::TSAdaptSetType;
+  using ::TSConvergedReason;
+  using ::TSConvergedReasons;
+  using ::TSCreate;
+  using ::TSDestroy;
+  using ::TSGetAdapt;
+  using ::TSGetApplicationContext;
+  using ::TSGetConvergedReason;
+  using ::TSGetSNES;
+  using ::TSGetSolution;
+  using ::TSGetStepNumber;
+  using ::TSGetTime;
+  using ::TSGetTimeStep;
+  using ::TSGetTolerances;
+  using ::TSMonitorSet;
+  using ::TSPostStep;
+  using ::TSReset;
+  using ::TSSetApplicationContext;
+  using ::TSSetErrorIfStepFails;
+  using ::TSSetExactFinalTime;
+  using ::TSSetFromOptions;
+  using ::TSSetFunctionDomainError;
+  using ::TSSetIFunction;
+  using ::TSSetIJacobian;
+  using ::TSSetMaxSNESFailures;
+  using ::TSSetMaxSteps;
+  using ::TSSetMaxTime;
+  using ::TSSetOptionsPrefix;
+  using ::TSSetPostStage;
+  using ::TSSetPostStep;
+  using ::TSSetPreStage;
+  using ::TSSetRHSFunction;
+  using ::TSSetRHSJacobian;
+  using ::TSSetSolution;
+  using ::TSSetTime;
+  using ::TSSetTimeStep;
+  using ::TSSetTolerances;
+  using ::TSSetType;
+  using ::TSSetUp;
+  using ::TSSolve;
+  using ::Vec;
+  using ::VecAssemblyBegin;
+  using ::VecAssemblyEnd;
+  using ::VecAXPBY;
+  using ::VecAXPY;
+  using ::VecAYPX;
+  using ::VecCopy;
+  using ::VecCreateGhost;
+  using ::VecCreateMPI;
+  using ::VecCreateNest;
+  using ::VecDestroy;
+  using ::VecDot;
+  using ::VecDuplicate;
+  using ::VecEqual;
+  using ::VecGetArray;
+  using ::VecGetArrayRead;
+  using ::VecGetLocalSize;
+  using ::VecGetOwnershipRange;
+  using ::VecGetSize;
+  using ::VecGhostGetLocalForm;
+  using ::VecGhostRestoreLocalForm;
+  using ::VecGhostUpdateBegin;
+  using ::VecGhostUpdateEnd;
+  using ::VecMAXPY;
+  using ::VecNestGetSize;
+  using ::VecNestGetSubVec;
+  using ::VecNorm;
+  using ::VecPointwiseMult;
+  using ::VecRestoreArray;
+  using ::VecRestoreArrayRead;
+  using ::VecScale;
+  using ::VecScatter;
+  using ::VecScatterBegin;
+  using ::VecScatterCreateToAll;
+  using ::VecScatterDestroy;
+  using ::VecScatterEnd;
+  using ::VecSet;
+  using ::VecSetValues;
+  using ::VecShift;
+  using ::VecSum;
+  using ::VecView;
+
+#  if DEAL_II_PETSC_VERSION_GTE(3, 22, 0)
+  using ::PetscLayoutFindOwner;
+#  else
+  // The following function is declared as a 'static inline' function
+  // and so can't be exported. (This was fixed in PETSc 3.22, see also
+  // https://gitlab.com/petsc/petsc/-/issues/1753.) Wrap it via a
+  // function implemented in namespace dealii:
+  namespace dealii
+  {
+    inline PetscErrorCode
+    PetscLayoutFindOwner(PetscLayout map, PetscInt idx, PetscMPIInt *owner)
+    {
+      return ::PetscLayoutFindOwner(map, idx, owner);
+    }
+  } // namespace dealii
+#  endif
+
+  // In general, we treat PETSc data types like PC, SNES, TS as
+  // opaque, which means that all we need to know and export is that
+  // they exist. In practice, these types are typedefs to pointers to
+  // internal structures, and we do not need to export these internal
+  // structures. But in petsc_compatibility, we have a couple of
+  // places where we do access the objects pointed to ourselves, and
+  // so the compiler needs to also know the structure pointed to --
+  // which means we have to export that as well. The following places
+  // are all guarded by the same version checks as used in
+  // petsc_compatibility.cc, where appropriate
+#  if !DEAL_II_PETSC_VERSION_GTE(3, 14, 0)
+  using ::_p_PC;
+#  endif
+  using ::_p_SNES;
+  using ::_p_TS;
+}
+
+
+// PETSc also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace PETSc_Macros                                \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                              \
+    namespace dealii                                                   \
+    {                                                                  \
+      export const auto &sym = dealii::PETSc_Macros::exportable_##sym; \
+    }
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPBCGS)
+#  undef KSPBCGS
+EXPORT_PREPROCESSOR_SYMBOL(KSPBCGS)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPBICG)
+#  undef KSPBICG
+EXPORT_PREPROCESSOR_SYMBOL(KSPBICG)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPCG)
+#  undef KSPCG
+EXPORT_PREPROCESSOR_SYMBOL(KSPCG)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPCGS)
+#  undef KSPCGS
+EXPORT_PREPROCESSOR_SYMBOL(KSPCGS)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPCHEBYSHEV)
+#  undef KSPCHEBYSHEV
+EXPORT_PREPROCESSOR_SYMBOL(KSPCHEBYSHEV)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPCR)
+#  undef KSPCR
+EXPORT_PREPROCESSOR_SYMBOL(KSPCR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPGMRES)
+#  undef KSPGMRES
+EXPORT_PREPROCESSOR_SYMBOL(KSPGMRES)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPLSQR)
+#  undef KSPLSQR
+EXPORT_PREPROCESSOR_SYMBOL(KSPLSQR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPPREONLY)
+#  undef KSPPREONLY
+EXPORT_PREPROCESSOR_SYMBOL(KSPPREONLY)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPRICHARDSON)
+#  undef KSPRICHARDSON
+EXPORT_PREPROCESSOR_SYMBOL(KSPRICHARDSON)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPTCQMR)
+#  undef KSPTCQMR
+EXPORT_PREPROCESSOR_SYMBOL(KSPTCQMR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(KSPTFQMR)
+#  undef KSPTFQMR
+EXPORT_PREPROCESSOR_SYMBOL(KSPTFQMR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATAIJ)
+#  undef MATAIJ
+EXPORT_PREPROCESSOR_SYMBOL(MATAIJ)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATMFFD)
+#  undef MATMFFD
+EXPORT_PREPROCESSOR_SYMBOL(MATMFFD)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATIS)
+#  undef MATIS
+EXPORT_PREPROCESSOR_SYMBOL(MATIS)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATNEST)
+#  undef MATNEST
+EXPORT_PREPROCESSOR_SYMBOL(MATNEST)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATSEQAIJ)
+#  undef MATSEQAIJ
+EXPORT_PREPROCESSOR_SYMBOL(MATSEQAIJ)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATSHELL)
+#  undef MATSHELL
+EXPORT_PREPROCESSOR_SYMBOL(MATSHELL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(MATSOLVERMUMPS)
+#  undef MATSOLVERMUMPS
+EXPORT_PREPROCESSOR_SYMBOL(MATSOLVERMUMPS)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCBDDC)
+#  undef PCBDDC
+EXPORT_PREPROCESSOR_SYMBOL(PCBDDC)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCBJACOBI)
+#  undef PCBJACOBI
+EXPORT_PREPROCESSOR_SYMBOL(PCBJACOBI)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCCHOLESKY)
+#  undef PCCHOLESKY
+EXPORT_PREPROCESSOR_SYMBOL(PCCHOLESKY)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_COMM_SELF)
+#  undef PETSC_COMM_SELF
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_COMM_SELF)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_DEFAULT)
+#  undef PETSC_DEFAULT
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_DEFAULT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_DECIDE)
+#  undef PETSC_DECIDE
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_DECIDE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_DETERMINE)
+#  undef PETSC_DETERMINE
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_DETERMINE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_MACHINE_EPSILON)
+#  undef PETSC_MACHINE_EPSILON
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_MACHINE_EPSILON)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCHYPRE)
+#  undef PCHYPRE
+EXPORT_PREPROCESSOR_SYMBOL(PCHYPRE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCICC)
+#  undef PCICC
+EXPORT_PREPROCESSOR_SYMBOL(PCICC)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCILU)
+#  undef PCILU
+EXPORT_PREPROCESSOR_SYMBOL(PCILU)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCJACOBI)
+#  undef PCJACOBI
+EXPORT_PREPROCESSOR_SYMBOL(PCJACOBI)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCLU)
+#  undef PCLU
+EXPORT_PREPROCESSOR_SYMBOL(PCLU)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCNONE)
+#  undef PCNONE
+EXPORT_PREPROCESSOR_SYMBOL(PCNONE)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCSHELL)
+#  undef PCSHELL
+EXPORT_PREPROCESSOR_SYMBOL(PCSHELL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PCSOR)
+#  undef PCSOR
+EXPORT_PREPROCESSOR_SYMBOL(PCSOR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(VECNEST)
+#  undef VECNEST
+EXPORT_PREPROCESSOR_SYMBOL(VECNEST)
+
+#endif

--- a/module/interface_module_partitions/slepc.ccm
+++ b/module/interface_module_partitions/slepc.ccm
@@ -1,0 +1,164 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from SLEPC into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_SLEPC
+#  include <slepceps.h>
+#  include <slepcst.h>
+#endif
+
+
+export module dealii:interface_partition_slepc;
+
+#ifdef DEAL_II_WITH_SLEPC
+
+export
+{
+  using ::EPS;
+  using ::EPSArnoldiSetDelayed;
+  using ::EPSComputeError;
+  using ::EPSConvergedReason;
+  using ::EPSCreate;
+  using ::EPSDestroy;
+  using ::EPSGDSetDoubleExpansion;
+  using ::EPSGetConverged;
+  using ::EPSGetEigenpair;
+  using ::EPSGetIterationNumber;
+  using ::EPSLanczosReorthogType;
+  using ::EPSLanczosSetReorthog;
+  using ::EPSProblemType;
+  using ::EPSSetConvergenceTest;
+  using ::EPSSetDimensions;
+  using ::EPSSetFromOptions;
+  using ::EPSSetInitialSpace;
+  using ::EPSSetOperators;
+  using ::EPSSetProblemType;
+  using ::EPSSetST;
+  using ::EPSSetTarget;
+  using ::EPSSetTolerances;
+  using ::EPSSetType;
+  using ::EPSSetWhichEigenpairs;
+  using ::EPSSolve;
+  using ::EPSWhich;
+  using ::SlepcFinalize;
+  using ::SlepcInitialize;
+  using ::SlepcInitializeCalled;
+  using ::ST;
+  using ::STCayleySetAntishift;
+  using ::STCreate;
+  using ::STDestroy;
+  using ::STMatMode;
+  using ::STSetKSP;
+  using ::STSetMatMode;
+  using ::STSetShift;
+  using ::STSetType;
+}
+
+
+// SLEPc also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace Slepc_Macros                                \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                              \
+    namespace dealii                                                   \
+    {                                                                  \
+      export const auto &sym = dealii::Slepc_Macros::exportable_##sym; \
+    }
+
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(EPSARNOLDI)
+#  undef EPSARNOLDI
+EXPORT_PREPROCESSOR_SYMBOL(EPSARNOLDI)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(EPSGD)
+#  undef EPSGD
+EXPORT_PREPROCESSOR_SYMBOL(EPSGD)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(EPSKRYLOVSCHUR)
+#  undef EPSKRYLOVSCHUR
+EXPORT_PREPROCESSOR_SYMBOL(EPSKRYLOVSCHUR)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(EPSJD)
+#  undef EPSJD
+EXPORT_PREPROCESSOR_SYMBOL(EPSJD)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(EPSLANCZOS)
+#  undef EPSLANCZOS
+EXPORT_PREPROCESSOR_SYMBOL(EPSLANCZOS)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(EPSPOWER)
+#  undef EPSPOWER
+EXPORT_PREPROCESSOR_SYMBOL(EPSPOWER)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(STSHIFT)
+#  undef STSHIFT
+EXPORT_PREPROCESSOR_SYMBOL(STSHIFT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(STSINVERT)
+#  undef STSINVERT
+EXPORT_PREPROCESSOR_SYMBOL(STSINVERT)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(STCAYLEY)
+#  undef STCAYLEY
+EXPORT_PREPROCESSOR_SYMBOL(STCAYLEY)
+
+#endif

--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -1,0 +1,785 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2012 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of
+// C++ headers into one partition that we can 'import' wherever we need.
+//
+// This file wraps 'namespace std'. It is loosely based on the
+// approach shown at
+//    https://github.com/davidstone/std_module
+// but it is a clean-room implementation in large part because we
+// use so many more functions than are exported in David Stone's
+// example.
+
+// The concrete list of C++ header files is from here:
+// https://stackoverflow.com/questions/2027991/list-of-standard-header-files-in-c-and-c
+
+module;
+
+#include <assert.h>
+#include <ctype.h>
+#include <deal.II/macros.h>
+#include <errno.h>
+#include <float.h>
+#include <limits.h>
+#include <locale.h>
+#include <math.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <algorithm>
+#include <any>
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <bit>
+#include <bitset>
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+#include <cfenv>
+#include <cfloat>
+#include <charconv>
+#include <chrono>
+#include <cinttypes>
+#include <climits>
+#include <clocale>
+#include <cmath>
+#include <codecvt>
+#include <compare>
+#include <complex>
+#include <concepts>
+#include <condition_variable>
+#include <coroutine>
+#include <csetjmp>
+#include <csignal>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <cuchar>
+#include <cwchar>
+#include <cwctype>
+#include <deque>
+#include <exception>
+#include <execution>
+#include <expected>
+#include <filesystem>
+#include <format>
+#include <forward_list>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <initializer_list>
+#include <iomanip>
+#include <ios>
+#include <iosfwd>
+#include <iostream>
+#include <istream>
+#include <iterator>
+#include <latch>
+#include <limits>
+#include <list>
+#include <locale>
+#include <map>
+#include <memory>
+#include <memory_resource>
+#include <mutex>
+#include <new>
+#include <numbers>
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <print>
+// #include <queue> // See https://github.com/llvm/llvm-project/issues/138558
+#include <random>
+#include <ranges>
+#include <ratio>
+#include <regex>
+#include <scoped_allocator>
+#include <semaphore>
+#include <set>
+#include <shared_mutex>
+#include <source_location>
+#include <span>
+#include <sstream>
+// #include <stack> // See https://github.com/llvm/llvm-project/issues/138558
+#include <stdexcept>
+#include <stop_token>
+#include <streambuf>
+#include <string>
+#include <string_view>
+#include <syncstream>
+#include <system_error>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <valarray>
+#include <variant>
+#include <vector>
+#include <version>
+
+
+export module dealii:interface_partition_std;
+
+export
+{
+  namespace std
+  {
+    // Some types
+    using std::int16_t;
+    using std::int32_t;
+    using std::int64_t;
+    using std::int8_t;
+    using std::intmax_t;
+    using std::ptrdiff_t;
+    using std::size_t;
+    using std::uint16_t;
+    using std::uint32_t;
+    using std::uint64_t;
+    using std::uint8_t;
+    using std::uint_least64_t;
+    using std::uintmax_t;
+    using std::uintptr_t;
+
+    // Types wrapping integers
+    using std::bool_constant;
+    using std::false_type;
+    using std::index_sequence;
+    using std::integer_sequence;
+    using std::integral_constant;
+    using std::make_index_sequence;
+    using std::make_integer_sequence;
+    using std::true_type;
+
+    // Type traits and concepts
+    using std::add_const_t;
+    using std::add_pointer_t;
+    using std::add_volatile_t;
+    using std::assignable_from;
+    using std::common_type;
+    using std::common_type_t;
+    using std::conditional_t;
+    using std::constructible_from;
+    using std::convertible_to;
+    using std::copy_constructible;
+    using std::decay_t;
+    using std::derived_from;
+    using std::destructible;
+    using std::enable_if;
+    using std::enable_if_t;
+    using std::extent_v;
+    using std::floating_point;
+    using std::integral;
+    using std::invocable;
+    using std::invoke_result_t;
+    using std::is_arithmetic_v;
+    using std::is_array_v;
+    using std::is_assignable_v;
+    using std::is_base_of_v;
+    using std::is_const_v;
+    using std::is_constant_evaluated;
+    using std::is_constructible_v;
+    using std::is_convertible;
+    using std::is_convertible_v;
+    using std::is_copy_assignable_v;
+    using std::is_copy_constructible_v;
+    using std::is_default_constructible_v;
+    using std::is_empty_v;
+    using std::is_enum_v;
+    using std::is_floating_point_v;
+    using std::is_function_v;
+    using std::is_fundamental_v;
+    using std::is_integral;
+    using std::is_integral_v;
+    using std::is_invocable_r_v;
+    using std::is_invocable_v;
+    using std::is_lvalue_reference_v;
+    using std::is_member_function_pointer_v;
+    using std::is_member_object_pointer_v;
+    using std::is_member_pointer_v;
+    using std::is_move_assignable_v;
+    using std::is_move_constructible_v;
+    using std::is_nothrow_constructible_v;
+    using std::is_nothrow_copy_assignable_v;
+    using std::is_nothrow_copy_constructible_v;
+    using std::is_nothrow_destructible_v;
+    using std::is_nothrow_move_assignable_v;
+    using std::is_nothrow_move_constructible_v;
+    using std::is_nothrow_swappable_v;
+    using std::is_null_pointer_v;
+    using std::is_pointer_v;
+    using std::is_reference_v;
+    using std::is_rvalue_reference_v;
+    using std::is_same;
+    using std::is_same_v;
+    using std::is_standard_layout_v;
+    using std::is_trivial_v;
+    using std::is_trivially_copy_assignable_v;
+    using std::is_trivially_copy_constructible_v;
+    using std::is_trivially_copyable;
+    using std::is_trivially_copyable_v;
+    using std::is_trivially_default_constructible_v;
+    using std::is_trivially_destructible_v;
+    using std::is_trivially_move_assignable_v;
+    using std::is_trivially_move_constructible_v;
+    using std::is_unsigned;
+    using std::is_unsigned_v;
+    using std::is_void_v;
+    using std::is_volatile_v;
+    using std::make_signed_t;
+    using std::make_unsigned_t;
+    using std::move_constructible;
+    using std::predicate;
+    using std::regular_invocable;
+    using std::remove_const_t;
+    using std::remove_cv_t;
+    using std::remove_cvref_t;
+    using std::remove_pointer_t;
+    using std::remove_reference;
+    using std::remove_reference_t;
+    using std::same_as;
+    using std::signed_integral;
+    using std::three_way_comparable;
+    using std::type_identity;
+    using std::type_identity_t;
+    using std::underlying_type_t;
+    using std::unsigned_integral;
+
+    // Numeric functions
+    using std::abs;
+    using std::acos;
+    using std::asin;
+    using std::atan;
+    using std::atan2;
+    using std::cbrt;
+    using std::ceil;
+    using std::clamp;
+    using std::conj;
+    using std::copysign;
+    using std::cos;
+#if defined(DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS)
+    using std::cyl_bessel_j;
+    using std::cyl_bessel_jf;
+#endif
+    using std::erf;
+    using std::erfc;
+    using std::exp;
+    using std::fabs;
+    using std::floor;
+    using std::fmax;
+    using std::fmin;
+    using std::hypot;
+    using std::imag;
+    using std::isfinite;
+    using std::isnan;
+    using std::llround;
+    using std::log;
+    using std::log10;
+    using std::log2;
+    using std::lround;
+    using std::max;
+    using std::min;
+    using std::minmax;
+    using std::norm;
+    using std::pow;
+    using std::real;
+    using std::round;
+    using std::signbit;
+    using std::sin;
+    using std::sqrt;
+    using std::tan;
+    using std::tanh;
+    using std::trunc;
+
+    // Exceptions
+    using std::bad_alloc;
+    using std::bad_cast;
+    using std::current_exception;
+    using std::exception;
+    using std::exception_ptr;
+    using std::invalid_argument;
+    using std::length_error;
+    using std::out_of_range;
+    using std::range_error;
+    using std::rethrow_exception;
+    using std::runtime_error;
+    using std::uncaught_exceptions;
+
+    // Iterators and ranges
+    using std::advance;
+    using std::back_inserter;
+    using std::begin;
+    using std::data;
+    using std::distance;
+    using std::end;
+    using std::next;
+    using std::prev;
+    using std::size;
+
+    using std::iterator_traits;
+
+    using std::bidirectional_iterator_tag;
+    using std::contiguous_iterator_tag;
+    using std::default_sentinel;
+    using std::default_sentinel_t;
+    using std::forward_iterator_tag;
+    using std::input_iterator_tag;
+    using std::make_reverse_iterator;
+    using std::output_iterator_tag;
+    using std::random_access_iterator_tag;
+    using std::reverse_iterator;
+
+#if DEAL_II_HAVE_CXX23
+    using std::from_range;
+    using std::from_range_t;
+#endif
+
+    namespace ranges
+    {
+      using std::ranges::data;
+      using std::ranges::iota_view;
+      using std::ranges::swap;
+    } // namespace ranges
+
+
+    // Containers and similar things
+    using std::any;
+    using std::any_cast;
+    using std::array;
+    using std::bitset;
+    using std::complex;
+    using std::deque;
+    using std::forward_list;
+    using std::initializer_list;
+    using std::list;
+    using std::make_optional;
+    using std::map;
+    using std::multimap;
+    using std::multiset;
+    using std::nullopt;
+    using std::optional;
+    // For now, don't export this class to work around a compiler bug:
+    // using std::queue;
+    using std::set;
+    using std::span;
+    // For now, don't export this class to work around a compiler bug:
+    // using std::stack;
+    using std::unordered_map;
+    using std::unordered_multimap;
+    using std::unordered_multiset;
+    using std::unordered_set;
+    using std::variant;
+    using std::vector;
+    using std::visit;
+
+    // Function objects, functors, and related concepts
+    using std::bind;
+    using std::bind_front;
+    using std::bit_and;
+    using std::cref;
+    using std::divides;
+    using std::equal_to;
+    using std::function;
+    using std::greater;
+    using std::greater_equal;
+    using std::identity;
+    using std::less;
+    using std::less_equal;
+    using std::minus;
+    using std::modulus;
+    using std::multiplies;
+    using std::not_equal_to;
+    using std::not_fn;
+    using std::plus;
+    using std::ref;
+
+#if DEAL_II_HAVE_CXX23
+    using std::to_underlying;
+    using std::unreachable;
+#endif
+
+    // Strings
+    using std::basic_string;
+    using std::basic_string_view;
+    using std::string;
+    using std::string_view;
+
+    using std::atoi;
+    using std::char_traits;
+    using std::chars_format;
+    using std::errc;
+    using std::from_chars;
+    using std::from_chars_result;
+    using std::getline;
+    using std::isalnum;
+    using std::isdigit;
+    using std::stod;
+    using std::stoi;
+    using std::stoull;
+    using std::strcat;
+    using std::strcmp;
+    using std::strcpy;
+    using std::strlen;
+    using std::strstr;
+    using std::strtod;
+    using std::strtol;
+    using std::to_string;
+    using std::toupper;
+
+
+    inline namespace literals
+    {
+      inline namespace string_view_literals
+      {
+        using std::literals::string_view_literals::operator""sv;
+
+      } // namespace string_view_literals
+    }   // namespace literals
+
+    // Algorithms
+    using std::accumulate;
+    using std::adjacent_find;
+    using std::all_of;
+    using std::any_of;
+    using std::binary_search;
+    using std::compare_three_way;
+    using std::copy;
+    using std::copy_backward;
+    using std::copy_n;
+    using std::count;
+    using std::count_if;
+    using std::equal;
+    using std::fill;
+    using std::fill_n;
+    using std::find;
+    using std::find_if;
+    using std::for_each;
+    using std::inner_product;
+    using std::inplace_merge;
+    using std::iota;
+    using std::is_sorted;
+    using std::lexicographical_compare;
+    using std::lower_bound;
+    using std::make_heap;
+    using std::max_element;
+    using std::memcpy;
+    using std::min_element;
+    using std::minmax_element;
+    using std::mismatch;
+    using std::move_backward;
+    using std::next_permutation;
+    using std::none_of;
+    using std::nth_element;
+    using std::partial_sum;
+    using std::partition;
+    using std::reduce;
+    using std::remove;
+    using std::remove_if;
+    using std::replace;
+    using std::reverse;
+    using std::rotate;
+    using std::search;
+    using std::set_intersection;
+    using std::shuffle;
+    using std::sort;
+    using std::sort_heap;
+    using std::stable_sort;
+    using std::transform;
+    using std::unique;
+    using std::upper_bound;
+
+    // Tuples and similar stuff
+    using std::apply;
+    using std::forward_as_tuple;
+    using std::get;
+    using std::get_if;
+    using std::holds_alternative;
+    using std::make_pair;
+    using std::make_tuple;
+    using std::pair;
+    using std::tie;
+    using std::tuple;
+    using std::tuple_element;
+    using std::tuple_element_t;
+    using std::tuple_size;
+    using std::tuple_size_v;
+
+    // Time stuff
+    using std::ctime;
+    using std::localtime;
+    using std::time;
+    using std::time_t;
+    using std::tm;
+
+    namespace chrono
+    {
+      using std::chrono::duration;
+      using std::chrono::duration_cast;
+      using std::chrono::high_resolution_clock;
+      using std::chrono::hours;
+      using std::chrono::microseconds;
+      using std::chrono::milliseconds;
+      using std::chrono::seconds;
+      using std::chrono::steady_clock;
+      using std::chrono::time_point;
+      using std::chrono::operator+;
+      using std::chrono::operator-;
+
+    } // namespace chrono
+
+    // Random generators
+    using std::discrete_distribution;
+    using std::geometric_distribution;
+    // For now, don't export these two to work around a compiler bug:
+    // using std::mt19937;
+    // using std::mt19937_64;
+    using std::normal_distribution;
+    using std::random_device;
+    using std::uniform_int_distribution;
+    using std::uniform_real_distribution;
+
+    // Memory, mutexes, and locking
+    using std::addressof;
+    using std::align;
+    using std::allocator;
+    using std::atomic;
+    using std::atomic_flag;
+    using std::condition_variable_any;
+    using std::dynamic_pointer_cast;
+    using std::free;
+    using std::make_shared;
+    using std::make_unique;
+    using std::malloc;
+    using std::memcmp;
+    using std::memcpy;
+    using std::memory_order;
+    using std::memory_order_acquire;
+    using std::memory_order_relaxed;
+    using std::memory_order_release;
+    using std::memset;
+    using std::pointer_traits;
+    using std::shared_ptr;
+    using std::unique_ptr;
+    using std::weak_ptr;
+
+    using std::lock_guard;
+    using std::mutex;
+    using std::scoped_lock;
+    using std::shared_lock;
+    using std::shared_mutex;
+    using std::try_to_lock;
+    using std::unique_lock;
+
+    // Threads, parallel, and asynchronous things, plus temporal stuff
+    using std::async;
+    using std::atexit;
+    using std::call_once;
+    using std::construct_at;
+    using std::destroy_at;
+    using std::future;
+    using std::future_status;
+    using std::launch;
+    using std::once_flag;
+    using std::promise;
+    using std::thread;
+
+    namespace this_thread
+    {
+      using std::this_thread::get_id;
+      using std::this_thread::sleep_for;
+      using std::this_thread::sleep_until;
+      using std::this_thread::yield;
+    } // namespace this_thread
+
+    // Files and file systems
+    namespace filesystem
+    {
+      using std::filesystem::create_directories;
+      using std::filesystem::create_directory;
+      using std::filesystem::directory_entry;
+      using std::filesystem::directory_iterator;
+      using std::filesystem::exists;
+      using std::filesystem::file_size;
+      using std::filesystem::is_directory;
+      using std::filesystem::path;
+      using std::filesystem::recursive_directory_iterator;
+      using std::filesystem::remove;
+      using std::filesystem::remove_all;
+      using std::filesystem::temp_directory_path;
+
+    } // namespace filesystem
+
+    // Input and output streams, files
+    using std::basic_istream;
+    using std::basic_ostream;
+    using std::cerr;
+    using std::cout;
+    using std::dec;
+    using std::endl;
+    using std::fclose;
+    using std::FILE;
+    using std::flush;
+    using std::fopen;
+    using std::fstream;
+    using std::hex;
+    using std::ifstream;
+    using std::inserter;
+    using std::ios;
+    using std::ios_base;
+    using std::istream;
+    using std::istreambuf_iterator;
+    using std::istringstream;
+    using std::left;
+    using std::ofstream;
+    using std::ostream;
+    using std::ostream_iterator;
+    using std::ostringstream;
+    using std::right;
+    using std::setfill;
+    using std::setprecision;
+    using std::setw;
+    using std::sprintf;
+    using std::streambuf;
+    using std::streampos;
+    using std::streamsize;
+    using std::stringstream;
+
+    // Locales
+    using std::locale;
+
+    // Things and tools that don't seem to go into any of the other
+    // categories:
+    using std::abort;
+    using std::as_bytes;
+    using std::as_const;
+    using std::as_writable_bytes;
+    using std::bit_cast;
+    using std::byte;
+    using std::declval;
+    using std::denorm_absent;
+    using std::endian;
+    using std::exchange;
+    using std::forward;
+    using std::getenv;
+    using std::hash;
+    using std::ignore;
+    using std::in_place;
+    using std::in_place_index;
+    using std::in_place_index_t;
+    using std::in_place_t;
+    using std::in_place_type;
+    using std::in_place_type_t;
+    using std::invoke;
+    using std::isspace;
+    using std::max;
+    using std::monostate;
+    using std::move;
+    using std::nullptr_t;
+    using std::numeric_limits;
+    using std::ref;
+    using std::reference_wrapper;
+    using std::round_toward_zero;
+    using std::strong_ordering;
+    using std::swap;
+    using std::swap_ranges;
+    using std::system;
+    using std::type_info;
+
+    // Some operators. These may actually be overloaded for a variety
+    // of argument types.
+    using std::operator+;
+    using std::operator-;
+    using std::operator*;
+    using std::operator/;
+    using std::operator|;
+    using std::operator<<;
+    using std::operator>>;
+    using std::operator==;
+    using std::operator!=;
+    using std::operator<=;
+    using std::operator>=;
+    using std::operator<;
+    using std::operator>;
+  } // namespace std
+
+#if defined(__GLIBCXX__) // For GCC's support library
+
+  namespace __gnu_cxx
+  {
+    using __gnu_cxx::operator-;
+    using __gnu_cxx::operator==;
+    using __gnu_cxx::operator<=>;
+  } // namespace __gnu_cxx
+
+#elif defined(_LIBCPP_VERSION) // For CLang's support library
+
+  _LIBCPP_BEGIN_NAMESPACE_STD
+
+  using std::operator==;
+  using std::operator!=;
+  using std::operator<=>;
+  using std::operator<;
+  using std::operator>;
+  using std::operator<=;
+  using std::operator>=;
+
+  _LIBCPP_END_NAMESPACE_STD
+
+#endif
+
+  // C++ also declares a few functions in the global namespace:
+  using ::operator new;
+  using ::operator delete;
+
+  // Finally also export some C functions and types we build on, or
+  // that we need to use because some of our external libraries use
+  // these types in their interfaces and/or macros:
+  using ::erf;
+  using ::fabs;
+  using ::int8_t;
+  using ::mkdtemp;
+  using ::posix_memalign;
+  using ::size_t;
+  using ::strcmp;
+
+  // And then also a couple of things that have to do with floating
+  // point exceptions:
+#ifdef DEAL_II_HAVE_FP_EXCEPTIONS
+  using ::feholdexcept;
+  using ::fenv_t;
+  using ::fesetenv;
+#endif
+
+} // export

--- a/module/interface_module_partitions/sundials.ccm
+++ b/module/interface_module_partitions/sundials.ccm
@@ -1,0 +1,217 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of
+// SUNDIALS into one partition that we can 'import' wherever we need.
+// This is the file that wraps everything we need from SUNDIALS into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_SUNDIALS
+#  include <arkode/arkode.h>
+#  include <arkode/arkode_arkstep.h>
+#  include <arkode/arkode_ls.h>
+#  include <ida/ida.h>
+#  include <idas/idas.h>
+#  include <idas/idas_ls.h>
+#  include <kinsol/kinsol.h>
+#  include <nvector/nvector_parallel.h>
+#  include <nvector/nvector_serial.h>
+#  include <sundials/sundials_config.h>
+#  include <sundials/sundials_iterative.h>
+#  include <sundials/sundials_linearsolver.h>
+#  include <sundials/sundials_math.h>
+#  include <sundials/sundials_matrix.h>
+#  include <sundials/sundials_nvector.h>
+#  include <sundials/sundials_types.h>
+#  include <sunlinsol/sunlinsol_dense.h>
+#  include <sunlinsol/sunlinsol_spgmr.h>
+#  include <sunmatrix/sunmatrix_dense.h>
+#  include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
+#endif
+
+
+export module dealii:interface_partition_sundials;
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+export
+{
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+#    undef sunbooleantype
+  using sunbooleantype = int;
+  using ::sunrealtype;
+#  else
+  using booleantype;
+  using ::realtype;
+#  endif
+
+  using ::_generic_N_Vector;
+  using ::ARKLsJacTimesSetupFn;
+  using ::ARKLsMassPrecSetupFn;
+  using ::ARKLsMassTimesSetupFn;
+  using ::ARKLsPrecSetupFn;
+  using ::ARKRhsFn;
+  using ::ARKStepCreate;
+  using ::ARKStepEvolve;
+  using ::ARKStepFree;
+  using ::ARKStepGetNumSteps;
+  using ::ARKStepSetInitStep;
+  using ::ARKStepSetJacTimes;
+  using ::ARKStepSetLinear;
+  using ::ARKStepSetLinearSolver;
+  using ::ARKStepSetMassLinearSolver;
+  using ::ARKStepSetMassPreconditioner;
+  using ::ARKStepSetMassTimes;
+  using ::ARKStepSetMaxNonlinIters;
+  using ::ARKStepSetNonlinearSolver;
+  using ::ARKStepSetOrder;
+  using ::ARKStepSetPreconditioner;
+  using ::ARKStepSetStopTime;
+  using ::ARKStepSetUserData;
+  using ::ARKStepSStolerances;
+  using ::ARKStepSVtolerances;
+  using ::IDACalcIC;
+  using ::IDACreate;
+  using ::IDAFree;
+  using ::IDAGetConsistentIC;
+  using ::IDAGetLastStep;
+  using ::IDAGetNumSteps;
+  using ::IDAInit;
+  using ::IDASetId;
+  using ::IDASetInitStep;
+  using ::IDASetJacFn;
+  using ::IDASetLinearSolver;
+  using ::IDASetLSNormFactor;
+  using ::IDASetMaxNonlinIters;
+  using ::IDASetMaxNumItersIC;
+  using ::IDASetMaxOrd;
+  using ::IDASetStopTime;
+  using ::IDASetSuppressAlg;
+  using ::IDASetUserData;
+  using ::IDASolve;
+  using ::IDASStolerances;
+  using ::IDASVtolerances;
+  using ::KINCreate;
+  using ::KINFree;
+  using ::KINGetNumNonlinSolvIters;
+  using ::KINInit;
+  using ::KINSetFuncNormTol;
+  using ::KINSetJacFn;
+  using ::KINSetLinearSolver;
+  using ::KINSetMAA;
+  using ::KINSetMaxBetaFails;
+  using ::KINSetMaxNewtonStep;
+  using ::KINSetMaxSetupCalls;
+  using ::KINSetNoInitSetup;
+  using ::KINSetNumMaxIters;
+  using ::KINSetOrthAA;
+  using ::KINSetRelErrFunc;
+  using ::KINSetScaledStepTol;
+  using ::KINSetUserData;
+  using ::KINSol;
+  using ::N_VCopyOps;
+  using ::N_VDestroy;
+  using ::N_Vector;
+  using ::N_Vector_ID;
+  using ::N_VFreeEmpty;
+  using ::N_VNewEmpty;
+  using ::SUNATimesFn;
+  using ::SUNContext;
+  using ::SUNContext_Create;
+  using ::SUNContext_Free;
+  using ::sunindextype;
+  using ::SUNLinearSolver;
+  using ::SUNLinearSolver_Type;
+  using ::SUNLinSol_SPGMR;
+  using ::SUNLinSolFree;
+  using ::SUNLinSolFreeEmpty;
+  using ::SUNLinSolNewEmpty;
+  using ::SUNMatDestroy;
+  using ::SUNMatNewEmpty;
+  using ::SUNMatrix;
+  using ::SUNMatrix_ID;
+  using ::SUNNonlinearSolver;
+  using ::SUNNonlinSol_FixedPoint;
+  using ::SUNPSetupFn;
+  using ::SUNPSolveFn;
+
+  // These following are all macros, and so we use the same approach
+  // as we do for the MPI macros:
+  namespace SUNDIALS_Macros
+  {
+    namespace ARKode
+    {
+      const auto normal = ARK_NORMAL;
+    }
+
+    namespace IDA
+    {
+      const auto normal      = IDA_NORMAL;
+      const auto y_init      = IDA_Y_INIT;
+      const auto ya_ydp_init = IDA_YA_YDP_INIT;
+    } // namespace IDA
+
+    namespace KINSOL
+    {
+      const auto fp         = KIN_FP;
+      const auto linesearch = KIN_LINESEARCH;
+      const auto none       = KIN_NONE;
+      const auto picard     = KIN_PICARD;
+    } // namespace KINSOL
+
+    const auto sun_false = SUNFALSE;
+    const auto sun_true  = SUNTRUE;
+  } // namespace SUNDIALS_Macros
+
+#  undef ARK_NORMAL
+
+#  undef IDA_NORMAL
+#  undef IDA_Y_INIT
+#  undef IDA_YA_YDP_INIT
+
+#  undef KIN_FP
+#  undef KIN_LINESEARCH
+#  undef KIN_NONE
+#  undef KIN_PICARD
+
+#  undef SUNFALSE
+#  undef SUNTRUE
+
+  const auto &ARK_NORMAL = SUNDIALS_Macros::ARKode::normal;
+
+  const auto &IDA_NORMAL      = SUNDIALS_Macros::IDA::normal;
+  const auto &IDA_Y_INIT      = SUNDIALS_Macros::IDA::y_init;
+  const auto &IDA_YA_YDP_INIT = SUNDIALS_Macros::IDA::ya_ydp_init;
+
+  const auto &KIN_FP         = SUNDIALS_Macros::KINSOL::fp;
+  const auto &KIN_LINESEARCH = SUNDIALS_Macros::KINSOL::linesearch;
+  const auto &KIN_NONE       = SUNDIALS_Macros::KINSOL::none;
+  const auto &KIN_PICARD     = SUNDIALS_Macros::KINSOL::picard;
+
+  const auto &SUNFALSE = SUNDIALS_Macros::sun_false;
+  const auto &SUNTRUE  = SUNDIALS_Macros::sun_true;
+}
+
+#endif

--- a/module/interface_module_partitions/taskflow.ccm
+++ b/module/interface_module_partitions/taskflow.ccm
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from ADOL-C into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_TASKFLOW
+#  include <taskflow/algorithm/for_each.hpp>
+#  include <taskflow/taskflow.hpp>
+#endif
+
+
+export module dealii:interface_partition_taskflow;
+
+#ifdef DEAL_II_WITH_TASKFLOW
+
+export
+{
+  namespace tf
+  {
+    using ::tf::Executor;
+    using ::tf::Future;
+    using ::tf::StaticPartitioner;
+    using ::tf::Task;
+    using ::tf::Taskflow;
+  } // namespace tf
+}
+
+#endif

--- a/module/interface_module_partitions/tbb.ccm
+++ b/module/interface_module_partitions/tbb.ccm
@@ -1,0 +1,84 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from TBB into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_TBB
+#  include <tbb/blocked_range.h>
+#  include <tbb/concurrent_unordered_map.h>
+#  include <tbb/parallel_for.h>
+#  include <tbb/parallel_reduce.h>
+#  include <tbb/partitioner.h>
+#  include <tbb/task.h>
+#  include <tbb/task_group.h>
+#  ifdef DEAL_II_TBB_WITH_ONEAPI
+#    include <tbb/parallel_pipeline.h>
+#  else
+#    include <tbb/pipeline.h>
+#  endif
+#  ifdef DEAL_II_TBB_WITH_ONEAPI
+#    include <tbb/global_control.h>
+#  else
+#    include <tbb/task_scheduler_init.h>
+#  endif
+#endif
+
+
+export module dealii:interface_partition_tbb;
+
+#ifdef DEAL_II_WITH_TBB
+
+export
+{
+  namespace tbb
+  {
+    using ::tbb::affinity_partitioner;
+    using ::tbb::auto_partitioner;
+    using ::tbb::blocked_range;
+    using ::tbb::concurrent_unordered_map;
+    using ::tbb::filter;
+    using ::tbb::filter_mode;
+    using ::tbb::flow_control;
+    using ::tbb::make_filter;
+    using ::tbb::parallel_for;
+    using ::tbb::parallel_pipeline;
+    using ::tbb::parallel_reduce;
+    using ::tbb::task_group;
+
+#  ifdef DEAL_II_TBB_WITH_ONEAPI
+    using ::tbb::global_control;
+#  else
+    using ::tbb::task_scheduler_init;
+#  endif
+
+  } // namespace tbb
+}
+
+#endif

--- a/module/interface_module_partitions/trilinos.ccm
+++ b/module/interface_module_partitions/trilinos.ccm
@@ -1,0 +1,441 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from TRILINOS into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_TRILINOS
+#  include <Amesos.h>
+#  include <AztecOO.h>
+#  include <BelosBlockCGSolMgr.hpp>
+#  include <BelosBlockGmresSolMgr.hpp>
+#  include <BelosEpetraAdapter.hpp>
+#  include <BelosIteration.hpp>
+#  include <BelosMultiVec.hpp>
+#  include <BelosOperator.hpp>
+#  include <BelosSolverManager.hpp>
+#  include <EpetraExt_MatrixMatrix.h>
+#  include <Epetra_BlockMap.h>
+#  include <Epetra_Comm.h>
+#  include <Epetra_ConfigDefs.h>
+#  include <Epetra_CrsGraph.h>
+#  include <Epetra_CrsMatrix.h>
+#  include <Epetra_Export.h>
+#  include <Epetra_FECrsGraph.h>
+#  include <Epetra_FECrsMatrix.h>
+#  include <Epetra_FEVector.h>
+#  include <Epetra_Import.h>
+#  include <Epetra_LinearProblem.h>
+#  include <Epetra_LocalMap.h>
+#  include <Epetra_Map.h>
+#  include <Epetra_MpiComm.h>
+#  include <Epetra_MultiVector.h>
+#  include <Epetra_Operator.h>
+#  include <Epetra_RowMatrix.h>
+#  include <Epetra_SerialComm.h>
+#  include <Epetra_Vector.h>
+#  include <Ifpack2_Factory.hpp>
+#  include <Ifpack2_IdentitySolver.hpp>
+#  include <Ifpack2_IdentitySolver_decl.hpp>
+#  include <Ifpack2_Preconditioner.hpp>
+#  include <Ifpack_Chebyshev.h>
+#  include <NOX_Abstract_Group.H>
+#  include <NOX_Abstract_Vector.H>
+#  include <NOX_Solver_Factory.H>
+#  include <NOX_Solver_Generic.H>
+#  include <NOX_StatusTest_Combo.H>
+#  include <NOX_StatusTest_MaxIters.H>
+#  include <NOX_StatusTest_NormF.H>
+#  include <NOX_StatusTest_RelativeNormF.H>
+#  include <Teuchos_BLAS_types.hpp>
+#  include <Teuchos_Comm.hpp>
+#  include <Teuchos_ConfigDefs.hpp>
+#  include <Teuchos_DefaultComm.hpp>
+#  include <Teuchos_DefaultMpiComm.hpp>
+#  include <Teuchos_OrdinalTraits.hpp>
+#  include <Teuchos_ParameterList.hpp>
+#  include <Teuchos_RCP.hpp>
+#  include <Teuchos_RCPDecl.hpp>
+
+#  include <functional>
+
+#  ifdef DEAL_II_TRILINOS_WITH_ROL
+#    include <ROL_Vector.hpp>
+#  endif
+
+#  ifdef DEAL_II_TRILINOS_WITH_SACADO
+#    include <Sacado.hpp>
+#    include <Sacado_Fad_DFad.hpp>
+#    include <Sacado_Fad_Ops.hpp>
+#    include <Sacado_trad.hpp>
+#  endif
+
+#  ifdef DEAL_II_TRILINOS_WITH_SEACAS
+#    include <exodusII.h>
+#  endif
+
+#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    include <Tpetra_Core.hpp>
+#    include <Tpetra_CrsGraph.hpp>
+#    include <Tpetra_CrsGraph_fwd.hpp>
+#    include <Tpetra_CrsMatrix.hpp>
+#    include <Tpetra_CrsMatrix_decl.hpp>
+#    include <Tpetra_CrsMatrix_fwd.hpp>
+#    include <Tpetra_Details_DefaultTypes.hpp>
+#    include <Tpetra_Export.hpp>
+#    include <Tpetra_Export_fwd.hpp>
+#    include <Tpetra_Import.hpp>
+#    include <Tpetra_Import_def.hpp>
+#    include <Tpetra_Import_fwd.hpp>
+#    include <Tpetra_Map.hpp>
+#    include <Tpetra_Map_def.hpp>
+#    include <Tpetra_Map_fwd.hpp>
+#    include <Tpetra_MultiVector_fwd.hpp>
+#    include <Tpetra_Operator.hpp>
+#    include <Tpetra_Operator_fwd.hpp>
+#    include <Tpetra_RowMatrix_fwd.hpp>
+#    include <Tpetra_Vector.hpp>
+#    include <Tpetra_Vector_decl.hpp>
+#    include <Tpetra_Vector_fwd.hpp>
+#    include <Tpetra_Version.hpp>
+
+#    ifdef DEAL_II_TRILINOS_WITH_AMESOS2
+#      include <Amesos2.hpp>
+#    endif
+#  endif
+#endif
+
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+#  include <zoltan_cpp.h>
+#endif
+
+
+export module dealii:interface_partition_trilinos;
+
+#ifdef DEAL_II_WITH_TRILINOS
+
+export
+{
+  using ::Amesos;
+  using ::Amesos_BaseSolver;
+  using ::AztecOO;
+  using ::AztecOO_StatusTest;
+  using ::Epetra_AddLocalAlso;
+  using ::Epetra_BlockMap;
+  using ::Epetra_CombineMode;
+  using ::Epetra_Comm;
+  using ::Epetra_CrsGraph;
+  using ::Epetra_CrsMatrix;
+  using ::Epetra_Export;
+  using ::Epetra_FECrsGraph;
+  using ::Epetra_FECrsMatrix;
+  using ::Epetra_FEVector;
+  using ::Epetra_Import;
+  using ::Epetra_LinearProblem;
+  using ::Epetra_LocalMap;
+  using ::Epetra_Map;
+  using ::Epetra_Max;
+  using ::Epetra_Min;
+  using ::Epetra_MpiComm;
+  using ::Epetra_MultiVector;
+  using ::Epetra_Operator;
+  using ::Epetra_RowMatrix;
+  using ::Epetra_SerialComm;
+  using ::Epetra_Vector;
+  using ::Ifpack_Chebyshev;
+  using ::Ifpack_Preconditioner;
+
+  // Epetra declares the following operator for Epetra_FECrsMatrix
+  // objects:
+  using ::operator<<;
+
+  namespace Belos
+  {
+    using ::Belos::BlockCGSolMgr;
+    using ::Belos::BlockGmresSolMgr;
+    using ::Belos::ETrans;
+    using ::Belos::LinearProblem;
+    using ::Belos::MultiVec;
+    using ::Belos::NormType;
+    using ::Belos::Operator;
+    using ::Belos::ReturnType;
+    using ::Belos::SolverManager;
+  } // namespace Belos
+
+  namespace EpetraExt
+  {
+    using ::EpetraExt::MatrixMatrix;
+  }
+
+  namespace NOX
+  {
+    namespace Abstract
+    {
+      using ::NOX::Abstract::Group;
+      using ::NOX::Abstract::Vector;
+    } // namespace Abstract
+
+    namespace Solver
+    {
+      using ::NOX::Solver::buildSolver;
+      using ::NOX::Solver::Generic;
+    } // namespace Solver
+
+    namespace StatusTest
+    {
+      using ::NOX::StatusTest::CheckType;
+      using ::NOX::StatusTest::Combo;
+      using ::NOX::StatusTest::Generic;
+      using ::NOX::StatusTest::MaxIters;
+      using ::NOX::StatusTest::NormF;
+      using ::NOX::StatusTest::RelativeNormF;
+      using ::NOX::StatusTest::StatusType;
+    } // namespace StatusTest
+
+
+    using ::NOX::CopyType;
+    using ::NOX::size_type;
+  } // namespace NOX
+
+#  ifdef DEAL_II_TRILINOS_WITH_ROL
+  namespace ROL
+  {
+    using ::ROL::makePtr;
+    using ::ROL::Ptr;
+    using ::ROL::Vector;
+    namespace Elementwise
+    {
+      using ::ROL::Elementwise::BinaryFunction;
+      using ::ROL::Elementwise::ReductionOp;
+      using ::ROL::Elementwise::UnaryFunction;
+    } // namespace Elementwise
+  }   // namespace ROL
+#  endif
+
+#  ifdef DEAL_II_TRILINOS_WITH_SACADO
+  namespace Sacado
+  {
+    namespace Fad
+    {
+      using ::Sacado::Fad::DFad;
+      using ::Sacado::Fad::Expr;
+      using ::Sacado::Fad::operator*;
+      using ::Sacado::Fad::operator/;
+      using ::Sacado::Fad::operator+;
+      using ::Sacado::Fad::operator-;
+      using ::Sacado::Fad::operator==;
+      using ::Sacado::Fad::operator!=;
+
+      namespace Exp
+      {
+        using ::Sacado::Fad::Exp::DynamicStorage;
+        using ::Sacado::Fad::Exp::GeneralFad;
+        using ::Sacado::Fad::Exp::operator*;
+        using ::Sacado::Fad::Exp::operator/;
+        using ::Sacado::Fad::Exp::operator+;
+        using ::Sacado::Fad::Exp::operator-;
+        using ::Sacado::Fad::Exp::operator==;
+        using ::Sacado::Fad::Exp::operator!=;
+        using ::Sacado::Fad::Exp::operator<<;
+        using ::Sacado::Fad::Exp::operator<;
+        using ::Sacado::Fad::Exp::operator>;
+        using ::Sacado::Fad::Exp::operator<=;
+        using ::Sacado::Fad::Exp::operator>=;
+        using ::Sacado::Fad::Exp::abs;
+        using ::Sacado::Fad::Exp::acos;
+        using ::Sacado::Fad::Exp::cos;
+        using ::Sacado::Fad::Exp::fabs;
+        using ::Sacado::Fad::Exp::sqrt;
+      } // namespace Exp
+    }   // namespace Fad
+
+    namespace Rad
+    {
+      using ::Sacado::Rad::ADvar;
+      using ::Sacado::Rad::ADvari;
+      using ::Sacado::Rad::operator*;
+      using ::Sacado::Rad::operator/;
+      using ::Sacado::Rad::operator+;
+      using ::Sacado::Rad::operator-;
+      using ::Sacado::Rad::operator==;
+      using ::Sacado::Rad::operator!=;
+      using ::Sacado::Rad::operator<;
+      using ::Sacado::Rad::operator>;
+      using ::Sacado::Rad::operator<=;
+      using ::Sacado::Rad::operator>=;
+      using ::Sacado::Rad::abs;
+      using ::Sacado::Rad::acos;
+      using ::Sacado::Rad::cos;
+      using ::Sacado::Rad::fabs;
+      using ::Sacado::Rad::sqrt;
+    } // namespace Rad
+  }   // namespace Sacado
+#  endif
+
+  namespace Teuchos
+  {
+    using ::Teuchos::Array;
+    using ::Teuchos::ArrayRCP;
+    using ::Teuchos::ArrayView;
+    using ::Teuchos::Comm;
+    using ::Teuchos::Copy;
+    using ::Teuchos::ETransp;
+#  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+    using ::Teuchos::make_rcp;
+#  endif // !DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+    using ::Teuchos::MpiComm;
+    using ::Teuchos::NO_TRANS;
+    using ::Teuchos::null;
+    using ::Teuchos::OrdinalTraits;
+    using ::Teuchos::ParameterList;
+    using ::Teuchos::rcp;
+    using ::Teuchos::RCP;
+    using ::Teuchos::rcp_const_cast;
+    using ::Teuchos::rcp_dynamic_cast;
+    using ::Teuchos::rcpFromRef;
+    using ::Teuchos::rcpFromUndefRef;
+    using ::Teuchos::ScalarTraits;
+    using ::Teuchos::SerialDenseMatrix;
+    using ::Teuchos::TRANS;
+    using ::Teuchos::VERB_EXTREME;
+  } // namespace Teuchos
+
+
+#  ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+  using ::Zoltan;
+  using ::ZOLTAN_ID_PTR;
+  using ::ZOLTAN_ID_TYPE;
+  using ::Zoltan_Initialize;
+#  endif
+}
+
+
+
+// Trilinos also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace Trilinos_Macros                             \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                                 \
+    namespace dealii                                                      \
+    {                                                                     \
+      export const auto &sym = dealii::Trilinos_Macros::exportable_##sym; \
+    }
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_solver)
+#  undef AZ_solver
+EXPORT_PREPROCESSOR_SYMBOL(AZ_solver)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_cg)
+#  undef AZ_cg
+EXPORT_PREPROCESSOR_SYMBOL(AZ_cg)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_cgs)
+#  undef AZ_cgs
+EXPORT_PREPROCESSOR_SYMBOL(AZ_cgs)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_gmres)
+#  undef AZ_gmres
+EXPORT_PREPROCESSOR_SYMBOL(AZ_gmres)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_kspace)
+#  undef AZ_kspace
+EXPORT_PREPROCESSOR_SYMBOL(AZ_kspace)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_bicgstab)
+#  undef AZ_bicgstab
+EXPORT_PREPROCESSOR_SYMBOL(AZ_bicgstab)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_tfqmr)
+#  undef AZ_tfqmr
+EXPORT_PREPROCESSOR_SYMBOL(AZ_tfqmr)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_output)
+#  undef AZ_output
+EXPORT_PREPROCESSOR_SYMBOL(AZ_output)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_all)
+#  undef AZ_all
+EXPORT_PREPROCESSOR_SYMBOL(AZ_all)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_none)
+#  undef AZ_none
+EXPORT_PREPROCESSOR_SYMBOL(AZ_none)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_conv)
+#  undef AZ_conv
+EXPORT_PREPROCESSOR_SYMBOL(AZ_conv)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_noscaled)
+#  undef AZ_noscaled
+EXPORT_PREPROCESSOR_SYMBOL(AZ_noscaled)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(AZ_precond)
+#  undef AZ_precond
+EXPORT_PREPROCESSOR_SYMBOL(AZ_precond)
+
+
+
+#  ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(ZOLTAN_OK)
+#    undef ZOLTAN_OK
+EXPORT_PREPROCESSOR_SYMBOL(ZOLTAN_OK)
+#  endif
+
+
+#endif

--- a/module/interface_module_partitions/umfpack.ccm
+++ b/module/interface_module_partitions/umfpack.ccm
@@ -1,0 +1,116 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from UMFPACK into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_UMFPACK
+#  include <umfpack.h>
+#endif
+
+
+export module dealii:interface_partition_umfpack;
+
+#ifdef DEAL_II_WITH_UMFPACK
+
+export
+{
+  using ::umfpack_dl_defaults;
+  using ::umfpack_dl_free_numeric;
+  using ::umfpack_dl_free_symbolic;
+  using ::umfpack_dl_numeric;
+  using ::umfpack_dl_solve;
+  using ::umfpack_dl_symbolic;
+  using ::umfpack_zl_numeric;
+  using ::umfpack_zl_solve;
+  using ::umfpack_zl_symbolic;
+}
+
+// Umfpack also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace Umfpack_Macros                              \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                                \
+    namespace dealii                                                     \
+    {                                                                    \
+      export const auto &sym = dealii::Umfpack_Macros::exportable_##sym; \
+    }
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(UMFPACK_CONTROL)
+#  undef UMFPACK_CONTROL
+EXPORT_PREPROCESSOR_SYMBOL(UMFPACK_CONTROL)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(UMFPACK_OK)
+#  undef UMFPACK_OK
+EXPORT_PREPROCESSOR_SYMBOL(UMFPACK_OK)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(UMFPACK_A)
+#  undef UMFPACK_A
+EXPORT_PREPROCESSOR_SYMBOL(UMFPACK_A)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(UMFPACK_At)
+#  undef UMFPACK_At
+EXPORT_PREPROCESSOR_SYMBOL(UMFPACK_At)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(UMFPACK_WARNING_singular_matrix)
+#  undef UMFPACK_WARNING_singular_matrix
+EXPORT_PREPROCESSOR_SYMBOL(UMFPACK_WARNING_singular_matrix)
+
+#endif

--- a/module/interface_module_partitions/vtk.ccm
+++ b/module/interface_module_partitions/vtk.ccm
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from VTK into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_VTK
+#  include <vtkDoubleArray.h>
+#  include <vtkSmartPointer.h>
+#endif
+
+
+export module dealii:interface_partition_vtk;
+
+#ifdef DEAL_II_WITH_VTK
+
+export
+{
+  using ::vtkDoubleArray;
+  using ::vtkSmartPointer;
+}
+
+#endif

--- a/module/interface_module_partitions/zlib.ccm
+++ b/module/interface_module_partitions/zlib.ccm
@@ -1,0 +1,109 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// It is very inefficient in the module system to have repeated
+// #includes in many module partition files because when you 'import'
+// those partitions, you also have to load everything they
+// #included. In other words, you get the same content *many times*,
+// once from each imported partition, rather than only once via the
+// old-style #include system. We deal with this by wrapping all of our
+// external packages into partitions that we can 'import' wherever we
+// need.
+
+// This is the file that wraps everything we need from ZLIB into one
+// module partition.
+
+
+module;
+
+#include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_ZLIB
+#  include <zlib.h>
+#endif
+
+
+export module dealii:interface_partition_zlib;
+
+#ifdef DEAL_II_WITH_ZLIB
+
+export
+{
+  using ::Bytef;
+  using ::compress2;
+  using ::compressBound;
+}
+
+// Zlib also defines quite a lot of symbols that are either
+// implemented as macros, or perhaps as constants in header
+// files. In the former case, they cannot be referenced in 'using'
+// expressions, and so we need to work around things by creating
+// *variables* of the same names. In the latter case, they are often
+// implemented as constants with internal linkage that we can't
+// re-export (e.g., if they are members of anonymous enums).
+//
+// Dealing with this situation requires creating some other set of
+// variable, undefining the macro names, and then creating variables
+// with the same names as the macro names. Because we would end up
+// with name clashes if these new variables were in the global
+// namespace for those MPI implementations that implement things as
+// variables in the global namespace, we put everything into the
+// dealii namespace.
+//
+// We put the exportable symbols into namespace 'dealii'. This is
+// necessary for cases where the symbol we create is derived not from
+// a preprocessor macro, but for example as a member of an anonymous
+// enum. Such symbols can't be exported, so we declare a variable that
+// we *can* export, but it will not have the type of the enum, but of
+// the underlying int. The compiler will therefore complain that the
+// variable we're creating here redeclares another one but with a
+// different type. We can avoid this by putting things into our own
+// namespace.
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace Zlib_Macros                                 \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                             \
+    namespace dealii                                                  \
+    {                                                                 \
+      export const auto &sym = dealii::Zlib_Macros::exportable_##sym; \
+    }
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(Z_OK)
+#  undef Z_OK
+EXPORT_PREPROCESSOR_SYMBOL(Z_OK)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(Z_NO_COMPRESSION)
+#  undef Z_NO_COMPRESSION
+EXPORT_PREPROCESSOR_SYMBOL(Z_NO_COMPRESSION)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(Z_BEST_COMPRESSION)
+#  undef Z_BEST_COMPRESSION
+EXPORT_PREPROCESSOR_SYMBOL(Z_BEST_COMPRESSION)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(Z_DEFAULT_COMPRESSION)
+#  undef Z_DEFAULT_COMPRESSION
+EXPORT_PREPROCESSOR_SYMBOL(Z_DEFAULT_COMPRESSION)
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(Z_BEST_SPEED)
+#  undef Z_BEST_SPEED
+EXPORT_PREPROCESSOR_SYMBOL(Z_BEST_SPEED)
+
+#endif


### PR DESCRIPTION
Let's start with the substantial patches for modules -- we'll see how far we get with this in the near future.

At this point, we have probably all understood why we can't use `#include`s in module files, but have to "wrap" external projects. This patch adds these wrappers for most of our external dependencies, including `namespace std`. Obviously, they're not useful for anything at this point, but I though I'd start getting these things out so people can look at them and give feedback. 

In particular, objections to using `module/` as the top-level directory, alongside the existing `include/` and `source/` directories? I put these wrappers into `module/interface_module_partitions/` because that's what these files are: They are part of the deal.II module, they are "partitions" in the sense that a module is generally implemented across a number of files, each of which defines a "partition" where all partitions at the end combine to the module, and they are "interfaces" in the sense that they declare things that are exported by the partition and can be imported into other partitions.

Part of #18071.