### PR TITLE
CMake: only configure ArborX 2.0 onwards when C++20 is available

### DIFF
--- a/cmake/configure/configure_50_arborx.cmake
+++ b/cmake/configure/configure_50_arborx.cmake
@@ -69,7 +69,23 @@ macro(feature_arborx_find_external var)
         set(ARBORX_ADDITIONAL_ERROR_STRING
           ${ARBORX_ADDITIONAL_ERROR_STRING}
           "Could not find a sufficient ArborX installation:\n"
-          "The ArborX version doesn't work with C++20 or higher. Try using a later ArborX release or try specifying a lower C++ standard.\n"
+          "The ArborX version doesn't work with C++20 or higher. "
+          "Try using a later ArborX release or try specifying a lower C++ standard.\n"
+          )
+        set(${var} FALSE)
+      endif()
+    endif()
+
+    if(ArborX_VERSION VERSION_GREATER_EQUAL 2.0.0)
+      if(NOT DEAL_II_HAVE_CXX20)
+        message(STATUS "Could not find a sufficient ArborX installation: "
+          "The ArborX version ${ArborX_VERSION} requires C++20 or higher."
+          )
+        set(ARBORX_ADDITIONAL_ERROR_STRING
+          ${ARBORX_ADDITIONAL_ERROR_STRING}
+          "Could not find a sufficient ArborX installation:\n"
+          "The ArborX version ${ArborX_VERSION} requires C++20 or higher. "
+          "Try using an earlier ArborX release or try specifying a higher C++ standard.\n"
           )
         set(${var} FALSE)
       endif()


### PR DESCRIPTION
In reference to: #18646
