### PR TITLE
SymmetricTensor: avoid ndarray for device support

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -2036,23 +2036,41 @@ namespace internal
             }
           case 2:
             {
-              constexpr dealii::ndarray<unsigned int, 2, 2> table = {
-                {{{0, 2}}, {{2, 1}}}};
+              constexpr unsigned int table[2][2] = {{0, 2}, {2, 1}};
               return table[indices[0]][indices[1]];
             }
           case 3:
             {
-              constexpr dealii::ndarray<unsigned int, 3, 3> table = {
-                {{{0, 3, 4}}, {{3, 1, 5}}, {{4, 5, 2}}}};
-              return table[indices[0]][indices[1]];
+              // Split the following table to avoid compiler warnings about
+              // uninitialized values:
+              // constexpr unsigned int table[3][3] = {{0, 3, 4},
+              //                                       {3, 1, 5},
+              //                                       {4, 5, 2}};
+
+              const unsigned int i = indices[0];
+              const unsigned int j = indices[1];
+              if (i == 0)
+                {
+                  constexpr unsigned int table[3] = {0, 3, 4};
+                  return table[j];
+                }
+              else if (i == 1)
+                {
+                  constexpr unsigned int table[3] = {3, 1, 5};
+                  return table[j];
+                }
+              else
+                {
+                  constexpr unsigned int table[3] = {4, 5, 2};
+                  return table[j];
+                }
             }
           case 4:
             {
-              constexpr dealii::ndarray<unsigned int, 4, 4> table = {
-                {{{0, 4, 5, 6}},
-                 {{4, 1, 7, 8}},
-                 {{5, 7, 2, 9}},
-                 {{6, 8, 9, 3}}}};
+              constexpr unsigned int table[4][4] = {{0, 4, 5, 6},
+                                                    {4, 1, 7, 8},
+                                                    {5, 7, 2, 9},
+                                                    {6, 8, 9, 3}};
               return table[indices[0]][indices[1]];
             }
           default:


### PR DESCRIPTION
extracted from #18486 with the goal to use SymmetricTensor in device code