### PR TITLE
Change type of a variable.

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -418,7 +418,7 @@ namespace Portable
 
         SharedData<dim, Number> shared_data(values, gradients, scratch_pad);
 
-        const unsigned int cell_index = team_member.league_rank();
+        const int cell_index = team_member.league_rank();
 
         typename MatrixFree<dim, Number>::Data data{team_member,
                                                     /* n_dofhandler */ 1,


### PR DESCRIPTION
Clang errors out on a construct where we use a brace-initializer list instead of a parenthesized constructor call. I'm not entirely sure what that's about -- the error is because `cell_index` in this context has type `unsigned int`, but when using a brace-initializer-list, it needs to be `int`. Either way, we use the parenthesized form in other places of this file, so let's just go with that here as well.