### PR TITLE
Remove some unnecessary `[[maybe_unused]]`s.

### DIFF
--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -72,7 +72,7 @@ InitFinalize::InitFinalize([[maybe_unused]] int    &argc,
                            const unsigned int       max_num_threads)
   : libraries(libraries)
 {
-  [[maybe_unused]] static bool constructor_has_already_run = false;
+  static bool constructor_has_already_run = false;
   Assert(constructor_has_already_run == false,
          ExcMessage("You can only create a single object of this class "
                     "in a program since it initializes the MPI system."));

--- a/source/cgal/surface_mesh.cc
+++ b/source/cgal/surface_mesh.cc
@@ -76,7 +76,7 @@ namespace
     else
       DEAL_II_ASSERT_UNREACHABLE();
 
-    [[maybe_unused]] const auto new_face = mesh.add_face(indices);
+    const auto new_face = mesh.add_face(indices);
     Assert(new_face != mesh.null_face(),
            ExcInternalError("While trying to build a CGAL facet, "
                             "CGAL encountered a orientation problem that it "

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -846,7 +846,7 @@ FiniteElement<dim, spacedim>::constraints(
   // TODO: the implementation makes the assumption that all faces have the
   // same number of dofs
   AssertDimension(this->n_unique_faces(), 1);
-  [[maybe_unused]] const unsigned int face_no = 0;
+  const unsigned int face_no = 0;
 
   Assert(subface_case == internal::SubfaceCase<dim>::case_isotropic,
          ExcMessage("Constraints for this element are only implemented "

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -951,7 +951,7 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
                     face_quadrature.point(k), subface);
               v_in(k) = this->poly_space.compute_value(i, p);
             }
-          [[maybe_unused]] const double result = H.least_squares(v_out, v_in);
+          const double result = H.least_squares(v_out, v_in);
           Assert(result < 1e-12, FETools::ExcLeastSquaresError(result));
 
           for (unsigned int j = 0; j < source_fe->n_dofs_per_face(face_no); ++j)

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -187,10 +187,10 @@ namespace internal
   template <int dim, int spacedim = dim>
   void
   copy_nonprimitive_base_element_values(
-    [[maybe_unused]] const FESystem<dim, spacedim> &fe,
-    [[maybe_unused]] const unsigned int             base_no,
-    const unsigned int                              n_q_points,
-    const UpdateFlags                               base_flags,
+    const FESystem<dim, spacedim> &fe,
+    const unsigned int             base_no,
+    const unsigned int             n_q_points,
+    const UpdateFlags              base_flags,
     const std::vector<typename FESystem<dim, spacedim>::BaseOffsets> &offsets,
     const FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
       &base_data,
@@ -1704,9 +1704,7 @@ FESystem<dim, spacedim>::initialize(
   Assert(count_nonzeros(multiplicities) > 0,
          ExcMessage("You only passed FiniteElements with multiplicity 0."));
 
-  [[maybe_unused]] const ReferenceCell reference_cell =
-    fes.front()->reference_cell();
-
+  const ReferenceCell reference_cell = fes.front()->reference_cell();
   Assert(std::all_of(fes.begin(),
                      fes.end(),
                      [reference_cell](const FiniteElement<dim, spacedim> *fe) {
@@ -1801,10 +1799,8 @@ FESystem<dim, spacedim>::initialize(
                            base_index = this->system_to_base_table[i].second;
         // Do not use `this` in Assert because nvcc when using C++20 assumes
         // that `this` is an integer and we get the following error: base
-        // operand of
-        // '->' is not a pointer
-        [[maybe_unused]] const unsigned int n_base_elements =
-          this->n_base_elements();
+        // operand of '->' is not a pointer
+        const unsigned int n_base_elements = this->n_base_elements();
         Assert(base < n_base_elements, ExcInternalError());
         Assert(base_index < base_element(base).unit_support_points.size(),
                ExcInternalError());
@@ -1967,13 +1963,12 @@ FESystem<dim, spacedim>::initialize(
           // Do not use `this` in Assert because nvcc when using C++20 assumes
           // that `this` is an integer and we get the following error: base
           // operand of '->' is not a pointer
-          [[maybe_unused]] const unsigned int n_elements =
+          const unsigned int n_elements =
             this->adjust_quad_dof_index_for_face_orientation_table[face_no]
               .n_elements();
-          [[maybe_unused]] const unsigned int n_face_orientations =
+          const unsigned int n_face_orientations =
             this->reference_cell().n_face_orientations(face_no);
-          [[maybe_unused]] const unsigned int n_dofs_per_quad =
-            this->n_dofs_per_quad(face_no);
+          const unsigned int n_dofs_per_quad = this->n_dofs_per_quad(face_no);
           Assert(n_elements == n_face_orientations * n_dofs_per_quad,
                  ExcInternalError());
 
@@ -2004,10 +1999,9 @@ FESystem<dim, spacedim>::initialize(
       // Do not use `this` in Assert because nvcc when using C++20 assumes that
       // `this` is an integer and we get the following error: base operand of
       // '->' is not a pointer
-      [[maybe_unused]] const unsigned int table_size =
+      const unsigned int table_size =
         this->adjust_line_dof_index_for_line_orientation_table.size();
-      [[maybe_unused]] const unsigned int n_dofs_per_line =
-        this->n_dofs_per_line();
+      const unsigned int n_dofs_per_line = this->n_dofs_per_line();
       Assert(table_size == n_dofs_per_line, ExcInternalError());
       unsigned int index = 0;
       for (unsigned int b = 0; b < this->n_base_elements(); ++b)

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -162,7 +162,7 @@ MappingQCache<dim, spacedim>::initialize(
       // Do not use `this` in Assert because nvcc when using C++20 assumes that
       // `this` is an integer and we get the following error: invalid type
       // argument of unary '*' (have 'int')
-      [[maybe_unused]] const unsigned int d = this->get_degree() + 1;
+      const unsigned int d = this->get_degree() + 1;
       AssertDimension(
         (*support_point_cache)[cell->level()][cell->index()].size(),
         Utilities::pow(d, dim));

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -130,11 +130,9 @@ MappingQEulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
 {
   const bool mg_vector = level != numbers::invalid_unsigned_int;
 
-  [[maybe_unused]] const types::global_dof_index n_dofs =
+  const types::global_dof_index n_dofs =
     mg_vector ? euler_dof_handler->n_dofs(level) : euler_dof_handler->n_dofs();
-  [[maybe_unused]] const types::global_dof_index vector_size =
-    euler_vector->size();
-
+  const types::global_dof_index vector_size = euler_vector->size();
   AssertDimension(vector_size, n_dofs);
 
   // we then transform our tria iterator into a dof iterator so we can access

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -450,7 +450,7 @@ SphericalManifold<dim, spacedim>::get_tangent_vector(
   const Point<spacedim> &p1,
   const Point<spacedim> &p2) const
 {
-  [[maybe_unused]] const double tol = 1e-10;
+  const double tol = 1e-10;
 
   Assert(p1 != p2, ExcMessage("p1 and p2 should not concide."));
 
@@ -628,11 +628,10 @@ namespace internal
 
       template <>
       Point<3>
-      do_get_new_point(
-        const ArrayView<const Tensor<1, 3>>            &directions,
-        [[maybe_unused]] const ArrayView<const double> &distances,
-        const ArrayView<const double>                  &weights,
-        const Point<3>                                 &candidate_point)
+      do_get_new_point(const ArrayView<const Tensor<1, 3>> &directions,
+                       const ArrayView<const double>       &distances,
+                       const ArrayView<const double>       &weights,
+                       const Point<3>                      &candidate_point)
       {
         AssertDimension(directions.size(), distances.size());
         AssertDimension(directions.size(), weights.size());

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2046,9 +2046,9 @@ namespace internal
 
       // count the number of objects, of unused single objects and of
       // unused pairs of objects
-      [[maybe_unused]] unsigned int n_quads          = 0;
-      unsigned int                  n_unused_pairs   = 0;
-      unsigned int                  n_unused_singles = 0;
+      unsigned int n_quads          = 0;
+      unsigned int n_unused_pairs   = 0;
+      unsigned int n_unused_singles = 0;
       for (unsigned int i = 0; i < tria_faces.quads.used.size(); ++i)
         {
           if (tria_faces.quads.used[i])
@@ -2274,9 +2274,9 @@ namespace internal
 
           // count the number of objects, of unused single objects and of
           // unused pairs of objects
-          [[maybe_unused]] unsigned int n_objects        = 0;
-          unsigned int                  n_unused_pairs   = 0;
-          unsigned int                  n_unused_singles = 0;
+          unsigned int n_objects        = 0;
+          unsigned int n_unused_pairs   = 0;
+          unsigned int n_unused_singles = 0;
           for (unsigned int i = 0; i < tria_objects.used.size(); ++i)
             {
               if (tria_objects.used[i])
@@ -5078,7 +5078,7 @@ namespace internal
 
                 triangulation.vertices[next_unused_vertex] = line->center(true);
 
-                [[maybe_unused]] bool pair_found = false;
+                bool pair_found = false;
                 for (; next_unused_line != endl; ++next_unused_line)
                   if (!next_unused_line->used() &&
                       !(++next_unused_line)->used())
@@ -5843,7 +5843,7 @@ namespace internal
                 // now that we created the right point, make up the
                 // two child lines.  To this end, find a pair of
                 // unused lines
-                [[maybe_unused]] bool pair_found = false;
+                bool pair_found = false;
                 for (; next_unused_line != endl; ++next_unused_line)
                   if (!next_unused_line->used() &&
                       !(++next_unused_line)->used())
@@ -12296,8 +12296,7 @@ void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
     ExcMessage(
       "Error: set_all_manifold_ids_on_boundary() can not be called on an empty Triangulation."));
 
-  [[maybe_unused]] bool boundary_found = false;
-
+  bool boundary_found = false;
   for (const auto &cell : this->active_cell_iterators())
     {
       // loop on faces

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -714,8 +714,8 @@ namespace OpenCASCADE
     double minDistance = 1e7;
     gp_Pnt tmp_proj(0.0, 0.0, 0.0);
 
-    [[maybe_unused]] unsigned int counter      = 0;
-    unsigned int                  face_counter = 0;
+    unsigned int counter      = 0;
+    unsigned int face_counter = 0;
 
     TopoDS_Shape out_shape;
     double       u = 0;


### PR DESCRIPTION
As of 917d49b6 we no longer get unused variable warnings for things only used in assertions, so we don't need the extra annotations.