### PR TITLE
Move an include directive to the right place.

### DIFF
--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -16,12 +16,14 @@
 #include <deal.II/distributed/p4est_wrappers.h>
 #include <deal.II/distributed/tria.h>
 
+#ifdef DEAL_II_WITH_P4EST
+#  include <sc_containers.h>
+#endif
+
+
 DEAL_II_NAMESPACE_OPEN
 
 #ifdef DEAL_II_WITH_P4EST
-
-#  include <sc_containers.h>
-
 
 namespace internal
 {


### PR DESCRIPTION
We have an `#include` directive inside `namespace dealii {...}`. I caused this in #18430. This PR fixes it.

Loosely related to #18071.