### PR TITLE
Update step-68 output

### DIFF
--- a/examples/step-68/doc/results.dox
+++ b/examples/step-68/doc/results.dox
@@ -9,14 +9,14 @@ On any number of cores, the simulation output will look like:
 
 @code
 bash$ mpirun -np 4 ./step-68 parameters.prm
-Number of particles inserted: 606
+Number of particles inserted: 384
 Repartitioning triangulation after particle generation
 Writing particle output file: analytical-particles-0
 Writing particle output file: analytical-particles-10
 Writing particle output file: analytical-particles-20
 Writing particle output file: analytical-particles-30
 ...
-Number of particles inserted: 606
+Number of particles inserted: 384
 Repartitioning triangulation after particle generation
 Writing particle output file: interpolated-particles-0
 Writing background field file: background-0


### PR DESCRIPTION
Some time after step-68 was added the number of particles changed, but was not updated in the documentation. The step-68 test result already contains the new number (384): https://github.com/dealii/dealii/blob/master/tests/examples/step-68.with_p4est%3Dtrue.output