### PR TITLE
Better document the assumptions underlying the definition of the deviatoric tensor.

### DIFF
--- a/doc/news/changes/minor/20250618Bangerth
+++ b/doc/news/changes/minor/20250618Bangerth
@@ -1,0 +1,11 @@
+Augmented: deal.II provides functions deviator(), deviator_tensor(),
+and Physics::Elasticity::StandardTensors::dev_P() that all relate to
+the computation of the "deviator" of a tensor. These functions use a
+factor of $\frac{1}{\text{dim}}$ in their definition. This factor is
+unquestionably correct for `dim==3`, but for `dim==2` it depends on
+whether the model represents a truly two-dimensional situation, or is
+thought of as a cross-section through a three-dimensional body. This
+is, in other words, a modeling assumption. The documentation of these
+functions now explicitly describes these sorts of considerations.
+<br>
+(Wolfgang Bangerth, 2025/06/18)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -77,6 +77,34 @@ DEAL_II_HOST DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
  *   \frac{\partial \text{dev}\mathbf{T}}{\partial \mathbf T} = \mathbb P.
  * \f]
  *
+ * @note This function uses $\frac{1}{\text{dim}}$ as the factor in the
+ *   definition of the deviator, and that is unquestionably correct for
+ *   three-dimensional models. However, whether this is the correct choice
+ *   for two-dimensional models is something that depends on how one thinks
+ *   about two-dimensional models. For example, in elasticity, one often
+ *   does two-dimensional simulations that are thought of as cross sections
+ *   of three-dimensional objects that are infinite in $z$-direction,
+ *   with the assumption that the $z$-displacements are zero and that
+ *   the $x$- and $y$-displacements do not vary in $z$-direction. Such
+ *   models are often described as
+ *   "<a
+ * href="https://en.wikipedia.org/wiki/Infinitesimal_strain_theory#Plane_strain">plane
+ * strain</a>", indicating that nonzero strain components are all in the $x$-$y$
+ * plane. The important point here is that while we only model two spatial
+ *   variables, in the background *the model really is three-dimensional*.
+ *   In these cases, the deviator should really contain $\frac{1}{3}$
+ *   as the factor in front of the divergence, and in those cases you will
+ *   not want to use the current function. On the other hand,
+ *   there are of course also models that truly are two-dimensional --
+ *   say the simulation of transport on the earth surface, or of the
+ *   deformation of monolayers of
+ *   [graphene](https://en.wikipedia.org/wiki/Graphene) (an inherently
+ *   two-dimensional material). In those cases, the factor
+ *   $\frac{1}{2}$ chosen in the definition of this function when using
+ *   `dim==2` is correct. Whether or not the current function is right for
+ *   you in two dimensions is therefore a question of what your model
+ *   represents.
+ *
  * @relatesalso SymmetricTensor
  */
 template <int dim, typename Number = double>
@@ -154,6 +182,34 @@ trace(const SymmetricTensor<2, dim2, Number> &);
  * is the identity operator. This
  * quantity equals the original tensor minus its contractive or dilative
  * component and refers to the shear in, for example, elasticity.
+ *
+ * @note This function uses $\frac{1}{\text{dim}}$ as the factor in the
+ *   definition of the deviator, and that is unquestionably correct for
+ *   three-dimensional models. However, whether this is the correct choice
+ *   for two-dimensional models is something that depends on how one thinks
+ *   about two-dimensional models. For example, in elasticity, one often
+ *   does two-dimensional simulations that are thought of as cross sections
+ *   of three-dimensional objects that are infinite in $z$-direction,
+ *   with the assumption that the $z$-displacements are zero and that
+ *   the $x$- and $y$-displacements do not vary in $z$-direction. Such
+ *   models are often described as
+ *   "<a
+ * href="https://en.wikipedia.org/wiki/Infinitesimal_strain_theory#Plane_strain">plane
+ * strain</a>", indicating that nonzero strain components are all in the $x$-$y$
+ * plane. The important point here is that while we only model two spatial
+ *   variables, in the background *the model really is three-dimensional*.
+ *   In these cases, the deviator should really contain $\frac{1}{3}$
+ *   as the factor in front of the divergence, and in those cases you will
+ *   not want to use the current function. On the other hand,
+ *   there are of course also models that truly are two-dimensional --
+ *   say the simulation of transport on the earth surface, or of the
+ *   deformation of monolayers of
+ *   [graphene](https://en.wikipedia.org/wiki/Graphene) (an inherently
+ *   two-dimensional material). In those cases, the factor
+ *   $\frac{1}{2}$ chosen in the definition of this function when using
+ *   `dim==2` is correct. Whether or not the current function is right for
+ *   you in two dimensions is therefore a question of what your model
+ *   represents.
  *
  * @relatesalso SymmetricTensor
  */

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -162,6 +162,35 @@ namespace Physics
        * This definition aligns with the fourth-order symmetric tensor that
        * is returned by deviator_tensor().
        *
+       * @note This function uses $\frac{1}{\text{dim}}$ as the factor in the
+       *   definition of the deviator, and that is unquestionably correct for
+       *   three-dimensional models. However, whether this is the correct choice
+       *   for two-dimensional models is something that depends on how one
+       *   thinks about two-dimensional models. For example, in elasticity, one
+       *   often does two-dimensional simulations that are thought of as cross
+       *   sections of three-dimensional objects that are infinite in
+       *   $z$-direction, with the assumption that the $z$-displacements are
+       *   zero and that the $x$- and $y$-displacements do not vary in
+       *   $z$-direction. Such models are often described as
+       *   "<a
+       * href="https://en.wikipedia.org/wiki/Infinitesimal_strain_theory#Plane_strain">plane
+       * strain</a>", indicating that nonzero strain components are all in the
+       *   $x$-$y$ plane. The important point here is that while we only
+       *   model two spatial variables, in the background *the model
+       *   really is three-dimensional*.  In these cases, the deviator
+       *   should really contain $\frac{1}{3}$ as the factor in front of
+       *   the divergence, and in those cases you will not want to use
+       *   the current function. On the other hand, there are of course
+       *   also models that truly are two-dimensional -- say the
+       *   simulation of transport on the earth surface, or of the
+       *   deformation of monolayers of
+       *   [graphene](https://en.wikipedia.org/wiki/Graphene) (an
+       *   inherently two-dimensional material). In those cases, the
+       *   factor $\frac{1}{2}$ chosen in the definition of this
+       *   function when using `dim==2` is correct. Whether or not the
+       *   current function is right for you in two dimensions is
+       *   therefore a question of what your model represents.
+       *
        * @dealiiWriggersA{47,3.129}
        * @dealiiHolzapfelA{232,6.105}
        */


### PR DESCRIPTION
At the ASPECT hackathon, @YiminJin has made a substantial effort to understand the correctness or lack thereof of two-dimensional models in ASPECT. At its core, this is a philosophical question: What do we actually mean by "two-dimensional". In ASPECT, we defined this as "plane strain" (see https://aspect-documentation.readthedocs.io/en/latest/user/methods/basic-equations/2d-models.html), and in those cases what @YiminJin figured out is that the definition of the "deviator" operator and tensor in deal.II is just wrong.

This patch summarizes the discussions we had about this topic in the documentation of the relevant functions.

Related to https://github.com/geodynamics/aspect/pull/6471 and https://github.com/geodynamics/aspect/issues/6434 and https://github.com/geodynamics/aspect/pull/6459