### PR TITLE
std.ccm: do not export std::snprintf

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -468,7 +468,6 @@ export
     using std::regex;
     using std::regex_match;
     using std::regex_search;
-    using std::snprintf;
     using std::sscanf;
     using std::stod;
     using std::stoi;


### PR DESCRIPTION
I am testing this change on the regression tester quickly.

References #18071 #18482