### PR TITLE
Provide dummy implementations of SparseDirectMUMPS when not configuring with MUMPS.

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -1099,6 +1099,24 @@ SparseDirectMUMPS::get_icntl()
   return id.icntl;
 }
 
+
+#else
+
+SparseDirectMUMPS::SparseDirectMUMPS(const AdditionalData &)
+{
+  AssertThrow(
+    false,
+    ExcMessage(
+      "To call this function you need MUMPS, but you configured deal.II "
+      "without passing the necessary switch to 'cmake'. Please consult the "
+      "installation instructions at https://dealii.org/current/readme.html"));
+}
+
+
+SparseDirectMUMPS::~SparseDirectMUMPS()
+{}
+
+
 #endif // DEAL_II_WITH_MUMPS
 
 


### PR DESCRIPTION
This is necessary to avoid another linker error with #18071.