### PR TITLE
Duplicate two p4est macros.

### DIFF
--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -17,7 +17,27 @@
 #include <deal.II/distributed/tria.h>
 
 #ifdef DEAL_II_WITH_P4EST
+#  include <p4est.h>
+#  include <p8est.h>
 #  include <sc_containers.h>
+
+// Below, we will use the P4EST_QUADRANT_INIT and P8EST_QUADRANT_INIT
+// function-like macros. If we are building the library based on
+// header files, we get these from the <p4est.h> and <p8est.h> header
+// inclusions. But if we build a C++20 module, we only import
+// declarations, not preprocessor macros. As a consequence, let us
+// duplicate these macros here, hoping that at some point, the p4est
+// library folks add regular functions that can do the job.
+#  ifndef P4EST_QUADRANT_INIT
+#    define P4EST_QUADRANT_INIT(q) \
+      ((void)std::memset((q), -1, sizeof(p4est_quadrant_t)))
+#  endif
+
+#  ifndef P8EST_QUADRANT_INIT
+#    define P8EST_QUADRANT_INIT(q) \
+      ((void)std::memset((q), -1, sizeof(p8est_quadrant_t)))
+#  endif
+
 #endif
 
 


### PR DESCRIPTION
This is the necessary follow-up to #18512 and the resolution to the discussion about the p4est macros we had in #18492. I chose to duplicate the macros, rather than ensure that `p4est.h` and `p8est.h` are *always* `#include`d, even for module builds. That's because (i) I really want to move away from header files when building modules, even if it's "only" an implementation partition (=source file), and (ii) because I have hope that @cburstedde will actually give us a *function* rather than a macro to do this job and that we can use in future versions of p4est.

Part of #18071.