### PR TITLE
Make wrappers modules of their own.

### DIFF
--- a/contrib/utilities/convert_header_file_to_interface_module_unit.py
+++ b/contrib/utilities/convert_header_file_to_interface_module_unit.py
@@ -118,7 +118,7 @@ for line in lines:
         )
 
         for external_project in used_external_projects:
-            output.write("import :interface_partition_" + external_project + ";\n")
+            output.write("import dealii.external." + external_project + ";\n")
 
         for inc in dealii_include_list:
             module_partition = "interface_partition_" + inc.replace("/", "_")

--- a/contrib/utilities/convert_source_file_to_implementation_module_unit.py
+++ b/contrib/utilities/convert_source_file_to_implementation_module_unit.py
@@ -104,7 +104,7 @@ for line in lines:
         )
 
         for external_project in used_external_projects:
-            output.write("import :interface_partition_" + external_project + ";\n")
+            output.write("import dealii.external." + external_project + ";\n")
 
         for inc in dealii_include_list:
             module_partition = "interface_partition_" + inc.replace("/", "_")


### PR DESCRIPTION
The current state of #18482 puts wrappers for external projects into separate modules. This requires an update to the scripts I have added in #18489.

Part of #18071.