### PR TITLE
Replace `-numeric_limits::max()` by `numeric_limits::lowest()`

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -436,7 +436,7 @@ unset_if_changed(CHECK_CXX_FEATURES_FLAGS_SAVED
 # Check that we can use feenableexcept through the C++11 header file cfenv:
 #
 # The test is a bit more complicated because we also check that no garbage
-# exception is thrown if we convert -std::numeric_limits<double>::max to a
+# exception is thrown if we convert std::numeric_limits<double>::lowest to a
 # string. This sadly happens with some compiler support libraries :-(
 #
 # - Timo Heister, 2015
@@ -451,7 +451,7 @@ set(_snippet
   {
     feenableexcept(FE_DIVBYZERO|FE_INVALID);
     std::ostringstream description;
-    const double lower_bound = -std::numeric_limits<double>::max();
+    const double lower_bound = std::numeric_limits<double>::lowest();
 
     description << lower_bound;
 

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -673,7 +673,7 @@ namespace Step31
     if (timestep_number != 0)
       {
         double min_temperature = std::numeric_limits<double>::max(),
-               max_temperature = -std::numeric_limits<double>::max();
+               max_temperature = std::numeric_limits<double>::lowest();
 
         for (const auto &cell : temperature_dof_handler.active_cell_iterators())
           {
@@ -699,7 +699,7 @@ namespace Step31
     else
       {
         double min_temperature = std::numeric_limits<double>::max(),
-               max_temperature = -std::numeric_limits<double>::max();
+               max_temperature = std::numeric_limits<double>::lowest();
 
         for (const auto &cell : temperature_dof_handler.active_cell_iterators())
           {

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1374,7 +1374,7 @@ namespace Step32
     // entropy as well as keeps track of the area/volume of the part of the
     // domain we locally own and the integral over the entropy on it:
     double min_entropy = std::numeric_limits<double>::max(),
-           max_entropy = -std::numeric_limits<double>::max(), area = 0,
+           max_entropy = std::numeric_limits<double>::lowest(), area = 0,
            entropy_integrated = 0;
 
     for (const auto &cell : temperature_dof_handler.active_cell_iterators())
@@ -1455,7 +1455,7 @@ namespace Step32
     std::vector<double> old_old_temperature_values(n_q_points);
 
     double min_local_temperature = std::numeric_limits<double>::max(),
-           max_local_temperature = -std::numeric_limits<double>::max();
+           max_local_temperature = std::numeric_limits<double>::lowest();
 
     if (timestep_number != 0)
       {
@@ -2915,7 +2915,7 @@ namespace Step32
             << " CG iterations for temperature" << std::endl;
 
       double temperature[2] = {std::numeric_limits<double>::max(),
-                               -std::numeric_limits<double>::max()};
+                               std::numeric_limits<double>::lowest()};
       double global_temperature[2];
 
       for (unsigned int i =

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -310,7 +310,7 @@ namespace Step36
     // ensure that we can ignore them should they show up in our
     // computations.
     double min_spurious_eigenvalue = std::numeric_limits<double>::max(),
-           max_spurious_eigenvalue = -std::numeric_limits<double>::max();
+           max_spurious_eigenvalue = std::numeric_limits<double>::lowest();
 
     for (unsigned int i = 0; i < dof_handler.n_dofs(); ++i)
       if (constraints.is_constrained(i))

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1696,7 +1696,7 @@ namespace Step42
                                                        mpi_communicator);
 
     double residual_norm;
-    double previous_residual_norm = -std::numeric_limits<double>::max();
+    double previous_residual_norm = std::numeric_limits<double>::lowest();
 
     const double correct_sigma = sigma_0;
 

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -1989,7 +1989,7 @@ namespace Step43
     if (timestep_number != 0)
       {
         double min_saturation = std::numeric_limits<double>::max(),
-               max_saturation = -std::numeric_limits<double>::max();
+               max_saturation = std::numeric_limits<double>::lowest();
 
         for (const auto &cell : saturation_dof_handler.active_cell_iterators())
           {
@@ -2015,7 +2015,7 @@ namespace Step43
     else
       {
         double min_saturation = std::numeric_limits<double>::max(),
-               max_saturation = -std::numeric_limits<double>::max();
+               max_saturation = std::numeric_limits<double>::lowest();
 
         for (const auto &cell : saturation_dof_handler.active_cell_iterators())
           {


### PR DESCRIPTION
This PR replaces [`-std::numeric_limits<T>::max`](https://en.cppreference.com/w/cpp/types/numeric_limits/max.html) by [`-std::numeric_limits<T>::lowest`](https://en.cppreference.com/w/cpp/types/numeric_limits/lowest) as per issue https://github.com/dealii/dealii/issues/18610.