### PR TITLE
Refactor mappings of Hessians.

### DIFF
--- a/include/deal.II/fe/mapping_internal.h
+++ b/include/deal.II/fe/mapping_internal.h
@@ -49,6 +49,19 @@ namespace internal
   apply_covariant_hessian(
     const DerivativeForm<1, dim, spacedim, Number> &covariant,
     const Tensor<3, dim, Number>                   &input);
+
+  /**
+   * Map the Hessian of a Piola vector field. For more information see the
+   * overload of Mapping::transform() which maps 3-differential forms from the
+   * reference cell to the physical cell.
+   */
+  template <int dim, int spacedim, typename Number>
+  Tensor<3, spacedim, Number>
+  apply_piola_hessian(
+    const DerivativeForm<1, dim, spacedim, Number> &covariant,
+    const DerivativeForm<1, dim, spacedim, Number> &contravariant,
+    const Number                                   &volume_element,
+    const Tensor<3, dim, Number>                   &input);
 } // namespace internal
 
 namespace internal
@@ -110,6 +123,51 @@ namespace internal
               tmp1[J][K] = covariant[i][0] * input[0][J][K];
               for (unsigned int I = 1; I < dim; ++I)
                 tmp1[J][K] += covariant[i][I] * input[I][J][K];
+            }
+        for (unsigned int j = 0; j < spacedim; ++j)
+          {
+            Number tmp2[dim];
+            for (unsigned int K = 0; K < dim; ++K)
+              {
+                tmp2[K] = covariant[j][0] * tmp1[0][K];
+                for (unsigned int J = 1; J < dim; ++J)
+                  tmp2[K] += covariant[j][J] * tmp1[J][K];
+              }
+            for (unsigned int k = 0; k < spacedim; ++k)
+              {
+                output[i][j][k] = covariant[k][0] * tmp2[0];
+                for (unsigned int K = 1; K < dim; ++K)
+                  output[i][j][k] += covariant[k][K] * tmp2[K];
+              }
+          }
+      }
+
+    return output;
+  }
+
+
+
+  template <int dim, int spacedim, typename Number>
+  inline Tensor<3, spacedim, Number>
+  apply_piola_hessian(
+    const DerivativeForm<1, dim, spacedim, Number> &covariant,
+    const DerivativeForm<1, dim, spacedim, Number> &contravariant,
+    const Number                                   &volume_element,
+    const Tensor<3, dim, Number>                   &input)
+  {
+    Tensor<3, spacedim, Number> output;
+    for (unsigned int i = 0; i < spacedim; ++i)
+      {
+        Number factor[dim];
+        for (unsigned int I = 0; I < dim; ++I)
+          factor[I] = contravariant[i][I] * (1. / volume_element);
+        Number tmp1[dim][dim];
+        for (unsigned int J = 0; J < dim; ++J)
+          for (unsigned int K = 0; K < dim; ++K)
+            {
+              tmp1[J][K] = factor[0] * input[0][J][K];
+              for (unsigned int I = 1; I < dim; ++I)
+                tmp1[J][K] += factor[I] * input[I][J][K];
             }
         for (unsigned int j = 0; j < spacedim; ++j)
           {

--- a/include/deal.II/fe/mapping_internal.h
+++ b/include/deal.II/fe/mapping_internal.h
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_mapping_internal_h
+#define dealii_mapping_internal_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/derivative_form.h>
+#include <deal.II/base/tensor.h>
+
+// Implementations of transformations used by several Mapping classes (such as
+// MappingFE, MappingQ, and MappingFEField, and MappingManifold)
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  /**
+   * Map the Hessian of a covariant vector field. For more information see the
+   * overload of Mapping::transform() which maps 3-differential forms from the
+   * reference cell to the physical cell.
+   */
+  template <int dim, int spacedim, typename Number>
+  Tensor<3, spacedim, Number>
+  apply_covariant_hessian(
+    const DerivativeForm<1, dim, spacedim, Number> &covariant,
+    const Tensor<3, dim, Number>                   &input);
+} // namespace internal
+
+namespace internal
+{
+  template <int dim, int spacedim, typename Number>
+  inline Tensor<3, spacedim, Number>
+  apply_covariant_hessian(
+    const DerivativeForm<1, dim, spacedim, Number> &covariant,
+    const Tensor<3, dim, Number>                   &input)
+  {
+    Tensor<3, spacedim, Number> output;
+    for (unsigned int i = 0; i < spacedim; ++i)
+      {
+        Number tmp1[dim][dim];
+        for (unsigned int J = 0; J < dim; ++J)
+          for (unsigned int K = 0; K < dim; ++K)
+            {
+              tmp1[J][K] = covariant[i][0] * input[0][J][K];
+              for (unsigned int I = 1; I < dim; ++I)
+                tmp1[J][K] += covariant[i][I] * input[I][J][K];
+            }
+        for (unsigned int j = 0; j < spacedim; ++j)
+          {
+            Number tmp2[dim];
+            for (unsigned int K = 0; K < dim; ++K)
+              {
+                tmp2[K] = covariant[j][0] * tmp1[0][K];
+                for (unsigned int J = 1; J < dim; ++J)
+                  tmp2[K] += covariant[j][J] * tmp1[J][K];
+              }
+            for (unsigned int k = 0; k < spacedim; ++k)
+              {
+                output[i][j][k] = covariant[k][0] * tmp2[0];
+                for (unsigned int K = 1; K < dim; ++K)
+                  output[i][j][k] += covariant[k][K] * tmp2[K];
+              }
+          }
+      }
+
+    return output;
+  }
+} // namespace internal
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -28,6 +28,7 @@
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_update_flags.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_internal.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_tools_geometry.h>
@@ -2407,34 +2408,8 @@ namespace internal
                 {
                   const DerivativeForm<1, dim, spacedim> covariant =
                     data.output_data->inverse_jacobians[q].transpose();
-
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] = covariant[i][0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] += covariant[i][I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = covariant[j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += covariant[j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] = covariant[k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] += covariant[k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_covariant_hessian(covariant, input[q]);
                 }
 
               return;

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -2408,37 +2408,11 @@ namespace internal
                     data.output_data->inverse_jacobians[q].transpose();
                   const DerivativeForm<1, dim, spacedim> contravariant =
                     data.output_data->jacobians[q];
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double factor[dim];
-                      for (unsigned int I = 0; I < dim; ++I)
-                        factor[I] =
-                          contravariant[i][I] * (1. / data.volume_elements[q]);
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] = factor[0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] += factor[I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = covariant[j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += covariant[j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] = covariant[k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] += covariant[k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_piola_hessian(covariant,
+                                                  contravariant,
+                                                  data.volume_elements[q],
+                                                  input[q]);
                 }
 
               return;

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -2364,37 +2364,12 @@ namespace internal
                     data.output_data->inverse_jacobians[q].transpose();
                   const DerivativeForm<1, dim, spacedim> contravariant =
                     data.output_data->jacobians[q];
-
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] =
-                              contravariant[i][0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] +=
-                                contravariant[i][I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = covariant[j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += covariant[j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] = covariant[k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] += covariant[k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_contravariant_hessian(covariant,
+                                                          contravariant,
+                                                          input[q]);
                 }
+
               return;
             }
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1901,37 +1901,11 @@ namespace internal
                     "update_contravariant_transformation"));
 
                 for (unsigned int q = 0; q < output.size(); ++q)
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] =
-                              data.contravariant[q][i][0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] +=
-                                data.contravariant[q][i][I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] =
-                                data.covariant[q][k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] +=
-                                  data.covariant[q][k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_contravariant_hessian(data.covariant[q],
+                                                          data.contravariant[q],
+                                                          input[q]);
+
                 return;
               }
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1940,39 +1940,11 @@ namespace internal
                     "update_volume_elements"));
 
                 for (unsigned int q = 0; q < output.size(); ++q)
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double factor[dim];
-                      for (unsigned int I = 0; I < dim; ++I)
-                        factor[I] =
-                          data.contravariant[q][i][I] / data.volume_elements[q];
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] = factor[0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] += factor[I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] =
-                                data.covariant[q][k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] +=
-                                  data.covariant[q][k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_piola_hessian(data.covariant[q],
+                                                  data.contravariant[q],
+                                                  data.volume_elements[q],
+                                                  input[q]);
 
                 return;
               }

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/fe_poly.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_fe.h>
+#include <deal.II/fe/mapping_internal.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/manifold_lib.h>
@@ -1942,37 +1943,9 @@ namespace internal
                     "update_covariant_transformation"));
 
                 for (unsigned int q = 0; q < output.size(); ++q)
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] =
-                              data.covariant[q][i][0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] +=
-                                data.covariant[q][i][I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] =
-                                data.covariant[q][k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] +=
-                                  data.covariant[q][k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_covariant_hessian(data.covariant[q],
+                                                      input[q]);
 
                 return;
               }

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -1099,39 +1099,11 @@ namespace internal
                     "update_volume_elements"));
 
                 for (unsigned int q = 0; q < output.size(); ++q)
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double factor[dim];
-                      for (unsigned int I = 0; I < dim; ++I)
-                        factor[I] =
-                          data.contravariant[q][i][I] / data.volume_elements[q];
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] = factor[0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] += factor[I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] =
-                                data.covariant[q][k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] +=
-                                  data.covariant[q][k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_piola_hessian(data.covariant[q],
+                                                  data.contravariant[q],
+                                                  data.volume_elements[q],
+                                                  input[q]);
 
                 return;
               }

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -1060,37 +1060,11 @@ namespace internal
                     "update_contravariant_transformation"));
 
                 for (unsigned int q = 0; q < output.size(); ++q)
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] =
-                              data.contravariant[q][i][0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] +=
-                                data.contravariant[q][i][I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] =
-                                data.covariant[q][k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] +=
-                                  data.covariant[q][k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_contravariant_hessian(data.covariant[q],
+                                                          data.contravariant[q],
+                                                          input[q]);
+
                 return;
               }
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -26,6 +26,7 @@
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_internal.h>
 #include <deal.II/fe/mapping_manifold.h>
 
 #include <deal.II/grid/manifold.h>
@@ -1101,37 +1102,9 @@ namespace internal
                     "update_covariant_transformation"));
 
                 for (unsigned int q = 0; q < output.size(); ++q)
-                  for (unsigned int i = 0; i < spacedim; ++i)
-                    {
-                      double tmp1[dim][dim];
-                      for (unsigned int J = 0; J < dim; ++J)
-                        for (unsigned int K = 0; K < dim; ++K)
-                          {
-                            tmp1[J][K] =
-                              data.covariant[q][i][0] * input[q][0][J][K];
-                            for (unsigned int I = 1; I < dim; ++I)
-                              tmp1[J][K] +=
-                                data.covariant[q][i][I] * input[q][I][J][K];
-                          }
-                      for (unsigned int j = 0; j < spacedim; ++j)
-                        {
-                          double tmp2[dim];
-                          for (unsigned int K = 0; K < dim; ++K)
-                            {
-                              tmp2[K] = data.covariant[q][j][0] * tmp1[0][K];
-                              for (unsigned int J = 1; J < dim; ++J)
-                                tmp2[K] += data.covariant[q][j][J] * tmp1[J][K];
-                            }
-                          for (unsigned int k = 0; k < spacedim; ++k)
-                            {
-                              output[q][i][j][k] =
-                                data.covariant[q][k][0] * tmp2[0];
-                              for (unsigned int K = 1; K < dim; ++K)
-                                output[q][i][j][k] +=
-                                  data.covariant[q][k][K] * tmp2[K];
-                            }
-                        }
-                    }
+                  output[q] =
+                    internal::apply_covariant_hessian(data.covariant[q],
+                                                      input[q]);
 
                 return;
               }


### PR DESCRIPTION
While I was working on the derivatives of a new `Mapping`, I noticed that essentially every mapping class (except `MappingCartesian` which ignores cross terms) contains the same code for derivative transformations. Rather than duplicate it a fourth time I moved all of the various Hessian mappings into a new header, `mapping_internal.h`.

If others agree on this general approach I'll continue consolidating transformations in upcoming patches.