### PR TITLE
Do not use deprecated p::d::SolutionTransfer in examples and tests.

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -71,13 +71,6 @@
 #include <locale>
 #include <string>
 
-// This is the only include file that is new: It introduces the
-// parallel::distributed::SolutionTransfer equivalent of the
-// SolutionTransfer class to take a solution from on mesh to the next
-// one upon mesh refinement, but in the case of parallel distributed
-// triangulations:
-#include <deal.II/distributed/solution_transfer.h>
-
 // The following classes are used in parallel distributed computations and
 // have all already been introduced in step-40:
 #include <deal.II/base/index_set.h>
@@ -3249,11 +3242,10 @@ namespace Step32
   void
   BoussinesqFlowProblem<dim>::refine_mesh(const unsigned int max_grid_level)
   {
-    parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-      temperature_trans(temperature_dof_handler);
-    parallel::distributed::SolutionTransfer<dim,
-                                            TrilinosWrappers::MPI::BlockVector>
-      stokes_trans(stokes_dof_handler);
+    SolutionTransfer<dim, TrilinosWrappers::MPI::Vector> temperature_trans(
+      temperature_dof_handler);
+    SolutionTransfer<dim, TrilinosWrappers::MPI::BlockVector> stokes_trans(
+      stokes_dof_handler);
 
     {
       TimerOutput::Scope timer_section(computing_timer,
@@ -3283,9 +3275,8 @@ namespace Step32
           cell->clear_refine_flag();
 
       // With all flags marked as necessary, we can then tell the
-      // parallel::distributed::SolutionTransfer objects to get ready to
-      // transfer data from one mesh to the next, which they will do when
-      // notified by
+      // SolutionTransfer objects to get ready to transfer data from one mesh to
+      // the next, which they will do when notified by
       // Triangulation as part of the @p execute_coarsening_and_refinement() call.
       // The syntax is similar to the non-%parallel solution transfer (with the
       // exception that here a pointer to the vector entries is enough). The

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -50,7 +50,6 @@
 
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
@@ -64,6 +63,7 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/fe_field_function.h>
+#include <deal.II/numerics/solution_transfer.h>
 
 #include <fstream>
 #include <iostream>
@@ -1874,8 +1874,8 @@ namespace Step42
 
     triangulation.prepare_coarsening_and_refinement();
 
-    parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-      solution_transfer(dof_handler);
+    SolutionTransfer<dim, TrilinosWrappers::MPI::Vector> solution_transfer(
+      dof_handler);
     if (transfer_solution)
       solution_transfer.prepare_for_coarsening_and_refinement(solution);
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -364,9 +364,8 @@ namespace Step48
   // cells whose center is within a radius of 11, and then refine once more
   // for a radius 6.  This simple ad hoc refinement could be done better by
   // adapting the mesh to the solution using error estimators during the time
-  // stepping as done in other example programs, and using
-  // parallel::distributed::SolutionTransfer to transfer the solution to the
-  // new mesh.
+  // stepping as done in other example programs, and using SolutionTransfer to
+  // transfer the solution to the new mesh.
   template <int dim>
   void SineGordonProblem<dim>::make_grid_and_dofs()
   {

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -52,7 +52,6 @@ namespace LA
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -87,6 +86,7 @@ namespace LA
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
 #include <deal.II/numerics/vector_tools.h>
+#include <deal.II/numerics/solution_transfer.h>
 
 // These are the only new include files with regard to step-60. In this
 // tutorial, the non-matching coupling between the solid and the fluid is
@@ -1664,8 +1664,7 @@ namespace Step70
           cell->clear_coarsen_flag();
       }
 
-    parallel::distributed::SolutionTransfer<spacedim, LA::MPI::BlockVector>
-      transfer(fluid_dh);
+    SolutionTransfer<spacedim, LA::MPI::BlockVector> transfer(fluid_dh);
 
     fluid_tria.prepare_coarsening_and_refinement();
     transfer.prepare_for_coarsening_and_refinement(locally_relevant_solution);

--- a/examples/step-86/step-86.cc
+++ b/examples/step-86/step-86.cc
@@ -41,7 +41,6 @@
 #include <deal.II/lac/sparsity_tools.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/dofs/dof_handler.h>
@@ -864,8 +863,8 @@ namespace Step86
     const std::vector<PETScWrappers::MPI::Vector> &all_in,
     std::vector<PETScWrappers::MPI::Vector>       &all_out)
   {
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      solution_trans(dof_handler);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> solution_trans(
+      dof_handler);
 
     std::vector<PETScWrappers::MPI::Vector> all_in_ghosted(all_in.size());
     std::vector<const PETScWrappers::MPI::Vector *> all_in_ghosted_ptr(

--- a/tests/distributed_grids/checkpointing_02.cc
+++ b/tests/distributed_grids/checkpointing_02.cc
@@ -30,7 +30,6 @@ const bool run_big = false;
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -51,6 +50,7 @@ const bool run_big = false;
 
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <fstream>
@@ -189,10 +189,8 @@ LaplaceProblem<dim>::run(unsigned int n_cycles_global,
 
         // To be sure, use two SolutionTransfer objects, because the second one
         // will get a large offset
-        parallel::distributed::SolutionTransfer<dim, VectorType> system_trans(
-          dof_handler);
-        parallel::distributed::SolutionTransfer<dim, VectorType> trans2(
-          dof_handler);
+        SolutionTransfer<dim, VectorType> system_trans(dof_handler);
+        SolutionTransfer<dim, VectorType> trans2(dof_handler);
 
         system_trans.prepare_for_serialization(x_system);
         trans2.prepare_for_serialization(y);
@@ -218,10 +216,8 @@ LaplaceProblem<dim>::run(unsigned int n_cycles_global,
         triangulation.coarsen_global(99);
         triangulation.load("restart.mesh");
 
-        parallel::distributed::SolutionTransfer<dim, VectorType> system_trans(
-          dof_handler);
-        parallel::distributed::SolutionTransfer<dim, VectorType> trans2(
-          dof_handler);
+        SolutionTransfer<dim, VectorType> system_trans(dof_handler);
+        SolutionTransfer<dim, VectorType> trans2(dof_handler);
         system_trans.deserialize(x_system);
         trans2.deserialize(y);
 

--- a/tests/distributed_grids/checkpointing_03.cc
+++ b/tests/distributed_grids/checkpointing_03.cc
@@ -27,7 +27,6 @@ const bool run_big = false;
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -48,6 +47,7 @@ const bool run_big = false;
 
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <fstream>
@@ -188,10 +188,8 @@ LaplaceProblem<dim>::run(unsigned int n_cycles_global,
 
         // To be sure, use two SolutionTransfer objects, because the second one
         // will get a large offset
-        parallel::distributed::SolutionTransfer<dim, VectorType> system_trans(
-          dof_handler);
-        parallel::distributed::SolutionTransfer<dim, VectorType> trans2(
-          dof_handler);
+        SolutionTransfer<dim, VectorType> system_trans(dof_handler);
+        SolutionTransfer<dim, VectorType> trans2(dof_handler);
 
 
         dof_handler.prepare_for_serialization_of_active_fe_indices();
@@ -219,10 +217,8 @@ LaplaceProblem<dim>::run(unsigned int n_cycles_global,
         triangulation.coarsen_global(99);
         triangulation.load("restart.mesh");
 
-        parallel::distributed::SolutionTransfer<dim, VectorType> system_trans(
-          dof_handler);
-        parallel::distributed::SolutionTransfer<dim, VectorType> trans2(
-          dof_handler);
+        SolutionTransfer<dim, VectorType> system_trans(dof_handler);
+        SolutionTransfer<dim, VectorType> trans2(dof_handler);
 
         dof_handler.deserialize_active_fe_indices();
         system_trans.deserialize(x_system);

--- a/tests/distributed_grids/solution_transfer_01.cc
+++ b/tests/distributed_grids/solution_transfer_01.cc
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -30,6 +29,8 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -46,7 +47,7 @@ test(std::ostream & /*out*/)
   static const FE_Q<dim> fe(2);
   dofh.distribute_dofs(fe);
 
-  parallel::distributed::SolutionTransfer<dim, Vector<double>> soltrans(dofh);
+  SolutionTransfer<dim, Vector<double>> soltrans(dofh);
 
   for (typename Triangulation<dim>::active_cell_iterator cell =
          tr.begin_active();

--- a/tests/distributed_grids/solution_transfer_02.cc
+++ b/tests/distributed_grids/solution_transfer_02.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -33,6 +32,7 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
@@ -73,7 +73,7 @@ test(std::ostream & /*out*/)
   static const FE_Q<dim> fe(1);
   dofh.distribute_dofs(fe);
 
-  parallel::distributed::SolutionTransfer<dim, Vector<double>> soltrans(dofh);
+  SolutionTransfer<dim, Vector<double>> soltrans(dofh);
 
   for (typename Triangulation<dim>::active_cell_iterator cell =
          tr.begin_active();

--- a/tests/distributed_grids/solution_transfer_03.cc
+++ b/tests/distributed_grids/solution_transfer_03.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -33,6 +32,7 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
@@ -72,7 +72,7 @@ test(std::ostream & /*out*/)
   static const FE_Q<dim> fe(1);
   dofh.distribute_dofs(fe);
 
-  parallel::distributed::SolutionTransfer<dim, Vector<double>> soltrans(dofh);
+  SolutionTransfer<dim, Vector<double>> soltrans(dofh);
 
   for (int i = 0; i < 4; ++i)
     {

--- a/tests/distributed_grids/solution_transfer_04.cc
+++ b/tests/distributed_grids/solution_transfer_04.cc
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/fe/fe_q.h>
@@ -30,6 +29,8 @@
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -49,8 +50,8 @@ test(std::ostream & /*out*/)
   static const FE_Q<dim> fe(2);
   dofh.distribute_dofs(fe);
 
-  parallel::distributed::SolutionTransfer<dim, Vector<double>> soltrans(dofh);
-  parallel::distributed::SolutionTransfer<dim, Vector<double>> soltrans2(dofh);
+  SolutionTransfer<dim, Vector<double>> soltrans(dofh);
+  SolutionTransfer<dim, Vector<double>> soltrans2(dofh);
 
   for (typename Triangulation<dim>::active_cell_iterator cell =
          tr.begin_active();

--- a/tests/fullydistributed_grids/solution_transfer_01.cc
+++ b/tests/fullydistributed_grids/solution_transfer_01.cc
@@ -17,7 +17,6 @@
 // Test distributed solution transfer with fullydistributed triangulations.
 
 #include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -30,6 +29,7 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../grid/tests.h"
@@ -77,8 +77,7 @@ test(TriangulationType &triangulation)
     "solution_transfer_" + std::to_string(dim) + "d_out";
 
   {
-    parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
-      dof_handler);
+    SolutionTransfer<dim, VectorType> solution_transfer(dof_handler);
     solution_transfer.prepare_for_serialization(vector);
 
     triangulation.save(filename);
@@ -90,8 +89,7 @@ test(TriangulationType &triangulation)
     triangulation.load(filename);
     dof_handler.distribute_dofs(FE_Q<dim>(2));
 
-    parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
-      dof_handler);
+    SolutionTransfer<dim, VectorType> solution_transfer(dof_handler);
     solution_transfer.deserialize(vector_loaded);
 
     vector_loaded.update_ghost_values();

--- a/tests/mpi/p4est_2d_constraintmatrix_04.cc
+++ b/tests/mpi/p4est_2d_constraintmatrix_04.cc
@@ -21,7 +21,6 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -42,6 +41,7 @@
 #include <deal.II/lac/trilinos_vector.h>
 
 #include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
@@ -182,9 +182,7 @@ test()
 
 
 
-      parallel::distributed::SolutionTransfer<dim,
-                                              TrilinosWrappers::MPI::Vector>
-        trans(dofh);
+      SolutionTransfer<dim, TrilinosWrappers::MPI::Vector> trans(dofh);
       tr.prepare_coarsening_and_refinement();
 
 

--- a/tests/mpi/p4est_3d_constraintmatrix_03.cc
+++ b/tests/mpi/p4est_3d_constraintmatrix_03.cc
@@ -21,7 +21,6 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -42,6 +41,7 @@
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 
 #include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
@@ -181,9 +181,7 @@ test()
               }
         }
 
-      parallel::distributed::SolutionTransfer<dim,
-                                              TrilinosWrappers::MPI::Vector>
-        trans(dofh);
+      SolutionTransfer<dim, TrilinosWrappers::MPI::Vector> trans(dofh);
       tr.prepare_coarsening_and_refinement();
 
 

--- a/tests/mpi/p4est_save_02.cc
+++ b/tests/mpi/p4est_save_02.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -34,6 +33,8 @@
 #include <deal.II/grid/tria_accessor.h>
 
 #include <deal.II/lac/petsc_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -81,8 +82,7 @@ test()
                                         locally_relevant_dofs,
                                         MPI_COMM_WORLD);
 
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
 
     for (unsigned int i = 0; i < locally_owned_dofs.n_elements(); ++i)
       {
@@ -123,8 +123,7 @@ test()
       DoFTools::extract_locally_relevant_dofs(dh);
 
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, MPI_COMM_WORLD);
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
     solution = 2;
     soltrans.deserialize(solution);
 

--- a/tests/mpi/p4est_save_03.cc
+++ b/tests/mpi/p4est_save_03.cc
@@ -20,7 +20,6 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -35,6 +34,8 @@
 #include <deal.II/grid/tria_accessor.h>
 
 #include <deal.II/lac/petsc_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -86,10 +87,8 @@ test()
                                          locally_relevant_dofs,
                                          MPI_COMM_WORLD);
 
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans(dh);
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans2(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans2(dh);
 
     for (unsigned int i = 0; i < locally_owned_dofs.n_elements(); ++i)
       {
@@ -136,10 +135,8 @@ test()
 
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, MPI_COMM_WORLD);
     PETScWrappers::MPI::Vector solution2(locally_owned_dofs, MPI_COMM_WORLD);
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans(dh);
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans2(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans2(dh);
     solution = 2;
     soltrans.deserialize(solution);
     soltrans2.deserialize(solution2);

--- a/tests/mpi/p4est_save_04.cc
+++ b/tests/mpi/p4est_save_04.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -34,6 +33,8 @@
 #include <deal.II/grid/tria_accessor.h>
 
 #include <deal.II/lac/petsc_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -84,8 +85,7 @@ test()
                                        locally_relevant_dofs,
                                        com_small);
 
-      parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-        soltrans(dh);
+      SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
 
       for (unsigned int i = 0; i < locally_owned_dofs.n_elements(); ++i)
         {
@@ -129,8 +129,7 @@ test()
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, com_all);
     solution = PetscScalar();
 
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
     soltrans.deserialize(solution);
 
     for (unsigned int i = 0; i < locally_owned_dofs.n_elements(); ++i)

--- a/tests/mpi/p4est_save_06.cc
+++ b/tests/mpi/p4est_save_06.cc
@@ -20,7 +20,6 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -35,6 +34,8 @@
 #include <deal.II/grid/tria_accessor.h>
 
 #include <deal.II/lac/petsc_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -91,8 +92,7 @@ test()
                                        locally_relevant_dofs,
                                        com_small);
 
-      parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-        soltrans(dh);
+      SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
 
       for (unsigned int i = 0; i < locally_owned_dofs.n_elements(); ++i)
         {
@@ -143,8 +143,7 @@ test()
     PETScWrappers::MPI::Vector solution(locally_owned_dofs, com_all);
     solution = PetscScalar();
 
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      soltrans(dh);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> soltrans(dh);
 
     soltrans.deserialize(solution);
 

--- a/tests/mpi/solution_transfer_01.cc
+++ b/tests/mpi/solution_transfer_01.cc
@@ -20,7 +20,6 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/tensor.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -41,6 +40,7 @@
 #include <deal.II/lac/petsc_vector.h>
 
 #include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
@@ -70,8 +70,7 @@ test()
                                       locally_relevant_dofs,
                                       MPI_COMM_WORLD);
 
-  parallel::distributed::SolutionTransfer<2, PETScWrappers::MPI::Vector>
-    soltrans(dh);
+  SolutionTransfer<2, PETScWrappers::MPI::Vector> soltrans(dh);
 
   tria.set_all_refine_flags();
   tria.prepare_coarsening_and_refinement();

--- a/tests/mpi/solution_transfer_04.cc
+++ b/tests/mpi/solution_transfer_04.cc
@@ -18,7 +18,6 @@
 // This tests is based on mpi/feindices_transfer.cc
 
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -29,6 +28,8 @@
 #include <deal.II/grid/grid_generator.h>
 
 #include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -97,8 +98,7 @@ test()
 
 
   // ----- transfer -----
-  parallel::distributed::SolutionTransfer<dim, TrilinosWrappers::MPI::Vector>
-    soltrans(dh);
+  SolutionTransfer<dim, TrilinosWrappers::MPI::Vector> soltrans(dh);
 
   soltrans.prepare_for_coarsening_and_refinement(old_solution);
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/solution_transfer_06.cc
+++ b/tests/mpi/solution_transfer_06.cc
@@ -14,12 +14,11 @@
 
 
 
-// Test parallel::distributed::SolutionTransfer for FE_Nothing
+// Test parallel distributed SolutionTransfer for FE_Nothing
 // (see also https://github.com/dealii/dealii/issues/10570).
 
 #include <deal.II/base/function.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -36,6 +35,8 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include <iostream>
 #include <vector>
@@ -76,9 +77,8 @@ transfer(const MPI_Comm comm)
   for (unsigned int i = 0; i < solution.size(); ++i)
     solution(i) = i;
 
-  parallel::distributed::
-    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
-      soltrans(dof_handler);
+  SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>> soltrans(
+    dof_handler);
 
   for (const auto &cell : tria.active_cell_iterators())
     cell->set_refine_flag();

--- a/tests/non_matching/step-70.cc
+++ b/tests/non_matching/step-70.cc
@@ -55,7 +55,6 @@ namespace LA
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -89,6 +88,7 @@ namespace LA
 
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 // These are the only new include files with regard to step-60. In this
@@ -1659,8 +1659,7 @@ namespace Step70
           cell->clear_coarsen_flag();
       }
 
-    parallel::distributed::SolutionTransfer<spacedim, LA::MPI::BlockVector>
-      transfer(fluid_dh);
+    SolutionTransfer<spacedim, LA::MPI::BlockVector> transfer(fluid_dh);
 
     fluid_tria.prepare_coarsening_and_refinement();
     transfer.prepare_for_coarsening_and_refinement(locally_relevant_solution);

--- a/tests/petsc/step-77-snes.cc
+++ b/tests/petsc/step-77-snes.cc
@@ -54,7 +54,6 @@
 #include <deal.II/base/conditional_ostream.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/grid/grid_tools.h>
@@ -437,8 +436,8 @@ namespace Step77
 
     triangulation.prepare_coarsening_and_refinement();
 
-    parallel::distributed::SolutionTransfer<dim, PETScWrappers::MPI::Vector>
-      solution_transfer(dof_handler);
+    SolutionTransfer<dim, PETScWrappers::MPI::Vector> solution_transfer(
+      dof_handler);
 
     PETScWrappers::MPI::Vector current_solution_tmp(locally_relevant_solution);
     solution_transfer.prepare_for_coarsening_and_refinement(


### PR DESCRIPTION
Follow-up to #15706.

Required by #18617.