### PR TITLE
Do not unconditionally trigger github workflows on branch push outside PRs

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -1,6 +1,11 @@
 name: indent
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'dealii-*'
+  pull_request:
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,9 @@ name: linux
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dealii-*'
   pull_request:
     types:
     - opened

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,6 +2,9 @@ name: osx
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dealii-*'
   pull_request:
     types:
     - opened

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -2,6 +2,9 @@ name: tidy
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dealii-*'
   pull_request:
     types:
     - opened

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,9 @@ name: windows
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dealii-*'
   pull_request:
     types:
     - opened


### PR DESCRIPTION
My credit card information on Github was out of date, and Github kindly informed me to update my information, and by-the-way was I aware that I used $250 worth of actions credits on two days last week alone on my repository `gassmoeller/dealii`? I dont have to pay the credits since deal.II is an open-source project, but this got me curious why I was using so many minutes on my personal fork. It turns out that our github workflows are set up in a way that they are triggered for every push to every branch on every users fork. These runs are independent on whether or not the branch is part of a PR, and in addition to the test runs that are also triggered on pull requests. My PRs last week alone triggered 10,206 minutes of Github actions runners that no one ever will ever look at. This seems like a significant waste of compute resources and energy. 

In this PR I modify the workflows to take over some settings we use in ASPECT, i.e. pushes only trigger workflows outside of PRs if they happen on the master branch or release branches. In practice that means nothing changes for PRs (workflows are triggered through the `pull_request` trigger there), and the only additional test runs outside of PRs are: 1. When a PR is merged into `master` a test runs on the merged `master` branch. 2. When a maintainer pushes something to a release branch or to `master` (usually only happening as part of a release).

I could see that rarely a user will want to see the result of the tests on one of their branches without opening a PR, but usually they do not even know where to look (the 'actions' tab on your personal fork is the only place that lists these test runs). I dont think that is a significant enough use case to justify the waste of resources (and we could remedy it if necessary by introducing a manual trigger if requested).
