### PR TITLE
Do not use deallog in step-39.

### DIFF
--- a/examples/step-39/doc/results.dox
+++ b/examples/step-39/doc/results.dox
@@ -4,65 +4,65 @@
 First, the program produces the usual logfile here stored in <tt>deallog</tt>. It reads (with omission of intermediate steps)
 
 @code
-DEAL::Element: FE_DGQ<2>(3)
-DEAL::Step 0
-DEAL::Triangulation 16 cells, 2 levels
-DEAL::DoFHandler 256 dofs, level dofs 64 256
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 13 iterations
-DEAL::energy-error: 0.297419
-DEAL::L2-error:     0.00452447
-DEAL::Estimate 0.990460
-DEAL::Writing solution to <sol-00.gnuplot>...
-DEAL::
-DEAL::Step 1
-DEAL::Triangulation 25 cells, 3 levels
-DEAL::DoFHandler 400 dofs, level dofs 64 256 192
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 14 iterations
-DEAL::energy-error: 0.258559
-DEAL::L2-error:     0.00288510
-DEAL::Estimate 0.738624
-DEAL::Writing solution to <sol-01.gnuplot>...
+Element: FE_DGQ<2>(3)
+Step 0
+Triangulation 16 cells, 2 levels
+DoFHandler 256 dofs, level dofs 64 256
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 13 iterations
+energy-error: 0.297419
+L2-error:     0.00452447
+Estimate 0.990460
+Writing solution to <sol-00.gnuplot>...
+
+Step 1
+Triangulation 25 cells, 3 levels
+DoFHandler 400 dofs, level dofs 64 256 192
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 14 iterations
+energy-error: 0.258559
+L2-error:     0.00288510
+Estimate 0.738624
+Writing solution to <sol-01.gnuplot>...
 
 ...
 
-DEAL::Step 10
-DEAL::Triangulation 232 cells, 11 levels
-DEAL::DoFHandler 3712 dofs, level dofs 64 256 896 768 768 640 512 256 256 256 256
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 15 iterations
-DEAL::energy-error: 0.0132475
-DEAL::L2-error:     1.00423e-05
-DEAL::Estimate 0.0470724
-DEAL::Writing solution to <sol-10.gnuplot>...
-DEAL::
-DEAL::Step 11
-DEAL::Triangulation 322 cells, 12 levels
-DEAL::DoFHandler 5152 dofs, level dofs 64 256 1024 1024 896 768 768 640 448 320 320 320
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 15 iterations
-DEAL::energy-error: 0.00934891
-DEAL::L2-error:     5.41095e-06
-DEAL::Estimate 0.0329102
-DEAL::Writing solution to <sol-11.gnuplot>...
-DEAL::
+Step 10
+Triangulation 232 cells, 11 levels
+DoFHandler 3712 dofs, level dofs 64 256 896 768 768 640 512 256 256 256 256
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 15 iterations
+energy-error: 0.0132475
+L2-error:     1.00423e-05
+Estimate 0.0470724
+Writing solution to <sol-10.gnuplot>...
+
+Step 11
+Triangulation 322 cells, 12 levels
+DoFHandler 5152 dofs, level dofs 64 256 1024 1024 896 768 768 640 448 320 320 320
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 15 iterations
+energy-error: 0.00934891
+L2-error:     5.41095e-06
+Estimate 0.0329102
+Writing solution to <sol-11.gnuplot>...
 @endcode
 
 This log for instance shows that the number of conjugate gradient
 iteration steps is constant at approximately 15.
+
 
 <h3>Postprocessing of the logfile</h3>
 

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -838,8 +838,8 @@ namespace Step39
     // and use it to solve the system.
     solver.solve(matrix, solution, right_hand_side, preconditioner);
 
-    deallog << "Converged in " << control.last_step() << " iterations"
-            << std::endl;
+    std::cout << "Converged in " << control.last_step() << " iterations"
+              << std::endl;
   }
 
 
@@ -977,8 +977,8 @@ namespace Step39
                                assembler);
     triangulation.load_user_indices(old_user_indices);
 
-    deallog << "energy-error: " << errors.block(0).l2_norm() << std::endl;
-    deallog << "L2-error:     " << errors.block(1).l2_norm() << std::endl;
+    std::cout << "energy-error: " << errors.block(0).l2_norm() << std::endl;
+    std::cout << "L2-error:     " << errors.block(1).l2_norm() << std::endl;
   }
 
 
@@ -992,8 +992,8 @@ namespace Step39
     const std::string filename =
       "sol-" + Utilities::int_to_string(cycle, 2) + ".gnuplot";
 
-    deallog << "Writing solution to <" << filename << ">..." << std::endl
-            << std::endl;
+    std::cout << "Writing solution to <" << filename << ">..." << std::endl
+              << std::endl;
     std::ofstream gnuplot_output(filename);
 
     DataOut<dim> data_out;
@@ -1010,10 +1010,10 @@ namespace Step39
   template <int dim>
   void InteriorPenaltyProblem<dim>::run(unsigned int n_steps)
   {
-    deallog << "Element: " << fe.get_name() << std::endl;
+    std::cout << "Element: " << fe.get_name() << std::endl;
     for (unsigned int s = 0; s < n_steps; ++s)
       {
-        deallog << "Step " << s << std::endl;
+        std::cout << "Step " << s << std::endl;
         if (estimates.block(0).empty())
           triangulation.refine_global(1);
         else
@@ -1023,26 +1023,27 @@ namespace Step39
             triangulation.execute_coarsening_and_refinement();
           }
 
-        deallog << "Triangulation " << triangulation.n_active_cells()
-                << " cells, " << triangulation.n_levels() << " levels"
-                << std::endl;
+        std::cout << "Triangulation " << triangulation.n_active_cells()
+                  << " cells, " << triangulation.n_levels() << " levels"
+                  << std::endl;
 
         setup_system();
-        deallog << "DoFHandler " << dof_handler.n_dofs() << " dofs, level dofs";
+        std::cout << "DoFHandler " << dof_handler.n_dofs()
+                  << " dofs, level dofs";
         for (unsigned int l = 0; l < triangulation.n_levels(); ++l)
-          deallog << ' ' << dof_handler.n_dofs(l);
-        deallog << std::endl;
+          std::cout << ' ' << dof_handler.n_dofs(l);
+        std::cout << std::endl;
 
-        deallog << "Assemble matrix" << std::endl;
+        std::cout << "Assemble matrix" << std::endl;
         assemble_matrix();
-        deallog << "Assemble multilevel matrix" << std::endl;
+        std::cout << "Assemble multilevel matrix" << std::endl;
         assemble_mg_matrix();
-        deallog << "Assemble right hand side" << std::endl;
+        std::cout << "Assemble right hand side" << std::endl;
         assemble_right_hand_side();
-        deallog << "Solve" << std::endl;
+        std::cout << "Solve" << std::endl;
         solve();
         error();
-        deallog << "Estimate " << estimate() << std::endl;
+        std::cout << "Estimate " << estimate() << std::endl;
         output_results(s);
       }
   }
@@ -1054,12 +1055,7 @@ int main()
 {
   try
     {
-      using namespace dealii;
       using namespace Step39;
-
-      deallog.depth_console(2);
-      std::ofstream logfile("deallog");
-      deallog.attach(logfile);
 
       InteriorPenaltyProblem<2> test1;
       test1.run(12);

--- a/tests/examples/step-39.output
+++ b/tests/examples/step-39.output
@@ -1,40 +1,40 @@
-DEAL::Element: FE_DGQ<2>(3)
-DEAL::Step 0
-DEAL::Triangulation 16 cells, 2 levels
-DEAL::DoFHandler 256 dofs, level dofs 64 256
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 13 iterations
-DEAL::energy-error: 0.297419
-DEAL::L2-error:     0.00452447
-DEAL::Estimate 0.990460
-DEAL::Writing solution to <sol-00.gnuplot>...
-DEAL::
-DEAL::Step 1
-DEAL::Triangulation 25 cells, 3 levels
-DEAL::DoFHandler 400 dofs, level dofs 64 256 192
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 14 iterations
-DEAL::energy-error: 0.258559
-DEAL::L2-error:     0.00288510
-DEAL::Estimate 0.738624
-DEAL::Writing solution to <sol-01.gnuplot>...
-DEAL::
-DEAL::Step 2
-DEAL::Triangulation 34 cells, 4 levels
-DEAL::DoFHandler 544 dofs, level dofs 64 256 256 128
-DEAL::Assemble matrix
-DEAL::Assemble multilevel matrix
-DEAL::Assemble right hand side
-DEAL::Solve
-DEAL::Converged in 15 iterations
-DEAL::energy-error: 0.189234
-DEAL::L2-error:     0.00147954
-DEAL::Estimate 0.657507
-DEAL::Writing solution to <sol-02.gnuplot>...
-DEAL::
+Element: FE_DGQ<2>(3)
+Step 0
+Triangulation 16 cells, 2 levels
+DoFHandler 256 dofs, level dofs 64 256
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 13 iterations
+energy-error: 0.297419
+L2-error:     0.00452447
+Estimate 0.990460
+Writing solution to <sol-00.gnuplot>...
+
+Step 1
+Triangulation 25 cells, 3 levels
+DoFHandler 400 dofs, level dofs 64 256 192
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 14 iterations
+energy-error: 0.258559
+L2-error:     0.00288510
+Estimate 0.738624
+Writing solution to <sol-01.gnuplot>...
+
+Step 2
+Triangulation 34 cells, 4 levels
+DoFHandler 544 dofs, level dofs 64 256 256 128
+Assemble matrix
+Assemble multilevel matrix
+Assemble right hand side
+Solve
+Converged in 15 iterations
+energy-error: 0.189234
+L2-error:     0.00147954
+Estimate 0.657507
+Writing solution to <sol-02.gnuplot>...
+


### PR DESCRIPTION
I think we have largely agreed that tutorial programs should just output to `std::cout` instead of `deallog`. This patch converts step-39, one of currently only 6 remaining programs.