### PR TITLE
contrib/utilities: update makeofflinedoc.sh to use https://dealii.org

### DIFF
--- a/contrib/utilities/makeofflinedoc.sh
+++ b/contrib/utilities/makeofflinedoc.sh
@@ -25,13 +25,14 @@ fi
 
 echo "Patching html files ..."
 sed -i 's#"https\?://www.dealii.org/images/#"images/#g' step_*.html class*.html
+sed -i 's#"https\?://dealii.org/images/#"images/#g' step_*.html class*.html
 
 echo "Downloading images (this will take a long time; press ctrl-c to cancel) ..."
 
 {
   trap "echo \"(skipping)\"" SIGINT
-  wget -q -nH -A svg,jpg,png,gif,webm -m -l 3 -np "https://www.dealii.org/images/steps"
-  wget -q -nH -A svg,jpg,png,gif,webm -m -l 3 -np "https://www.dealii.org/images/shape-functions"
+  wget -q -nH -A svg,jpg,png,gif,webm -m -l 3 -np "https://dealii.org/images/steps"
+  wget -q -nH -A svg,jpg,png,gif,webm -m -l 3 -np "https://dealii.org/images/shape-functions"
   rm -f robots.txt* images/robots.txt*
 }
 


### PR DESCRIPTION
We are now redirecting all traffic from `https://www.dealii.org` to `https://dealii.org`. The make_offlinedoc.sh script now fails because the command doesn't honor the (server side) rewrite. Avoid this problem by simply using the proper URL starting with `https://dealii.org/`.
