### PR TITLE
Fix another 9.7 changelog.

### DIFF
--- a/doc/news/9.6.0-vs-9.7.0.h
+++ b/doc/news/9.6.0-vs-9.7.0.h
@@ -620,13 +620,9 @@ inconvenience this causes.
  </li>
 
  <li>
-  New: FE_Simplex_Poly now implements FiniteElement::face_to_cell_index(),
+  New: FE_SimplexPoly now implements FiniteElement::face_to_cell_index(),
   enabling periodicity for derived classes, with restrictions similar to the
-  implementation in FE_Q_Base. Additionally,
-  GridGenerator::hyper_rectangle_with_simplicies() now accepts an additional
-  boolean argument which, in 3D, breaks each cubical cell into six tetrahedra
-  instead of five.  This mesh meets the restrictions of
-  FE_Simplex_Poly::face_to_cell_index().
+  implementation in FE_Q_Base.
   <br>
   (Kyle Schwiebert, 2025/04/04)
  </li>


### PR DESCRIPTION
We ended up redoing the second change and moving the relevant functionality to GridGenerator::hyper_rectangle_with_simplicies().