### PR TITLE
Update Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,6 @@ jobs:
       run: |
         patch --version
         cmake --version
-        wmic logicaldisk get size, freespace, caption
     - name: configure
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_CXX_FLAGS="-WX /D FE_EVAL_FACTORY_DEGREE_MAX=2" -T host=x64 -A x64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
 
     steps:
     - uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
         ctest --test-dir build --build-config Debug --extra-verbose
     - name: upload library
       # run only if a PR is merged into master
-      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2025' }}
       uses: actions/upload-artifact@v4
       with:
         name: dealii-${{ matrix.os }}


### PR DESCRIPTION
Part of #18523. According to https://github.com/actions/runner-images/issues/12045, the 2019 image will no longer be supported by the end of June so we need to replace the runner anyway.