### PR TITLE
Fix some issues with example tests.

### DIFF
--- a/tests/examples/CMakeLists.txt.in
+++ b/tests/examples/CMakeLists.txt.in
@@ -30,7 +30,7 @@ foreach(_step ${_steps})
 
   # Create symbolic links to the output files:
   file(GLOB _output_files
-    "${_base_directory}/${_step}*.output*" "${_base_directory}/${_step}*.run_only"
+    "${_base_directory}/${_step}.*output*" "${_base_directory}/${_step}.*run_only"
     )
   foreach(_file ${_output_files})
     get_filename_component(_destination "${_file}" NAME)

--- a/tests/examples/CMakeLists.txt.in
+++ b/tests/examples/CMakeLists.txt.in
@@ -32,6 +32,12 @@ foreach(_step ${_steps})
   file(GLOB _output_files
     "${_base_directory}/${_step}.*output*" "${_base_directory}/${_step}.*run_only"
     )
+  if(NOT _output_files)
+    message(FATAL_ERROR
+      "\nMissing ${_step}.output file for example ${_step}.\n"
+      "Consult tests/examples/README.md for instructions.\n"
+      )
+  endif()
   foreach(_file ${_output_files})
     get_filename_component(_destination "${_file}" NAME)
     set(_destination "${CMAKE_CURRENT_SOURCE_DIR}/${_destination}")


### PR DESCRIPTION
The previous pattern with which we found output files for a tutorial was erroneous. The previous position of the wildcard allowed many more output files to be associated with a tutorial. For example, for `_step=step-6`, it found `step-6.output`, `step-60.with_umfpack=true.with_muparser=true.output`, `step-61.output`, etc. This is corrected with the first commit.

In the second commit, the new conditional checks that there is at least one output file per tutorial. In other words, we ensure that there is at least one test for each tutorial.

Motivated and blocked by #18663.