### PR TITLE
Mark up some DEAL_II_NAMESPACE_OPEN/CLOSE statements for module scripts.

### DIFF
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -152,62 +152,62 @@ abs(const adtl::adouble &x);
 #  endif
 #endif
 
-DEAL_II_NAMESPACE_CLOSE
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
 
-namespace std
+  namespace std
 {
   template <typename Number, std::size_t width>
-  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
-  sqrt(const ::dealii::VectorizedArray<Number, width> &);
+  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width> sqrt(
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, std::size_t width>
-  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
-  abs(const ::dealii::VectorizedArray<Number, width> &);
+  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width> abs(
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, std::size_t width>
-  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
-  max(const ::dealii::VectorizedArray<Number, width> &,
-      const ::dealii::VectorizedArray<Number, width> &);
+  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width> max(
+    const ::dealii::VectorizedArray<Number, width> &,
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, std::size_t width>
-  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
-  min(const ::dealii::VectorizedArray<Number, width> &,
-      const ::dealii::VectorizedArray<Number, width> &);
+  DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width> min(
+    const ::dealii::VectorizedArray<Number, width> &,
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, size_t width>
-  ::dealii::VectorizedArray<Number, width>
-  pow(const ::dealii::VectorizedArray<Number, width> &, const Number p);
+  ::dealii::VectorizedArray<Number, width> pow(
+    const ::dealii::VectorizedArray<Number, width> &, const Number p);
   template <typename Number, size_t width>
-  ::dealii::VectorizedArray<Number, width>
-  sin(const ::dealii::VectorizedArray<Number, width> &);
+  ::dealii::VectorizedArray<Number, width> sin(
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, size_t width>
-  ::dealii::VectorizedArray<Number, width>
-  cos(const ::dealii::VectorizedArray<Number, width> &);
+  ::dealii::VectorizedArray<Number, width> cos(
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, size_t width>
-  ::dealii::VectorizedArray<Number, width>
-  tan(const ::dealii::VectorizedArray<Number, width> &);
+  ::dealii::VectorizedArray<Number, width> tan(
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, size_t width>
-  ::dealii::VectorizedArray<Number, width>
-  exp(const ::dealii::VectorizedArray<Number, width> &);
+  ::dealii::VectorizedArray<Number, width> exp(
+    const ::dealii::VectorizedArray<Number, width> &);
   template <typename Number, size_t width>
-  ::dealii::VectorizedArray<Number, width>
-  log(const ::dealii::VectorizedArray<Number, width> &);
+  ::dealii::VectorizedArray<Number, width> log(
+    const ::dealii::VectorizedArray<Number, width> &);
 } // namespace std
 
-DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
-/**
- * Namespace for the declaration of universal constants. Since the
- * availability in <tt>math.h</tt> is not always guaranteed, we put them here.
- * Since this file is included by <tt>base/config.h</tt>, they are available
- * to the whole library.
- *
- * The constants defined here are a subset of the <tt>M_XXX</tt> constants
- * sometimes declared in the system include file <tt>math.h</tt>, but without
- * the prefix <tt>M_</tt>.
- *
- * In addition to that, we declare  <tt>invalid_unsigned_int</tt> to be the
- * largest unsigned integer representable; this value is widely used in the
- * library as a marker for an invalid index, an invalid size of an array, and
- * similar purposes.
- */
-namespace numbers
+  /**
+   * Namespace for the declaration of universal constants. Since the
+   * availability in <tt>math.h</tt> is not always guaranteed, we put them here.
+   * Since this file is included by <tt>base/config.h</tt>, they are available
+   * to the whole library.
+   *
+   * The constants defined here are a subset of the <tt>M_XXX</tt> constants
+   * sometimes declared in the system include file <tt>math.h</tt>, but without
+   * the prefix <tt>M_</tt>.
+   *
+   * In addition to that, we declare  <tt>invalid_unsigned_int</tt> to be the
+   * largest unsigned integer representable; this value is widely used in the
+   * library as a marker for an invalid index, an invalid size of an array, and
+   * similar purposes.
+   */
+  namespace numbers
 {
   /**
    * e
@@ -268,22 +268,19 @@ namespace numbers
    * double</code>, this function may return <code>false</code> even if the
    * number is finite with respect to type <code>long double</code>.
    */
-  bool
-  is_finite(const double x);
+  bool is_finite(const double x);
 
   /**
    * Return @p true if real and imaginary parts of the given complex number
    * are finite.
    */
-  bool
-  is_finite(const std::complex<double> &x);
+  bool is_finite(const std::complex<double> &x);
 
   /**
    * Return @p true if real and imaginary parts of the given complex number
    * are finite.
    */
-  bool
-  is_finite(const std::complex<float> &x);
+  bool is_finite(const std::complex<float> &x);
 
   /**
    * Return @p true if real and imaginary parts of the given complex number
@@ -293,8 +290,7 @@ namespace numbers
    * numbers that are infinite in terms of <code>double</code>, but finite
    * with respect to <code>long double</code>.
    */
-  bool
-  is_finite(const std::complex<long double> &x);
+  bool is_finite(const std::complex<long double> &x);
 
   /**
    * Return whether two numbers are equal to one another.
@@ -307,8 +303,8 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  constexpr DEAL_II_HOST_DEVICE bool
-  values_are_equal(const Number1 &value_1, const Number2 &value_2);
+  constexpr DEAL_II_HOST_DEVICE bool values_are_equal(const Number1 &value_1,
+                                                      const Number2 &value_2);
 
   /**
    * Return whether two numbers are not equal to one another.
@@ -321,8 +317,8 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  constexpr bool
-  values_are_not_equal(const Number1 &value_1, const Number2 &value_2);
+  constexpr bool values_are_not_equal(const Number1 &value_1,
+                                      const Number2 &value_2);
 
   /**
    * Return whether or not a value is equal to zero.
@@ -332,8 +328,7 @@ namespace numbers
    * by the input arguments.
    */
   template <typename Number>
-  constexpr DEAL_II_HOST_DEVICE bool
-  value_is_zero(const Number &value);
+  constexpr DEAL_II_HOST_DEVICE bool value_is_zero(const Number &value);
 
   /**
    * Return whether @p value_1 is less than that of @p value_2.
@@ -346,8 +341,7 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  bool
-  value_is_less_than(const Number1 &value_1, const Number2 &value_2);
+  bool value_is_less_than(const Number1 &value_1, const Number2 &value_2);
 
   /**
    * Return whether @p value_1 is less than or equal to that of @p value_2.
@@ -360,9 +354,8 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  bool
-  value_is_less_than_or_equal_to(const Number1 &value_1,
-                                 const Number2 &value_2);
+  bool value_is_less_than_or_equal_to(const Number1 &value_1,
+                                      const Number2 &value_2);
 
 
 
@@ -377,8 +370,7 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  bool
-  value_is_greater_than(const Number1 &value_1, const Number2 &value_2);
+  bool value_is_greater_than(const Number1 &value_1, const Number2 &value_2);
 
   /**
    * Return whether @p value_1 is greater than or equal to that of @p value_2.
@@ -391,9 +383,8 @@ namespace numbers
    * of @p value_1.
    */
   template <typename Number1, typename Number2>
-  bool
-  value_is_greater_than_or_equal_to(const Number1 &value_1,
-                                    const Number2 &value_2);
+  bool value_is_greater_than_or_equal_to(const Number1 &value_1,
+                                         const Number2 &value_2);
 
   /**
    * A structure that, together with its partial specializations
@@ -507,24 +498,21 @@ namespace numbers
 
   // --------------- inline and template functions ---------------- //
 
-  inline bool
-  is_nan(const double x)
+  inline bool is_nan(const double x)
   {
     return std::isnan(x);
   }
 
 
 
-  inline bool
-  is_finite(const double x)
+  inline bool is_finite(const double x)
   {
     return std::isfinite(x);
   }
 
 
 
-  inline bool
-  is_finite(const std::complex<double> &x)
+  inline bool is_finite(const std::complex<double> &x)
   {
     // Check complex numbers for infinity
     // by testing real and imaginary part
@@ -533,8 +521,7 @@ namespace numbers
 
 
 
-  inline bool
-  is_finite(const std::complex<float> &x)
+  inline bool is_finite(const std::complex<float> &x)
   {
     // Check complex numbers for infinity
     // by testing real and imaginary part
@@ -543,8 +530,7 @@ namespace numbers
 
 
 
-  inline bool
-  is_finite(const std::complex<long double> &x)
+  inline bool is_finite(const std::complex<long double> &x)
   {
     // Same for std::complex<long double>
     return (is_finite(x.real()) && is_finite(x.imag()));
@@ -552,8 +538,8 @@ namespace numbers
 
 
   template <typename number>
-  constexpr DEAL_II_HOST_DEVICE const number &
-  NumberTraits<number>::conjugate(const number &x)
+  constexpr DEAL_II_HOST_DEVICE const number &NumberTraits<number>::conjugate(
+    const number &x)
   {
     return x;
   }
@@ -570,8 +556,8 @@ namespace numbers
 
 
   template <typename number>
-  typename NumberTraits<number>::real_type
-  NumberTraits<number>::abs(const number &x)
+  typename NumberTraits<number>::real_type NumberTraits<number>::abs(
+    const number &x)
   {
     // Make things work with AD types
     using std::abs;
@@ -588,8 +574,8 @@ namespace numbers
 
 
   template <typename number>
-  constexpr std::complex<number>
-  NumberTraits<std::complex<number>>::conjugate(const std::complex<number> &x)
+  constexpr std::complex<number> NumberTraits<std::complex<number>>::conjugate(
+    const std::complex<number> &x)
   {
     return std::conj(x);
   }

--- a/include/deal.II/boost_adaptors/bounding_box.h
+++ b/include/deal.II/boost_adaptors/bounding_box.h
@@ -30,7 +30,11 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/geometry/strategies/strategies.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
-namespace boost
+
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
+
+  namespace boost
 {
   namespace geometry
   {
@@ -134,5 +138,8 @@ namespace boost
     } // namespace traits
   }   // namespace geometry
 } // namespace boost
+
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
+  DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/boost_adaptors/point.h
+++ b/include/deal.II/boost_adaptors/point.h
@@ -29,7 +29,10 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
-namespace boost
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
+
+  namespace boost
 {
   namespace geometry
   {
@@ -95,6 +98,8 @@ namespace boost
   }   // namespace geometry
 } // namespace boost
 
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
+  DEAL_II_NAMESPACE_CLOSE
 
 
 #endif

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -408,9 +408,9 @@ namespace ChunkSparseMatrixIterators
 
 } // namespace ChunkSparseMatrixIterators
 
-DEAL_II_NAMESPACE_CLOSE
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
 
-namespace std
+  namespace std
 {
   template <typename number, bool Constness>
   struct iterator_traits<
@@ -424,28 +424,28 @@ namespace std
   };
 } // namespace std
 
-DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
 
 
-/**
- * Sparse matrix. This class implements the function to store values in the
- * locations of a sparse matrix denoted by a SparsityPattern. The separation
- * of sparsity pattern and values is done since one can store data elements of
- * different type in these locations without the SparsityPattern having to
- * know this, and more importantly one can associate more than one matrix with
- * the same sparsity pattern.
- *
- * The use of this class is demonstrated in step-51.
- *
- * @note Instantiations for this template are provided for <tt>@<float@> and
- * @<double@></tt>; others can be generated in application programs (see the
- * section on
- * @ref Instantiations
- * in the manual).
- */
-template <typename number>
-class ChunkSparseMatrix : public virtual EnableObserverPointer
+  /**
+   * Sparse matrix. This class implements the function to store values in the
+   * locations of a sparse matrix denoted by a SparsityPattern. The separation
+   * of sparsity pattern and values is done since one can store data elements of
+   * different type in these locations without the SparsityPattern having to
+   * know this, and more importantly one can associate more than one matrix with
+   * the same sparsity pattern.
+   *
+   * The use of this class is demonstrated in step-51.
+   *
+   * @note Instantiations for this template are provided for <tt>@<float@> and
+   * @<double@></tt>; others can be generated in application programs (see the
+   * section on
+   * @ref Instantiations
+   * in the manual).
+   */
+  template <typename number>
+  class ChunkSparseMatrix : public virtual EnableObserverPointer
 {
 public:
   /**

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -26,10 +26,14 @@
 #  include <cfenv>
 #endif
 
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
+
+
 // DEAL_II_FORTRAN_MANGLE confuses doxygen a lot and these functions aren't part
 // of our public API anyway, so don't generate any doxygen for them
 #ifndef DOXYGEN
-extern "C"
+  extern "C"
 {
   void DEAL_II_FORTRAN_MANGLE(saxpy,
                               SAXPY)(const dealii::types::blas_int *n,
@@ -1397,18 +1401,18 @@ extern "C"
 }
 #endif
 
-DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
 
 
-template <typename number1, typename number2, typename number3>
-inline void
-axpy(const dealii::types::blas_int *,
-     const number1 *,
-     const number2 *,
-     const dealii::types::blas_int *,
-     number3 *,
-     const dealii::types::blas_int *)
+  template <typename number1, typename number2, typename number3>
+  inline void
+  axpy(const dealii::types::blas_int *,
+       const number1 *,
+       const number2 *,
+       const dealii::types::blas_int *,
+       number3 *,
+       const dealii::types::blas_int *)
 {
   DEAL_II_NOT_IMPLEMENTED();
 }

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -463,9 +463,9 @@ namespace SparseMatrixIterators
 
 } // namespace SparseMatrixIterators
 
-DEAL_II_NAMESPACE_CLOSE
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
 
-namespace std
+  namespace std
 {
   template <typename number, bool Constness>
   struct iterator_traits<
@@ -480,43 +480,43 @@ namespace std
   };
 } // namespace std
 
-DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
-/**
- * @}
- */
+  /**
+   * @}
+   */
 
 
-// TODO: Add multithreading to the other vmult functions.
+  // TODO: Add multithreading to the other vmult functions.
 
-/**
- * Sparse matrix. This class implements the functionality to store matrix
- * entry values in the locations denoted by a SparsityPattern. See
- * @ref Sparsity
- * for a discussion about the separation between sparsity patterns and
- * matrices.
- *
- * The elements of a SparseMatrix are stored in the same order in which the
- * SparsityPattern class stores its entries. Within each row, elements are
- * generally stored left-to-right in increasing column index order; the
- * exception to this rule is that if the matrix is square (m() == n()), then
- * the diagonal entry is stored as the first element in each row to make
- * operations like applying a Jacobi or SSOR preconditioner faster. As a
- * consequence, if you traverse the elements of a row of a SparseMatrix with
- * the help of iterators into this object (using SparseMatrix::begin and
- * SparseMatrix::end) you will find that the elements are not sorted by column
- * index within each row whenever the matrix is square.
- *
- * @note Instantiations for this template are provided for <tt>@<float@> and
- * @<double@></tt>; others can be generated in application programs (see the
- * section on
- * @ref Instantiations
- * in the manual).
- *
- * @ingroup Matrix1
- */
-template <typename number>
-class SparseMatrix : public virtual EnableObserverPointer
+  /**
+   * Sparse matrix. This class implements the functionality to store matrix
+   * entry values in the locations denoted by a SparsityPattern. See
+   * @ref Sparsity
+   * for a discussion about the separation between sparsity patterns and
+   * matrices.
+   *
+   * The elements of a SparseMatrix are stored in the same order in which the
+   * SparsityPattern class stores its entries. Within each row, elements are
+   * generally stored left-to-right in increasing column index order; the
+   * exception to this rule is that if the matrix is square (m() == n()), then
+   * the diagonal entry is stored as the first element in each row to make
+   * operations like applying a Jacobi or SSOR preconditioner faster. As a
+   * consequence, if you traverse the elements of a row of a SparseMatrix with
+   * the help of iterators into this object (using SparseMatrix::begin and
+   * SparseMatrix::end) you will find that the elements are not sorted by column
+   * index within each row whenever the matrix is square.
+   *
+   * @note Instantiations for this template are provided for <tt>@<float@> and
+   * @<double@></tt>; others can be generated in application programs (see the
+   * section on
+   * @ref Instantiations
+   * in the manual).
+   *
+   * @ingroup Matrix1
+   */
+  template <typename number>
+  class SparseMatrix : public virtual EnableObserverPointer
 {
 public:
   /**

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -463,9 +463,9 @@ namespace TrilinosWrappers
   } // namespace SparseMatrixIterators
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
 
-namespace std
+  namespace std
 {
   template <bool Constness>
   struct iterator_traits<
@@ -481,10 +481,10 @@ namespace std
   };
 } // namespace std
 
-DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
 
-namespace TrilinosWrappers
+  namespace TrilinosWrappers
 {
   /**
    * This class implements a wrapper to use the Trilinos distributed sparse
@@ -2759,24 +2759,22 @@ namespace TrilinosWrappers
 
 
 
-  inline SparseMatrix::const_iterator
-  SparseMatrix::begin() const
+  inline SparseMatrix::const_iterator SparseMatrix::begin() const
   {
     return begin(0);
   }
 
 
 
-  inline SparseMatrix::const_iterator
-  SparseMatrix::end() const
+  inline SparseMatrix::const_iterator SparseMatrix::end() const
   {
     return const_iterator(this, m(), 0);
   }
 
 
 
-  inline SparseMatrix::const_iterator
-  SparseMatrix::begin(const size_type r) const
+  inline SparseMatrix::const_iterator SparseMatrix::begin(const size_type r)
+    const
   {
     AssertIndexRange(r, m());
     if (in_local_range(r) && (row_length(r) > 0))
@@ -2787,8 +2785,7 @@ namespace TrilinosWrappers
 
 
 
-  inline SparseMatrix::const_iterator
-  SparseMatrix::end(const size_type r) const
+  inline SparseMatrix::const_iterator SparseMatrix::end(const size_type r) const
   {
     AssertIndexRange(r, m());
 
@@ -2806,24 +2803,21 @@ namespace TrilinosWrappers
 
 
 
-  inline SparseMatrix::iterator
-  SparseMatrix::begin()
+  inline SparseMatrix::iterator SparseMatrix::begin()
   {
     return begin(0);
   }
 
 
 
-  inline SparseMatrix::iterator
-  SparseMatrix::end()
+  inline SparseMatrix::iterator SparseMatrix::end()
   {
     return iterator(this, m(), 0);
   }
 
 
 
-  inline SparseMatrix::iterator
-  SparseMatrix::begin(const size_type r)
+  inline SparseMatrix::iterator SparseMatrix::begin(const size_type r)
   {
     AssertIndexRange(r, m());
     if (in_local_range(r) && (row_length(r) > 0))
@@ -2834,8 +2828,7 @@ namespace TrilinosWrappers
 
 
 
-  inline SparseMatrix::iterator
-  SparseMatrix::end(const size_type r)
+  inline SparseMatrix::iterator SparseMatrix::end(const size_type r)
   {
     AssertIndexRange(r, m());
 
@@ -2853,8 +2846,7 @@ namespace TrilinosWrappers
 
 
 
-  inline bool
-  SparseMatrix::in_local_range(const size_type index) const
+  inline bool SparseMatrix::in_local_range(const size_type index) const
   {
     TrilinosWrappers::types::int_type begin, end;
 #      ifndef DEAL_II_WITH_64BIT_INDICES
@@ -2871,8 +2863,7 @@ namespace TrilinosWrappers
 
 
 
-  inline bool
-  SparseMatrix::is_compressed() const
+  inline bool SparseMatrix::is_compressed() const
   {
     return compressed;
   }
@@ -2883,22 +2874,20 @@ namespace TrilinosWrappers
   // frequently, and the compiler can optimize away some unnecessary loops
   // when the sizes are given at compile time.
   template <>
-  void
-  SparseMatrix::set<TrilinosScalar>(const size_type       row,
-                                    const size_type       n_cols,
-                                    const size_type      *col_indices,
-                                    const TrilinosScalar *values,
-                                    const bool            elide_zero_values);
+  void SparseMatrix::set<TrilinosScalar>(const size_type       row,
+                                         const size_type       n_cols,
+                                         const size_type      *col_indices,
+                                         const TrilinosScalar *values,
+                                         const bool elide_zero_values);
 
 
 
   template <typename Number>
-  void
-  SparseMatrix::set(const size_type  row,
-                    const size_type  n_cols,
-                    const size_type *col_indices,
-                    const Number    *values,
-                    const bool       elide_zero_values)
+  void SparseMatrix::set(const size_type  row,
+                         const size_type  n_cols,
+                         const size_type *col_indices,
+                         const Number    *values,
+                         const bool       elide_zero_values)
   {
     std::vector<TrilinosScalar> trilinos_values(n_cols);
     std::copy(values, values + n_cols, trilinos_values.begin());
@@ -2908,10 +2897,9 @@ namespace TrilinosWrappers
 
 
 
-  inline void
-  SparseMatrix::set(const size_type      i,
-                    const size_type      j,
-                    const TrilinosScalar value)
+  inline void SparseMatrix::set(const size_type      i,
+                                const size_type      j,
+                                const TrilinosScalar value)
   {
     AssertIsFinite(value);
 
@@ -2920,10 +2908,9 @@ namespace TrilinosWrappers
 
 
 
-  inline void
-  SparseMatrix::set(const std::vector<size_type>     &indices,
-                    const FullMatrix<TrilinosScalar> &values,
-                    const bool                        elide_zero_values)
+  inline void SparseMatrix::set(const std::vector<size_type>     &indices,
+                                const FullMatrix<TrilinosScalar> &values,
+                                const bool elide_zero_values)
   {
     Assert(indices.size() == values.m(),
            ExcDimensionMismatch(indices.size(), values.m()));
@@ -2939,10 +2926,9 @@ namespace TrilinosWrappers
 
 
 
-  inline void
-  SparseMatrix::add(const size_type      i,
-                    const size_type      j,
-                    const TrilinosScalar value)
+  inline void SparseMatrix::add(const size_type      i,
+                                const size_type      j,
+                                const TrilinosScalar value)
   {
     AssertIsFinite(value);
 
@@ -2975,8 +2961,7 @@ namespace TrilinosWrappers
 
   // inline "simple" functions that are called frequently and do only involve
   // a call to some Trilinos function.
-  inline SparseMatrix::size_type
-  SparseMatrix::m() const
+  inline SparseMatrix::size_type SparseMatrix::m() const
   {
 #      ifndef DEAL_II_WITH_64BIT_INDICES
     return matrix->NumGlobalRows();
@@ -2987,8 +2972,7 @@ namespace TrilinosWrappers
 
 
 
-  inline SparseMatrix::size_type
-  SparseMatrix::n() const
+  inline SparseMatrix::size_type SparseMatrix::n() const
   {
     // If the matrix structure has not been fixed (i.e., we did not have a
     // sparsity pattern), it does not know about the number of columns so we
@@ -2999,8 +2983,7 @@ namespace TrilinosWrappers
 
 
 
-  inline unsigned int
-  SparseMatrix::local_size() const
+  inline unsigned int SparseMatrix::local_size() const
   {
     return matrix->NumMyRows();
   }
@@ -3024,8 +3007,7 @@ namespace TrilinosWrappers
 
 
 
-  inline std::uint64_t
-  SparseMatrix::n_nonzero_elements() const
+  inline std::uint64_t SparseMatrix::n_nonzero_elements() const
   {
     // Trilinos uses 64bit functions internally for attribute access, which
     // return `long long`. They also offer 32bit variants that return `int`,
@@ -3037,11 +3019,10 @@ namespace TrilinosWrappers
 
 
   template <typename SparsityPatternType>
-  inline void
-  SparseMatrix::reinit(const IndexSet            &parallel_partitioning,
-                       const SparsityPatternType &sparsity_pattern,
-                       const MPI_Comm             communicator,
-                       const bool                 exchange_data)
+  inline void SparseMatrix::reinit(const IndexSet &parallel_partitioning,
+                                   const SparsityPatternType &sparsity_pattern,
+                                   const MPI_Comm             communicator,
+                                   const bool                 exchange_data)
   {
     reinit(parallel_partitioning,
            parallel_partitioning,
@@ -3053,13 +3034,13 @@ namespace TrilinosWrappers
 
 
   template <typename number>
-  inline void
-  SparseMatrix::reinit(const IndexSet &parallel_partitioning,
-                       const ::dealii::SparseMatrix<number> &sparse_matrix,
-                       const MPI_Comm                        communicator,
-                       const double                          drop_tolerance,
-                       const bool                            copy_values,
-                       const ::dealii::SparsityPattern      *use_this_sparsity)
+  inline void SparseMatrix::reinit(
+    const IndexSet                       &parallel_partitioning,
+    const ::dealii::SparseMatrix<number> &sparse_matrix,
+    const MPI_Comm                        communicator,
+    const double                          drop_tolerance,
+    const bool                            copy_values,
+    const ::dealii::SparsityPattern      *use_this_sparsity)
   {
     Epetra_Map map =
       parallel_partitioning.make_trilinos_map(communicator, false);
@@ -3073,48 +3054,42 @@ namespace TrilinosWrappers
 
 
 
-  inline const Epetra_CrsMatrix &
-  SparseMatrix::trilinos_matrix() const
+  inline const Epetra_CrsMatrix &SparseMatrix::trilinos_matrix() const
   {
     return static_cast<const Epetra_CrsMatrix &>(*matrix);
   }
 
 
 
-  inline const Epetra_CrsGraph &
-  SparseMatrix::trilinos_sparsity_pattern() const
+  inline const Epetra_CrsGraph &SparseMatrix::trilinos_sparsity_pattern() const
   {
     return matrix->Graph();
   }
 
 
 
-  inline IndexSet
-  SparseMatrix::locally_owned_domain_indices() const
+  inline IndexSet SparseMatrix::locally_owned_domain_indices() const
   {
     return IndexSet(matrix->DomainMap());
   }
 
 
 
-  inline IndexSet
-  SparseMatrix::locally_owned_range_indices() const
+  inline IndexSet SparseMatrix::locally_owned_range_indices() const
   {
     return IndexSet(matrix->RangeMap());
   }
 
 
 
-  inline void
-  SparseMatrix::prepare_add()
+  inline void SparseMatrix::prepare_add()
   {
     // nothing to do here
   }
 
 
 
-  inline void
-  SparseMatrix::prepare_set()
+  inline void SparseMatrix::prepare_set()
   {
     // nothing to do here
   }
@@ -3122,10 +3097,9 @@ namespace TrilinosWrappers
 
 
   template <typename VectorType>
-  inline TrilinosScalar
-  SparseMatrix::residual(VectorType       &dst,
-                         const VectorType &x,
-                         const VectorType &b) const
+  inline TrilinosScalar SparseMatrix::residual(VectorType & dst,
+                                               const VectorType &x,
+                                               const VectorType &b) const
   {
     vmult(dst, x);
     dst -= b;
@@ -3321,12 +3295,11 @@ namespace TrilinosWrappers
   }   // namespace internal
 
   template <>
-  void
-  SparseMatrix::set<TrilinosScalar>(const size_type       row,
-                                    const size_type       n_cols,
-                                    const size_type      *col_indices,
-                                    const TrilinosScalar *values,
-                                    const bool            elide_zero_values);
+  void SparseMatrix::set<TrilinosScalar>(const size_type       row,
+                                         const size_type       n_cols,
+                                         const size_type      *col_indices,
+                                         const TrilinosScalar *values,
+                                         const bool elide_zero_values);
 #    endif // DOXYGEN
 
 } /* namespace TrilinosWrappers */

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -684,10 +684,10 @@ namespace Particles
 
 } // namespace Particles
 
-DEAL_II_NAMESPACE_CLOSE
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
 
 
-namespace boost
+  namespace boost
 {
   namespace geometry
   {
@@ -716,5 +716,9 @@ namespace boost
     } // namespace index
   }   // namespace geometry
 } // namespace boost
+
+
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
+  DEAL_II_NAMESPACE_CLOSE
 
 #endif


### PR DESCRIPTION
The scripts added in #18489 that convert existing files into module partitions create the necessary statements that declare the partition and import other partitions by looking for `DEAL_II_NAMESPACE_OPEN/CLOSE`. This works fine if a file contains exactly one of each at the top and the bottom, but there are a number of files where we open and close the namespace repeatedly. In those cases, I need to make sure I only expand the first opening and last closing statement. This is made more complicated by the fact that there are files in which we have
```
#ifdef DEAL_II_WITH_SOMETHING
DEAL_II_NAMESPACE_OPEN
...
DEAL_II_NAMESPACE_CLOSE
#else
DEAL_II_NAMESPACE_OPEN
...
DEAL_II_NAMESPACE_CLOSE
#endif
```
Here, I need to expand *all* places because they are all first or last statements, just depending on what external dependencies we have -- so simply looking for the first and last occurrence in a file is not sufficient. 

The only solution I could come up with is to specifically mark up the places I don't want to expand. This happens in 8 files, so not very many. The only real downside to the problem is that clang-format chooses to change its mind about indentation based on whether or not there is a comment after the namespace macro -- that's a nuisance, but perhaps more for only this patch than for actually working with our code base in the future.

Part of #18071.