### PR TITLE
Add doxygen deprecation tag to already `DEAL_II_DEPRECATED_EARLY` function.

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1611,6 +1611,8 @@ public:
    * The normal points in outwards direction as seen from the first cell of
    * this interface.
    *
+   * @deprecated Use the function normal_vector().
+   *
    * @dealiiRequiresUpdateFlags{update_normal_vectors}
    */
   DEAL_II_DEPRECATED_EARLY_WITH_COMMENT("Use the function normal_vector().")


### PR DESCRIPTION
`doxygen` doesn't know anything about the deprecation. Currently, only the compiler complains when using the function.