### PR TITLE
MSVC c++20 compatibility - DoFInvalidAccessor template instantiations 

### DIFF
--- a/source/dofs/dof_accessor.inst.in
+++ b/source/dofs/dof_accessor.inst.in
@@ -67,7 +67,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
 for (deal_II_struct_dimension : DIMENSIONS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
+#if deal_II_dimension <= deal_II_space_dimension
     template class DoFInvalidAccessor<deal_II_struct_dimension,
                                       deal_II_dimension,
                                       deal_II_space_dimension>;
+#endif
   }


### PR DESCRIPTION
Fixes #18757.
Related to #18758.

Compiling with MSVC with /std:c++20 produces the error in #18757. It is caused by attempting to instantiate a template for which a constraint is not satisfied. GCC and Clang silently ignore unused invalid template instantiations, or otherwise handle them gracefully, while MSVC doesn't ignore and produces an error. This PR resolves the issue by not attempting to instantiate the invalid combinations in the first place.

I am not aware of any MSVC flags that would force the MSVC to behave as GCC or Clang in this case.