### PR TITLE
Rename cell_to_face_patch to cell_to_face_patch_numbering

### DIFF
--- a/doc/news/changes/incompatibilities/20250710Wichrowski
+++ b/doc/news/changes/incompatibilities/20250710Wichrowski
@@ -1,0 +1,2 @@
+Changed: renamed FETools::cell_to_face_patch_numbering(...); the old cell_to_face_patch() was marked deprecated.
+(Michał Wichrowski, 2025/09/15)

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -950,10 +950,27 @@ namespace FETools
    */
   template <int dim>
   std::pair<std::vector<unsigned int>, std::vector<unsigned int>>
-  cell_to_face_patch(const unsigned int &degree,
-                     const unsigned int &direction,
-                     const bool         &cell_hierarchical_numbering,
-                     const bool         &is_continuous);
+  cell_to_face_patch_numbering(const unsigned int &degree,
+                               const unsigned int &direction,
+                               const bool         &cell_hierarchical_numbering,
+                               const bool         &is_continuous);
+
+
+  /**
+   * @copydoc FETools::cell_to_face_patch_numbering()
+   *
+   * @deprecated Use FETools::cell_to_face_patch_numbering() instead.
+   */
+  template <int dim>
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Use FETools::cell_to_face_patch_numbering() instead.")
+  std::pair<
+    std::vector<unsigned int>,
+    std::vector<unsigned int>> cell_to_face_patch(const unsigned int &degree,
+                                                  const unsigned int &direction,
+                                                  const bool &
+                                                    cell_hierarchical_numbering,
+                                                  const bool &is_continuous);
 
   /**
    * Given an index of a face DoF, compute the cell DoF index. This function is

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -3248,10 +3248,10 @@ namespace FETools
 
   template <int dim>
   std::pair<std::vector<unsigned int>, std::vector<unsigned int>>
-  cell_to_face_patch(const unsigned int &degree,
-                     const unsigned int &direction,
-                     const bool         &cell_hierarchical_numbering,
-                     const bool         &is_continuous)
+  cell_to_face_patch_numbering(const unsigned int &degree,
+                               const unsigned int &direction,
+                               const bool         &cell_hierarchical_numbering,
+                               const bool         &is_continuous)
   {
     AssertThrow(dim > 1, ExcInvalidFEDimension(1, dim));
     AssertThrow(direction < dim, ExcInvalidFEDimension(direction, dim));
@@ -3339,6 +3339,21 @@ namespace FETools
         result = renumbered_result;
       }
     return std::make_pair(results[0], results[1]);
+  }
+
+
+
+  template <int dim>
+  std::pair<std::vector<unsigned int>, std::vector<unsigned int>>
+  cell_to_face_patch(const unsigned int &degree,
+                     const unsigned int &direction,
+                     const bool         &cell_hierarchical_numbering,
+                     const bool         &is_continuous)
+  {
+    return cell_to_face_patch_numbering<dim>(degree,
+                                             direction,
+                                             cell_hierarchical_numbering,
+                                             is_continuous);
   }
 
   template <int dim, int spacedim>

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -275,6 +275,12 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
                                             const bool &,
                                             const bool &);
 
+      template std::pair<std::vector<unsigned int>, std::vector<unsigned int>>
+      cell_to_face_patch_numbering<deal_II_dimension>(const unsigned int &,
+                                                      const unsigned int &,
+                                                      const bool &,
+                                                      const bool &);
+
 #endif
     \}
   }

--- a/tests/fe/cell_face_lex.cc
+++ b/tests/fe/cell_face_lex.cc
@@ -40,10 +40,10 @@ test(unsigned int degree,
      bool         is_continuous)
 {
   std::pair<std::vector<unsigned int>, std::vector<unsigned int>> result =
-    FETools::cell_to_face_patch<dim>(degree,
-                                     direction,
-                                     cell_hierarchical_numbering,
-                                     is_continuous);
+    FETools::cell_to_face_patch_numbering<dim>(degree,
+                                               direction,
+                                               cell_hierarchical_numbering,
+                                               is_continuous);
 
   deallog << "Results for degree = " << degree << ", dim = " << dim
           << ", direction = " << direction


### PR DESCRIPTION
Update the function name for clarity and consistency across the codebase. Adjust all references to the renamed function accordingly.