### PR TITLE
std.ccm: add missing include

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -30,6 +30,8 @@
 
 module;
 
+#include <deal.II/macros.h>
+
 #include <algorithm>
 #include <any>
 #include <array>


### PR DESCRIPTION
During all the last minute pull requests, we lost the line including the `deal.II/macros.h` header. Without it, of course, the include guard doesn't work.

In reference to #18742 #18585 #18518
