### PR TITLE
Removed the duplicate code from PoynomialsRaviartThomas class

### DIFF
--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -22,8 +22,8 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/tensor.h>
 #include <deal.II/base/polynomials_vector_anisotropic.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <mutex>
@@ -33,7 +33,7 @@
 DEAL_II_NAMESPACE_OPEN
 
 /**
- * This class implements the <i>H<sup>div</sup></i>-conforming, 
+ * This class implements the <i>H<sup>div</sup></i>-conforming,
  * Raviart-Thomas polynomials as described in the book by Brezzi and Fortin.
  * Most of the functionality comes from the vector-valued anisotropic
  * polynomials class .

--- a/source/base/polynomials_raviart_thomas.cc
+++ b/source/base/polynomials_raviart_thomas.cc
@@ -30,8 +30,10 @@ template <int dim>
 PolynomialsRaviartThomas<dim>::PolynomialsRaviartThomas(
   const unsigned int normal_degree,
   const unsigned int tangential_degree)
-  : PolynomialsVectorAnisotropic<dim>(normal_degree, tangential_degree,
-                               get_lexicographic_numbering(normal_degree, tangential_degree))
+  : PolynomialsVectorAnisotropic<dim>(
+      normal_degree,
+      tangential_degree,
+      get_lexicographic_numbering(normal_degree, tangential_degree))
 {}
 
 
@@ -49,7 +51,8 @@ PolynomialsRaviartThomas<dim>::n_polynomials(
   const unsigned int normal_degree,
   const unsigned int tangential_degree)
 {
-  return PolynomialsVectorAnisotropic<dim>::n_polynomials(normal_degree, tangential_degree);
+  return PolynomialsVectorAnisotropic<dim>::n_polynomials(normal_degree,
+                                                          tangential_degree);
 }
 
 


### PR DESCRIPTION
This PR is related to PR #18258 as we remove here most of the duplicated code, which is already in PolynomialsVectorAnisotropic class, from the PolynomialsRaviartThomas. All the changes are made in a way that nothing should break in deal.ii library. We hope to completely remove the PolynomialsRaviartThomas class later when we adapt necessary parts of the library (e.g. FE_RaviartThomas/FE_RaviartThomasNodal)  to the class PolynomialsVectorAnisotropic.