### PR TITLE
Add MUMPS to "solvers and preconditioners" groups

### DIFF
--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -470,6 +470,8 @@ private:
  * There are instantiations of this class for SparseMatrix<double>,
  * SparseMatrix<float>, BlockSparseMatrix<double>, and
  * BlockSparseMatrix<float>.
+ *
+ * @ingroup Solvers Preconditioners
  */
 class SparseDirectMUMPS : public EnableObserverPointer
 {


### PR DESCRIPTION
The new MUMPS interface is not showing up in the "Preconditioners" and "Solvers"  group in the documentation.  This should fix it.