### PR TITLE
Matrix-free face setup in 1d: allow neighbors to differ by more than 1 level

### DIFF
--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -821,15 +821,22 @@ namespace internal
                             for (unsigned int c = 0; c < n_children; ++c)
                               {
                                 typename dealii::Triangulation<
-                                  dim>::cell_iterator neighbor_c =
-                                  (dim > 1 ?
-                                     (dcell->at_boundary(f) ?
-                                        dcell
-                                          ->periodic_neighbor_child_on_subface(
-                                            f, c) :
-                                        dcell->neighbor_child_on_subface(f,
-                                                                         c)) :
-                                     neighbor->child(1 - f));
+                                  dim>::cell_iterator neighbor_c;
+                                if (dim > 1)
+                                  neighbor_c =
+                                    (dcell->at_boundary(f) ?
+                                       dcell
+                                         ->periodic_neighbor_child_on_subface(
+                                           f, c) :
+                                       dcell->neighbor_child_on_subface(f, c));
+                                else
+                                  {
+                                    // in 1D, adjacent cells can differ by
+                                    // more than 1 level
+                                    neighbor_c = neighbor->child(1 - f);
+                                    while (!neighbor_c->is_active())
+                                      neighbor_c = neighbor_c->child(1 - f);
+                                  }
                                 const types::subdomain_id neigh_domain =
                                   neighbor_c->subdomain_id();
                                 const unsigned int neighbor_face_no =

--- a/tests/matrix_free/dg_pbc_03.cc
+++ b/tests/matrix_free/dg_pbc_03.cc
@@ -38,8 +38,7 @@ void
 test(const bool periodicity, const bool adaptive)
 {
   deallog.push(std::to_string(dim) + "d");
-  Triangulation<dim> tria(
-    Triangulation<dim>::limit_level_difference_at_vertices);
+  Triangulation<dim> tria;
   GridGenerator::hyper_cube(tria);
 
   if (periodicity)
@@ -71,6 +70,12 @@ test(const bool periodicity, const bool adaptive)
     {
       tria.begin_active()->set_refine_flag();
       tria.execute_coarsening_and_refinement();
+      if (dim == 1 && !periodicity)
+        {
+          // create a cell that differs by two levels
+          tria.last()->set_refine_flag();
+          tria.execute_coarsening_and_refinement();
+        }
       deallog.push("adaptive");
     }
   else
@@ -79,7 +84,6 @@ test(const bool periodicity, const bool adaptive)
   FE_DGQ<dim>     fe(1);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs();
   AffineConstraints<double> constraints;
   constraints.close();
 

--- a/tests/matrix_free/dg_pbc_03.output
+++ b/tests/matrix_free/dg_pbc_03.output
@@ -11,10 +11,10 @@ DEAL:1d:periodic:uniform ::Interior faces: 63 1
 DEAL:1d:periodic:uniform ::Exterior faces: 1 63 
 DEAL:1d:periodic:uniform ::Boundary faces: 0 0 
 DEAL::
-DEAL:1d:boundary:adaptive::Active cells: 65
-DEAL:1d:boundary:adaptive::Cell batches: 65
-DEAL:1d:boundary:adaptive::Interior faces: 63 1 
-DEAL:1d:boundary:adaptive::Exterior faces: 1 63 
+DEAL:1d:boundary:adaptive::Active cells: 66
+DEAL:1d:boundary:adaptive::Cell batches: 66
+DEAL:1d:boundary:adaptive::Interior faces: 64 1 
+DEAL:1d:boundary:adaptive::Exterior faces: 1 64 
 DEAL:1d:boundary:adaptive::Boundary faces: 1 1 
 DEAL::
 DEAL:1d:periodic:adaptive::Active cells: 65


### PR DESCRIPTION
At https://github.com/MeltPoolDG/MeltPoolDG-dev/issues/1126 with @koch-andreas, @mschreter and @peterrum we found out that the new code from #18756 could throw an assertion when faces differed by more than 1 level (which is possible in 1d). This is now fixed.