### PR TITLE
Fix argument list to dummy MUMPS constructor

### DIFF
--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -443,6 +443,7 @@ private:
 };
 
 
+
 /**
  * This class provides an interface to the parallel sparse direct solver <a
  * href="https://mumps-solver.org">MUMPS</a>. MUMPS is direct method based on

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -1091,9 +1091,12 @@ SparseDirectMUMPS::get_icntl()
 }
 
 
+
 #else
 
-SparseDirectMUMPS::SparseDirectMUMPS(const AdditionalData &)
+
+SparseDirectMUMPS::SparseDirectMUMPS(const AdditionalData &, const MPI_Comm &)
+  : mpi_communicator(MPI_COMM_SELF)
 {
   AssertThrow(
     false,
@@ -1102,6 +1105,7 @@ SparseDirectMUMPS::SparseDirectMUMPS(const AdditionalData &)
       "without passing the necessary switch to 'cmake'. Please consult the "
       "installation instructions at https://dealii.org/current/readme.html"));
 }
+
 
 
 SparseDirectMUMPS::~SparseDirectMUMPS()


### PR DESCRIPTION
After merging #18503, we have problems with compiling the library in case MUMPS is not present. This is because the underlying data interface changed between the time the branch was created for #18503 and when I merged. Let's see if this works, I had success locally.