### PR TITLE
try to hide trilinos 16 warnings

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -604,6 +604,7 @@ _Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")           /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Wextra\"")                     /*!*/ \
 _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
 _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")              \
+_Pragma("GCC diagnostic ignored \"-Wcpp\"")                             \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-copy\"")                 \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
 _Pragma("GCC diagnostic ignored \"-Wdeprecated-volatile\"")             \

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -33,10 +33,14 @@
 
 
 #ifdef DEAL_II_WITH_TRILINOS
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Map.h>
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #    include <Tpetra_Map.hpp>
 #  endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 #endif
 
 #ifdef DEAL_II_WITH_PETSC

--- a/include/deal.II/base/trilinos_utilities.h
+++ b/include/deal.II/base/trilinos_utilities.h
@@ -20,6 +20,8 @@
 #include <deal.II/base/exceptions.h>
 
 #ifdef DEAL_II_WITH_TRILINOS
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Comm.h>
 #  include <Epetra_Map.h>
 #  include <Teuchos_Comm.hpp>
@@ -34,6 +36,7 @@
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #    include <Teuchos_RCPDecl.hpp>
 #  endif // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -39,7 +39,9 @@
 #  include <deal.II/lac/trilinos_tpetra_block_vector.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_MultiVector.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #endif
 

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -34,7 +34,9 @@
 #  include <deal.II/lac/trilinos_epetra_communication_pattern.h>
 #  include <deal.II/lac/trilinos_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Import.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 #include <boost/io/ios_state.hpp>

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -22,7 +22,9 @@
 
 #  include <deal.II/base/communication_pattern_base.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Import.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -28,7 +28,9 @@
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_type_traits.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_FEVector.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 

--- a/include/deal.II/lac/trilinos_index_access.h
+++ b/include/deal.II/lac/trilinos_index_access.h
@@ -21,10 +21,13 @@
 
 #  include <deal.II/base/types.h>
 
+
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_BlockMap.h>
 #  include <Epetra_CrsGraph.h>
 #  include <Epetra_CrsMatrix.h>
 #  include <Epetra_MultiVector.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -25,12 +25,14 @@
 #  include <deal.II/lac/la_parallel_vector.h>
 #  include <deal.II/lac/trilinos_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Map.h>
 #  include <Epetra_MpiComm.h>
 #  include <Epetra_MultiVector.h>
 #  include <Epetra_RowMatrix.h>
 #  include <Epetra_Vector.h>
 #  include <Teuchos_ParameterList.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -27,6 +27,8 @@
 #  include <deal.II/lac/solver_control.h>
 #  include <deal.II/lac/vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+
 // for AztecOO solvers
 #  include <Amesos.h>
 #  include <AztecOO.h>
@@ -43,6 +45,9 @@
 #    include <BelosOperator.hpp>
 #    include <BelosSolverManager.hpp>
 #  endif
+
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 
 #  include <memory>
 

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -33,6 +33,7 @@
 #    include <deal.II/lac/vector_memory.h>
 #    include <deal.II/lac/vector_operation.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #    include <Epetra_Comm.h>
 #    include <Epetra_CrsGraph.h>
 #    include <Epetra_Export.h>
@@ -41,6 +42,7 @@
 #    include <Epetra_MpiComm.h>
 #    include <Epetra_MultiVector.h>
 #    include <Epetra_Operator.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #    include <cmath>
 #    include <iterator>

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -27,9 +27,11 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/sparsity_pattern_base.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_FECrsGraph.h>
 #  include <Epetra_Map.h>
 #  include <Epetra_MpiComm.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <cmath>
 #  include <memory>

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -29,11 +29,13 @@
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_type_traits.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_ConfigDefs.h>
 #  include <Epetra_FEVector.h>
 #  include <Epetra_LocalMap.h>
 #  include <Epetra_Map.h>
 #  include <Epetra_MpiComm.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 #  include <utility>

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #ifdef DEAL_II_WITH_TRILINOS
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  ifdef DEAL_II_WITH_MPI
 #    include <Epetra_MpiComm.h>
 #  endif
@@ -32,6 +33,7 @@
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #    include <Tpetra_Map.hpp>
 #  endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -28,7 +28,9 @@
 #    include <deal.II/lac/trilinos_parallel_block_vector.h>
 #    include <deal.II/lac/trilinos_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #    include <Epetra_MpiComm.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  endif
 #endif
 

--- a/source/base/trilinos_utilities.cc
+++ b/source/base/trilinos_utilities.cc
@@ -16,12 +16,14 @@
 #include <deal.II/base/trilinos_utilities.h>
 
 #ifdef DEAL_II_WITH_TRILINOS
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  ifdef DEAL_II_WITH_MPI
 #    include <Epetra_MpiComm.h>
 #    include <Teuchos_DefaultComm.hpp>
 #  endif
 #  include <Epetra_SerialComm.h>
 #  include <Teuchos_RCP.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/lac/trilinos_epetra_communication_pattern.cc
+++ b/source/lac/trilinos_epetra_communication_pattern.cc
@@ -18,7 +18,9 @@
 
 #  include <deal.II/base/index_set.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Map.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -20,11 +20,13 @@
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_MultiVector.h>
 #  include <Ifpack.h>
 #  include <Ifpack_Chebyshev.h>
 #  include <Teuchos_ParameterList.hpp>
 #  include <Teuchos_RCP.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -21,6 +21,8 @@
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+
 #  include <Epetra_MultiVector.h>
 #  include <Ifpack.h>
 #  include <Ifpack_Chebyshev.h>
@@ -28,6 +30,8 @@
 #  include <Teuchos_RCP.hpp>
 #  include <ml_MultiLevelPreconditioner.h>
 #  include <ml_include.h>
+
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -22,11 +22,15 @@
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_vector.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+
 #  include <AztecOO_StatusTest.h>
 #  include <AztecOO_StatusTestCombo.h>
 #  include <AztecOO_StatusTestMaxIters.h>
 #  include <AztecOO_StatusTestResNorm.h>
 #  include <AztecOO_StatusType.h>
+
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <cmath>
 #  include <limits>

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -29,6 +29,7 @@
 
 #  include <boost/container/small_vector.hpp>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  ifdef DEAL_II_TRILINOS_WITH_EPETRAEXT
 #    include <EpetraExt_MatrixMatrix.h>
 #  endif
@@ -36,6 +37,7 @@
 #  include <Teuchos_RCP.hpp>
 #  include <ml_epetra_utils.h>
 #  include <ml_struct.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -23,7 +23,9 @@
 #  include <deal.II/lac/dynamic_sparsity_pattern.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Export.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <limits>
 

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -26,9 +26,11 @@
 
 #  include <boost/io/ios_state.hpp>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_Export.h>
 #  include <Epetra_Import.h>
 #  include <Epetra_Vector.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <cmath>
 #  include <memory>


### PR DESCRIPTION
Trilinos 16 deprecates various packages (epetra, ML, AztecOO) and including any of the headers prints a warning. Let's silence them.

See #18631