### PR TITLE
Avoid comparing signed and unsigned integers.

### DIFF
--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -519,7 +519,8 @@ namespace Portable
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
     get_dof_value(int dof) const
   {
-    Assert(dof >= 0 && dof < tensor_dofs_per_component, ExcInternalError());
+    Assert(dof >= 0 && dof < static_cast<int>(tensor_dofs_per_component),
+           ExcInternalError());
     if constexpr (n_components_ == 1)
       {
         return shared_data->values(dof, 0);

--- a/include/deal.II/matrix_free/portable_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/portable_tensor_product_kernels.h
@@ -59,8 +59,8 @@ namespace Portable
       const ViewTypeIn src,
       const int        N)
     {
-      Assert(dst.size() >= N, ExcInternalError());
-      Assert(src.size() >= N, ExcInternalError());
+      Assert(dst.size() >= static_cast<unsigned int>(N), ExcInternalError());
+      Assert(src.size() >= static_cast<unsigned int>(N), ExcInternalError());
       Kokkos::parallel_for(Kokkos::TeamVectorRange(team_member, N),
                            [&](const int i) {
                              if constexpr (add)

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1420,7 +1420,7 @@ namespace MatrixFreeTools
             Kokkos::parallel_for(
               Kokkos::TeamThreadRange(data->team_member,
                                       dofs_per_cell / n_components),
-              [&](int j) {
+              [&](unsigned int j) {
                 typename decltype(fe_eval)::value_type val = {};
 
                 if constexpr (n_components == 1)


### PR DESCRIPTION
Clang complains about comparisons between signed and unsigned integers. The matrix-free framework liberally uses signed integers even for things such as indices, but I don't know enough about whether these variables could be `unsigned` so just silence the warning via a cast.