### PR TITLE
Remove some more casts to void.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -2096,7 +2096,6 @@ namespace Utilities
                       &process_answer,
         const MPI_Comm comm)
       {
-        (void)comm;
         Assert(Utilities::MPI::n_mpi_processes(comm) == 1,
                ExcMessage("You shouldn't use the 'Serial' class on "
                           "communicators that have more than one process "

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1195,7 +1195,6 @@ template <class Iterator>
 inline void
 Tensor<0, dim, Number>::unroll(const Iterator begin, const Iterator end) const
 {
-  (void)end;
   AssertDimension(std::distance(begin, end), n_independent_components);
   Assert(dim != 0,
          ExcMessage("Cannot unroll an object of type Tensor<0,0,Number>"));
@@ -1580,7 +1579,6 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
   Tensor<rank_, dim, Number>::operator=(const Number &d) &
 {
   Assert(numbers::value_is_zero(d), ExcScalarAssignmentOnlyForZeroValue());
-  (void)d;
 
   for (unsigned int i = 0; i < dim; ++i)
     values[i] = internal::NumberType<Number>::value(0.0);
@@ -1820,7 +1818,6 @@ Tensor<rank_, dim, Number>::unroll(const Iterator begin,
     {
       // For rank-1 tensors, we can simply copy the current elements from
       // our linear array into the output range:
-      (void)end;
       Assert(std::distance(begin, end) >= dim,
              ExcMessage(
                "The provided iterator range must contain at least 'dim' "
@@ -1852,7 +1849,6 @@ Tensor<rank_, dim, Number>::unrolled_to_component_indices(const unsigned int i)
   // Work-around nvcc warning
   unsigned int dummy = n_independent_components;
   AssertIndexRange(i, dummy);
-  (void)dummy;
 
   if constexpr (dim == 0)
     {

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2833,7 +2833,6 @@ AffineConstraints<number>::merge(
   const MergeConflictBehavior            merge_conflict_behavior,
   const bool                             allow_different_local_lines)
 {
-  (void)allow_different_local_lines;
   Assert(allow_different_local_lines ||
            local_lines == other_constraints.local_lines,
          ExcMessage(

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -2410,7 +2410,6 @@ namespace internal
       size_type shift = 0)
     {
       Assert(shift == 0, ExcNotImplemented());
-      (void)shift;
       std::vector<size_type> constrained_local_dofs_host;
       constrained_local_dofs_host.reserve(cm.size());
 
@@ -3672,7 +3671,6 @@ namespace internal
                 const size_type       column,
                 SparseMatrixIterator &matrix_values)
       {
-        (void)row;
         if (value != LocalType())
           {
             while (matrix_values->column() < column)

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1116,7 +1116,6 @@ namespace BlockMatrixIterators
     : matrix(matrix)
     , base_iterator(matrix->block(0, 0).begin())
   {
-    (void)col;
     Assert(col == 0, ExcNotImplemented());
 
     // check if this is a regular row or
@@ -1316,7 +1315,6 @@ namespace BlockMatrixIterators
     : matrix(matrix)
     , base_iterator(matrix->block(0, 0).begin())
   {
-    (void)col;
     Assert(col == 0, ExcNotImplemented());
     // check if this is a regular row or
     // the end of the matrix

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -384,7 +384,6 @@ BlockVector<Number>::BlockVector(const std::vector<size_type> &block_sizes,
   // first set sizes of blocks, but
   // don't initialize them as we will
   // copy elements soon
-  (void)end;
   reinit(block_sizes, true);
   InputIterator start = first;
   for (size_type b = 0; b < block_sizes.size(); ++b)

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -298,7 +298,6 @@ template <typename number>
 ChunkSparseMatrix<number> &
 ChunkSparseMatrix<number>::operator=(const ChunkSparseMatrix<number> &m)
 {
-  (void)m;
   Assert(m.cols == nullptr && m.val == nullptr && m.max_len == 0,
          ExcMessage(
            "This operator can only be called if the provided right "
@@ -332,7 +331,6 @@ ChunkSparseMatrix<number>::ChunkSparseMatrix(const ChunkSparsityPattern &c,
   , val(nullptr)
   , max_len(0)
 {
-  (void)id;
   Assert(c.n_rows() == id.m(), ExcDimensionMismatch(c.n_rows(), id.m()));
   Assert(c.n_cols() == id.n(), ExcDimensionMismatch(c.n_cols(), id.n()));
 
@@ -373,7 +371,6 @@ template <typename number>
 ChunkSparseMatrix<number> &
 ChunkSparseMatrix<number>::operator=(const double d)
 {
-  (void)d;
   Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
 
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
@@ -414,7 +411,6 @@ template <typename number>
 ChunkSparseMatrix<number> &
 ChunkSparseMatrix<number>::operator=(const IdentityMatrix &id)
 {
-  (void)id;
   Assert(cols->n_rows() == id.m(),
          ExcDimensionMismatch(cols->n_rows(), id.m()));
   Assert(cols->n_cols() == id.n(),
@@ -595,7 +591,6 @@ ChunkSparseMatrix<number>::extract_row_copy(const size_type row,
                                             size_type      *column_indices,
                                             number         *values) const
 {
-  (void)array_length;
   AssertIndexRange(cols->row_length(row), array_length + 1);
   AssertIndexRange(row, m());
   const unsigned int chunk_size  = cols->get_chunk_size();
@@ -1211,8 +1206,6 @@ ChunkSparseMatrix<number>::precondition_Jacobi(Vector<somenumber>       &dst,
                                                const Vector<somenumber> &src,
                                                const number /*om*/) const
 {
-  (void)dst;
-  (void)src;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1235,8 +1228,6 @@ ChunkSparseMatrix<number>::precondition_SSOR(Vector<somenumber>       &dst,
 {
   // to understand how this function works you may want to take a look at the
   // CVS archives to see the original version which is much clearer...
-  (void)dst;
-  (void)src;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1291,7 +1282,6 @@ void
 ChunkSparseMatrix<number>::SOR(Vector<somenumber> &dst,
                                const number /*om*/) const
 {
-  (void)dst;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1308,7 +1298,6 @@ void
 ChunkSparseMatrix<number>::TSOR(Vector<somenumber> &dst,
                                 const number /*om*/) const
 {
-  (void)dst;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1328,9 +1317,6 @@ ChunkSparseMatrix<number>::PSOR(
   const std::vector<size_type> &inverse_permutation,
   const number /*om*/) const
 {
-  (void)dst;
-  (void)permutation;
-  (void)inverse_permutation;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1355,9 +1341,6 @@ ChunkSparseMatrix<number>::TPSOR(
   const std::vector<size_type> &inverse_permutation,
   const number /*om*/) const
 {
-  (void)dst;
-  (void)permutation;
-  (void)inverse_permutation;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1381,8 +1364,6 @@ ChunkSparseMatrix<number>::SOR_step(Vector<somenumber>       &v,
                                     const Vector<somenumber> &b,
                                     const number /*om*/) const
 {
-  (void)v;
-  (void)b;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1403,8 +1384,6 @@ ChunkSparseMatrix<number>::TSOR_step(Vector<somenumber>       &v,
                                      const Vector<somenumber> &b,
                                      const number /*om*/) const
 {
-  (void)v;
-  (void)b;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
@@ -1437,7 +1416,6 @@ void
 ChunkSparseMatrix<number>::SSOR(Vector<somenumber> &dst,
                                 const number /*om*/) const
 {
-  (void)dst;
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),

--- a/include/deal.II/lac/diagonal_matrix.h
+++ b/include/deal.II/lac/diagonal_matrix.h
@@ -353,7 +353,6 @@ DiagonalMatrix<VectorType>::operator()(const size_type i,
                                        const size_type j) const
 {
   Assert(i == j, ExcIndexRange(j, i, i + 1));
-  (void)j;
   return diagonal(i);
 }
 
@@ -364,7 +363,6 @@ typename VectorType::value_type &
 DiagonalMatrix<VectorType>::operator()(const size_type i, const size_type j)
 {
   Assert(i == j, ExcIndexRange(j, i, i + 1));
-  (void)j;
   return diagonal(i);
 }
 

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -963,7 +963,6 @@ namespace DynamicSparsityPatternIterators
   inline int
   Iterator::operator-(const Iterator &other) const
   {
-    (void)other;
     Assert(accessor.sparsity_pattern == other.accessor.sparsity_pattern,
            ExcInternalError());
     DEAL_II_NOT_IMPLEMENTED();

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -1185,7 +1185,6 @@ FullMatrix<number> &
 FullMatrix<number>::operator=(const number d)
 {
   Assert(d == number(0), ExcScalarAssignmentOnlyForZeroValue());
-  (void)d; // removes -Wunused-parameter warning in optimized mode
 
   if (this->n_elements() != 0)
     this->reset_values();

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1835,7 +1835,6 @@ FullMatrix<number>::gauss_jordan()
   for (size_type i = 0; i < N; ++i)
     diagonal_sum += std::abs((*this)(i, i));
   const double typical_diagonal_element = diagonal_sum / N;
-  (void)typical_diagonal_element;
 
   // initialize the array that holds
   // the permutations that we find

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -1352,7 +1352,6 @@ namespace PETScWrappers
            ExcMessage("The serialized value of size (" + std::to_string(size) +
                       ") does not match the current size (" +
                       std::to_string(this->size()) + ")"));
-    (void)size;
     ar &local_range;
     Assert(local_range == this->local_range(),
            ExcMessage("The serialized value of local_range (" +
@@ -1361,7 +1360,6 @@ namespace PETScWrappers
                       ") does not match the current local_range (" +
                       std::to_string(this->local_range().first) + ", " +
                       std::to_string(this->local_range().second) + ")"));
-    (void)local_range;
 
     PetscScalar *array = nullptr;
     int          ierr  = VecGetArray(petsc_vector(), &array);

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -187,7 +187,6 @@ namespace internal
     // for a serial computation (don't!), or nobody implemented, instantiated,
     // and tested the parallel version for your vector type.
     Assert(other == nullptr, ExcNotImplemented());
-    (void)other;
     return prev;
   }
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -1115,7 +1115,6 @@ namespace internal
     block(VectorType &vector, const unsigned int b)
     {
       AssertDimension(b, 0);
-      (void)b;
       return vector;
     }
 
@@ -1128,7 +1127,6 @@ namespace internal
     block(const VectorType &vector, const unsigned int b)
     {
       AssertDimension(b, 0);
-      (void)b;
       return vector;
     }
 

--- a/include/deal.II/lac/solver_idr.h
+++ b/include/deal.II/lac/solver_idr.h
@@ -261,7 +261,6 @@ namespace internal
     block(VectorType &vector, const unsigned int b)
     {
       AssertDimension(b, 0);
-      (void)b;
       return vector;
     }
 

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -88,7 +88,6 @@ template <typename number>
 SparseMatrix<number> &
 SparseMatrix<number>::operator=(const SparseMatrix<number> &m)
 {
-  (void)m;
   Assert(m.cols == nullptr && m.val == nullptr && m.max_len == 0,
          ExcMessage("This operator can only be called if the provided right "
                     "hand side is an empty matrix. This operator can not be "
@@ -138,7 +137,6 @@ SparseMatrix<number>::SparseMatrix(const SparsityPattern &c,
   , val(nullptr)
   , max_len(0)
 {
-  (void)id;
   Assert(c.n_rows() == id.m(), ExcDimensionMismatch(c.n_rows(), id.m()));
   Assert(c.n_cols() == id.n(), ExcDimensionMismatch(c.n_cols(), id.n()));
 
@@ -164,7 +162,6 @@ template <typename number>
 SparseMatrix<number> &
 SparseMatrix<number>::operator=(const double d)
 {
-  (void)d;
   Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
 
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
@@ -204,7 +201,6 @@ template <typename number>
 SparseMatrix<number> &
 SparseMatrix<number>::operator=(const IdentityMatrix &id)
 {
-  (void)id;
   Assert(cols->n_rows() == id.m(),
          ExcDimensionMismatch(cols->n_rows(), id.m()));
   Assert(cols->n_cols() == id.n(),
@@ -407,7 +403,6 @@ SparseMatrix<number>::copy_from(const TrilinosWrappers::SparseMatrix &matrix)
         value_cache.data(),
         reinterpret_cast<TrilinosWrappers::types::int_type *>(
           colnum_cache.data()));
-      (void)ierr;
       Assert(ierr == 0, ExcTrilinosError(ierr));
 
       // resize arrays to the size actually used

--- a/include/deal.II/lac/sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/sparse_matrix_ez.templates.h
@@ -69,7 +69,6 @@ template <typename number>
 SparseMatrixEZ<number> &
 SparseMatrixEZ<number>::operator=(const SparseMatrixEZ<number> &m)
 {
-  (void)m;
   Assert(m.empty(),
          ExcMessage("This operator can only be called if the provided right "
                     "hand side is an empty matrix. This operator can not be "
@@ -83,7 +82,6 @@ template <typename number>
 SparseMatrixEZ<number> &
 SparseMatrixEZ<number>::operator=(const double d)
 {
-  (void)d;
   Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
 
   typename std::vector<Entry>::iterator       e   = data.begin();

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -584,7 +584,6 @@ namespace internal
           std::array<AlignedVector<Number>, dim>  &eigenvalues)
     {
       const unsigned int n_rows_1d = mass_matrix[0].n_cols();
-      (void)n_rows_1d;
 
       for (unsigned int dir = 0; dir < dim; ++dir)
         {

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2010,9 +2010,6 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
           Assert(dst.Map().SameAs(mtrx.DomainMap()) == true,
                  ExcMessage("Row map of matrix does not fit with vector map!"));
         }
-      (void)mtrx; // removes -Wunused-variable in optimized mode
-      (void)src;
-      (void)dst;
     }
 
     inline void
@@ -2039,9 +2036,6 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
                  ExcMessage(
                    "Row map of operator does not fit with vector map!"));
         }
-      (void)op; // removes -Wunused-variable in optimized mode
-      (void)src;
-      (void)dst;
     }
 
 

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
@@ -116,8 +116,6 @@ namespace LinearAlgebra
                                       block_sparsity_pattern.n_block_cols()));
 
           const size_type n_block_rows = tpetra_maps.size();
-          (void)n_block_rows;
-
           Assert(n_block_rows == block_sparsity_pattern.n_block_rows(),
                  ExcDimensionMismatch(n_block_rows,
                                       block_sparsity_pattern.n_block_rows()));

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -850,7 +850,6 @@ namespace LinearAlgebra
     SparseMatrix<Number, MemorySpace> &
     SparseMatrix<Number, MemorySpace>::operator=(const double d)
     {
-      (void)d;
       Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
 
       if (compressed)

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -450,7 +450,6 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace> &
     Vector<Number, MemorySpace>::operator=(const Number s)
     {
-      (void)s;
       Assert(s == Number(0.0),
              ExcMessage("Only 0 can be assigned to a vector."));
 

--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -267,7 +267,6 @@ namespace Portable
     , shared_data(data->shared_data)
     , cell_id(data->team_member.league_rank())
   {
-    (void)dof_index;
     AssertIndexRange(dof_index, data->n_dofhandler);
   }
 

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -928,9 +928,6 @@ namespace internal
                        VectorizedArrayType             &res,
                        std::bool_constant<true>) const
     {
-      (void)vec_ptr;
-      (void)constant_offset;
-      (void)vec;
       Assert(vec_ptr == vec.begin() + constant_offset, ExcInternalError());
       res.scatter(indices, vec_ptr);
     }

--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -224,7 +224,6 @@ namespace MeshWorker
     // We permit different numbers of matrices, vectors and DoF index vectors.
     // So we have to be a bit permissive here.
     constexpr int max_index = std::max({n_matrices, n_vectors, n_dof_indices});
-    (void)max_index;
     Assert(index < max_index, ExcIndexRange(index, 0, max_index));
 
     if (index < n_matrices)

--- a/include/deal.II/numerics/cell_data_transfer.templates.h
+++ b/include/deal.II/numerics/cell_data_transfer.templates.h
@@ -127,14 +127,7 @@ CellDataTransfer<dim, spacedim, VectorType>::
         }
     }
 
-  if constexpr (running_in_debug_mode())
-    {
-      n_active_cells_pre = triangulation->n_active_cells();
-    }
-  else
-    {
-      (void)n_active_cells_pre;
-    }
+  n_active_cells_pre = triangulation->n_active_cells();
 }
 
 
@@ -150,10 +143,6 @@ CellDataTransfer<dim, spacedim, VectorType>::unpack(const VectorType &in,
              ExcDimensionMismatch(in.size(), n_active_cells_pre));
       Assert(out.size() == triangulation->n_active_cells(),
              ExcDimensionMismatch(out.size(), triangulation->n_active_cells()));
-    }
-  else
-    {
-      (void)n_active_cells_pre;
     }
 
   // Transfer data of persisting cells.

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -756,8 +756,7 @@ namespace internal
     dealii::hp::FESubfaceValues<dim, spacedim> &fe_subface_values,
     const typename KellyErrorEstimator<dim, spacedim>::Strategy strategy)
   {
-    const auto neighbor = cell->neighbor(face_no);
-    (void)neighbor;
+    const auto         neighbor           = cell->neighbor(face_no);
     const unsigned int n_solution_vectors = solutions.size();
     const auto         face               = cell->face(face_no);
 
@@ -1171,7 +1170,6 @@ KellyErrorEstimator<dim, spacedim>::estimate(
     }
 
   const unsigned int n_components = dof_handler.get_fe(0).n_components();
-  (void)n_components;
 
   // sanity checks
   Assert(solutions.size() > 0, ExcNoSolutions());

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -581,8 +581,6 @@ namespace MatrixCreator
         return;
 
       const unsigned int dofs_per_cell = data.dof_indices.size();
-      (void)dofs_per_cell;
-
       Assert(data.cell_matrix.m() == dofs_per_cell, ExcInternalError());
       Assert(data.cell_matrix.n() == dofs_per_cell, ExcInternalError());
       Assert((right_hand_side == nullptr) ||
@@ -1364,7 +1362,6 @@ namespace MatrixCreator
     Assert(fe_is_hermite ||
              matrix.n() == dof.n_boundary_dofs(boundary_functions),
            ExcInternalError());
-    (void)fe_is_hermite;
 
     Assert(matrix.n() == matrix.m(), ExcInternalError());
     Assert(matrix.n() == rhs_vector.size(), ExcInternalError());

--- a/include/deal.II/numerics/vector_tools_constraints.templates.h
+++ b/include/deal.II/numerics/vector_tools_constraints.templates.h
@@ -692,7 +692,6 @@ namespace VectorTools
                     for (unsigned int d = 0; d < dim; ++d)
                       Assert(vector_dofs.dof_indices[d] < n_dofs,
                              ExcInternalError());
-                    (void)n_dofs;
 
                     // we need the normal vector on this face. we know that
                     // it is a vector of length 1 but at least with higher
@@ -1567,7 +1566,6 @@ namespace VectorTools
       }
     AssertDimension(n_total_constraints_found,
                     no_normal_flux_constraints.n_constraints());
-    (void)n_total_constraints_found;
   }
 
 

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -527,7 +527,6 @@ namespace VectorTools
       const Vector<Number>                                              &vector,
       const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
     {
-      (void)tria;
       AssertDimension(tria.n_active_cells(), vector.size());
       return vector[cell->active_cell_index()];
     }
@@ -616,9 +615,6 @@ namespace VectorTools
                                           spacedim,
                                           typename VectorType::value_type>>> &)
     {
-      (void)evaluation_flags;
-      (void)first_selected_component;
-
       Assert(n_components == 1 && first_selected_component == 0,
              ExcMessage(
                "A cell-data vector can only have a single component."));

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -422,7 +422,6 @@ namespace VectorTools
                               /* starting_offset = */ 0,
                               fe_values,
                               function_values);
-            (void)offset;
             Assert(offset == n_components, ExcInternalError());
 
             FETools::convert_generalized_support_point_values_to_dof_values(
@@ -992,7 +991,6 @@ namespace VectorTools
       intergridmap.get_source_grid();
     const DoFHandler<dim, spacedim> &dof_handler_2 =
       intergridmap.get_destination_grid();
-    (void)dof_handler_2;
 
     Assert(
       dof_handler_1.get_fe_collection() == dof_handler_2.get_fe_collection(),

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -90,7 +90,6 @@ namespace VectorTools
     std::enable_if_t<dealii::is_serial_vector<VectorType>::value == false>
     subtract_mean_value(VectorType &v, const std::vector<bool> &p_select)
     {
-      (void)p_select;
       Assert(p_select.empty(), ExcNotImplemented());
       // In case of an empty boolean mask operate on the whole vector:
       v.add(-v.mean_value());

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -168,7 +168,6 @@ namespace parallel
     Assert(&triangulation == &(dof_handler.get_triangulation()),
            ExcMessage(
              "Triangulation associated with the DoFHandler has changed!"));
-    (void)triangulation;
 
     // Skip if the DoFHandler has not been initialized yet.
     if (dof_handler.get_fe_collection().empty())

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -55,7 +55,6 @@ namespace parallel
         (partition_zoltan | partition_metis | partition_zorder |
          partition_custom_signal) &
         settings;
-      (void)partition_settings;
       Assert(partition_settings == partition_auto ||
                partition_settings == partition_metis ||
                partition_settings == partition_zoltan ||

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -207,7 +207,6 @@ FE_Nothing<dim, spacedim>::compare_for_domination(
   const unsigned int                  codim) const
 {
   Assert(codim <= dim, ExcImpossibleInDim(dim));
-  (void)codim;
 
   if (!dominate)
     // if FE_Nothing does not dominate, there are no requirements
@@ -279,8 +278,6 @@ FE_Nothing<dim, spacedim>::get_interpolation_matrix(
 {
   // Since this element has no dofs,
   // the interpolation matrix is necessarily empty.
-  (void)interpolation_matrix;
-
   Assert(interpolation_matrix.m() == 0,
          ExcDimensionMismatch(interpolation_matrix.m(), 0));
   Assert(interpolation_matrix.n() == 0,
@@ -298,8 +295,6 @@ FE_Nothing<dim, spacedim>::get_face_interpolation_matrix(
 {
   // since this element has no face dofs, the
   // interpolation matrix is necessarily empty
-  (void)interpolation_matrix;
-
   Assert(interpolation_matrix.m() == 0,
          ExcDimensionMismatch(interpolation_matrix.m(), 0));
   Assert(interpolation_matrix.n() == 0,
@@ -318,8 +313,6 @@ FE_Nothing<dim, spacedim>::get_subface_interpolation_matrix(
 {
   // since this element has no face dofs, the
   // interpolation matrix is necessarily empty
-
-  (void)interpolation_matrix;
   Assert(interpolation_matrix.m() == 0,
          ExcDimensionMismatch(interpolation_matrix.m(), 0));
   Assert(interpolation_matrix.n() == 0,

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -69,8 +69,6 @@ FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const Quadrature<1> &points)
       get_riaf_vector(points.size() - 1))
 {
   const int degree = points.size() - 1;
-  (void)degree;
-
   Assert(degree > 0,
          ExcMessage("This element can only be used for polynomial degrees "
                     "at least zero"));

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1432,7 +1432,6 @@ namespace GridGenerator
                 cell->face(5)->set_all_boundary_ids(1);
                 ++count;
               }
-          (void)count;
           Assert(count == 48, ExcInternalError());
         }
       else
@@ -2322,7 +2321,6 @@ namespace GridGenerator
         default:
           DEAL_II_ASSERT_UNREACHABLE();
       }
-    (void)twisted_data; // make the static analyzer happy
     Assert(
       !twisted_data,
       ExcInvalidInputOrientation(
@@ -7519,8 +7517,6 @@ namespace GridGenerator
                           const bool          colorize)
   {
     Assert(dim == 2 || dim == 3, ExcNotImplemented());
-    (void)colorize;
-    (void)n_cells;
     Assert(inner_radius < outer_radius,
            ExcMessage("outer_radius has to be bigger than inner_radius."));
     if (n_shells == 0)
@@ -7584,8 +7580,6 @@ namespace GridGenerator
         const double                                         radius) {
         (void)center;
         (void)radial_vertex_tolerance;
-        (void)face;
-        (void)radius;
         for (unsigned int vertex_n = 0;
              vertex_n < GeometryInfo<dim>::vertices_per_face;
              ++vertex_n)

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2130,7 +2130,6 @@ namespace GridTools
     const FullMatrix<double> &matrix)
   {
     static const int space_dim = CellIterator::AccessorType::space_dimension;
-    (void)space_dim;
     AssertIndexRange(direction, space_dim);
 
     if constexpr (running_in_debug_mode())
@@ -2227,10 +2226,7 @@ namespace GridTools
   {
     static const int dim       = MeshType::dimension;
     static const int space_dim = MeshType::space_dimension;
-    (void)dim;
-    (void)space_dim;
     AssertIndexRange(direction, space_dim);
-
     Assert(dim == space_dim, ExcNotImplemented());
 
     // Loop over all cells on the highest level and collect all boundary
@@ -2309,8 +2305,6 @@ namespace GridTools
   {
     static const int dim       = MeshType::dimension;
     static const int space_dim = MeshType::space_dimension;
-    (void)dim;
-    (void)space_dim;
     AssertIndexRange(direction, space_dim);
 
     // Loop over all cells on the highest level and collect all boundary

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -1048,7 +1048,6 @@ namespace TriangulationDescription
           const unsigned int n_mpi_ranks =
             dealii::Utilities::MPI::n_mpi_processes(
               partition.get_mpi_communicator());
-          (void)n_mpi_ranks;
 
           for (unsigned int i = 0; i < partition.locally_owned_size(); ++i)
             {

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -44,7 +44,6 @@ BlockSparsityPatternBase<SparsityPatternType>::BlockSparsityPatternBase(
   const BlockSparsityPatternBase &s)
   : BlockSparsityPatternBase()
 {
-  (void)s;
   Assert(s.n_block_rows() == 0 && s.n_block_cols() == 0,
          ExcMessage(
            "This constructor can only be called if the provided argument "

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -232,7 +232,6 @@ DynamicSparsityPattern::DynamicSparsityPattern(const DynamicSparsityPattern &s)
   , have_entries(false)
   , rowset(0)
 {
-  (void)s;
   Assert(s.rows == 0 && s.cols == 0,
          ExcMessage(
            "This constructor can only be called if the provided argument "
@@ -271,7 +270,6 @@ DynamicSparsityPattern::DynamicSparsityPattern(const size_type n)
 DynamicSparsityPattern &
 DynamicSparsityPattern::operator=(const DynamicSparsityPattern &s)
 {
-  (void)s;
   Assert(s.n_rows() == 0 && s.n_cols() == 0,
          ExcMessage(
            "This operator can only be called if the provided argument "

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -416,7 +416,6 @@ template <typename number>
 LAPACKFullMatrix<number> &
 LAPACKFullMatrix<number>::operator=(const number d)
 {
-  (void)d;
   Assert(d == number(0), ExcScalarAssignmentOnlyForZeroValue());
 
   if (this->n_elements() != 0)
@@ -1504,7 +1503,6 @@ LAPACKFullMatrix<number>::compute_cholesky_factorization()
 
   const types::blas_int mm = this->m();
   const types::blas_int nn = this->n();
-  (void)mm;
   Assert(mm == nn, ExcDimensionMismatch(mm, nn));
 
   number *const         values = this->values.data();

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -137,7 +137,6 @@ namespace PETScWrappers
   MatrixBase &
   MatrixBase::operator=(const value_type d)
   {
-    (void)d;
     Assert(d == value_type(), ExcScalarAssignmentOnlyForZeroValue());
 
     assert_is_compressed();

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -270,7 +270,6 @@ namespace PETScWrappers
                           const size_type n,
                           const size_type locally_owned_size)
     {
-      (void)n;
       AssertIndexRange(locally_owned_size, n + 1);
       ghosted = false;
 
@@ -291,7 +290,6 @@ namespace PETScWrappers
                           const size_type locally_owned_size,
                           const IndexSet &ghostnodes)
     {
-      (void)n;
       AssertIndexRange(locally_owned_size, n + 1);
       // If the size of the index set can be converted to a PetscInt then every
       // index can also be converted

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -551,7 +551,6 @@ namespace PETScWrappers
 #  ifdef DEAL_II_PETSC_WITH_HYPRE
     initialize();
 #  else // DEAL_II_PETSC_WITH_HYPRE
-    (void)pc;
     Assert(false,
            ExcMessage("Your PETSc installation does not include a copy of "
                       "the hypre package necessary for this preconditioner."));

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -800,8 +800,6 @@ namespace PETScWrappers
         "the MUMPS package necessary for this solver. You will need to configure "
         "PETSc so that it includes MUMPS, recompile it, and then re-configure "
         "and recompile deal.II as well."));
-
-    // Cast to void to silence compiler warnings
     (void)A;
     (void)x;
     (void)b;

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -444,7 +444,6 @@ ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
                                    &n_proc_cols_B);
       Assert(n_local_rows_B == n_rows, ExcInternalError());
       Assert(n_local_cols_B == n_columns, ExcInternalError());
-      (void)n_local_cols_B;
 
       int lda  = std::max(1, n_local_rows_B);
       int info = 0;
@@ -618,7 +617,6 @@ ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
                                    &n_proc_cols_B);
       Assert(n_local_rows_B == n_rows, ExcInternalError());
       Assert(n_local_cols_B == n_columns, ExcInternalError());
-      (void)n_local_cols_B;
 
       int lda  = std::max(1, n_local_rows_B);
       int info = 0;

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -50,7 +50,6 @@ SparsityPattern::SparsityPattern()
 SparsityPattern::SparsityPattern(const SparsityPattern &s)
   : SparsityPattern()
 {
-  (void)s;
   Assert(s.empty(),
          ExcMessage(
            "This constructor can only be called if the provided argument "
@@ -182,7 +181,6 @@ SparsityPattern::SparsityPattern(const SparsityPattern &original,
 SparsityPattern &
 SparsityPattern::operator=(const SparsityPattern &s)
 {
-  (void)s;
   Assert(s.empty(),
          ExcMessage(
            "This operator can only be called if the provided argument "

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -307,7 +307,6 @@ namespace SparsityTools
         cell_weights.empty(),
         ExcMessage(
           "The cell weighting functionality for Zoltan has not yet been implemented."));
-      (void)cell_weights;
 
       // MPI environment must have been initialized by this point.
       std::unique_ptr<Zoltan> zz = std::make_unique<Zoltan>(MPI_COMM_SELF);
@@ -375,7 +374,6 @@ namespace SparsityTools
                                       export_local_ids,
                                       export_procs,
                                       export_to_part);
-      (void)rc;
 
       // check for error code in partitioner
       Assert(rc == ZOLTAN_OK, ExcInternalError());
@@ -501,8 +499,6 @@ namespace SparsityTools
                        num_objects,
                        global_ids.data(),
                        color_exp.data());
-
-    (void)rc;
     // Check for error code
     Assert(rc == ZOLTAN_OK, ExcInternalError());
 

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -88,15 +88,12 @@ namespace TrilinosWrappers
                                 block_sparsity_pattern.n_block_cols()));
 
     const size_type n_block_rows = epetra_maps.size();
-    (void)n_block_rows;
-
     Assert(n_block_rows == block_sparsity_pattern.n_block_rows(),
            ExcDimensionMismatch(n_block_rows,
                                 block_sparsity_pattern.n_block_rows()));
     Assert(n_block_rows == block_sparsity_pattern.n_block_cols(),
            ExcDimensionMismatch(n_block_rows,
                                 block_sparsity_pattern.n_block_cols()));
-
 
     // Call the other basic reinit function, ...
     reinit(block_sparsity_pattern.n_block_rows(),

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -114,7 +114,6 @@ namespace LinearAlgebra
         {
           const int ierr = vector->PutScalar(0.);
           Assert(ierr == 0, ExcTrilinosError(ierr));
-          (void)ierr;
         }
     }
 
@@ -169,7 +168,6 @@ namespace LinearAlgebra
               const int ierr =
                 vector->Import(V.trilinos_vector(), data_exchange, Insert);
               Assert(ierr == 0, ExcTrilinosError(ierr));
-              (void)ierr;
             }
           else
             vector = std::make_unique<Epetra_FEVector>(V.trilinos_vector());
@@ -187,7 +185,6 @@ namespace LinearAlgebra
 
       const int ierr = vector->PutScalar(s);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
 
       return *this;
     }
@@ -280,7 +277,6 @@ namespace LinearAlgebra
         {
           const int ierr = vector->Update(1., V.trilinos_vector(), 1.);
           Assert(ierr == 0, ExcTrilinosError(ierr));
-          (void)ierr;
         }
       else
         {
@@ -292,7 +288,6 @@ namespace LinearAlgebra
                                           data_exchange,
                                           Epetra_AddLocalAlso);
           Assert(ierr == 0, ExcTrilinosError(ierr));
-          (void)ierr;
         }
 
       return *this;
@@ -321,7 +316,6 @@ namespace LinearAlgebra
       double    result(0.);
       const int ierr = vector->Dot(V.trilinos_vector(), &result);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
 
       return result;
     }
@@ -348,7 +342,6 @@ namespace LinearAlgebra
 
       const int ierr = vector->Update(a, V.trilinos_vector(), 1.);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
     }
 
 
@@ -369,7 +362,6 @@ namespace LinearAlgebra
       const int ierr =
         vector->Update(a, V.trilinos_vector(), b, W.trilinos_vector(), 1.);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
     }
 
 
@@ -394,7 +386,6 @@ namespace LinearAlgebra
       const int ierr =
         vector->Multiply(1.0, scaling_factors.trilinos_vector(), *vector, 0.0);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
     }
 
 
@@ -410,7 +401,6 @@ namespace LinearAlgebra
           // Otherwise, just update
           int ierr = vector->Update(a, V.trilinos_vector(), 0.);
           Assert(ierr == 0, ExcTrilinosError(ierr));
-          (void)ierr;
         }
     }
 
@@ -452,7 +442,6 @@ namespace LinearAlgebra
 
       int ierr = vector->MeanValue(&mean_value);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
 
       return mean_value;
     }
@@ -465,7 +454,6 @@ namespace LinearAlgebra
       double norm(0.);
       int    ierr = vector->Norm1(&norm);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
 
       return norm;
     }
@@ -478,7 +466,6 @@ namespace LinearAlgebra
       double norm(0.);
       int    ierr = vector->Norm2(&norm);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
 
       return norm;
     }
@@ -491,7 +478,6 @@ namespace LinearAlgebra
       double norm(0.);
       int    ierr = vector->NormInf(&norm);
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
 
       return norm;
     }
@@ -610,7 +596,6 @@ namespace LinearAlgebra
       int     ierr = vector->ExtractView(&val, &leading_dimension);
 
       Assert(ierr == 0, ExcTrilinosError(ierr));
-      (void)ierr;
       out.precision(precision);
       if (scientific)
         out.setf(std::ios::scientific, std::ios::floatfield);

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -141,8 +141,6 @@ namespace TrilinosWrappers
       if (constant_modes_dimension > 0)
         {
           const size_type global_size = TrilinosWrappers::n_global_rows(matrix);
-          (void)global_length; // work around compiler warning about unused
-                               // function in release mode
           Assert(global_size ==
                    static_cast<size_type>(TrilinosWrappers::global_length(
                      distributed_constant_modes)),
@@ -172,7 +170,6 @@ namespace TrilinosWrappers
                     static_cast<double>(constant_modes[d][mode_index]);
                 }
             }
-          (void)expected_mode_size;
 
           parameter_list.set("null space: type", "pre-computed");
           parameter_list.set("null space: dimension",

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -148,9 +148,6 @@ namespace TrilinosWrappers
                                     TrilinosWrappers::global_length(
                                       distributed_constant_modes)));
 
-        (void)n_relevant_rows;
-        (void)global_length;
-
         // Reshape null space as a contiguous vector of doubles so that
         // Trilinos can read from it.
         for (size_type d = 0; d < constant_modes_dimension; ++d)

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -399,7 +399,6 @@ namespace TrilinosWrappers
                                                     rhs_n_entries,
                                                     rhs_value_ptr,
                                                     rhs_index_ptr);
-            (void)ierr;
             Assert(ierr == 0, ExcTrilinosError(ierr));
 
             ierr = matrix->ExtractMyRowView(row_local,
@@ -565,7 +564,6 @@ namespace TrilinosWrappers
       // check whether we got the number of columns right.
       AssertDimension(sparsity_pattern.n_cols(),
                       TrilinosWrappers::n_global_cols(*graph));
-      (void)n_global_cols;
 
       // And now finally generate the matrix.
       matrix = std::make_unique<Epetra_FECrsMatrix>(Copy, *graph, false);
@@ -758,7 +756,6 @@ namespace TrilinosWrappers
             {
               Epetra_Export exporter(nonlocal_graph->RowMap(), row_space_map);
               int ierr = graph->Export(*nonlocal_graph, exporter, Add);
-              (void)ierr;
               Assert(ierr == 0, ExcTrilinosError(ierr));
             }
 
@@ -1131,7 +1128,6 @@ namespace TrilinosWrappers
         int             num_entries;
         const int       ierr =
           matrix->ExtractMyRowView(local_row, num_entries, values, col_indices);
-        (void)ierr;
 
         Assert(ierr == 0, ExcTrilinosError(ierr));
 
@@ -1205,7 +1201,6 @@ namespace TrilinosWrappers
                                             nnz_extracted,
                                             values,
                                             col_indices);
-        (void)ierr;
         Assert(ierr == 0, ExcTrilinosError(ierr));
 
         Assert(nnz_present == nnz_extracted,
@@ -1280,7 +1275,6 @@ namespace TrilinosWrappers
                                             nnz_extracted,
                                             values,
                                             col_indices);
-        (void)ierr;
         Assert(ierr == 0, ExcTrilinosError(ierr));
 
         Assert(nnz_present == nnz_extracted,
@@ -1772,7 +1766,6 @@ namespace TrilinosWrappers
   SparseMatrix &
   SparseMatrix::operator=(const double d)
   {
-    (void)d;
     Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
     compress(VectorOperation::unknown); // TODO: why do we do this? Should we
                                         // not check for is_compressed?
@@ -1827,7 +1820,6 @@ namespace TrilinosWrappers
                                                 rhs_n_entries,
                                                 rhs_value_ptr,
                                                 rhs_index_ptr);
-        (void)ierr;
         Assert(ierr == 0, ExcTrilinosError(ierr));
 
         ierr =
@@ -1905,7 +1897,6 @@ namespace TrilinosWrappers
   {
     const int ierr = matrix->Scale(a);
     Assert(ierr == 0, ExcTrilinosError(ierr));
-    (void)ierr; // removes -Wunused-variable in optimized mode
 
     return *this;
   }
@@ -1921,7 +1912,6 @@ namespace TrilinosWrappers
 
     const int ierr = matrix->Scale(factor);
     Assert(ierr == 0, ExcTrilinosError(ierr));
-    (void)ierr; // removes -Wunused-variable in optimized mode
 
     return *this;
   }
@@ -1983,9 +1973,6 @@ namespace TrilinosWrappers
                           "Are you trying to put the product of the "
                           "matrix with a vector into a vector that has "
                           "ghost elements?"));
-        (void)m;
-        (void)in;
-        (void)out;
       }
     } // namespace SparseMatrixImplementation
   }   // namespace internal
@@ -1998,8 +1985,6 @@ namespace TrilinosWrappers
   {
     Assert(&src != &dst, ExcSourceEqualsDestination());
     Assert(matrix->Filled(), ExcMatrixNotCompressed());
-    (void)src;
-    (void)dst;
 
     internal::SparseMatrixImplementation::check_vector_map_equality(*matrix,
                                                                     src,
@@ -2020,7 +2005,6 @@ namespace TrilinosWrappers
 
     const int ierr = matrix->Multiply(false, tril_src, tril_dst);
     Assert(ierr == 0, ExcTrilinosError(ierr));
-    (void)ierr; // removes -Wunused-variable in optimized mode
   }
 
 
@@ -2061,7 +2045,6 @@ namespace TrilinosWrappers
 
     const int ierr = matrix->Multiply(true, tril_src, tril_dst);
     Assert(ierr == 0, ExcTrilinosError(ierr));
-    (void)ierr; // removes -Wunused-variable in optimized mode
   }
 
 
@@ -2282,7 +2265,6 @@ namespace TrilinosWrappers
           {
             const int ierr =
               matrix->ExtractMyRowView(i, num_entries, values, indices);
-            (void)ierr;
             Assert(ierr == 0, ExcTrilinosError(ierr));
 
             for (TrilinosWrappers::types::int_type j = 0; j < num_entries; ++j)
@@ -2700,7 +2682,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2740,7 +2721,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2777,7 +2757,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2817,7 +2796,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2876,7 +2854,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2914,7 +2891,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2948,7 +2924,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorDomainMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),
@@ -2986,7 +2961,6 @@ namespace TrilinosWrappers
           AssertDimension(i_local_size, first_op_init_map.NumMyPoints());
           const Epetra_Map &second_op_init_map = second_op.OperatorRangeMap();
           AssertDimension(i_local_size, second_op_init_map.NumMyPoints());
-          (void)second_op_init_map;
           Intermediate tril_int(View,
                                 first_op_init_map,
                                 const_cast<TrilinosScalar *>(i->begin()),

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -135,7 +135,6 @@ namespace TrilinosWrappers
     , graph(
         new Epetra_FECrsGraph(View, *column_space_map, *column_space_map, 0))
   {
-    (void)input_sparsity;
     Assert(input_sparsity.n_rows() == 0,
            ExcMessage(
              "Copy constructor only works for empty sparsity patterns."));
@@ -828,7 +827,6 @@ namespace TrilinosWrappers
             int ierr = graph->ExtractGlobalRowView(trilinos_i,
                                                    nnz_extracted,
                                                    col_indices);
-            (void)ierr;
             Assert(ierr == 0, ExcTrilinosError(ierr));
             Assert(nnz_present == nnz_extracted,
                    ExcDimensionMismatch(nnz_present, nnz_extracted));
@@ -854,7 +852,6 @@ namespace TrilinosWrappers
             // an error.
             int ierr =
               graph->ExtractMyRowView(trilinos_i, nnz_extracted, col_indices);
-            (void)ierr;
             Assert(ierr == 0, ExcTrilinosError(ierr));
 
             Assert(nnz_present == nnz_extracted,

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -236,9 +236,7 @@ namespace TrilinosWrappers
             {
               // old and new vectors have exactly the same map, i.e. size and
               // parallel distribution
-              int ierr;
-              ierr = vector->GlobalAssemble(last_action);
-              (void)ierr;
+              int ierr = vector->GlobalAssemble(last_action);
               Assert(ierr == 0, ExcTrilinosError(ierr));
 
               ierr = vector->PutScalar(0.0);
@@ -391,7 +389,6 @@ namespace TrilinosWrappers
           else
             {
               const int ierr = vector->PutScalar(0.);
-              (void)ierr;
               Assert(ierr == 0, ExcTrilinosError(ierr));
             }
 

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -304,8 +304,6 @@ namespace internal
       const std::vector<unsigned int>  &constraint_pool_row_index,
       const std::vector<unsigned char> &irregular_cells)
     {
-      (void)constraint_pool_row_index;
-
       // first reorder the active FE index.
       const bool have_hp = dofs_per_cell.size() > 1;
       if (cell_active_fe_index.size() > 0)

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -581,7 +581,6 @@ namespace MGTools
                         const bool                       keep_constrained_dofs)
   {
     const types::global_dof_index n_dofs = dof.n_dofs(level);
-    (void)n_dofs;
 
     Assert(sparsity.n_rows() == n_dofs,
            ExcDimensionMismatch(sparsity.n_rows(), n_dofs));
@@ -611,7 +610,6 @@ namespace MGTools
                              const bool keep_constrained_dofs)
   {
     const types::global_dof_index n_dofs = dof.n_dofs(level);
-    (void)n_dofs;
 
     Assert(sparsity.n_rows() == n_dofs,
            ExcDimensionMismatch(sparsity.n_rows(), n_dofs));
@@ -687,11 +685,8 @@ namespace MGTools
 
     const types::global_dof_index fine_dofs   = dof.n_dofs(level);
     const types::global_dof_index coarse_dofs = dof.n_dofs(level - 1);
-    (void)fine_dofs;
-    (void)coarse_dofs;
 
     // Matrix maps from fine level to coarse level
-
     Assert(sparsity.n_rows() == coarse_dofs,
            ExcDimensionMismatch(sparsity.n_rows(), coarse_dofs));
     Assert(sparsity.n_cols() == fine_dofs,
@@ -749,8 +744,6 @@ namespace MGTools
     const FiniteElement<dim>     &fe     = dof.get_fe();
     const types::global_dof_index n_dofs = dof.n_dofs(level);
     const unsigned int            n_comp = fe.n_components();
-    (void)n_dofs;
-    (void)n_comp;
 
     Assert(sparsity.n_rows() == n_dofs,
            ExcDimensionMismatch(sparsity.n_rows(), n_dofs));
@@ -932,11 +925,8 @@ namespace MGTools
 
     const types::global_dof_index fine_dofs   = dof.n_dofs(level);
     const types::global_dof_index coarse_dofs = dof.n_dofs(level - 1);
-    (void)fine_dofs;
-    (void)coarse_dofs;
 
     // Matrix maps from fine level to coarse level
-
     Assert(sparsity.n_rows() == coarse_dofs,
            ExcDimensionMismatch(sparsity.n_rows(), coarse_dofs));
     Assert(sparsity.n_cols() == fine_dofs,
@@ -1018,8 +1008,6 @@ namespace MGTools
                                   const unsigned int       level)
   {
     const types::global_dof_index n_dofs = dof.n_dofs(level);
-    (void)n_dofs;
-
     Assert(sparsity.n_rows() == n_dofs,
            ExcDimensionMismatch(sparsity.n_rows(), n_dofs));
     Assert(sparsity.n_cols() == n_dofs,

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -110,7 +110,6 @@ MGTransferPrebuilt<VectorType>::restrict_and_add(const unsigned int from_level,
 {
   Assert((from_level >= 1) && (from_level <= prolongation_matrices.size()),
          ExcIndexRange(from_level, 1, prolongation_matrices.size() + 1));
-  (void)from_level;
 
   prolongation_matrices[from_level - 1]->Tvmult_add(dst, src);
 }

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -184,7 +184,6 @@ DataOutStack<dim, spacedim>::add_data_vector(
            names.size(), dof_handler->get_fe(0).n_components()));
   for (const auto &name : names)
     {
-      (void)name;
       Assert(name.find_first_not_of("abcdefghijklmnopqrstuvwxyz"
                                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                     "0123456789_<>()") == std::string::npos,

--- a/source/numerics/matrix_tools.cc
+++ b/source/numerics/matrix_tools.cc
@@ -311,7 +311,6 @@ namespace MatrixTools
     for (; dof != endd; ++dof)
       {
         Assert(dof->first < n_dofs, ExcInternalError());
-        (void)n_dofs;
 
         // get global index and index
         // in the block in which this

--- a/source/numerics/matrix_tools_once.cc
+++ b/source/numerics/matrix_tools_once.cc
@@ -248,8 +248,6 @@ namespace MatrixTools
                             const bool                      eliminate_columns)
       {
         Assert(eliminate_columns == false, ExcNotImplemented());
-        (void)eliminate_columns;
-
         Assert(matrix.n() == right_hand_side.size(),
                ExcDimensionMismatch(matrix.n(), right_hand_side.size()));
         Assert(matrix.n() == solution.size(),

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -524,7 +524,6 @@ PointValueHistory<dim>::add_component_names(
     component_mask.find(vector_name);
   Assert(mask != component_mask.end(), ExcMessage("vector_name not in class"));
   unsigned int n_stored = mask->second.n_selected_components();
-  (void)n_stored;
   Assert(component_names.size() == n_stored,
          ExcDimensionMismatch(component_names.size(), n_stored));
 


### PR DESCRIPTION
Like the other recent patches: since we added the `if (false)` branch we don't need these casts any more to prevent warnings in release mode when using assertion macros.