### PR TITLE
Fix a regular expression.

### DIFF
--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -149,7 +149,7 @@ foreach my $file (@src_files)
             }
 
             # update markdown links of the form "[text](./filename)"
-            $line =~ s/(\[.*\])\(.\//\1\(..\/code-gallery\/$gallery\//g;
+            $line =~ s/(\[.*?\])\(.\//\1\(..\/code-gallery\/$gallery\//g;
             print "$line";
         }
 


### PR DESCRIPTION
This is another one of the issues in #18676. We have a regex that fixes up paths in the code gallery for places where the `README.md` file has something of the form `![text](x.png)` to make sure `x.png` gets the right path. The regex fails for lines that look like
```
![text](x.png) ![text](y.png)
```
because it eats too much text from the first `[` to the last `]`. We just need to use a non-greedy version of `.*`.