### PR TITLE
gh-actions: build deal.II on windows with c++20.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
         cmake --version
     - name: configure
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_CXX_FLAGS="-WX /D FE_EVAL_FACTORY_DEGREE_MAX=2" -T host=x64 -A x64
+        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_CXX_FLAGS="/WX /std:c++20 /D FE_EVAL_FACTORY_DEGREE_MAX=2" -T host=x64 -A x64
     - name: print detailed.log
       run: type build/detailed.log
     - name: build


### PR DESCRIPTION
Related to #18757.

Let's check whether we can reproduce the issue.

I also corrected the [treat warnings as errors](https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level) flag.