### PR TITLE
Adapt deal_ii_setup_target to allow linking against modules.

### DIFF
--- a/cmake/macros/macro_deal_ii_setup_target.cmake
+++ b/cmake/macros/macro_deal_ii_setup_target.cmake
@@ -18,12 +18,14 @@
 #
 # Usage:
 #       deal_ii_setup_target(target)
-#       deal_ii_setup_target(target DEBUG|RELEASE)
+#       deal_ii_setup_target(target [DEBUG|RELEASE] [MODULE])
 #
-# This appends the deal.II target to the link interface of the specified
+# This macro appends the deal.II target to the link interface of the specified
 # target, which in turn ensures that necessary include directories, linker
 # flags, compile flags and compile definitions are set.
 #
+# DEBUG or RELEASE build type
+# ---------------------------
 # If no "DEBUG" or "RELEASE" keyword is specified after the target, the
 # current CMAKE_BUILD_TYPE is used instead. A CMAKE_BUILD_TYPE "Debug" is
 # equivalent to the DEBUG keyword, a CMAKE_BUILD_TYPE "Release" is
@@ -33,8 +35,21 @@
 # and the build type is different from "Debug", or "Release".
 #
 # If the requested build type is not available (e.g. DEBUG request but
-# deal.II was compiled with release mode only), the macro throws a
+# deal.II was compiled with release mode only), the macro also throws a
 # FATAL_ERROR.
+#
+# MODULE build type
+# -----------------
+# If the MODULE argument is provided, then the macro links the target against
+# the version of the library that is built into a C++20 module. In that case,
+# the target should use
+#   import dealii;
+# instead of
+#   #include <deal.II/...>
+# to learn about deal.II's functions and classes.
+#
+# The macro will throw a FATAL_ERROR if MODULE is specified among the arguments,
+# but the library was not built with modules.
 #
 
 macro(deal_ii_setup_target _target)
@@ -54,9 +69,11 @@ macro(deal_ii_setup_target _target)
 
   #
   # Parse the optional arguments passed to this macro. These
-  # may only contain the build type (DEBUG or RELEASE).
+  # may only contain the build type (DEBUG or RELEASE), and the
+  # MODULE keyword.
   #
   set(_build)
+  set(_module)
   foreach (_arg ${ARGN})
     if("${_arg}" MATCHES "^(DEBUG|RELEASE)$")
       if("${_build}" STREQUAL "")
@@ -69,10 +86,30 @@ macro(deal_ii_setup_target _target)
           "\n\n"
           )
       endif()
+    elseif("${_arg}" STREQUAL "MODULE")
+      if("${_module}" STREQUAL "")
+        if(DEAL_II_BUILD_CXX20_MODULE)
+          set(_module "ON")
+        else()
+          message(FATAL_ERROR
+            "\nYou provided the MODULE option to the deal_ii_setup_target() macro, "
+            "but this option can only be used if the library was actually built "
+            "with C++20 modules enabled."
+            "\n\n"
+            )
+        endif()
+      else()
+        message(FATAL_ERROR
+          "\nThe deal_ii_setup_target() macro can take optional arguments, "
+          "but the MODULE option can only be specified once. The arguments "
+          "you passed are <${ARGN}>."
+          "\n\n"
+          )
+      endif()
     else()
       message(FATAL_ERROR
         "\nThe deal_ii_setup_target() macro was called with an invalid argument. "
-        "Valid arguments are (none), DEBUG, or RELEASE. "
+        "Valid arguments are (none), DEBUG or RELEASE, and MODULE. "
         "The argument given is \"${_arg}\"."
         "\n\n"
         )
@@ -121,5 +158,17 @@ macro(deal_ii_setup_target _target)
       )
   endif()
 
-  target_link_libraries(${_target} ${DEAL_II_TARGET_${_build}})
+  #
+  # Now link against the right deal.II library target
+  #
+  if("${_module}" STREQUAL "")
+    target_link_libraries(${_target} ${DEAL_II_TARGET_${_build}})
+  else()
+    target_link_libraries(${_target} ${DEAL_II_TARGET_NAME}_module_${_build}})
+    # Make sure CMake figures out that we need to scan the sources for
+    # module. This should happen automatically via policy 0155, but
+    # doesn't appear to work with CMake 3.28. In any case, it doesn't
+    # hurt to be explicit.
+    set_property(TARGET ${_target} PROPERTY CXX_SCAN_FOR_MODULES ON)
+  endif()
 endmacro()


### PR DESCRIPTION
The next step for #18071: We need to be able to set up downstream targets that can link against the module library. We can do that through the existing `deal_ii_setup_target()` macro.