### PR TITLE
Silence a maybe-uninitialized warning.

### DIFF
--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -93,9 +93,10 @@ Manifold<dim, spacedim>::get_new_point(
             });
 
   // Now loop over points in the order of their associated weight
+  DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
   Point<spacedim> p = surrounding_points[permutation[0]];
-  double          w = weights[permutation[0]];
-
+  DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+  double w = weights[permutation[0]];
   for (unsigned int i = 1; i < n_points; ++i)
     {
       double weight = 0.0;


### PR DESCRIPTION
Fixes #18686.

`gcc` really only complains about a maybe-uninitialized variable `permutation` in this particular line. We use the exact same variable in the next line, but there it is fine. This clearly is a bogus warning.