### PR TITLE
simplify kokkos device logic

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -538,34 +538,24 @@
           }))                                                                \
         }                                                                    \
       while (false)
-#  else /*if DEAL_II_KOKKOS_VERSION_GTE(3,6,0)*/
-#    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-#      define Assert(cond, exc)                                              \
-        do                                                                   \
-          {                                                                  \
-            if (DEAL_II_BUILTIN_EXPECT(!(cond), false))                      \
-              ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-                ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-                  abort_or_throw_on_exception,                               \
-                __FILE__,                                                    \
-                __LINE__,                                                    \
-                __PRETTY_FUNCTION__,                                         \
-                #cond,                                                       \
-                #exc,                                                        \
-                exc);                                                        \
-          }                                                                  \
-        while (false)
-#    else /*#ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
-#      define Assert(cond, exc)     \
-        do                          \
-          {                         \
-            if (!(cond))            \
-              Kokkos::abort(#cond); \
-          }                         \
-        while (false)
-#    endif /*ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
-#  endif   /*KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST*/
-#else      /*ifdef DEBUG*/
+#  else /*if DEAL_II_KOKKOS_VERSION_GTE(3,6,0), no device support: */
+#    define Assert(cond, exc)                                              \
+      do                                                                   \
+        {                                                                  \
+          if (DEAL_II_BUILTIN_EXPECT(!(cond), false))                      \
+            ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
+              ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
+                abort_or_throw_on_exception,                               \
+              __FILE__,                                                    \
+              __LINE__,                                                    \
+              __PRETTY_FUNCTION__,                                         \
+              #cond,                                                       \
+              #exc,                                                        \
+              exc);                                                        \
+        }                                                                  \
+      while (false)
+#  endif /*DEAL_II_KOKKOS_VERSION_GTE(3,6,0)*/
+#else    /*ifdef DEBUG*/
 #  define Assert(cond, exc) \
     do                      \
       {                     \

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1114,14 +1114,8 @@ namespace internal
           "This function is not implemented for std::complex<Number>!\n");
       }))
 #  else
-#    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
+      // We do not support device code for Kokkos < 3.7:
       val *= s;
-#    else
-      (void)val;
-      (void)s;
-      Kokkos::abort(
-        "This function is not implemented for std::complex<Number>!\n");
-#    endif
 #  endif
     }
   } // namespace ComplexWorkaround

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -966,37 +966,8 @@ namespace Utilities
   constexpr DEAL_II_HOST_DEVICE T
   pow(const T base, const int iexp)
   {
-#if defined(DEBUG) && !defined(DEAL_II_CXX14_CONSTEXPR_BUG)
-    // Up to __builtin_expect this is the same code as in the 'Assert' macro.
-    // The call to __builtin_expect turns out to be problematic.
-#  if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
-    KOKKOS_IF_ON_HOST(({
-      if (!(iexp >= 0))
-        ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
-          ::dealii::deal_II_exceptions::internals::ExceptionHandling::
-            abort_or_throw_on_exception,
-          __FILE__,
-          __LINE__,
-          __PRETTY_FUNCTION__,
-          "iexp>=0",
-          "ExcMessage(\"The exponent must not be negative!\")",
-          ExcMessage("The exponent must not be negative!"));
-    }))
-#  else
-#    ifdef KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST
-    if (!(iexp >= 0))
-      ::dealii::deal_II_exceptions::internals::issue_error_noreturn(
-        ::dealii::deal_II_exceptions::internals::ExceptionHandling::
-          abort_or_throw_on_exception,
-        __FILE__,
-        __LINE__,
-        __PRETTY_FUNCTION__,
-        "iexp>=0",
-        "ExcMessage(\"The exponent must not be negative!\")",
-        ExcMessage("The exponent must not be negative!"));
-#    endif
-#  endif
-#endif
+    Assert(iexp >= 0, ExcMessage("The exponent must not be negative!"));
+
     // The "exponentiation by squaring" algorithm used below has to be expressed
     // in an iterative version since SYCL doesn't allow recursive functions used
     // in device code.


### PR DESCRIPTION
We require 3.7 when device support is enabled, so we can simplify some code