### PR TITLE
Use std::pair for tuples of two elements.

### DIFF
--- a/source/base/mpi_remote_point_evaluation.cc
+++ b/source/base/mpi_remote_point_evaluation.cc
@@ -166,9 +166,9 @@ namespace Utilities
           this->point_ptrs[std::get<1>(data.recv_components[i]) + 1]++;
         }
 
-      std::tuple<unsigned int, unsigned int> n_owning_processes_default{
+      std::pair<unsigned int, unsigned int> n_owning_processes_default{
         numbers::invalid_unsigned_int, 0};
-      std::tuple<unsigned int, unsigned int> n_owning_processes_local =
+      std::pair<unsigned int, unsigned int> n_owning_processes_local =
         n_owning_processes_default;
 
       for (unsigned int i = 0; i < data.n_searched_points; ++i)
@@ -184,18 +184,18 @@ namespace Utilities
         }
 
       const auto n_owning_processes_global =
-        Utilities::MPI::all_reduce<std::tuple<unsigned int, unsigned int>>(
+        Utilities::MPI::all_reduce<std::pair<unsigned int, unsigned int>>(
           n_owning_processes_local,
           tria.get_mpi_communicator(),
           [&](const auto &a,
-              const auto &b) -> std::tuple<unsigned int, unsigned int> {
+              const auto &b) -> std::pair<unsigned int, unsigned int> {
             if (a == n_owning_processes_default)
               return b;
 
             if (b == n_owning_processes_default)
               return a;
 
-            return std::tuple<unsigned int, unsigned int>{
+            return std::pair<unsigned int, unsigned int>{
               std::min(std::get<0>(a), std::get<0>(b)),
               std::max(std::get<1>(a), std::get<1>(b))};
           });


### PR DESCRIPTION
For some reason, BOOST serialization does not seem to support serializing `std::tuple` -- at least not the version we bundle. This has tripped up others before: https://stackoverflow.com/questions/14744303/does-boost-support-serialization-of-c11s-stdtuple/14928368#14928368 It's not clear to me why I'm running into this now, and perhaps I am doing something stupid (likely), but in any case, the place where I happen to have that problem has tuples with only two elements -- so we might as well use `std::pair`.

Part of #18071.