### PR TITLE
Use correct data type.

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -1710,7 +1710,7 @@ namespace internal
     AssertDimension(indices.size(), out.size());
     AssertDimension(indices.size(), array[0].size());
     // set all entries in array to a valid element
-    int index = 0;
+    std::size_t index = 0;
     for (; index < N; ++index)
       if (indices[index] != numbers::invalid_unsigned_int)
         break;


### PR DESCRIPTION
Clang complains about comparing the `int` variable `index` against `N`, which is of type `std::size_t`. Just use the latter type for both.