### PR TITLE
Doxygen Layout: move detailed description to the top

### DIFF
--- a/doc/doxygen/DoxygenLayout.xml.in
+++ b/doc/doxygen/DoxygenLayout.xml.in
@@ -29,6 +29,7 @@
   <class>
     <briefdescription visible="yes"/>
     <includes visible="$SHOW_INCLUDE_FILES"/>
+    <detaileddescription title=""/>
     <inheritancegraph visible="$CLASS_GRAPH"/>
     <collaborationgraph visible="$COLLABORATION_GRAPH"/>
     <memberdecl>
@@ -65,7 +66,6 @@
       <related title="" subtitle=""/>
       <membergroups visible="yes"/>
     </memberdecl>
-    <detaileddescription title=""/>
     <memberdef>
       <inlineclasses title=""/>
       <typedefs title=""/>


### PR DESCRIPTION
Class documentation is currently ordered in the following way:
- brief description
- inheritance diagramm
- list of all members
- detailed description

This PR moves the detailed description to the top (after the @brief description we rarely use)

FYI @bangerth 