### PR TITLE
Remove a template instantiation optimization when building modules.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -2147,13 +2147,24 @@ inline types::global_dof_index
 
 
 
+// Declare the existence of explicit instantiations of the class
+// above. This is not strictly necessary, but tells the compiler to
+// avoid instantiating templates that we know are instantiated in
+// .cc files and so can be referenced without implicit
+// instantiations.
+//
+// Unfortunately, this does not seem to work when building modules
+// because the compiler (well, Clang at least) then just doesn't
+// instantiate these classes at all, even though their members are
+// defined and explicitly instantiated in a .cc file.
+#  ifndef DEAL_II_BUILDING_CXX20_MODULE
 extern template class DoFHandler<1, 1>;
 extern template class DoFHandler<1, 2>;
 extern template class DoFHandler<1, 3>;
 extern template class DoFHandler<2, 2>;
 extern template class DoFHandler<2, 3>;
 extern template class DoFHandler<3, 3>;
-
+#  endif
 
 #endif // DOXYGEN
 

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4937,12 +4937,24 @@ bool
 Triangulation<1, 3>::prepare_coarsening_and_refinement();
 
 
+// Declare the existence of explicit instantiations of the class
+// above. This is not strictly necessary, but tells the compiler to
+// avoid instantiating templates that we know are instantiated in
+// .cc files and so can be referenced without implicit
+// instantiations.
+//
+// Unfortunately, this does not seem to work when building modules
+// because the compiler (well, Clang at least) then just doesn't
+// instantiate these classes at all, even though their members are
+// defined and explicitly instantiated in a .cc file.
+#  ifndef DEAL_II_BUILDING_CXX20_MODULE
 extern template class Triangulation<1, 1>;
 extern template class Triangulation<1, 2>;
 extern template class Triangulation<1, 3>;
 extern template class Triangulation<2, 2>;
 extern template class Triangulation<2, 3>;
 extern template class Triangulation<3, 3>;
+#  endif
 
 #endif // DOXYGEN
 

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -182,9 +182,18 @@ namespace hp
 
 
 #ifndef DOXYGEN
-  // Declare the existence of explicit instantiations of the class
-  // above to avoid certain warnings issues by clang and
-  // newer (LLVM-based) Intel compilers:
+// Declare the existence of explicit instantiations of the class
+// above. This is not strictly necessary, but tells the compiler to
+// avoid instantiating templates that we know are instantiated in
+// .cc files and so can be referenced without implicit
+// instantiations. In the current case, this also avoids certain
+// warnings issues by clang and newer (LLVM-based) Intel compilers.
+//
+// Unfortunately, this does not seem to work when building modules
+// because the compiler (well, Clang at least) then just doesn't
+// instantiate these classes at all, even though their members are
+// defined and explicitly instantiated in a .cc file.
+#  ifndef DEAL_II_BUILDING_CXX20_MODULE
   extern template struct StaticMappingQ1<1, 1>;
   extern template struct StaticMappingQ1<1, 2>;
   extern template struct StaticMappingQ1<1, 3>;
@@ -192,7 +201,7 @@ namespace hp
   extern template struct StaticMappingQ1<2, 3>;
   extern template struct StaticMappingQ1<3, 3>;
 
-#  ifndef _MSC_VER
+#    ifndef _MSC_VER
   extern template MappingCollection<1, 1>
     StaticMappingQ1<1, 1>::mapping_collection;
   extern template MappingCollection<1, 2>
@@ -205,6 +214,7 @@ namespace hp
     StaticMappingQ1<2, 3>::mapping_collection;
   extern template MappingCollection<3, 3>
     StaticMappingQ1<3, 3>::mapping_collection;
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
In three files, we have an optimization where we say something like
```
  extern template class Triangulation<1,1>;
```
which in essence tells the compiler that it is not necessary to implicitly instantiate the class template because there is an *explicit* instantiation elsewhere (namely, in a `.cc` file). This turns out to not work when building modules (#18071), at least with Clang: The compiler in that case simply never compiles any of the instantiations it sees in the `.cc` file at all -- it reports errors in them, but it does not put the compiled functions into the object files.

I'm pretty sure that's a compiler bug that I will report in the next few days, but for the moment the right thing seems to be to just not do the optimization when we are building modules. 