### PR TITLE
Centralize the places where we call P4EST_QUADRANT_INIT/P8EST_QUADRANT_INIT.

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -120,11 +120,17 @@ namespace internal
 
 
     /**
-     * A structure whose explicit specializations contain pointers to the
+     * A structure whose explicit specializations represent the
      * relevant p4est_* and p8est_* functions. Using this structure, for
-     * example by saying functions<dim>::quadrant_compare, we can write code
-     * in a dimension independent way, either calling p4est_quadrant_compare
-     * or p8est_quadrant_compare, depending on template argument.
+     * example by saying functions<dim>::quadrant_compare(...), we can write
+     * code in a dimension independent way, either calling
+     * p4est_quadrant_compare or p8est_quadrant_compare, depending on template
+     * argument.
+     *
+     * In most cases, the members of this class are simply pointers to
+     * p4est_* or p8est_* functions. In one case, it's simply a static
+     * member function that dispatches to things p4est chooses to
+     * implement via a macro.
      */
     template <int dim>
     struct functions;
@@ -143,6 +149,9 @@ namespace internal
       static void (&quadrant_set_morton)(types<2>::quadrant *quadrant,
                                          int                 level,
                                          std::uint64_t       id);
+
+      static void
+      quadrant_init(types<2>::quadrant &q);
 
       static int (&quadrant_is_equal)(const types<2>::quadrant *q1,
                                       const types<2>::quadrant *q2);
@@ -344,6 +353,9 @@ namespace internal
       static void (&quadrant_set_morton)(types<3>::quadrant *quadrant,
                                          int                 level,
                                          std::uint64_t       id);
+
+      static void
+      quadrant_init(types<3>::quadrant &q);
 
       static int (&quadrant_is_equal)(const types<3>::quadrant *q1,
                                       const types<3>::quadrant *q2);

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -354,6 +354,12 @@ namespace internal
                                               std::uint64_t       id) =
       p4est_quadrant_set_morton;
 
+    void
+    functions<2>::quadrant_init(types<2>::quadrant &q)
+    {
+      P4EST_QUADRANT_INIT(&q);
+    }
+
     int (&functions<2>::quadrant_is_equal)(const types<2>::quadrant *q1,
                                            const types<2>::quadrant *q2) =
       p4est_quadrant_is_equal;
@@ -566,6 +572,12 @@ namespace internal
                                               int                 level,
                                               std::uint64_t       id) =
       p8est_quadrant_set_morton;
+
+    void
+    functions<3>::quadrant_init(types<3>::quadrant &q)
+    {
+      P8EST_QUADRANT_INIT(&q);
+    }
 
     int (&functions<3>::quadrant_is_equal)(const types<3>::quadrant *q1,
                                            const types<3>::quadrant *q2) =
@@ -782,18 +794,7 @@ namespace internal
       for (unsigned int c = 0;
            c < dealii::GeometryInfo<dim>::max_children_per_cell;
            ++c)
-        switch (dim)
-          {
-            case 2:
-              P4EST_QUADRANT_INIT(&p4est_children[c]);
-              break;
-            case 3:
-              P8EST_QUADRANT_INIT(&p4est_children[c]);
-              break;
-            default:
-              DEAL_II_NOT_IMPLEMENTED();
-          }
-
+        functions<dim>::quadrant_init(p4est_children[c]);
 
       functions<dim>::quadrant_childrenv(&p4est_cell, p4est_children);
     }
@@ -802,17 +803,7 @@ namespace internal
     void
     init_coarse_quadrant(typename types<dim>::quadrant &quad)
     {
-      switch (dim)
-        {
-          case 2:
-            P4EST_QUADRANT_INIT(&quad);
-            break;
-          case 3:
-            P8EST_QUADRANT_INIT(&quad);
-            break;
-          default:
-            DEAL_II_NOT_IMPLEMENTED();
-        }
+      functions<dim>::quadrant_init(quad);
       functions<dim>::quadrant_set_morton(&quad,
                                           /*level=*/0,
                                           /*index=*/0);

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -463,17 +463,7 @@ namespace
           p4est_child[GeometryInfo<dim>::max_children_per_cell];
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
              ++c)
-          switch (dim)
-            {
-              case 2:
-                P4EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              case 3:
-                P8EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              default:
-                DEAL_II_NOT_IMPLEMENTED();
-            }
+          internal::p4est::functions<dim>::quadrant_init(p4est_child[c]);
 
 
         internal::p4est::functions<dim>::quadrant_childrenv(&p4est_cell,
@@ -531,18 +521,7 @@ namespace
             for (unsigned int c = 0;
                  c < GeometryInfo<dim>::max_children_per_cell;
                  ++c)
-              switch (dim)
-                {
-                  case 2:
-                    P4EST_QUADRANT_INIT(&p4est_child[c]);
-                    break;
-                  case 3:
-                    P8EST_QUADRANT_INIT(&p4est_child[c]);
-                    break;
-                  default:
-                    DEAL_II_NOT_IMPLEMENTED();
-                }
-
+              internal::p4est::functions<dim>::quadrant_init(p4est_child[c]);
 
             internal::p4est::functions<dim>::quadrant_childrenv(&p4est_cell,
                                                                 p4est_child);
@@ -1353,17 +1332,7 @@ namespace
           p4est_child[GeometryInfo<dim>::max_children_per_cell];
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
              ++c)
-          switch (dim)
-            {
-              case 2:
-                P4EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              case 3:
-                P8EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              default:
-                DEAL_II_NOT_IMPLEMENTED();
-            }
+          internal::p4est::functions<dim>::quadrant_init(p4est_child[c]);
         internal::p4est::functions<dim>::quadrant_childrenv(&p4est_cell,
                                                             p4est_child);
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
@@ -1643,17 +1612,7 @@ namespace
 
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
              ++c)
-          switch (dim)
-            {
-              case 2:
-                P4EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              case 3:
-                P8EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              default:
-                DEAL_II_NOT_IMPLEMENTED();
-            }
+          internal::p4est::functions<dim>::quadrant_init(p4est_child[c]);
 
         dealii::internal::p4est::functions<dim>::quadrant_childrenv(
           &p4est_cell, p4est_child);
@@ -1684,17 +1643,7 @@ namespace
           p4est_child[GeometryInfo<dim>::max_children_per_cell];
         for (unsigned int c = 0; c < GeometryInfo<dim>::max_children_per_cell;
              ++c)
-          switch (dim)
-            {
-              case 2:
-                P4EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              case 3:
-                P8EST_QUADRANT_INIT(&p4est_child[c]);
-                break;
-              default:
-                DEAL_II_NOT_IMPLEMENTED();
-            }
+          internal::p4est::functions<dim>::quadrant_init(p4est_child[c]);
 
         dealii::internal::p4est::functions<dim>::quadrant_childrenv(
           &p4est_cell, p4est_child);


### PR DESCRIPTION
Following up on the discussion on #18492, this patch centralizes the places where we call the `P4EST_QUADRANT_INIT` and `P8EST_QUADRANT_INIT` macros, so that there is only one place we will later have to address. I do this centralization using the same framework we already use to make calling p4est functions dimension-independent, using a `struct` we invented to wrap p4est function calls many years ago.

I will address the issue of the macros in a follow-up once this is in.

Part of #18071.