### PR TITLE
Add Mac OS 15 CI build

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
 
     steps:
     - uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Part of #18523. The Mac OS builds don't take long so adding another one seems OK.