### PR TITLE
Use C++ compiler for compile and link checks.

### DIFF
--- a/cmake/configure/configure_50_scalapack.cmake
+++ b/cmake/configure/configure_50_scalapack.cmake
@@ -29,16 +29,16 @@ macro(feature_scalapack_find_external var)
     if (${var})
       clear_cmake_required()
       set(CMAKE_REQUIRED_LIBRARIES ${SCALAPACK_LIBRARIES} ${LAPACK_LIBRARIES})
-      CHECK_C_SOURCE_COMPILES("
-        void pdsyevr_();
-        void pssyevr_();
+      CHECK_CXX_SOURCE_COMPILES("
+        extern \"C\" void pdsyevr_();
+        extern \"C\" void pssyevr_();
         int main(){
           pdsyevr_();
           pssyevr_();
           return 0;
         }"
         DEAL_II_SCALAPACK_HAS_PDSYEVR_PSSYEVR)
-        reset_cmake_required()
+      reset_cmake_required()
 
       if(NOT DEAL_II_SCALAPACK_HAS_PDSYEVR_PSSYEVR)
         message(STATUS "Could not find a sufficient SCALAPACK installation: "


### PR DESCRIPTION
For the reasons describes in #18481, we should be using the C++ compiler for compile/link checks, not the C compiler. This fixes the one remaining place.

Fixes #18481.