### PR TITLE
Also indent module files.

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -60,7 +60,7 @@ checks
 # Process all source and header files:
 #
 
-process_changed "tests include source examples cmake/scripts contrib/python-bindings" ".*\.(cc|h)" format_file
+process_changed "tests include source module examples cmake/scripts contrib/python-bindings" ".*\.(cc|ccm|h)" format_file
 process_changed "source" ".*\.inst.in" format_inst
 
 #

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -64,7 +64,7 @@ checks
 # Process all source and header files:
 #
 
-process "tests include source examples contrib/python-bindings" ".*\.(cc|h)" format_file
+process "tests include source module examples contrib/python-bindings" ".*\.(cc|ccm|h)" format_file
 process "source" ".*\.inst.in" format_inst
 
 #


### PR DESCRIPTION
After #18482, we will also have source files in `module/`, and these should also be automatically indented, like everything else. This patch adds the necessary rules, specifically the need to add the file extension `.ccm` (for interface units) to the list.

We pass these paths to `find`, which is ok with simply not finding anything in listed directories. So this patch is safe even though #18482 isn't in yet.

Part of #18071.