### PR TITLE
BoundingBox: make things work without an extra boost header.

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -618,7 +618,10 @@ void
 BoundingBox<spacedim, Number>::serialize(Archive &ar,
                                          const unsigned int /*version*/)
 {
-  ar &boundary_points;
+  // Avoid including boost/serialization/utility.hpp by unpacking the pair
+  // ourselves
+  ar &boundary_points.first;
+  ar &boundary_points.second;
 }
 
 


### PR DESCRIPTION
This is also about 5% faster.