### PR TITLE
trilinos.ccm guard against inclusion of optional Ifpack2

### DIFF
--- a/module/interface_module_partitions/trilinos.ccm
+++ b/module/interface_module_partitions/trilinos.ccm
@@ -60,10 +60,6 @@ module;
 #  include <Epetra_RowMatrix.h>
 #  include <Epetra_SerialComm.h>
 #  include <Epetra_Vector.h>
-#  include <Ifpack2_Factory.hpp>
-#  include <Ifpack2_IdentitySolver.hpp>
-#  include <Ifpack2_IdentitySolver_decl.hpp>
-#  include <Ifpack2_Preconditioner.hpp>
 #  include <Ifpack_Chebyshev.h>
 #  include <NOX_Abstract_Group.H>
 #  include <NOX_Abstract_Vector.H>
@@ -128,6 +124,14 @@ module;
 #    ifdef DEAL_II_TRILINOS_WITH_AMESOS2
 #      include <Amesos2.hpp>
 #    endif
+
+#    ifdef DEAL_II_TRILINOS_WITH_IFPACK2
+#      include <Ifpack2_Factory.hpp>
+#      include <Ifpack2_IdentitySolver.hpp>
+#      include <Ifpack2_IdentitySolver_decl.hpp>
+#      include <Ifpack2_Preconditioner.hpp>
+#    endif
+
 #  endif
 #endif
 


### PR DESCRIPTION
Looking into how we do C++20 modules and reading about the external wrappers I was of course curious what we do in Trilinos.
Since working on the Tpetra wrappers I noticed that the header files for Ifpack2, the *i*ncomplete *f*actorization preconditioners, were always included.
However, we list Ifpack2 as optional (for now) since it is part of the Tpetra stack, 
so I placed it after Amesos2 (direct solvers) in the module wrapper.