### PR TITLE
Move some functions in the matrix-free framework.

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -24,6 +24,7 @@
 
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/shape_info.h>
+#include <deal.II/matrix_free/task_info.h>
 
 #include <array>
 #include <memory>
@@ -785,6 +786,32 @@ namespace internal
         if (fe_index_conversion[i][first_selected_component] == fe_degree)
           return i;
       return numbers::invalid_unsigned_int;
+    }
+
+
+    template <typename StreamType>
+    void
+    DoFInfo::print_memory_consumption(StreamType     &out,
+                                      const TaskInfo &task_info) const
+    {
+      out << "       Memory row starts indices:    ";
+      task_info.print_memory_statistics(out,
+                                        (row_starts.capacity() *
+                                         sizeof(*row_starts.begin())));
+      out << "       Memory dof indices:           ";
+      task_info.print_memory_statistics(
+        out, MemoryConsumption::memory_consumption(dof_indices));
+      out << "       Memory constraint indicators: ";
+      task_info.print_memory_statistics(
+        out, MemoryConsumption::memory_consumption(constraint_indicator));
+      out << "       Memory plain indices:         ";
+      task_info.print_memory_statistics(
+        out,
+        MemoryConsumption::memory_consumption(row_starts_plain_indices) +
+          MemoryConsumption::memory_consumption(plain_dof_indices));
+      out << "       Memory vector partitioner:    ";
+      task_info.print_memory_statistics(
+        out, MemoryConsumption::memory_consumption(*vector_partitioner));
     }
 
 #endif // ifndef DOXYGEN

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -628,33 +628,6 @@ namespace internal
 
 
 
-    template <typename StreamType>
-    void
-    DoFInfo::print_memory_consumption(StreamType     &out,
-                                      const TaskInfo &task_info) const
-    {
-      out << "       Memory row starts indices:    ";
-      task_info.print_memory_statistics(out,
-                                        (row_starts.capacity() *
-                                         sizeof(*row_starts.begin())));
-      out << "       Memory dof indices:           ";
-      task_info.print_memory_statistics(
-        out, MemoryConsumption::memory_consumption(dof_indices));
-      out << "       Memory constraint indicators: ";
-      task_info.print_memory_statistics(
-        out, MemoryConsumption::memory_consumption(constraint_indicator));
-      out << "       Memory plain indices:         ";
-      task_info.print_memory_statistics(
-        out,
-        MemoryConsumption::memory_consumption(row_starts_plain_indices) +
-          MemoryConsumption::memory_consumption(plain_dof_indices));
-      out << "       Memory vector partitioner:    ";
-      task_info.print_memory_statistics(
-        out, MemoryConsumption::memory_consumption(*vector_partitioner));
-    }
-
-
-
     template <typename Number>
     void
     DoFInfo::print(const std::vector<Number>       &constraint_pool_data,

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -33,12 +33,12 @@
 
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/mapping_info_storage.h>
+#include <deal.II/matrix_free/task_info.h>
 
 #include <memory>
 
 
 DEAL_II_NAMESPACE_OPEN
-
 
 namespace internal
 {
@@ -306,6 +306,39 @@ namespace internal
     {
       AssertIndexRange(cell_no, cell_type.size());
       return cell_type[cell_no];
+    }
+
+
+
+    template <int dim, typename Number, typename VectorizedArrayType>
+    template <typename StreamType>
+    void
+    MappingInfo<dim, Number, VectorizedArrayType>::print_memory_consumption(
+      StreamType     &out,
+      const TaskInfo &task_info) const
+    {
+      out << "    Cell types:                      ";
+      task_info.print_memory_statistics(out,
+                                        cell_type.capacity() *
+                                          sizeof(GeometryType));
+      out << "    Face types:                      ";
+      task_info.print_memory_statistics(out,
+                                        face_type.capacity() *
+                                          sizeof(GeometryType));
+
+      out << "    Faces by cells types:            ";
+      task_info.print_memory_statistics(out,
+                                        faces_by_cells_type.capacity() *
+                                          ReferenceCells::max_n_faces<dim>() *
+                                          sizeof(GeometryType));
+
+      for (unsigned int j = 0; j < cell_data.size(); ++j)
+        {
+          out << "    Data component " << j << std::endl;
+          cell_data[j].print_memory_consumption(out, task_info);
+          face_data[j].print_memory_consumption(out, task_info);
+          face_data_by_cells[j].print_memory_consumption(out, task_info);
+        }
     }
 
   } // end of namespace MatrixFreeFunctions

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -3383,37 +3383,6 @@ namespace internal
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
-    template <typename StreamType>
-    void
-    MappingInfo<dim, Number, VectorizedArrayType>::print_memory_consumption(
-      StreamType     &out,
-      const TaskInfo &task_info) const
-    {
-      out << "    Cell types:                      ";
-      task_info.print_memory_statistics(out,
-                                        cell_type.capacity() *
-                                          sizeof(GeometryType));
-      out << "    Face types:                      ";
-      task_info.print_memory_statistics(out,
-                                        face_type.capacity() *
-                                          sizeof(GeometryType));
-
-      out << "    Faces by cells types:            ";
-      task_info.print_memory_statistics(out,
-                                        faces_by_cells_type.capacity() *
-                                          ReferenceCells::max_n_faces<dim>() *
-                                          sizeof(GeometryType));
-
-      for (unsigned int j = 0; j < cell_data.size(); ++j)
-        {
-          out << "    Data component " << j << std::endl;
-          cell_data[j].print_memory_consumption(out, task_info);
-          face_data[j].print_memory_consumption(out, task_info);
-          face_data_by_cells[j].print_memory_consumption(out, task_info);
-        }
-    }
-
   } // namespace MatrixFreeFunctions
 } // end of namespace internal
 

--- a/include/deal.II/matrix_free/mapping_info_storage.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.h
@@ -29,6 +29,8 @@
 
 #include <deal.II/hp/q_collection.h>
 
+#include <deal.II/matrix_free/task_info.h>
+
 #include <memory>
 
 
@@ -363,6 +365,65 @@ namespace internal
       return 0;
     }
 
+
+    template <int structdim, int spacedim, typename Number>
+    template <typename StreamType>
+    void
+    MappingInfoStorage<structdim, spacedim, Number>::print_memory_consumption(
+      StreamType     &out,
+      const TaskInfo &task_info) const
+    {
+      // print_memory_statistics involves global communication, so we can
+      // disable the check here only if no processor has any such data
+      const std::size_t size =
+        Utilities::MPI::sum(jacobians[0].size(), task_info.communicator);
+      if (size > 0)
+        {
+          out << "      Memory JxW data:               ";
+          task_info.print_memory_statistics(
+            out,
+            MemoryConsumption::memory_consumption(data_index_offsets) +
+              MemoryConsumption::memory_consumption(JxW_values));
+          out << "      Memory Jacobian data:          ";
+          task_info.print_memory_statistics(
+            out,
+            MemoryConsumption::memory_consumption(jacobians[0]) +
+              MemoryConsumption::memory_consumption(jacobians[1]));
+          out << "      Memory second derivative data: ";
+          task_info.print_memory_statistics(
+            out,
+            MemoryConsumption::memory_consumption(jacobian_gradients[0]) +
+              MemoryConsumption::memory_consumption(jacobian_gradients[1]) +
+              MemoryConsumption::memory_consumption(
+                jacobian_gradients_non_inverse[0]) +
+              MemoryConsumption::memory_consumption(
+                jacobian_gradients_non_inverse[1]));
+        }
+      const std::size_t normal_size =
+        Utilities::MPI::sum(normal_vectors.size(), task_info.communicator);
+      if (normal_size > 0)
+        {
+          out << "      Memory normal vectors data:    ";
+          task_info.print_memory_statistics(
+            out,
+            MemoryConsumption::memory_consumption(normal_vectors) +
+              MemoryConsumption::memory_consumption(
+                normals_times_jacobians[0]) +
+              MemoryConsumption::memory_consumption(
+                normals_times_jacobians[1]));
+        }
+
+      const std::size_t quad_size =
+        Utilities::MPI::sum(quadrature_points.size(), task_info.communicator);
+      if (quad_size > 0)
+        {
+          out << "      Memory quadrature points:      ";
+          task_info.print_memory_statistics(
+            out,
+            MemoryConsumption::memory_consumption(quadrature_point_offsets) +
+              MemoryConsumption::memory_consumption(quadrature_points));
+        }
+    }
   } // end of namespace MatrixFreeFunctions
 } // end of namespace internal
 

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -190,67 +190,6 @@ namespace internal
              MemoryConsumption::memory_consumption(quadrature_points);
     }
 
-
-
-    template <int structdim, int spacedim, typename Number>
-    template <typename StreamType>
-    void
-    MappingInfoStorage<structdim, spacedim, Number>::print_memory_consumption(
-      StreamType     &out,
-      const TaskInfo &task_info) const
-    {
-      // print_memory_statistics involves global communication, so we can
-      // disable the check here only if no processor has any such data
-      const std::size_t size =
-        Utilities::MPI::sum(jacobians[0].size(), task_info.communicator);
-      if (size > 0)
-        {
-          out << "      Memory JxW data:               ";
-          task_info.print_memory_statistics(
-            out,
-            MemoryConsumption::memory_consumption(data_index_offsets) +
-              MemoryConsumption::memory_consumption(JxW_values));
-          out << "      Memory Jacobian data:          ";
-          task_info.print_memory_statistics(
-            out,
-            MemoryConsumption::memory_consumption(jacobians[0]) +
-              MemoryConsumption::memory_consumption(jacobians[1]));
-          out << "      Memory second derivative data: ";
-          task_info.print_memory_statistics(
-            out,
-            MemoryConsumption::memory_consumption(jacobian_gradients[0]) +
-              MemoryConsumption::memory_consumption(jacobian_gradients[1]) +
-              MemoryConsumption::memory_consumption(
-                jacobian_gradients_non_inverse[0]) +
-              MemoryConsumption::memory_consumption(
-                jacobian_gradients_non_inverse[1]));
-        }
-      const std::size_t normal_size =
-        Utilities::MPI::sum(normal_vectors.size(), task_info.communicator);
-      if (normal_size > 0)
-        {
-          out << "      Memory normal vectors data:    ";
-          task_info.print_memory_statistics(
-            out,
-            MemoryConsumption::memory_consumption(normal_vectors) +
-              MemoryConsumption::memory_consumption(
-                normals_times_jacobians[0]) +
-              MemoryConsumption::memory_consumption(
-                normals_times_jacobians[1]));
-        }
-
-      const std::size_t quad_size =
-        Utilities::MPI::sum(quadrature_points.size(), task_info.communicator);
-      if (quad_size > 0)
-        {
-          out << "      Memory quadrature points:      ";
-          task_info.print_memory_statistics(
-            out,
-            MemoryConsumption::memory_consumption(quadrature_point_offsets) +
-              MemoryConsumption::memory_consumption(quadrature_points));
-        }
-    }
-
   } // namespace MatrixFreeFunctions
 } // end of namespace internal
 


### PR DESCRIPTION
There are a number of functions `print_memory_consumption()` in the matrix-free framework that take a `StreamType` template argument. These currently reside in the `.template.h` files, where they are not visible to all code that just includes the `.h` file, so these functions require explicit instantiations. But some of these explicit instantiations are missing. Specifically, here is an example of an instantiation I need, but that is missing:
```
void dealii::internal::MatrixFreeFunctions::MappingInfo<1, double, dealii::VectorizedArray<double, 2ul> >::print_memory_consumption<std::__1::basic_ostream<char, std::__1::char_traits<char> > >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, dealii::internal::MatrixFreeFunctions::TaskInfo const&) const
```
Apparently, this function is not instantiated by the following piece of code in `mapping_info.inst.in`:
```
for (deal_II_dimension : DIMENSIONS;
     deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
  {
[...]
    template void internal::MatrixFreeFunctions::MappingInfo<
      deal_II_dimension,
      deal_II_scalar_vectorized::value_type,
      deal_II_scalar_vectorized>::
      print_memory_consumption<std::ostream>(std::ostream &, const TaskInfo &)
        const;
    template void internal::MatrixFreeFunctions::MappingInfo<
      deal_II_dimension,
      deal_II_scalar_vectorized::value_type,
      deal_II_scalar_vectorized>::
      print_memory_consumption<ConditionalOStream>(ConditionalOStream &,
                                                   const TaskInfo &) const;
  }
```
I must admit that I don't know why that is -- but in any case, it can be fixed by moving the function into the `.h` file where I think it should rightfully reside anyway.

Found while poking around for #18071.