### PR TITLE
Fix step-30.

### DIFF
--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -711,8 +711,8 @@ namespace Step30
       // We only need to consider cells which are flagged for refinement.
       if (cell->refine_flag_set())
         {
-          std::array<double, dim> jump_in_coordinate_direction;
-          std::array<double, dim> face_area_in_coordinate_direction;
+          std::array<double, dim> jump_in_coordinate_direction      = {};
+          std::array<double, dim> face_area_in_coordinate_direction = {};
 
           for (const auto face_no : cell->face_indices())
             {


### PR DESCRIPTION
We assume these arrays are filled with zeros - without the call to fill() they instead contain arbitrary values (i.e., undefined behavior).