### PR TITLE
Also include revision.h into macros.h.

### DIFF
--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -49,6 +49,7 @@ if(DEAL_II_WITH_CXX20_MODULE)
     OUTPUT ${_dealii_macros_header}
     DEPENDS
       "${CMAKE_CURRENT_BINARY_DIR}/../include/deal.II/base/config.h"
+      "${CMAKE_CURRENT_BINARY_DIR}/../include/deal.II/base/revision.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/../include/deal.II/base/exception_macros.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/include/deal.II/boost_macros.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/include/deal.II/petsc_macros.h"
@@ -56,6 +57,7 @@ if(DEAL_II_WITH_CXX20_MODULE)
       ${CMAKE_COMMAND}
       ARGS -E cat
       "${CMAKE_CURRENT_BINARY_DIR}/../include/deal.II/base/config.h"
+      "${CMAKE_CURRENT_BINARY_DIR}/../include/deal.II/base/revision.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/../include/deal.II/base/exception_macros.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/include/deal.II/boost_macros.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/include/deal.II/petsc_macros.h"


### PR DESCRIPTION
Part of #18071. `revision.h` is another macros-only header that we need to bundle into `deal.II/macros.h`. We don't need this to *build* the module, but some downstream codes will want to access the information from `revision.h`. (Specifically, ASPECT does.)
