### PR TITLE
fix nvcc work-around in petsc_matrix_base.h

### DIFF
--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -68,7 +68,7 @@ namespace PETScWrappers
      */
     class const_iterator
     {
-#  ifdef __CUDA_ARCH__
+#  ifdef __CUDACC__
       // NVCC, at least until 12.6, fails to compile the
       // implementations of the nested Accessor class if
       // it is declared as private. Work around this by


### PR DESCRIPTION
Compilation fails for me even with the workaround in petsc_matrix_base.h because nvcc 12.3 with gcc 12.3 complain about accessor being private. The macro used until now is only defined when compiling device code, not when nvcc is compiling the host version of the code. This is now fixed because ``__CUDACC__`` is always defined when nvcc is used. :man_shrugging: 