### PR TITLE
Fix step-79 crash

### DIFF
--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -2411,18 +2411,24 @@ namespace SAND
 
         // At the end of the outer loop, we have to update the
         // barrier parameter, for which we use the following
-        // formula. The rest of the function is then simply about
-        // checking the outer loop convergence condition, and if
+        // algorithm: First we reduce the barrier parameter
+        // to the smaller of two potential values (causing first a
+        // linear and later an exponential decrease), then
+        // we ensure we do not reduce the barrier parameter
+        // below a lower limit.
+        // Once we reach the lower limit for the barrier parameter
+        // the rest of the function is simply about
+        // checking the outer loop convergence condition, and when
         // we decide to terminate computations, about writing the
         // final "design" as an STL file for use in 3d printing,
         // and to output some timing information.
         const double barrier_size_multiplier = .8;
         const double barrier_size_exponent   = 1.2;
 
-        barrier_size =
-          std::clamp(barrier_size * barrier_size_multiplier,
-                     min_barrier_size,
-                     std::pow(barrier_size, barrier_size_exponent));
+        barrier_size = std::min(barrier_size * barrier_size_multiplier,
+                                std::pow(barrier_size, barrier_size_exponent));
+
+        barrier_size = std::max(barrier_size, min_barrier_size);
 
         std::cout << std::endl;
       }


### PR DESCRIPTION
Running step-79 to the end results in the following error message in the final iteration:
```
/usr/include/c++/13/bits/stl_algo.h:3669: constexpr const _Tp& std::clamp(const _Tp&, const _Tp&, const _Tp&) [with _Tp = double]: Assertion '!(__hi < __lo)' failed.
```

This is triggered, because the higher limit of std::clamp is smaller than the lower limit. Trying to fix the order of argument doesnt work, because `std::clamp` is the wrong function for the operation performed here. #18256 replaced the previous use of `std::min(std::max ...` by `std::clamp` [here](https://github.com/dealii/dealii/pull/18256/files#diff-bedd35f3640e21dc714790e48d3ecf121c21df458b0061f0dc49e6ae9cd4a4daL2423), because it *looked* as if it was a clamp operation. In practice it is an algorithm that reduces `barrier_size` to the minimum of two other numbers (where it is undetermined which of them is smaller), and then ensures the result is not below a lower limit. I tried to explain this better in the comment and restored the previous version of the code (with some formatting improvements to make the separate purpose of the `std::min` and `std::max` more obvious).