### PR TITLE
ArborX: fix compilation with versions < 2

### DIFF
--- a/include/deal.II/arborx/access_traits.h
+++ b/include/deal.II/arborx/access_traits.h
@@ -1261,7 +1261,6 @@ namespace ArborX
                           sphere.second},
                    sph_nearest.get_n_nearest_neighbors());
   }
-} // namespace ArborX
 #  else
   template <int dim, typename Number>
   inline std::size_t


### PR DESCRIPTION
This fixes a closing braces mismatch when ArborX is configured with version 1.6.

In reference to #18564
