### PR TITLE
Revert "Remove the inclusion of Kokkos_Macros.h from config.h."

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -16,6 +16,11 @@
 #define dealii_config_h
 
 /***********************************************************************
+ * Some deal.II macros depends on Kokkos macros:
+ */
+#include <Kokkos_Macros.hpp>
+
+/***********************************************************************
  * Information about deal.II:
  */
 

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/types.h>
 
 #include <cmath>


### PR DESCRIPTION
This reverts commit 980e009f234c95faf0ac38740d1f0863f7aee540.

As also noted in https://github.com/dealii/dealii/issues/18698#issuecomment-3080030131, we currently do need `Kokkos_Macros.h` for module builds. I had this patch in my local tree all along, but had hoped to come up with a better solution. Alas, we ran out of time, so let's put this patch into the repo and I'll have to think about it at some later point. This way, I hope we can get to a state where everyone can build.

Part of #18071.