### PR TITLE
Remove duplicated reference

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -1911,17 +1911,6 @@
 
 %%% sparse communication pattern
 
-@article{hoefler2010scalable,
-  title={Scalable communication protocols for dynamic sparse data exchange},
-  author={Hoefler, Torsten and Siebert, Christian and Lumsdaine, Andrew},
-  journal={ACM Sigplan Notices},
-  volume={45},
-  number={5},
-  pages={159--168},
-  year={2010},
-  publisher={ACM New York, NY, USA}
-}
-
 @article{burman2015cutfem,
   title={CutFEM: discretizing geometry and partial differential equations},
   author={Burman, Erik and Claus, Susanne and Hansbo, Peter and Larson, Mats G and Massing, Andr{\'e}},


### PR DESCRIPTION
Related to https://github.com/dealii/dealii/issues/18585. The other entry is
```
@article{hoefler2010scalable,
  author =    {T. Hoefler and C. Siebert and A. Lumsdaine},
  title =     {Scalable communication protocols for dynamic sparse data exchange},
  journal =   {ACM Sigplan Notices},
  publisher = {ACM New York, NY, USA},
  year =      {2010},
  volume =    {45},
  number =    {5},
  pages =     {159--168},
  url =       {https://doi.org/10.1145/1837853.1693476}
}
```