### PR TITLE
github: disable windows-2025 for the moment

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025]
+        os: [windows-2022]
 
     steps:
     - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
         ctest --test-dir build --build-config Debug --extra-verbose
     - name: upload library
       # run only if a PR is merged into master
-      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2025' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
       uses: actions/upload-artifact@v4
       with:
         name: dealii-${{ matrix.os }}


### PR DESCRIPTION
Reverts part of #18524.

The tester on `windows-2025` somehow continues to get stuck. From the logs it looks like it happens during the cmake configuration, but this might be a fallacy. `windows-latest` still points to `windows-2022`, so maybe let's try again once github makes the 2025 image the new standard.