### PR TITLE
Replace deprecated std::shared_ptr<T>::unique

### DIFF
--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -654,7 +654,7 @@ CellDataStorage<CellIteratorType, DataType>::erase(const CellIteratorType &cell)
   for (unsigned int i = 0; i < it->second.size(); ++i)
     {
       Assert(
-        it->second[i].unique(),
+        it->second[i].use_count() == 1,
         ExcMessage(
           "Can not erase the cell data multiple objects reference its data."));
     }
@@ -678,7 +678,7 @@ CellDataStorage<CellIteratorType, DataType>::clear()
       for (unsigned int i = 0; i < it->second.size(); ++i)
         {
           Assert(
-            it->second[i].unique(),
+            it->second[i].use_count() == 1,
             ExcMessage(
               "Can not erase the cell data, multiple objects reference it."));
         }


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/memory/shared_ptr/unique.html shows that `std::shared_ptr<T>::unique` has bee deprecated in C++17 and was removed for the C++20 standard.
Addresses https://cdash.dealii.org/test/2217221.