### PR TITLE
Fix name of an HTML anchor.

### DIFF
--- a/examples/step-1/doc/intro.dox
+++ b/examples/step-1/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-1-Intro"></a>
+<a name="step_1-Intro"></a>
 <h1>Introduction</h1>
 
 <h3> About the tutorial </h3>

--- a/examples/step-10/doc/intro.dox
+++ b/examples/step-10/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-10-Intro"></a>
+<a name="step_10-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-11/doc/intro.dox
+++ b/examples/step-11/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-11-Intro"></a>
+<a name="step_11-Intro"></a>
 <h1>Introduction</h1>
 
 The problem we will be considering is the solution of Laplace's problem with

--- a/examples/step-12/doc/intro.dox
+++ b/examples/step-12/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-12-Intro"></a>
+<a name="step_12-Intro"></a>
 <h1>An example of an advection problem using the Discountinuous Galerkin method</h1>
 
 <h3>Overview</h3>

--- a/examples/step-13/doc/intro.dox
+++ b/examples/step-13/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-13-Intro"></a>
+<a name="step_13-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Background and purpose</h3>

--- a/examples/step-14/doc/intro.dox
+++ b/examples/step-14/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-14-Intro"></a>
+<a name="step_14-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>The maths</h3>

--- a/examples/step-15/doc/intro.dox
+++ b/examples/step-15/doc/intro.dox
@@ -6,7 +6,7 @@ is by him.
 <br>
 
 
-<a name="step-15-Intro"></a>
+<a name="step_15-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Foreword</h3>

--- a/examples/step-16/doc/intro.dox
+++ b/examples/step-16/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-16-Intro"></a>
+<a name="step_16-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-17/doc/intro.dox
+++ b/examples/step-17/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-17-Intro"></a>
+<a name="step_17-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Overview</h3>

--- a/examples/step-18/doc/intro.dox
+++ b/examples/step-18/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-18-Intro"></a>
+<a name="step_18-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-19/doc/intro.dox
+++ b/examples/step-19/doc/intro.dox
@@ -10,7 +10,7 @@ awards DMS-1821210, EAR-1550901, and OAC-1835673.
   the publication @cite GLHPW2018 if you use particle functionality in your
   own work.
 
-<a name="step-19-Intro"></a>
+<a name="step_19-Intro"></a>
 <h1>Introduction</h1>
 
 The finite element method in general, and deal.II in particular, were invented

--- a/examples/step-2/doc/intro.dox
+++ b/examples/step-2/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-2-Intro"></a>
+<a name="step_2-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{9}

--- a/examples/step-20/doc/intro.dox
+++ b/examples/step-20/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-20-Intro"></a>
+<a name="step_20-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{19,20,21}

--- a/examples/step-21/doc/intro.dox
+++ b/examples/step-21/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-21-Intro"></a> <h1>Introduction</h1>
+<a name="step_21-Intro"></a> <h1>Introduction</h1>
 
 This program grew out of a student project by Yan Li at Texas A&amp;M
 University. Most of the work for this program is by her.

--- a/examples/step-22/doc/intro.dox
+++ b/examples/step-22/doc/intro.dox
@@ -11,7 +11,7 @@ California Institute of Technology.
 
 
 
-<a name="step-22-Intro"></a>
+<a name="step_22-Intro"></a>
 <h1>Introduction</h1>
 
 This program deals with the Stokes system of equations which reads as

--- a/examples/step-23/doc/intro.dox
+++ b/examples/step-23/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-23-Intro"></a>
+<a name="step_23-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{28}

--- a/examples/step-24/doc/intro.dox
+++ b/examples/step-24/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-24-Intro"></a>
+<a name="step_24-Intro"></a>
 <h1>Introduction</h1>
 
 This program grew out of a student project by Xing Jin at Texas A&amp;M

--- a/examples/step-25/doc/intro.dox
+++ b/examples/step-25/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-25-Intro"></a> <h1>Introduction</h1>
+<a name="step_25-Intro"></a> <h1>Introduction</h1>
 
 This program grew out of a student project by Ivan Christov at Texas A&amp;M
 University. Most of the work for this program is by him.

--- a/examples/step-26/doc/intro.dox
+++ b/examples/step-26/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-26-Intro"></a>
+<a name="step_26-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{29,30}

--- a/examples/step-27/doc/intro.dox
+++ b/examples/step-27/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-27-Intro"></a>
+<a name="step_27-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program attempts to show how to use $hp$-finite element methods

--- a/examples/step-28/doc/intro.dox
+++ b/examples/step-28/doc/intro.dox
@@ -21,7 +21,7 @@ href="https://www.semanticscholar.org/paper/Three-dimensional-h-adaptivity-for-t
 <br>
 
 
-<a name="step-28-Intro"></a> <h1>Introduction</h1>
+<a name="step_28-Intro"></a> <h1>Introduction</h1>
 In this example, we intend to solve the multigroup diffusion approximation of
 the neutron transport equation. Essentially, the way to view this is as follows: In a
 nuclear reactor, neutrons are speeding around at different energies, get

--- a/examples/step-29/doc/intro.dox
+++ b/examples/step-29/doc/intro.dox
@@ -9,7 +9,7 @@ the UMFPACK sparse direct solver. Refer to the <a
 href="../../readme.html#umfpack">ReadMe</a> for instructions how to do this.
 
 
-<a name="step-29-Intro"></a>
+<a name="step_29-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-3/doc/intro.dox
+++ b/examples/step-3/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-3-Intro"></a>
+<a name="step_3-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{10}

--- a/examples/step-30/doc/intro.dox
+++ b/examples/step-30/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-30-Intro"></a>
+<a name="step_30-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-31/doc/intro.dox
+++ b/examples/step-31/doc/intro.dox
@@ -10,7 +10,7 @@ California Institute of Technology.
 </i>
 
 
-<a name="step-31-Intro"></a>
+<a name="step_31-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>The Boussinesq equations</h3>

--- a/examples/step-32/doc/intro.dox
+++ b/examples/step-32/doc/intro.dox
@@ -25,7 +25,7 @@ more flexible in solving many kinds of related problems.
 </i>
 
 
-<a name="step-32-Intro"></a>
+<a name="step_32-Intro"></a>
 <h1>Introduction</h1>
 
 This program does pretty much exactly what step-31 already does: it

--- a/examples/step-33/doc/intro.dox
+++ b/examples/step-33/doc/intro.dox
@@ -29,7 +29,7 @@ can be solved more efficiently.
 
 
 
-<a name="step-33-Intro"></a> <h1>Introduction</h1>
+<a name="step_33-Intro"></a> <h1>Introduction</h1>
 
 <h3>Euler flow</h3>
 

--- a/examples/step-34/doc/intro.dox
+++ b/examples/step-34/doc/intro.dox
@@ -4,7 +4,7 @@ the three dimensional case).  </i>
 
 @dealiiTutorialDOI{10.5281/zenodo.495473,https://zenodo.org/badge/DOI/10.5281/zenodo.495473.svg}
 
-<a name="step-34-Intro"></a>
+<a name="step_34-Intro"></a>
 
 <h1>Introduction</h1>
 

--- a/examples/step-35/doc/intro.dox
+++ b/examples/step-35/doc/intro.dox
@@ -3,7 +3,7 @@ This program grew out of a student project by Abner Salgado at Texas A&M
 University. Most of the work for this program is by him.
 </i>
 
-<a name="step-35-Intro"></a>
+<a name="step_35-Intro"></a>
 <h1> Introduction </h1>
 
 <h3> Motivation </h3>

--- a/examples/step-36/doc/intro.dox
+++ b/examples/step-36/doc/intro.dox
@@ -45,7 +45,7 @@ library; SLEPc itself builds on the <a
 href="http://www.mcs.anl.gov/petsc/" target="_top">PETSc</a> library
 for linear algebra contents.
 
-<a name="step-36-Intro"></a>
+<a name="step_36-Intro"></a>
 <h1>Introduction</h1>
 
 The basic equation of stationary quantum mechanics is the

--- a/examples/step-37/doc/intro.dox
+++ b/examples/step-37/doc/intro.dox
@@ -18,7 +18,7 @@ were supported by Gauss Centre for Supercomputing e.V. (www.gauss-centre.eu)
 by providing computing time on the GCS Supercomputer SuperMUC at Leibniz
 Supercomputing Centre (LRZ, www.lrz.de) through project id pr83te. </i>
 
-<a name="step-37-Intro"></a>
+<a name="step_37-Intro"></a>
 <h1>Introduction</h1>
 
 This example shows how to implement a matrix-free method, that is, a method

--- a/examples/step-38/doc/intro.dox
+++ b/examples/step-38/doc/intro.dox
@@ -8,7 +8,7 @@ do not necessarily reflect the views of the National Science Foundation
 (NSF).
 </i>
 
-<a name="step-38-Intro"></a>
+<a name="step_38-Intro"></a>
 
 <h1>Introduction</h1>
 

--- a/examples/step-39/doc/intro.dox
+++ b/examples/step-39/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-39-Intro"></a>
+<a name="step_39-Intro"></a>
 
 In this program, we use the interior penalty method and Nitsche's weak
 boundary conditions to solve Poisson's equation. We use multigrid

--- a/examples/step-4/doc/intro.dox
+++ b/examples/step-4/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-4-Intro"></a>
+<a name="step_4-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{12,13}

--- a/examples/step-40/doc/intro.dox
+++ b/examples/step-40/doc/intro.dox
@@ -21,7 +21,7 @@ PETSc configuration; see the page linked to from the installation
 instructions for PETSc.
 
 
-<a name="step-40-Intro"></a>
+<a name="step_40-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{41.5,41.75}

--- a/examples/step-41/doc/intro.dox
+++ b/examples/step-41/doc/intro.dox
@@ -5,7 +5,7 @@ This material is based upon work partly supported by ThyssenKrupp Steel Europe.
 </i>
 
 
-<a name="step-41-Intro"></a>
+<a name="step_41-Intro"></a>
 <h3>Introduction</h3>
 
 This example is based on the Laplace equation in 2d and deals with the

--- a/examples/step-42/doc/intro.dox
+++ b/examples/step-42/doc/intro.dox
@@ -13,7 +13,7 @@ in the following paper:
 
 
 
-<a name="step-42-Intro"></a>
+<a name="step_42-Intro"></a>
 <h3>Introduction</h3>
 
 This example is an extension of step-41, considering a 3d contact problem with an

--- a/examples/step-43/doc/intro.dox
+++ b/examples/step-43/doc/intro.dox
@@ -30,7 +30,7 @@ California Institute of Technology, or of The University of California
 </i>
 
 
-<a name="step-43-Intro"></a> <h1>Introduction</h1>
+<a name="step_43-Intro"></a> <h1>Introduction</h1>
 
 The simulation of multiphase flow in porous media is a ubiquitous problem, and
 we have previously addressed it already in some form in step-20 and

--- a/examples/step-44/doc/intro.dox
+++ b/examples/step-44/doc/intro.dox
@@ -6,7 +6,7 @@ Forschungsgemeinschaft, DFG), grant STE 544/39-1,  and the National Research Fou
 
 @dealiiTutorialDOI{10.5281/zenodo.439772,https://zenodo.org/badge/DOI/10.5281/zenodo.439772.svg}
 
-<a name="step-44-Intro"></a>
+<a name="step_44-Intro"></a>
 <h1>Introduction</h1>
 
 The subject of this tutorial is nonlinear solid mechanics.

--- a/examples/step-45/doc/intro.dox
+++ b/examples/step-45/doc/intro.dox
@@ -1,5 +1,5 @@
 <i>This program was contributed by Daniel Arndt and Matthias Maier.</i>
-<a name="step-45-Intro"></a>
+<a name="step_45-Intro"></a>
 <h1>Introduction</h1>
 
 In this example we present how to use periodic boundary conditions in

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -8,7 +8,7 @@ reflect the views of the National Science Foundation or of The University of
 California &ndash; Davis.  </i>
 
 
-<a name="step-46-Intro"></a>
+<a name="step_46-Intro"></a>
 <h1>Introduction</h1>
 
 This program deals with the problem of coupling different physics in different

--- a/examples/step-47/doc/intro.dox
+++ b/examples/step-47/doc/intro.dox
@@ -8,7 +8,7 @@ Timo Heister and Wolfgang Bangerth acknowledge support through NSF
 awards DMS-1821210, EAR-1550901, and OAC-1835673.
 </i>
 
-<a name="step-47-Intro"></a>
+<a name="step_47-Intro"></a>
 <h1>Introduction</h1>
 
 This program deals with the <a

--- a/examples/step-48/doc/intro.dox
+++ b/examples/step-48/doc/intro.dox
@@ -11,7 +11,7 @@ application: Graph partitioning and coloring&quot; by Katharina
 Kormann and Martin Kronbichler in: Proceedings of the 7th IEEE
 International Conference on e-Science, 2011.  </i>
 
-<a name="step-48-Intro"></a>
+<a name="step_48-Intro"></a>
 <h1>Introduction</h1>
 
 This program demonstrates how to use the cell-based implementation of finite

--- a/examples/step-49/doc/intro.dox
+++ b/examples/step-49/doc/intro.dox
@@ -1,7 +1,7 @@
 <i>This program was contributed by Timo Heister. Parts of the results section
 were contributed by Yuhan Zhou, Wolfgang Bangerth, David Wells, and Sean Ingimarson.</i>
 
-<a name="step-49-Intro"></a>
+<a name="step_49-Intro"></a>
 <h1> Introduction </h1>
 This tutorial is an extension to step-1 and demonstrates several ways to
 obtain more involved meshes than the ones shown there.

--- a/examples/step-5/doc/intro.dox
+++ b/examples/step-5/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-5-Intro"></a>
+<a name="step_5-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{14}

--- a/examples/step-50/doc/intro.dox
+++ b/examples/step-50/doc/intro.dox
@@ -14,7 +14,7 @@ or Trilinos library installed. The installation of deal.II together with these a
 libraries is described in the <a href="../../readme.html" target="body">README</a> file.
 
 
-<a name="step-50-Intro"></a>
+<a name="step_50-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-51/doc/intro.dox
+++ b/examples/step-51/doc/intro.dox
@@ -2,7 +2,7 @@
 This program was contributed by Martin Kronbichler and Scott Miller.
 </i>
 
-<a name="step-51-Intro"></a>
+<a name="step_51-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program presents the implementation of a hybridizable

--- a/examples/step-53/doc/intro.dox
+++ b/examples/step-53/doc/intro.dox
@@ -13,7 +13,7 @@ information.
 href="https://github.com/dealii/dealii/blob/master/examples/step-53/step-53.ipynb">github</a>.
 
 
-<a name="step-53-Intro"></a>
+<a name="step_53-Intro"></a>
 <h1>Introduction</h1>
 
 Partial differential equations for realistic problems are often posed on

--- a/examples/step-54/doc/intro.dox
+++ b/examples/step-54/doc/intro.dox
@@ -7,7 +7,7 @@ your geometries.
 
 @dealiiTutorialDOI{10.5281/zenodo.546220,https://zenodo.org/badge/DOI/10.5281/zenodo.546220.svg}
 
-<a name="step-54-Intro"></a>
+<a name="step_54-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-55/doc/intro.dox
+++ b/examples/step-55/doc/intro.dox
@@ -18,7 +18,7 @@ and the p4est library installed. The installation of deal.II together with
 these additional libraries is described in the <a href="../../readme.html"
 target="body">README</a> file.
 
-<a name="step-55-Intro"></a>
+<a name="step_55-Intro"></a>
 <h1>Introduction</h1>
 
 Building on step-40, this tutorial shows how to solve linear PDEs with several

--- a/examples/step-56/doc/intro.dox
+++ b/examples/step-56/doc/intro.dox
@@ -13,7 +13,7 @@ undertaken. This work was supported by EPSRC grant no EP/K032208/1.
 
 @dealiiTutorialDOI{10.5281/zenodo.400995,https://zenodo.org/badge/DOI/10.5281/zenodo.400995.svg}
 
-<a name="step-56-Intro"></a>
+<a name="step_56-Intro"></a>
 <h1>Introduction</h1>
 
 <h3> Stokes Problem </h3>

--- a/examples/step-57/doc/intro.dox
+++ b/examples/step-57/doc/intro.dox
@@ -8,7 +8,7 @@ Award No. EAR-0949446 and The University of California-Davis.
 
 @dealiiTutorialDOI{10.5281/zenodo.484156,https://zenodo.org/badge/DOI/10.5281/zenodo.484156.svg}
 
-<a name="step-57-Intro"></a>
+<a name="step_57-Intro"></a>
 <h1>Introduction</h1>
 
 <h3> Navier Stokes Equations </h3>

--- a/examples/step-58/doc/intro.dox
+++ b/examples/step-58/doc/intro.dox
@@ -10,7 +10,7 @@ Geodynamics initiative (CIG), through the National Science Foundation under
 Award No. EAR-1550901 and The University of California-Davis.
 </i>
 
-<a name="step-58-Intro"></a>
+<a name="step_58-Intro"></a>
 <h1>Introduction</h1>
 
 The <a

--- a/examples/step-59/doc/intro.dox
+++ b/examples/step-59/doc/intro.dox
@@ -6,7 +6,7 @@ This work was partly supported by the German Research Foundation (DFG) through
 the project "High-order discontinuous Galerkin for the exa-scale" (ExaDG)
 within the priority program "Software for Exascale Computing" (SPPEXA). </i>
 
-<a name="step-59-Intro"></a>
+<a name="step_59-Intro"></a>
 <h1>Introduction</h1>
 
 Matrix-free operator evaluation enables very efficient implementations of

--- a/examples/step-6/doc/intro.dox
+++ b/examples/step-6/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-6-Intro"></a>
+<a name="step_6-Intro"></a>
 <h1>Introduction</h1>
 
 @dealiiVideoLecture{15,16,17,17.25,17.5,17.75}

--- a/examples/step-61/doc/intro.dox
+++ b/examples/step-61/doc/intro.dox
@@ -4,7 +4,7 @@ Some more information about this program, as well as more numerical
 results, are presented in @cite Wang2019 .
 </i>
 
-<a name="step-61-Intro"></a>
+<a name="step_61-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program presents an implementation of the "weak Galerkin"

--- a/examples/step-63/doc/intro.dox
+++ b/examples/step-63/doc/intro.dox
@@ -9,7 +9,7 @@ Davis.
 
 @dealiiTutorialDOI{10.5281/zenodo.3382899,https://zenodo.org/badge/DOI/10.5281/zenodo.3382899.svg}
 
-<a name="step-63-Intro"></a>
+<a name="step_63-Intro"></a>
 <h1>Introduction</h1>
 
 This program solves an advection-diffusion problem using a geometric multigrid

--- a/examples/step-65/doc/intro.dox
+++ b/examples/step-65/doc/intro.dox
@@ -2,7 +2,7 @@
 This program was contributed by Martin Kronbichler.
 </i>
 
-<a name="step-65-Intro"></a>
+<a name="step_65-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program presents an advanced manifold class,

--- a/examples/step-66/doc/intro.dox
+++ b/examples/step-66/doc/intro.dox
@@ -17,7 +17,7 @@ and advice in writing this tutorial.
 </i>
 
 
-<a name="step-66-Intro"></a>
+<a name="step_66-Intro"></a>
 <h1>Introduction</h1>
 
 The aim of this tutorial program is to demonstrate how to solve a nonlinear

--- a/examples/step-67/doc/intro.dox
+++ b/examples/step-67/doc/intro.dox
@@ -8,7 +8,7 @@ the project "High-order discontinuous Galerkin for the exa-scale" (ExaDG)
 within the priority program "Software for Exascale Computing" (SPPEXA).
 </i>
 
-<a name="step-67-Intro"></a>
+<a name="step_67-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program solves the Euler equations of fluid dynamics using an

--- a/examples/step-69/doc/intro.dox
+++ b/examples/step-69/doc/intro.dox
@@ -25,7 +25,7 @@ integration, see @cite GuermondEtAl2018
 
 @dealiiTutorialDOI{10.5281/zenodo.3698223,https://zenodo.org/badge/DOI/10.5281/zenodo.3698223.svg}
 
-<a name="step-69-Intro"></a>
+<a name="step_69-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial presents a first-order scheme for solving compressible

--- a/examples/step-7/doc/intro.dox
+++ b/examples/step-7/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-7-Intro"></a>
+<a name="step_7-Intro"></a>
 <h1>Introduction</h1>
 
 In this program, we will mainly consider two aspects:

--- a/examples/step-74/doc/intro.dox
+++ b/examples/step-74/doc/intro.dox
@@ -9,7 +9,7 @@ EAR-0949446 and EAR-1550901 and The University of California -- Davis.
 
 @dealiiTutorialDOI{10.5281/zenodo.5812174,https://zenodo.org/badge/DOI/10.5281/zenodo.5812174.svg}
 
-<a name="step-74-Intro"></a>
+<a name="step_74-Intro"></a>
 <h1><em>Symmetric interior penalty Galerkin</em> (SIPG) method for Poisson's equation</h1>
 
 <h3>Overview</h3>

--- a/examples/step-75/doc/intro.dox
+++ b/examples/step-75/doc/intro.dox
@@ -20,7 +20,7 @@ href="../../readme.html" target="body">README</a> file.
 
 
 
-<a name="step-75-Intro"></a>
+<a name="step_75-Intro"></a>
 <h1>Introduction</h1>
 
 In the finite element context, more degrees of freedom usually yield a

--- a/examples/step-76/doc/intro.dox
+++ b/examples/step-76/doc/intro.dox
@@ -16,7 +16,7 @@ element implementations with hybrid parallelization and improved data locality"
 within the KONWIHR program.
 </i>
 
-<a name="step-76-Intro"></a>
+<a name="step_76-Intro"></a>
 <h1>Introduction</h1>
 
 This tutorial program solves the Euler equations of fluid dynamics, using an

--- a/examples/step-77/doc/intro.dox
+++ b/examples/step-77/doc/intro.dox
@@ -13,7 +13,7 @@ discussed in the <a href="#Results">results section</a> below.
 </i>
 <br>
 
-<a name="step-77-Intro"></a>
+<a name="step_77-Intro"></a>
 <h1>Introduction</h1>
 
 The step-15 program solved the following, nonlinear equation

--- a/examples/step-78/doc/intro.dox
+++ b/examples/step-78/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-78-Intro"></a>
+<a name="step_78-Intro"></a>
 <h1>Introduction</h1>
 
 The Black-Scholes equation is a partial differential equation that falls a bit

--- a/examples/step-79/doc/intro.dox
+++ b/examples/step-79/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-79-Intro"></a>
+<a name="step_79-Intro"></a>
 <h1>Introduction</h1>
 
 Topology Optimization of Elastic Media is a technique used to optimize a

--- a/examples/step-8/doc/intro.dox
+++ b/examples/step-8/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-8-Intro"></a>
+<a name="step_8-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-81/doc/intro.dox
+++ b/examples/step-81/doc/intro.dox
@@ -3,7 +3,7 @@
   and Matthias Maier (Texas A&M University).
 </i>
 
-<a name="step-81-Intro"></a>
+<a name="step_81-Intro"></a>
 
 <h1> Introduction </h1>
 

--- a/examples/step-82/doc/intro.dox
+++ b/examples/step-82/doc/intro.dox
@@ -7,7 +7,7 @@
 
 @dealiiTutorialDOI{10.5281/zenodo.5598180,https://zenodo.org/badge/DOI/10.5281/zenodo.5598180.svg}
 
-<a name="step-82-Intro"></a>
+<a name="step_82-Intro"></a>
 <h1>Introduction</h1>
 <h3>Problem Statement</h3>
 

--- a/examples/step-83/doc/intro.dox
+++ b/examples/step-83/doc/intro.dox
@@ -12,7 +12,7 @@ Award No. EAR-1550901 and The University of California-Davis.
 </i>
 <br>
 
-<a name="step-83-Intro"></a>
+<a name="step_83-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-85/doc/intro.dox
+++ b/examples/step-85/doc/intro.dox
@@ -6,7 +6,7 @@ eSSENCE of e-Science and the Swedish Research Council
 under grants 2014-6088 (Kreiss) and 2017-05038 (Massing).
 </i>
 
-<a name="step-85-Intro"></a>
+<a name="step_85-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>The Cut Finite Element Method</h3>

--- a/examples/step-86/doc/intro.dox
+++ b/examples/step-86/doc/intro.dox
@@ -8,7 +8,7 @@ Foundation grants OAC-1835673, DMS-1821210, and EAR-1925595.
 </i>
 <br>
 
-<a name="step-86-Intro"></a>
+<a name="step_86-Intro"></a>
 <h1>Introduction</h1>
 
 step-26 solved the simple heat equation, one of the prototypical examples

--- a/examples/step-9/doc/intro.dox
+++ b/examples/step-9/doc/intro.dox
@@ -1,4 +1,4 @@
-<a name="step-9-Intro"></a>
+<a name="step_9-Intro"></a>
 <h1>Introduction</h1>
 
 

--- a/examples/step-90/doc/intro.dox
+++ b/examples/step-90/doc/intro.dox
@@ -7,7 +7,7 @@ Infrastructure in Geodynamics initiative (CIG), through the NSF under Award
 EAR-0949446, EAR-1550901, EAR-2149126 via the University of California -- Davis.
 </i>
 
-<a name="step-90-Intro"></a>
+<a name="step_90-Intro"></a>
 <h1>Introduction</h1>
 
 In this tutorial, we implement the trace finite element method (TraceFEM) in deal.II. TraceFEM solves PDEs posed on a

--- a/examples/step-93/doc/intro.dox
+++ b/examples/step-93/doc/intro.dox
@@ -2,7 +2,7 @@
 Bangerth.</i>
 <br>
 
-<a name="step-93-Intro"></a>
+<a name="step_93-Intro"></a>
 <h1>Introduction</h1>
 
 In all previous tutorial programs, we have only ever dealt with

--- a/examples/step-95/doc/intro.dox
+++ b/examples/step-95/doc/intro.dox
@@ -9,7 +9,7 @@ Foundation (DFG) under the project
  Grant Agreement No. 456365667.
 </i>
 
-<a name="step-95-Intro"></a>
+<a name="step_95-Intro"></a>
 <h1>Introduction</h1>
 
 <h3>Matrix-free Cut Finite Element Method / Discontinuous Galerkin Method</h3>


### PR DESCRIPTION
As shown in #18676, we have a lot of broken links. Here is one cause: We create a table of contents that asks for an anchor of the form `step_97-Intro`, but we often spell it `step-97-Intro`. Make this uniform.