### PR TITLE
Avoid deprecation warning for using a deprecated class in a deprecated function

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -250,6 +250,7 @@ namespace Utilities
          */
         virtual ~Interface() = default;
 
+        DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
         /**
          * Run the consensus algorithm and return a vector of process ranks
          * that have requested answers from the current process.
@@ -266,6 +267,7 @@ namespace Utilities
         DEAL_II_DEPRECATED
         std::vector<unsigned int>
         run(Process<RequestType, AnswerType> &process, const MPI_Comm comm);
+        DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
         /**
          * Run the consensus algorithm and return a vector of process ranks


### PR DESCRIPTION
Fixes #18768.