### PR TITLE
Avoid the use of offsetof.

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -27,6 +27,12 @@
 
 #include <boost/serialization/utility.hpp>
 
+// In this file, we use offsetof, which is a macro. When compiling
+// with C++20 modules, this presents a problem because we wrap all of
+// namespace std -- and then don't have access to macros. As a
+// consequence, we really do need the following #include, even when
+// building modules:
+#include <cstddef> // Do not convert for module purposes
 #include <iostream>
 #include <limits>
 #include <numeric>


### PR DESCRIPTION
`offsetof` is defined as a macro, and on top of that as an implementation-defined one. We can't use macros in modules, or at least not easily. This is a conundrum -- there is no standards-conforming way to replace it, but there are many ways to implement something that's hard to see being wrong. Here's one way to do it.

I recognize this might be controversial -- discussion welcome.

Part of #18071.