### PR TITLE
Remove `(void)` casts for `AssertNothrow()` variables.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -680,6 +680,10 @@
 #  define AssertNothrow(cond, exc) \
     do                             \
       {                            \
+        if (false)                 \
+          if (!(cond))             \
+            {                      \
+            }                      \
       }                            \
     while (false)
 #endif

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -1310,7 +1310,6 @@ namespace HDF5
               // Release the HDF5 resource
               const herr_t ret = H5Tclose(*pointer);
               AssertNothrow(ret >= 0, ExcInternalError());
-              (void)ret;
               delete pointer;
             });
 
@@ -1333,7 +1332,6 @@ namespace HDF5
               // Release the HDF5 resource
               const herr_t ret = H5Tclose(*pointer);
               AssertNothrow(ret >= 0, ExcInternalError());
-              (void)ret;
               delete pointer;
             });
           *t_type = H5Tcreate(H5T_COMPOUND, sizeof(std::complex<double>));

--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -95,7 +95,6 @@ namespace HDF5
       // Release the HDF5 resource
       const herr_t ret = H5Dclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
-      (void)ret;
       delete pointer;
     });
     dataspace      = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
@@ -104,7 +103,6 @@ namespace HDF5
       // Release the HDF5 resource
       const herr_t ret = H5Sclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
-      (void)ret;
       delete pointer;
     });
 
@@ -154,7 +152,6 @@ namespace HDF5
       // Release the HDF5 resource
       const herr_t ret = H5Dclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
-      (void)ret;
       delete pointer;
     });
     dataspace      = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
@@ -163,7 +160,6 @@ namespace HDF5
       // Release the HDF5 resource
       const herr_t ret = H5Sclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
-      (void)ret;
       delete pointer;
     });
 
@@ -331,7 +327,6 @@ namespace HDF5
       // Release the HDF5 resource
       const herr_t ret = H5Gclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
-      (void)ret;
       delete pointer;
     });
     switch (mode)
@@ -420,7 +415,6 @@ namespace HDF5
       // Release the HDF5 resource
       const herr_t err = H5Fclose(*pointer);
       AssertNothrow(err >= 0, ExcInternalError());
-      (void)err;
       delete pointer;
     });
 

--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -427,8 +427,7 @@ InitFinalize::finalize()
             }
           else
             {
-              [[maybe_unused]] const int ierr = MPI_Finalize();
-
+              const int ierr = MPI_Finalize();
               AssertNothrow(ierr == MPI_SUCCESS, dealii::ExcMPI(ierr));
             }
         }

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -241,10 +241,8 @@ namespace Utilities
       auto deleter = [](MPI_Datatype *p) {
         if (p != nullptr)
           {
-            [[maybe_unused]] const int ierr = MPI_Type_free(p);
-
+            const int ierr = MPI_Type_free(p);
             AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
-
             delete p;
           }
       };

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -112,7 +112,6 @@ namespace PETScWrappers
   MatrixBase::~MatrixBase()
   {
     PetscErrorCode ierr = MatDestroy(&matrix);
-    (void)ierr;
     AssertNothrow(ierr == 0, ExcPETScError(ierr));
   }
 

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -79,7 +79,6 @@ namespace PETScWrappers
     BlockSparseMatrix::~BlockSparseMatrix()
     {
       PetscErrorCode ierr = MatDestroy(&petsc_nest_matrix);
-      (void)ierr;
       AssertNothrow(ierr == 0, ExcPETScError(ierr));
     }
 

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -48,7 +48,6 @@ namespace PETScWrappers
     SparseMatrix::~SparseMatrix()
     {
       PetscErrorCode ierr = MatDestroy(&matrix);
-      (void)ierr;
       AssertNothrow(ierr == 0, ExcPETScError(ierr));
     }
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -149,7 +149,6 @@ namespace PETScWrappers
     const PetscErrorCode ierr =
       PetscObjectReference(reinterpret_cast<PetscObject>(vector));
     AssertNothrow(ierr == 0, ExcPETScError(ierr));
-    (void)ierr;
     this->determine_ghost_indices();
   }
 
@@ -159,7 +158,6 @@ namespace PETScWrappers
   {
     const PetscErrorCode ierr = VecDestroy(&vector);
     AssertNothrow(ierr == 0, ExcPETScError(ierr));
-    (void)ierr;
   }
 
 

--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -64,8 +64,6 @@ namespace SLEPcWrappers
       {
         // Destroy the solver object.
         const PetscErrorCode ierr = EPSDestroy(&eps);
-
-        (void)ierr;
         AssertNothrow(ierr == 0, ExcSLEPcError(ierr));
       }
   }

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -39,7 +39,6 @@ namespace SLEPcWrappers
     if (st != nullptr)
       {
         const PetscErrorCode ierr = STDestroy(&st);
-        (void)ierr;
         AssertNothrow(ierr == 0, SolverBase::ExcSLEPcError(ierr));
       }
   }


### PR DESCRIPTION
We can use the same trick as in #18458 to avoid the cast.