### PR TITLE
Tools for SBM: ClosestSurfacePoint class 

### DIFF
--- a/include/deal.II/non_matching/closest_surface_point.h
+++ b/include/deal.II/non_matching/closest_surface_point.h
@@ -1,0 +1,283 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2018 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_closest_surface_point
+#define dealii_closest_surface_point
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/quadrature.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace NonMatching
+{
+
+
+  /**
+   * @brief A class for computing the closest points on a surface defined by a level set function.
+   *
+   * This class implements algorithms to find the closest points on a surface
+   * (zero level set) to a given set of query points. The surface is implicitly
+   * defined by a level set function discretized on a finite element mesh. The
+   * class uses Newton's method to iteratively find the closest surface points
+   * by minimizing the distance function subject to the constraint that the
+   * point lies on the zero level set.
+   *
+   * The implementation supports:
+   * - Level set functions discretized on DoFHandler with cartesian grid.
+   * - Configurable Newton iteration parameters (tolerance, maximum iterations)
+   * - Multi-level support for adaptive mesh refinement scenarios
+   *
+   * @tparam dim The spatial dimension of the problem
+   * @tparam VECTOR The vector type used to store the level set function values
+   *
+   * @note The level set function should be negative inside the domain, positive outside,
+   *       and zero on the surface boundary.
+   *
+   * @warning The Newton iteration may not converge for points that are too far from the surface
+   *          or in regions where the level set function has poor conditioning.
+   */
+  template <int dim, class VECTOR>
+  class ClosestSurfacePoint : public EnableObserverPointer
+  {
+  public:
+    /**
+     * Additional data for the closest surface point computation.
+     */
+    struct AdditionalData
+    {
+      /**
+       * The level of the DoFHandler to use. If set to
+       * numbers::invalid_unsigned_int, the finest level is used.
+       */
+      unsigned int level = numbers::invalid_unsigned_int;
+      /**
+       * The tolerance for the Newton iteration.
+       */
+      double tolerance = 1e-10;
+      /**
+       * The maximum number of iterations for the Newton iteration.
+       */
+      unsigned int n_iterations = 20;
+    };
+
+    using VectorType = VECTOR;
+
+    /**
+     * Constructor for the ClosestSurfacePoint class.
+     */
+    ClosestSurfacePoint(const VectorType      &level_set,
+                        const DoFHandler<dim> &dof_handler,
+                        const AdditionalData  &data = AdditionalData());
+
+
+    /**
+     * @brief Computes closest points to given set of points.
+     *
+     * @return A pair of vectors, where the first vector contains the shifted quadrature points in absolute
+     * coordinates, and the second vector contains the corresponding shifted
+     * points in coordinates of the reference cell.
+     *
+     * @param search_cell The cell in the triangulation where the search for closest surface points is performed.
+     * @param reference_cell The reference cell in which local coordinates unit points are outputed.
+     * @param quadrature_points The original quadrature points to be shifted.
+     */
+    std::pair<std::vector<Point<dim>>, std::vector<Point<dim>>>
+    compute_closest_surface_points(
+      const typename Triangulation<dim>::cell_iterator &search_cell,
+      const typename Triangulation<dim>::cell_iterator &reference_cell,
+      const std::vector<Point<dim>> &quadrature_points) const;
+
+  private:
+    AdditionalData         data;
+    const DoFHandler<dim> &dof_handler;
+    const VectorType      &level_set;
+    MappingCartesian<dim>  mapping;
+
+
+
+    void
+    newton_monolithic(const Point<dim>         &point,
+                      const FiniteElement<dim> &fe,
+                      const std::vector<double> dof_values,
+                      Point<dim>               &closest_point) const;
+  };
+
+  template <int dim, class VECTOR>
+  ClosestSurfacePoint<dim, VECTOR>::ClosestSurfacePoint(
+    const VectorType      &level_set,
+    const DoFHandler<dim> &dof_handler,
+    const AdditionalData  &data)
+    : data(data)
+    , dof_handler(dof_handler)
+    , level_set(level_set)
+  {
+    if (data.level != numbers::invalid_unsigned_int)
+      {
+        AssertThrow(data.level <
+                      dof_handler.get_triangulation().n_global_levels(),
+                    dealii::ExcMessage("Level is larger than number of levels "
+                                       "in the triangulation"));
+      }
+  }
+
+  template <int dim, class VECTOR>
+  std::pair<std::vector<Point<dim>>, std::vector<Point<dim>>>
+  ClosestSurfacePoint<dim, VECTOR>::compute_closest_surface_points(
+    const typename Triangulation<dim>::cell_iterator &search_cell,
+    const typename Triangulation<dim>::cell_iterator &reference_cell,
+    const std::vector<Point<dim>>                    &quadrature_points) const
+  {
+    std::vector<Point<dim>> closest_unit_search_points(quadrature_points);
+    for (unsigned int q = 0; q < quadrature_points.size(); ++q)
+      closest_unit_search_points[q] =
+        mapping.transform_real_to_unit_cell(search_cell, quadrature_points[q]);
+
+    std::vector<double> dof_values_level_set(
+      dof_handler.get_fe().dofs_per_cell);
+    std::vector<types::global_dof_index> level_set_dof_indices(
+      dof_handler.get_fe().dofs_per_cell);
+
+    typename DoFHandler<dim>::cell_iterator dof_cell(
+      &search_cell->get_triangulation(),
+      search_cell->level(),
+      search_cell->index(),
+      &dof_handler);
+
+    if (data.level != numbers::invalid_unsigned_int)
+      dof_cell->get_mg_dof_indices(level_set_dof_indices);
+    else
+      dof_cell->get_dof_indices(level_set_dof_indices);
+
+    level_set.extract_subvector_to(level_set_dof_indices.begin(),
+                                   level_set_dof_indices.end(),
+                                   dof_values_level_set.begin());
+
+    for (size_t i = 0; i < closest_unit_search_points.size(); ++i)
+      {
+        newton_monolithic(closest_unit_search_points[i],
+                          dof_handler.get_fe(),
+                          dof_values_level_set,
+                          closest_unit_search_points[i]);
+      }
+    std::vector<Point<dim>> closest_real_points(quadrature_points.size());
+    std::vector<Point<dim>> closest_unit_reference_points(
+      quadrature_points.size());
+    // back to absolute coordinates
+    for (unsigned int q = 0; q < quadrature_points.size(); ++q)
+      closest_real_points[q] =
+        mapping.transform_unit_to_real_cell(search_cell,
+                                            closest_unit_search_points[q]);
+
+    for (unsigned int q = 0; q < quadrature_points.size(); ++q)
+      closest_unit_reference_points[q] =
+        mapping.transform_real_to_unit_cell(reference_cell,
+                                            closest_real_points[q]);
+
+    return {closest_real_points, closest_unit_reference_points};
+  }
+
+
+
+  template <int dim, class VECTOR>
+  void
+  ClosestSurfacePoint<dim, VECTOR>::newton_monolithic(
+    const Point<dim>         &point,
+    const FiniteElement<dim> &fe,
+    const std::vector<double> dof_values,
+    Point<dim>               &closest_point) const
+  {
+    AssertDimension(dof_values.size(), fe.dofs_per_cell);
+
+    Assert(fe.degree > 1,
+           dealii::ExcMessage(
+             " The Newton iteration to find closest surface points "
+             "requires hessians that are not available degree = 1."));
+
+    // X, Y, Z, lambda
+    Vector<double> current_solution(dim + 1);
+    Vector<double> solution_update(dim + 1);
+
+    Vector<double>     residual(dim + 1);
+    FullMatrix<double> hessian(dim + 1, dim + 1);
+
+    for (unsigned int i = 0; i < dim; ++i)
+      current_solution[i] = closest_point[i];
+
+
+    for (unsigned int newton_iter = 0; newton_iter < data.n_iterations;
+         ++newton_iter)
+      {
+        hessian             = 0.0;
+        residual            = 0.0;
+        const double lambda = current_solution[dim];
+        for (unsigned int k = 0; k < dof_values.size(); ++k)
+          {
+            const auto value_k = fe.shape_value(k, closest_point);
+            const auto grad_k  = fe.shape_grad(k, closest_point);
+            const auto hess_k  = fe.shape_grad_grad(k, closest_point);
+            for (unsigned int i = 0; i < dim; ++i)
+              {
+                for (unsigned int j = 0; j < dim; ++j)
+                  hessian(i, j) += lambda * dof_values[k] * hess_k[i][j];
+
+                hessian(i, dim) += dof_values[k] * grad_k[i];
+                hessian(dim, i) += dof_values[k] * grad_k[i];
+              }
+
+            for (unsigned int i = 0; i < dim; ++i)
+              residual[i] -= lambda * dof_values[k] * grad_k[i];
+
+            residual[dim] -= dof_values[k] * value_k;
+          }
+
+
+        for (unsigned int i = 0; i < dim; ++i)
+          {
+            residual[i] -= current_solution[i] - point[i];
+            hessian[i][i] += 1.0;
+          }
+
+        if (residual.l2_norm() < data.tolerance)
+          break;
+
+
+        hessian.gauss_jordan();
+        hessian.vmult(solution_update, residual);
+        current_solution += solution_update;
+
+        for (unsigned int i = 0; i < dim; ++i)
+          closest_point[i] = current_solution[i];
+      }
+
+    Assert(residual.l2_norm() < 1e-10,
+           dealii::ExcMessage("Newton iteration did not converge"));
+  }
+
+} // namespace NonMatching
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/non_matching/closest_surface_point.h
+++ b/include/deal.II/non_matching/closest_surface_point.h
@@ -46,10 +46,9 @@ namespace NonMatching
    * by minimizing the distance function subject to the constraint that the
    * point lies on the zero level set.
    *
-   * The implementation supports:
    * - Level set functions discretized on DoFHandler with cartesian grid.
    * - Configurable Newton iteration parameters (tolerance, maximum iterations)
-   * - Multi-level support for adaptive mesh refinement scenarios
+   * - Supports active cells and MG cells
    *
    * @tparam dim The spatial dimension of the problem
    * @tparam VECTOR The vector type used to store the level set function values
@@ -94,6 +93,7 @@ namespace NonMatching
                         const AdditionalData  &data = AdditionalData());
 
 
+
     /**
      * @brief Computes closest points to given set of points.
      *
@@ -119,12 +119,45 @@ namespace NonMatching
 
 
 
+    /**
+     * Find the closest point on a surface using Newton's method with a
+     * monolithic approach.
+     *
+     * This function implements Newton's method to find the point on the surface
+     * defined by the finite element and DOF values that is closest to the given
+     * input point. The monolithic approach solves the constrained optimization
+     * problem:
+     *
+     * @f[
+     * \min_{x} \frac{1}{2} \|x - x_0 \|^2 \quad \text{subject to} \quad \phi(x)
+     * = 0
+     * @f]
+     *
+     * where @f$\phi(x)@f$ is the level set function. Using Lagrange
+     * multipliers, this becomes the unconstrained problem:
+     *
+     * @f[
+     * \min_{x, \lambda} L(x, \lambda) = \frac{1}{2} \|x - x_0\|^2 + \lambda
+     * \phi(x)
+     * @f]
+     *
+     * Newton's method iteratively solves this system using the Hessian.
+     *
+     * @param[in] point The reference point for which to find the closest
+     * surface point
+     * @param[in] fe The finite element used to define the surface geometry
+     * @param[in] dof_values The degrees of freedom values that define the
+     * surface
+     * @param[out] closest_point The computed closest point on the surface
+     */
     void
     newton_monolithic(const Point<dim>         &point,
                       const FiniteElement<dim> &fe,
                       const std::vector<double> dof_values,
                       Point<dim>               &closest_point) const;
   };
+
+
 
   template <int dim, class VECTOR>
   ClosestSurfacePoint<dim, VECTOR>::ClosestSurfacePoint(
@@ -143,6 +176,8 @@ namespace NonMatching
                                        "in the triangulation"));
       }
   }
+
+
 
   template <int dim, class VECTOR>
   std::pair<std::vector<Point<dim>>, std::vector<Point<dim>>>

--- a/include/deal.II/non_matching/closest_surface_point.h
+++ b/include/deal.II/non_matching/closest_surface_point.h
@@ -151,10 +151,10 @@ namespace NonMatching
      * @param[out] closest_point The computed closest point on the surface
      */
     void
-    newton_monolithic(const Point<dim>         &point,
-                      const FiniteElement<dim> &fe,
-                      const std::vector<double> dof_values,
-                      Point<dim>               &closest_point) const;
+    newton_monolithic(const Point<dim>          &point,
+                      const FiniteElement<dim>  &fe,
+                      const std::vector<double> &dof_values,
+                      Point<dim>                &closest_point) const;
   };
 
 
@@ -240,10 +240,10 @@ namespace NonMatching
   template <int dim, class VECTOR>
   void
   ClosestSurfacePoint<dim, VECTOR>::newton_monolithic(
-    const Point<dim>         &point,
-    const FiniteElement<dim> &fe,
-    const std::vector<double> dof_values,
-    Point<dim>               &closest_point) const
+    const Point<dim>          &point,
+    const FiniteElement<dim>  &fe,
+    const std::vector<double> &dof_values,
+    Point<dim>                &closest_point) const
   {
     AssertDimension(dof_values.size(), fe.dofs_per_cell);
 

--- a/tests/non_matching/closest_surfrace_point_01.cc
+++ b/tests/non_matching/closest_surfrace_point_01.cc
@@ -1,0 +1,220 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_signed_distance.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_cartesian.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/non_matching/closest_surface_point.h>
+#include <deal.II/non_matching/mesh_classifier.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <cmath>
+
+#include "../tests.h"
+
+
+
+// Test for NonMatching::ClosestSurfacePoint using a unit sphere level set
+
+
+template <int dim>
+void
+test()
+{
+  deallog << "Testing ClosestSurfacePoint in " << dim << "D" << std::endl;
+
+  // Create hypercube [-1.2, 1.2]^dim
+  Triangulation<dim> triangulation;
+  GridGenerator::hyper_cube(triangulation, -1.2, 1.2);
+
+  // Refine 3 times
+  triangulation.refine_global(3);
+
+  deallog << "Number of active cells: " << triangulation.n_active_cells()
+          << std::endl;
+
+  // Create DoFHandler with FE_Q(2)
+  DoFHandler<dim> dof_handler(triangulation);
+  // Use high order FE so that the points the points are close to unit sphere
+  FE_Q<dim> fe(4);
+  dof_handler.distribute_dofs(fe);
+
+  deallog << "Number of DoFs: " << dof_handler.n_dofs() << std::endl;
+
+  // Create level set vector and interpolate unit sphere function
+  Vector<double>                               level_set(dof_handler.n_dofs());
+  const Functions::SignedDistance::Sphere<dim> signed_distance_sphere;
+
+  // Interpolate the signed distance function
+  VectorTools::interpolate(dof_handler, signed_distance_sphere, level_set);
+
+  // Create ClosestSurfacePoint object
+  typename NonMatching::ClosestSurfacePoint<dim, Vector<double>>::AdditionalData
+    data;
+  data.tolerance    = 1e-10;
+  data.n_iterations = 20;
+
+  NonMatching::ClosestSurfacePoint<dim, Vector<double>> closest_point_finder(
+    level_set, dof_handler, data);
+
+  NonMatching::MeshClassifier<dim> mesh_classifier(dof_handler, level_set);
+  mesh_classifier.reclassify();
+
+  // Test parameters
+  const double tolerance =
+    dof_handler.begin_active()->minimum_vertex_distance() * 1e-2;
+  unsigned int n_tested_points    = 0;
+  unsigned int n_points_on_sphere = 0;
+
+  // Limit the number of test cells to cut down on test time
+  int n_test_cells = 20;
+
+  // Loop over all cells
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      // Check if cell potentially intersects the unit sphere
+      // (cell contains points both inside and outside unit sphere)
+      std::vector<Point<dim>> vertices;
+      bool                    has_inside  = false;
+      bool                    has_outside = false;
+
+      const NonMatching::LocationToLevelSet cell_location =
+        mesh_classifier.location_to_level_set(cell);
+      if (cell_location == NonMatching::LocationToLevelSet::outside)
+        continue;
+
+      for (const auto &face : GeometryInfo<dim>::face_indices())
+        {
+          if (n_test_cells <= 0)
+            continue;
+
+          // Check if cell has a neighbor on this face
+          if (cell->at_boundary(face))
+            continue;
+
+          const auto                            neighbor = cell->neighbor(face);
+          const NonMatching::LocationToLevelSet neighbor_location =
+            mesh_classifier.location_to_level_set(neighbor);
+
+          // ignore neighbors that are inside the level set
+          if (neighbor_location == NonMatching::LocationToLevelSet::inside)
+            continue;
+
+          // Decrease the number of remaining test cells
+          --n_test_cells;
+
+          // neighbor is outside or intersected, so we can test the face
+          // Create test points on the face
+          QGauss<dim - 1>   face_quadrature(3);
+          FEFaceValues<dim> fe_face_values(fe,
+                                           face_quadrature,
+                                           update_quadrature_points);
+          fe_face_values.reinit(cell, face);
+
+          // Get the quadrature points on the face
+          std::vector<Point<dim>> face_points;
+          for (unsigned int q = 0; q < face_quadrature.size(); ++q)
+            {
+              face_points.push_back(fe_face_values.quadrature_point(q));
+            }
+
+          // Run closest point finder: search_cell=neighbor,
+          // reference_cell=cell
+          auto closest_points_result =
+            closest_point_finder.compute_closest_surface_points(neighbor,
+                                                                cell,
+                                                                face_points);
+
+          // Extract the results
+          const auto &closest_real_points = closest_points_result.first;
+          const auto &closest_unit_reference_points =
+            closest_points_result.second;
+
+          // Test the results
+          for (unsigned int q = 0; q < face_points.size(); ++q)
+            {
+              n_tested_points++;
+
+              const Point<dim> &original_point = face_points[q];
+              const Point<dim> &closest_point  = closest_real_points[q];
+
+              const Point<dim> &true_closest_point =
+                original_point / original_point.norm();
+
+              // Check that the closest point is actually on the unit sphere
+              const double distance_from_origin = closest_point.norm();
+              if (std::abs(distance_from_origin - 1.0) < tolerance)
+                {
+                  n_points_on_sphere++;
+                }
+              else
+                {
+                  deallog << "Point not on unit sphere: "
+                          << "Original point: " << original_point
+                          << ", Closest point: " << closest_point
+                          << ", Distance from origin: " << distance_from_origin
+                          << std::endl;
+                }
+
+              // Check that the closest point is close to the true closest
+              // point
+              const double distance_to_true =
+                (closest_point - true_closest_point).norm();
+              if (distance_to_true > tolerance)
+                {
+                  deallog << "Distance to true closest point too large: "
+                          << "Original point: " << original_point
+                          << ", Closest point: " << closest_point
+                          << ", True closest point: " << true_closest_point
+                          << ", Distance: " << distance_to_true << std::endl;
+                }
+            }
+        }
+    }
+
+  deallog << "Tested " << n_tested_points << " points" << std::endl;
+  deallog << "Points on unit sphere (within tolerance): " << n_points_on_sphere
+          << std::endl;
+  deallog << "Success rate: "
+          << (double)n_points_on_sphere / n_tested_points * 100.0 << "%"
+          << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  deallog << std::setprecision(8);
+
+  test<2>();
+  test<3>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/non_matching/closest_surfrace_point_01.cc
+++ b/tests/non_matching/closest_surfrace_point_01.cc
@@ -91,6 +91,8 @@ test()
   unsigned int n_tested_points    = 0;
   unsigned int n_points_on_sphere = 0;
 
+  MappingCartesian<dim> mapping;
+
   // Limit the number of test cells to cut down on test time
   int n_test_cells = 20;
 
@@ -194,6 +196,19 @@ test()
                           << ", Closest point: " << closest_point
                           << ", True closest point: " << true_closest_point
                           << ", Distance: " << distance_to_true << std::endl;
+                }
+
+              // Check if the real point corresponds with the unit point
+              const Point<dim> unit_closest_point =
+                mapping.transform_real_to_unit_cell(cell, closest_point);
+              if ((unit_closest_point - closest_unit_reference_points[q])
+                    .norm() > 1e-8)
+                {
+                  deallog << "Closest point does not correspond to unit point: "
+                          << "Original point: " << original_point
+                          << ", Closest point: " << closest_point
+                          << ", Unit closest point: " << unit_closest_point
+                          << std::endl;
                 }
             }
         }

--- a/tests/non_matching/closest_surfrace_point_01.cc
+++ b/tests/non_matching/closest_surfrace_point_01.cc
@@ -163,6 +163,8 @@ test()
               const Point<dim> &original_point = face_points[q];
               const Point<dim> &closest_point  = closest_real_points[q];
 
+              // Calculate the true closest point on the unit sphere (normalized
+              // original point)
               const Point<dim> &true_closest_point =
                 original_point / original_point.norm();
 

--- a/tests/non_matching/closest_surfrace_point_01.output
+++ b/tests/non_matching/closest_surfrace_point_01.output
@@ -1,0 +1,14 @@
+
+DEAL::Testing ClosestSurfacePoint in 2D
+DEAL::Number of active cells: 64
+DEAL::Number of DoFs: 1089
+DEAL::Tested 60 points
+DEAL::Points on unit sphere (within tolerance): 60
+DEAL::Success rate: 100.00000%
+DEAL::Testing ClosestSurfacePoint in 3D
+DEAL::Number of active cells: 512
+DEAL::Number of DoFs: 35937
+DEAL::Tested 180 points
+DEAL::Points on unit sphere (within tolerance): 180
+DEAL::Success rate: 100.00000%
+DEAL::OK


### PR DESCRIPTION
A class that allows easy search of closest point on immersed surface.  
The methods compute_closest_surface_points takes vector of points (presumeably quadrature points on a face) and computes corresponding points on  immersed surface given by a level set function.

The closest points are returned in both absolute coordinates and coordinate system of reference_cell. The former is required in assembly (or MF evalaution) of SBM-FEM operators.