### PR TITLE
Fix interpolation component in step-93

### DIFF
--- a/examples/step-93/doc/intro.dox
+++ b/examples/step-93/doc/intro.dox
@@ -31,7 +31,7 @@ functions and that, after discretization of the whole problem, are not
 tied to one of the cells of the mesh. As a consequence, we call these
 unknowns *non-local degrees of freedom* to represent that they are not
 tied to a specific locality: They represent something that does not
-depend to the spatial variable $\mathbf x$ at all, and is not the
+depend on the spatial variable $\mathbf x$ at all, and is not the
 result of a discretization process.
 
 Before going into how we solve this issue, let us first state the concrete set of equations.

--- a/examples/step-93/step-93.cc
+++ b/examples/step-93/step-93.cc
@@ -712,7 +712,12 @@ namespace Step93
     // interpolate the target function $\bar u$ onto the mesh, then
     // add the data to our data_out object.
     Vector<double> target(new_dof_handler.n_dofs());
-    VectorTools::interpolate(new_dof_handler, target_function, target);
+    VectorTools::interpolate(new_dof_handler,
+                             ScalarFunctionFromFunctionObject<dim, double>(
+                               [&](const Point<dim> &x) {
+                                 return target_function.value(x, 0);
+                               }),
+                             target);
     data_out.add_data_vector(new_dof_handler, target, "u_bar");
 
     // In order to visualize the sum of the heat sources $\sum_k C^k


### PR DESCRIPTION
One more fix in the tutorial programs. If I run step-93 in debug mode it crashes with the following message:
```
Number of active cells: 16384
Number of degrees of freedom: 66049+66049+4 = 132102
Number of nonlocal dofs: 4
Beginning solve...
Wall time: 562.295s
Solved in 39973 MINRES iterations.

--------------------------------------------------------
An error occurred in line <602> of file </home/rene/software/dealii/include/deal.II/numerics/vector_tools_interpolate.templates.h> in function
    void dealii::VectorTools::interpolate(const dealii::DoFHandler<dim, spacedim>&, const dealii::Function<spacedim, typename VectorType::value_type>&, VectorType&, const dealii::ComponentMask&, unsigned int) [with int dim = 2; int spacedim = 2; VectorType = dealii::Vector<double>; typename VectorType::value_type = double]
The violated condition was:
    ::dealii::deal_II_exceptions::internals::compare_for_equality(dof.get_fe_collection().n_components(), function.n_components)
Additional information:
    Two sizes or dimensions were supposed to be equal, but aren't. They
    are 1 and 3.

Stacktrace:
-----------
#0  /home/rene/software/deal.II-dev/lib/libdeal_II.g.so.9.7.0-pre: void dealii::VectorTools::interpolate<2, 2, dealii::Vector<double> >(dealii::DoFHandler<2, 2> const&, dealii::Function<2, dealii::Vector<double>::value_type> const&, dealii::Vector<double>&, dealii::ComponentMask const&, unsigned int)
#1  ./step-93: Step93::Step93<2>::output_results() const
#2  ./step-93: Step93::Step93<2>::run()
#3  ./step-93: main
--------------------------------------------------------
```

This is because the target_function has 3 components, but the FE of the DoFHandler only 1. This happens to work correctly in release mode, because the assert is removed, and the interpolation interpolates the first component of the function into the vector, which is intended.

This PR fixes the crash and does not change the result.