### PR TITLE
Fix more modules for external dependencies

### DIFF
--- a/source/arborx/access_traits.cc
+++ b/source/arborx/access_traits.cc
@@ -16,6 +16,8 @@
 
 #ifdef DEAL_II_WITH_ARBORX
 
+#  include <ArborX.hpp>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace ArborXWrappers

--- a/source/lac/ginkgo_solver.cc
+++ b/source/lac/ginkgo_solver.cc
@@ -21,6 +21,8 @@
 
 #  include <deal.II/lac/exceptions.h>
 
+#  include <ginkgo/ginkgo.hpp>
+
 #  include <cmath>
 #  include <memory>
 


### PR DESCRIPTION
These two build fine after these changes (basically replicating the includes from the corresponding header file).