### PR TITLE
Add the script that creates the primary module interface unit.

### DIFF
--- a/contrib/utilities/build_primary_interface_unit.py
+++ b/contrib/utilities/build_primary_interface_unit.py
@@ -35,16 +35,16 @@ print("module;")
 print("export module dealii;")
 
 # Go through all input files and check their exported module partitions:
-for module_input_file in sys.argv[1:] :
+for module_input_file in sys.argv[1:]:
     input = open(module_input_file, "r")
 
     # Read through the lines of the file and see where it exports a
     # module partition. Then 'export import' that partition:
-    for line in input :
+    for line in input:
         m = match_export.match(line)
-        if m :
+        if m:
             print("export import :" + m.group(1) + ";")
-            
+
             # A file can only contain a single interface module
             # partition. So once we found one, we can stop parsing.
-            break;
+            break


### PR DESCRIPTION
The output of the scripts in #18489 include the converted header files (called "interface units"), each of which contains an interface partition. All exported interface partitions jointly form the "module interface", and this is described in a file that simply lists all of these interface partition as exported -- that file is called the "primary module interface unit".

This script creates it, based on a list of interface units as inputs.

Part of #18071.