### PR TITLE
MappingP1: only compute the covariant once.

### DIFF
--- a/include/deal.II/fe/mapping_p1.h
+++ b/include/deal.II/fe/mapping_p1.h
@@ -221,9 +221,14 @@ public:
     mutable Tensor<1, spacedim> affine_component;
 
     /**
-     * Linear component of the transformation.
+     * Linear component of the transformation (the contravariant).
      */
     mutable DerivativeForm<1, dim, spacedim> linear_component;
+
+    /**
+     * Covariant form of the linear transformation.
+     */
+    mutable DerivativeForm<1, dim, spacedim> covariant;
 
     /**
      * Determinant of linear_component.


### PR DESCRIPTION
I did some more profiling and saw that, in the same load vector benchmark, I was computing the covariant about 10 places per cell - its easy enough to just compute it once and store it with the rest of the transformation.

I elected to unconditionally compute the covariant (and determinant of the contravariant in the last PR) since they are constant on each cell and needed most of the time.