### PR TITLE
Fix deprecation warnings in grid generator and manifold

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -1268,7 +1268,7 @@ template <int dim, int spacedim>
 inline const Point<spacedim> &
 SphericalManifold<dim, spacedim>::get_center() const
 {
-  return center;
+  return p_center;
 }
 
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -3798,7 +3798,9 @@ namespace GridGenerator
       dynamic_cast<const PolarManifold<2> *>(
         &tria_2.get_manifold(cylindrical_manifold_id));
     Assert(m_ptr != nullptr, ExcInternalError());
-    const Point<3>     axial_point(m_ptr->center[0], m_ptr->center[1], 0.0);
+    const Point<3>     axial_point(m_ptr->get_center()[0],
+                               m_ptr->get_center()[1],
+                               0.0);
     const Tensor<1, 3> direction{{0.0, 0.0, 1.0}};
 
     tria.set_manifold(cylindrical_manifold_id, FlatManifold<3>());
@@ -4044,7 +4046,9 @@ namespace GridGenerator
       dynamic_cast<const PolarManifold<2> *>(
         &tria_2.get_manifold(cylindrical_manifold_id));
     Assert(m_ptr != nullptr, ExcInternalError());
-    const Point<3>     axial_point(m_ptr->center[0], m_ptr->center[1], 0.0);
+    const Point<3>     axial_point(m_ptr->get_center()[0],
+                               m_ptr->get_center()[1],
+                               0.0);
     const Tensor<1, 3> direction{{0.0, 0.0, 1.0}};
 
     tria.set_manifold(cylindrical_manifold_id, FlatManifold<3>());

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -123,6 +123,7 @@ namespace internal
 // PolarManifold
 // ============================================================
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 template <int dim, int spacedim>
 PolarManifold<dim, spacedim>::PolarManifold(const Point<spacedim> center)
   : ChartManifold<dim, spacedim, spacedim>(
@@ -130,6 +131,7 @@ PolarManifold<dim, spacedim>::PolarManifold(const Point<spacedim> center)
   , center(center)
   , p_center(center)
 {}
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
 
@@ -331,12 +333,12 @@ PolarManifold<dim, spacedim>::normal_vector(
   // (tangential to the sphere).  In this case, the normal vector is
   // easy to compute since it is proportional to the vector from the
   // center to the point 'p'.
-  if (spherical_face_is_horizontal<dim, spacedim>(face, center))
+  if (spherical_face_is_horizontal<dim, spacedim>(face, p_center))
     {
       // So, if this is a "horizontal" face, then just compute the normal
       // vector as the one from the center to the point 'p', adequately
       // scaled.
-      const Tensor<1, spacedim> unnormalized_spherical_normal = p - center;
+      const Tensor<1, spacedim> unnormalized_spherical_normal = p - p_center;
       const Tensor<1, spacedim> normalized_spherical_normal =
         unnormalized_spherical_normal / unnormalized_spherical_normal.norm();
       return normalized_spherical_normal;
@@ -355,6 +357,7 @@ PolarManifold<dim, spacedim>::normal_vector(
 // SphericalManifold
 // ============================================================
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 template <int dim, int spacedim>
 SphericalManifold<dim, spacedim>::SphericalManifold(
   const Point<spacedim> center)
@@ -362,6 +365,7 @@ SphericalManifold<dim, spacedim>::SphericalManifold(
   , p_center(center)
   , polar_manifold(center)
 {}
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
 


### PR DESCRIPTION
While testing https://github.com/dealii/dealii/releases/tag/v9.7.0-rc1 on different systems I came across deprecation warnings like the following (and more on the same topic) on a system with Intel compilers 19.1.1 (TACC Frontera):

```
/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/source/grid/manifold_lib.cc(131): warning #1786: member "dealii::PolarManifold<dim, spacedim>::center" (declared at line 153 of "/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/include/deal.II/grid/manifold_lib.h") was declared deprecated ("Access the center with get_center() instead.")
    , center(center)
      ^

/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/source/grid/manifold_lib.cc(364): warning #1786: member "dealii::SphericalManifold<dim, spacedim>::center" (declared at line 359 of "/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/include/deal.II/grid/manifold_lib.h") was declared deprecated ("Access the center with get_center() instead.")
    : center(center)
      ^

/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/source/grid/manifold_lib.cc(131): warning #1786: member "dealii::PolarManifold<dim, spacedim>::center" (declared at line 153 of "/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/include/deal.II/grid/manifold_lib.h") was declared deprecated ("Access the center with get_center() instead.")
    , center(center)
      ^

/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/source/grid/manifold_lib.cc(364): warning #1786: member "dealii::SphericalManifold<dim, spacedim>::center" (declared at line 359 of "/scratch1/03834/gassmoel/tmp/unpack/deal.II-v9.7.0-rc1/include/deal.II/grid/manifold_lib.h") was declared deprecated ("Access the center with get_center() instead.")
    : center(center)
      ^

```

It looks like the member variable `center` was deprecated, but we still use it in a few places in the library. I replaced those uses inside the classes with the replacement (private) variable `p_center` and outside the classes with `get_center()`. However, at least in the constructors of the two affected classes we need to set the deprecated variable for users that still use it. I tried disabling the deprecation warnings with `DEAL_II_DISABLE_EXTRA_DIAGNOSTICS`, but that didnt seem to help, I still see the warnings listed above (I fixed all other related warnings with the changes in this PR). Did I overlook something? Is there a better way to disable the deprecation warnings for an access to a deprecated variable?

Follow-up to #17187.