### PR TITLE
Adapted FE_RaviartThomas to the new PolynomialsVectorAnisotropic class

### DIFF
--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -145,6 +145,14 @@ public:
   clone() const override;
 
   /**
+   * Compute the lexicographic to hierarchic numbering underlying this class,
+   * necessary for the creation of the respective vector polynomial space.
+   */
+  std::vector<unsigned int>
+  get_lexicographic_numbering(const unsigned int normal_degree,
+                              const unsigned int tangential_degree) const;
+
+  /**
    * This function returns @p true, if the shape function @p shape_index has
    * non-zero function values somewhere on the face @p face_index.
    *
@@ -351,6 +359,14 @@ public:
   // documentation inherited from the base class
   virtual std::unique_ptr<FiniteElement<dim, dim>>
   clone() const override;
+
+  /**
+   * Compute the lexicographic to hierarchic numbering underlying this class,
+   * necessary for the creation of the respective vector polynomial space.
+   */
+  std::vector<unsigned int>
+  get_lexicographic_numbering(const unsigned int normal_degree,
+                              const unsigned int tangential_degree) const;
 
   virtual void
   get_face_interpolation_matrix(const FiniteElement<dim> &source,

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -148,9 +148,8 @@ public:
    * Compute the lexicographic to hierarchic numbering underlying this class,
    * necessary for the creation of the respective vector polynomial space.
    */
-  std::vector<unsigned int>
-  get_lexicographic_numbering(const unsigned int normal_degree,
-                              const unsigned int tangential_degree) const;
+  static std::vector<unsigned int>
+  get_lexicographic_numbering(const unsigned int degree);
 
   /**
    * This function returns @p true, if the shape function @p shape_index has
@@ -359,14 +358,6 @@ public:
   // documentation inherited from the base class
   virtual std::unique_ptr<FiniteElement<dim, dim>>
   clone() const override;
-
-  /**
-   * Compute the lexicographic to hierarchic numbering underlying this class,
-   * necessary for the creation of the respective vector polynomial space.
-   */
-  std::vector<unsigned int>
-  get_lexicographic_numbering(const unsigned int normal_degree,
-                              const unsigned int tangential_degree) const;
 
   virtual void
   get_face_interpolation_matrix(const FiniteElement<dim> &source,

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -268,8 +268,8 @@ namespace internal
           const unsigned int dofs_per_face_normal = fe_in.n_dofs_per_face();
 
           lexicographic_numbering =
-            PolynomialsRaviartThomas<dim>::get_lexicographic_numbering(
-              fe_in.degree - 1);
+            FE_RaviartThomas<dim>::get_lexicographic_numbering(fe_in.degree -
+                                                               1);
 
           // To get the right shape_values of the RT element
           std::vector<unsigned int> lex_normal, lex_tangent;

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -21,7 +21,6 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_piecewise.h>
-#include <deal.II/base/polynomials_raviart_thomas.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 #include <deal.II/base/utilities.h>

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -14,7 +14,7 @@
 
 
 #include <deal.II/base/polynomial.h>
-#include <deal.II/base/polynomials_raviart_thomas.h>
+#include <deal.II/base/polynomials_vector_anisotropic.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
@@ -43,16 +43,20 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim>
 FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
   : FE_PolyTensor<dim>(
-      PolynomialsRaviartThomas<dim>(deg),
+      PolynomialsVectorAnisotropic<dim>(deg + 1,
+                                        deg,
+                                        get_lexicographic_numbering(deg + 1,
+                                                                    deg)),
       FiniteElementData<dim>(get_dpo_vector(deg),
                              dim,
                              deg + 1,
                              FiniteElementData<dim>::Hdiv),
-      std::vector<bool>(PolynomialsRaviartThomas<dim>::n_polynomials(deg),
-                        true),
-      std::vector<ComponentMask>(PolynomialsRaviartThomas<dim>::n_polynomials(
-                                   deg),
-                                 ComponentMask(std::vector<bool>(dim, true))))
+      std::vector<bool>(
+        PolynomialsVectorAnisotropic<dim>::n_polynomials(deg + 1, deg),
+        true),
+      std::vector<ComponentMask>(
+        PolynomialsVectorAnisotropic<dim>::n_polynomials(deg + 1, deg),
+        ComponentMask(std::vector<bool>(dim, true))))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
   const unsigned int n_dofs = this->n_dofs_per_cell();
@@ -690,6 +694,71 @@ FE_RaviartThomas<dim>::has_support_on_face(const unsigned int shape_index,
     }
 
   return true;
+}
+
+
+
+template <int dim>
+std::vector<unsigned int>
+FE_RaviartThomas<dim>::get_lexicographic_numbering(
+  const unsigned int normal_degree,
+  const unsigned int tangential_degree) const
+{
+  const unsigned int n_dofs_face =
+    Utilities::pow(tangential_degree + 1, dim - 1);
+  std::vector<unsigned int> lexicographic_numbering;
+  // component 1
+  for (unsigned int j = 0; j < n_dofs_face; ++j)
+    {
+      lexicographic_numbering.push_back(j);
+      if (normal_degree > 1)
+        for (unsigned int i = n_dofs_face * 2 * dim;
+             i < n_dofs_face * 2 * dim + normal_degree - 1;
+             ++i)
+          lexicographic_numbering.push_back(i + j * (normal_degree - 1));
+      lexicographic_numbering.push_back(n_dofs_face + j);
+    }
+
+  // component 2
+  unsigned int layers = (dim == 3) ? tangential_degree + 1 : 1;
+  for (unsigned int k = 0; k < layers; ++k)
+    {
+      unsigned int k_add = k * (tangential_degree + 1);
+      for (unsigned int j = n_dofs_face * 2;
+           j < n_dofs_face * 2 + tangential_degree + 1;
+           ++j)
+        lexicographic_numbering.push_back(j + k_add);
+
+      if (normal_degree > 1)
+        for (unsigned int i = n_dofs_face * (2 * dim + (normal_degree - 1));
+             i < n_dofs_face * (2 * dim + (normal_degree - 1)) +
+                   (normal_degree - 1) * (tangential_degree + 1);
+             ++i)
+          {
+            lexicographic_numbering.push_back(i + k_add * tangential_degree);
+          }
+      for (unsigned int j = n_dofs_face * 3;
+           j < n_dofs_face * 3 + tangential_degree + 1;
+           ++j)
+        lexicographic_numbering.push_back(j + k_add);
+    }
+
+  // component 3
+  if (dim == 3)
+    {
+      for (unsigned int i = 4 * n_dofs_face; i < 5 * n_dofs_face; ++i)
+        lexicographic_numbering.push_back(i);
+      if (normal_degree > 1)
+        for (unsigned int i =
+               6 * n_dofs_face + n_dofs_face * 2 * (normal_degree - 1);
+             i < 6 * n_dofs_face + n_dofs_face * 3 * (normal_degree - 1);
+             ++i)
+          lexicographic_numbering.push_back(i);
+      for (unsigned int i = 5 * n_dofs_face; i < 6 * n_dofs_face; ++i)
+        lexicographic_numbering.push_back(i);
+    }
+
+  return lexicographic_numbering;
 }
 
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -45,8 +45,7 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
   : FE_PolyTensor<dim>(
       PolynomialsVectorAnisotropic<dim>(deg + 1,
                                         deg,
-                                        get_lexicographic_numbering(deg + 1,
-                                                                    deg)),
+                                        get_lexicographic_numbering(deg)),
       FiniteElementData<dim>(get_dpo_vector(deg),
                              dim,
                              deg + 1,
@@ -700,45 +699,37 @@ FE_RaviartThomas<dim>::has_support_on_face(const unsigned int shape_index,
 
 template <int dim>
 std::vector<unsigned int>
-FE_RaviartThomas<dim>::get_lexicographic_numbering(
-  const unsigned int normal_degree,
-  const unsigned int tangential_degree) const
+FE_RaviartThomas<dim>::get_lexicographic_numbering(const unsigned int degree)
 {
-  const unsigned int n_dofs_face =
-    Utilities::pow(tangential_degree + 1, dim - 1);
+  const unsigned int        n_dofs_face = Utilities::pow(degree + 1, dim - 1);
   std::vector<unsigned int> lexicographic_numbering;
   // component 1
   for (unsigned int j = 0; j < n_dofs_face; ++j)
     {
       lexicographic_numbering.push_back(j);
-      if (normal_degree > 1)
-        for (unsigned int i = n_dofs_face * 2 * dim;
-             i < n_dofs_face * 2 * dim + normal_degree - 1;
-             ++i)
-          lexicographic_numbering.push_back(i + j * (normal_degree - 1));
+      for (unsigned int i = n_dofs_face * 2 * dim;
+           i < n_dofs_face * 2 * dim + degree;
+           ++i)
+        lexicographic_numbering.push_back(i + j * degree);
       lexicographic_numbering.push_back(n_dofs_face + j);
     }
 
   // component 2
-  unsigned int layers = (dim == 3) ? tangential_degree + 1 : 1;
+  unsigned int layers = (dim == 3) ? degree + 1 : 1;
   for (unsigned int k = 0; k < layers; ++k)
     {
-      unsigned int k_add = k * (tangential_degree + 1);
-      for (unsigned int j = n_dofs_face * 2;
-           j < n_dofs_face * 2 + tangential_degree + 1;
+      unsigned int k_add = k * (degree + 1);
+      for (unsigned int j = n_dofs_face * 2; j < n_dofs_face * 2 + degree + 1;
            ++j)
         lexicographic_numbering.push_back(j + k_add);
 
-      if (normal_degree > 1)
-        for (unsigned int i = n_dofs_face * (2 * dim + (normal_degree - 1));
-             i < n_dofs_face * (2 * dim + (normal_degree - 1)) +
-                   (normal_degree - 1) * (tangential_degree + 1);
-             ++i)
-          {
-            lexicographic_numbering.push_back(i + k_add * tangential_degree);
-          }
-      for (unsigned int j = n_dofs_face * 3;
-           j < n_dofs_face * 3 + tangential_degree + 1;
+      for (unsigned int i = n_dofs_face * (2 * dim + degree);
+           i < n_dofs_face * (2 * dim + degree) + degree * (degree + 1);
+           ++i)
+        {
+          lexicographic_numbering.push_back(i + k_add * degree);
+        }
+      for (unsigned int j = n_dofs_face * 3; j < n_dofs_face * 3 + degree + 1;
            ++j)
         lexicographic_numbering.push_back(j + k_add);
     }
@@ -748,12 +739,10 @@ FE_RaviartThomas<dim>::get_lexicographic_numbering(
     {
       for (unsigned int i = 4 * n_dofs_face; i < 5 * n_dofs_face; ++i)
         lexicographic_numbering.push_back(i);
-      if (normal_degree > 1)
-        for (unsigned int i =
-               6 * n_dofs_face + n_dofs_face * 2 * (normal_degree - 1);
-             i < 6 * n_dofs_face + n_dofs_face * 3 * (normal_degree - 1);
-             ++i)
-          lexicographic_numbering.push_back(i);
+      for (unsigned int i = 6 * n_dofs_face + n_dofs_face * 2 * degree;
+           i < 6 * n_dofs_face + n_dofs_face * 3 * degree;
+           ++i)
+        lexicographic_numbering.push_back(i);
       for (unsigned int i = 5 * n_dofs_face; i < 6 * n_dofs_face; ++i)
         lexicographic_numbering.push_back(i);
     }

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -67,10 +67,10 @@ namespace
 template <int dim>
 FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int degree)
   : FE_PolyTensor<dim>(
-      PolynomialsVectorAnisotropic<dim>(degree + 1,
-                                        degree,
-                                        get_lexicographic_numbering(degree + 1,
-                                                                    degree)),
+      PolynomialsVectorAnisotropic<dim>(
+        degree + 1,
+        degree,
+        FE_RaviartThomas<dim>::get_lexicographic_numbering(degree)),
       FiniteElementData<dim>(get_rt_dpo_vector(dim, degree),
                              dim,
                              degree + 1,
@@ -85,7 +85,7 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int degree)
   this->mapping_kind = {mapping_raviart_thomas};
 
   const std::vector<unsigned int> numbering =
-    get_lexicographic_numbering(degree + 1, degree);
+    FE_RaviartThomas<dim>::get_lexicographic_numbering(degree);
 
   // First, initialize the generalized support points and quadrature weights,
   // since they are required for interpolation.
@@ -238,71 +238,6 @@ FE_RaviartThomasNodal<dim>::has_support_on_face(
 
   // In all other cases, return true, which is safe
   return true;
-}
-
-
-
-template <int dim>
-std::vector<unsigned int>
-FE_RaviartThomasNodal<dim>::get_lexicographic_numbering(
-  const unsigned int normal_degree,
-  const unsigned int tangential_degree) const
-{
-  const unsigned int n_dofs_face =
-    Utilities::pow(tangential_degree + 1, dim - 1);
-  std::vector<unsigned int> lexicographic_numbering;
-  // component 1
-  for (unsigned int j = 0; j < n_dofs_face; ++j)
-    {
-      lexicographic_numbering.push_back(j);
-      if (normal_degree > 1)
-        for (unsigned int i = n_dofs_face * 2 * dim;
-             i < n_dofs_face * 2 * dim + normal_degree - 1;
-             ++i)
-          lexicographic_numbering.push_back(i + j * (normal_degree - 1));
-      lexicographic_numbering.push_back(n_dofs_face + j);
-    }
-
-  // component 2
-  unsigned int layers = (dim == 3) ? tangential_degree + 1 : 1;
-  for (unsigned int k = 0; k < layers; ++k)
-    {
-      unsigned int k_add = k * (tangential_degree + 1);
-      for (unsigned int j = n_dofs_face * 2;
-           j < n_dofs_face * 2 + tangential_degree + 1;
-           ++j)
-        lexicographic_numbering.push_back(j + k_add);
-
-      if (normal_degree > 1)
-        for (unsigned int i = n_dofs_face * (2 * dim + (normal_degree - 1));
-             i < n_dofs_face * (2 * dim + (normal_degree - 1)) +
-                   (normal_degree - 1) * (tangential_degree + 1);
-             ++i)
-          {
-            lexicographic_numbering.push_back(i + k_add * tangential_degree);
-          }
-      for (unsigned int j = n_dofs_face * 3;
-           j < n_dofs_face * 3 + tangential_degree + 1;
-           ++j)
-        lexicographic_numbering.push_back(j + k_add);
-    }
-
-  // component 3
-  if (dim == 3)
-    {
-      for (unsigned int i = 4 * n_dofs_face; i < 5 * n_dofs_face; ++i)
-        lexicographic_numbering.push_back(i);
-      if (normal_degree > 1)
-        for (unsigned int i =
-               6 * n_dofs_face + n_dofs_face * 2 * (normal_degree - 1);
-             i < 6 * n_dofs_face + n_dofs_face * 3 * (normal_degree - 1);
-             ++i)
-          lexicographic_numbering.push_back(i);
-      for (unsigned int i = 5 * n_dofs_face; i < 6 * n_dofs_face; ++i)
-        lexicographic_numbering.push_back(i);
-    }
-
-  return lexicographic_numbering;
 }
 
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -14,7 +14,7 @@
 
 
 #include <deal.II/base/polynomial.h>
-#include <deal.II/base/polynomials_raviart_thomas.h>
+#include <deal.II/base/polynomials_vector_anisotropic.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature_lib.h>
 
@@ -66,24 +66,32 @@ namespace
 
 template <int dim>
 FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int degree)
-  : FE_PolyTensor<dim>(PolynomialsRaviartThomas<dim>(degree),
-                       FiniteElementData<dim>(get_rt_dpo_vector(dim, degree),
-                                              dim,
-                                              degree + 1,
-                                              FiniteElementData<dim>::Hdiv),
-                       std::vector<bool>(1, false),
-                       std::vector<ComponentMask>(
-                         PolynomialsRaviartThomas<dim>::n_polynomials(degree),
-                         ComponentMask(std::vector<bool>(dim, true))))
+  : FE_PolyTensor<dim>(
+      PolynomialsVectorAnisotropic<dim>(degree + 1,
+                                        degree,
+                                        get_lexicographic_numbering(degree + 1,
+                                                                    degree)),
+      FiniteElementData<dim>(get_rt_dpo_vector(dim, degree),
+                             dim,
+                             degree + 1,
+                             FiniteElementData<dim>::Hdiv),
+      std::vector<bool>(1, false),
+      std::vector<ComponentMask>(
+        PolynomialsVectorAnisotropic<dim>::n_polynomials(degree + 1, degree),
+        ComponentMask(std::vector<bool>(dim, true))))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
 
   this->mapping_kind = {mapping_raviart_thomas};
 
+  const std::vector<unsigned int> numbering =
+    get_lexicographic_numbering(degree + 1, degree);
+
   // First, initialize the generalized support points and quadrature weights,
   // since they are required for interpolation.
   this->generalized_support_points =
-    PolynomialsRaviartThomas<dim>(degree).get_polynomial_support_points();
+    PolynomialsVectorAnisotropic<dim>(degree + 1, degree, numbering)
+      .get_polynomial_support_points();
   AssertDimension(this->generalized_support_points.size(),
                   this->n_dofs_per_cell());
 
@@ -230,6 +238,71 @@ FE_RaviartThomasNodal<dim>::has_support_on_face(
 
   // In all other cases, return true, which is safe
   return true;
+}
+
+
+
+template <int dim>
+std::vector<unsigned int>
+FE_RaviartThomasNodal<dim>::get_lexicographic_numbering(
+  const unsigned int normal_degree,
+  const unsigned int tangential_degree) const
+{
+  const unsigned int n_dofs_face =
+    Utilities::pow(tangential_degree + 1, dim - 1);
+  std::vector<unsigned int> lexicographic_numbering;
+  // component 1
+  for (unsigned int j = 0; j < n_dofs_face; ++j)
+    {
+      lexicographic_numbering.push_back(j);
+      if (normal_degree > 1)
+        for (unsigned int i = n_dofs_face * 2 * dim;
+             i < n_dofs_face * 2 * dim + normal_degree - 1;
+             ++i)
+          lexicographic_numbering.push_back(i + j * (normal_degree - 1));
+      lexicographic_numbering.push_back(n_dofs_face + j);
+    }
+
+  // component 2
+  unsigned int layers = (dim == 3) ? tangential_degree + 1 : 1;
+  for (unsigned int k = 0; k < layers; ++k)
+    {
+      unsigned int k_add = k * (tangential_degree + 1);
+      for (unsigned int j = n_dofs_face * 2;
+           j < n_dofs_face * 2 + tangential_degree + 1;
+           ++j)
+        lexicographic_numbering.push_back(j + k_add);
+
+      if (normal_degree > 1)
+        for (unsigned int i = n_dofs_face * (2 * dim + (normal_degree - 1));
+             i < n_dofs_face * (2 * dim + (normal_degree - 1)) +
+                   (normal_degree - 1) * (tangential_degree + 1);
+             ++i)
+          {
+            lexicographic_numbering.push_back(i + k_add * tangential_degree);
+          }
+      for (unsigned int j = n_dofs_face * 3;
+           j < n_dofs_face * 3 + tangential_degree + 1;
+           ++j)
+        lexicographic_numbering.push_back(j + k_add);
+    }
+
+  // component 3
+  if (dim == 3)
+    {
+      for (unsigned int i = 4 * n_dofs_face; i < 5 * n_dofs_face; ++i)
+        lexicographic_numbering.push_back(i);
+      if (normal_degree > 1)
+        for (unsigned int i =
+               6 * n_dofs_face + n_dofs_face * 2 * (normal_degree - 1);
+             i < 6 * n_dofs_face + n_dofs_face * 3 * (normal_degree - 1);
+             ++i)
+          lexicographic_numbering.push_back(i);
+      for (unsigned int i = 5 * n_dofs_face; i < 6 * n_dofs_face; ++i)
+        lexicographic_numbering.push_back(i);
+    }
+
+  return lexicographic_numbering;
 }
 
 


### PR DESCRIPTION
This PR is related to the PR #18258, as we removed the dependence on the `PolynomialsRaviartThomas` class from the `FE_RaviartThomas`/`FE_RaviartThomasNodal` and adapted the classes, including the matrix-free part,  to the new class `PolynomialsVectorAnisotropic`. We needed to add some functionality to the finite element classes, e.g. lexicographic numbering.  That is needed for `PolynomialsVectorAnisotropic`, as it is more general class than the  `PolynomialsRaviartThomas`. We believe that these changes will help to remove the latter class completely at some point. I think, with this PR there are only 2-3 classes left in the library with which we can still see `PolynomialsRaviartThomas`: `FE_DGVector`/`FE_DGRaviartThomas` and `PolynomialsRT_Bubbles`.