### PR TITLE
Remove remaining occurences of p::d::SolutionTransfer in examples and tests.

### DIFF
--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -25,7 +25,6 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -44,7 +44,7 @@
 #include <deal.II/base/timer.h>
 #include <deal.II/base/work_stream.h>
 
-#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -2535,9 +2535,8 @@ namespace Step69
       {
         print_head(pcout, "resume interrupted computation");
 
-        parallel::distributed::
-          SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
-            solution_transfer(offline_data.dof_handler);
+        SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
+          solution_transfer(offline_data.dof_handler);
 
         std::vector<LinearAlgebra::distributed::Vector<double> *> vectors;
         std::transform(U.begin(),
@@ -2673,9 +2672,8 @@ namespace Step69
   {
     print_head(pcout, "checkpoint computation");
 
-    parallel::distributed::
-      SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
-        solution_transfer(offline_data.dof_handler);
+    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
+      solution_transfer(offline_data.dof_handler);
 
     std::vector<const LinearAlgebra::distributed::Vector<double> *> vectors;
     std::transform(U.begin(),

--- a/tests/distributed_grids/large_vtu_01.cc
+++ b/tests/distributed_grids/large_vtu_01.cc
@@ -29,7 +29,6 @@ const bool run_big = false;
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/tests/distributed_grids/solution_transfer_05.cc
+++ b/tests/distributed_grids/solution_transfer_05.cc
@@ -19,7 +19,6 @@
 
 #include <deal.II/base/mpi.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -30,6 +29,8 @@
 #include <deal.II/grid/grid_generator.h>
 
 #include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -74,9 +75,8 @@ main(int argc, char **argv)
 
   v.print(deallog.get_file_stream());
 
-  parallel::distributed::
-    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<Number>>
-      solution_trans(dof_handler, true /*enabling averaging*/);
+  SolutionTransfer<dim, LinearAlgebra::distributed::Vector<Number>>
+    solution_trans(dof_handler, true /*enabling averaging*/);
 
   v.update_ghost_values();
   solution_trans.prepare_for_coarsening_and_refinement(v);

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -16,7 +16,6 @@
 #include <deal.II/base/conditional_ostream.h>
 
 #include <deal.II/distributed/grid_refinement.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/mpi/p4est_save_01.cc
+++ b/tests/mpi/p4est_save_01.cc
@@ -19,7 +19,6 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/mpi/solution_transfer_05.cc
+++ b/tests/mpi/solution_transfer_05.cc
@@ -23,7 +23,6 @@
 
 #include <deal.II/base/function.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -39,6 +38,7 @@
 
 #include <deal.II/lac/la_parallel_vector.h>
 
+#include <deal.II/numerics/solution_transfer.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
@@ -81,11 +81,10 @@ test()
                            dgq_solution);
   dgq_solution.update_ghost_values();
 
-  parallel::distributed::
-    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
+  SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
 
 
-      dgq_soltrans(dgq_dof_handler);
+    dgq_soltrans(dgq_dof_handler);
   dgq_soltrans.prepare_for_coarsening_and_refinement(dgq_solution);
 
   // refine and transfer

--- a/tests/mpi/solution_transfer_11.cc
+++ b/tests/mpi/solution_transfer_11.cc
@@ -17,7 +17,6 @@
 // Test distributed SolutionTransfer with hp-refinement and manually set flags.
 
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -30,6 +29,8 @@
 #include <deal.II/hp/fe_collection.h>
 
 #include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
 
 #include "../tests.h"
 
@@ -108,9 +109,8 @@ test()
       }
 
   // initiate refinement and transfer
-  parallel::distributed::
-    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
-      soltrans(dofh);
+  SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>> soltrans(
+    dofh);
   soltrans.prepare_for_coarsening_and_refinement(solution);
 
   tria.execute_coarsening_and_refinement();

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -25,7 +25,6 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/performance/timing_step_68.cc
+++ b/tests/performance/timing_step_68.cc
@@ -31,7 +31,6 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
 
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/simplex/step-68.cc
+++ b/tests/simplex/step-68.cc
@@ -34,7 +34,6 @@
 
 #include <deal.II/distributed/cell_weights.h>
 #include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/solution_transfer.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>


### PR DESCRIPTION
Follow-up to https://github.com/dealii/dealii/pull/15706, #18618.

Required by https://github.com/dealii/dealii/pull/18617.