### PR TITLE
doxygen: hide TEMPL_* macros

### DIFF
--- a/source/lac/la_parallel_block_vector.cc
+++ b/source/lac/la_parallel_block_vector.cc
@@ -30,15 +30,17 @@ namespace LinearAlgebra
 {
   namespace distributed
   {
-#define TEMPL_COPY_CONSTRUCTOR(S1, S2)                    \
-  template BlockVector<S1, ::dealii::MemorySpace::Host> & \
-  BlockVector<S1, ::dealii::MemorySpace::Host>::operator= \
-    <S2>(const BlockVector<S2, ::dealii::MemorySpace::Host> &)
+#ifndef DOXYGEN
+#  define TEMPL_COPY_CONSTRUCTOR(S1, S2)                    \
+    template BlockVector<S1, ::dealii::MemorySpace::Host> & \
+    BlockVector<S1, ::dealii::MemorySpace::Host>::operator= \
+      <S2>(const BlockVector<S2, ::dealii::MemorySpace::Host> &)
 
     TEMPL_COPY_CONSTRUCTOR(double, float);
     TEMPL_COPY_CONSTRUCTOR(float, double);
 
-#undef TEMPL_COPY_CONSTRUCTOR
+#  undef TEMPL_COPY_CONSTRUCTOR
+#endif
   } // namespace distributed
 } // namespace LinearAlgebra
 

--- a/source/lac/la_parallel_vector.cc
+++ b/source/lac/la_parallel_vector.cc
@@ -28,24 +28,25 @@ namespace LinearAlgebra
 {
   namespace distributed
   {
-#define TEMPL_COPY_CONSTRUCTOR(S1, S2)               \
-  template Vector<S1, ::dealii::MemorySpace::Host> & \
-  Vector<S1, ::dealii::MemorySpace::Host>::operator= \
-    <S2>(const Vector<S2, ::dealii::MemorySpace::Host> &)
+#ifndef DOXYGEN
+
+#  define TEMPL_COPY_CONSTRUCTOR(S1, S2)               \
+    template Vector<S1, ::dealii::MemorySpace::Host> & \
+    Vector<S1, ::dealii::MemorySpace::Host>::operator= \
+      <S2>(const Vector<S2, ::dealii::MemorySpace::Host> &)
 
     TEMPL_COPY_CONSTRUCTOR(double, float);
     TEMPL_COPY_CONSTRUCTOR(float, double);
-#ifdef DEAL_II_WITH_COMPLEX_VALUES
+#  ifdef DEAL_II_WITH_COMPLEX_VALUES
     TEMPL_COPY_CONSTRUCTOR(std::complex<double>, std::complex<float>);
     TEMPL_COPY_CONSTRUCTOR(std::complex<float>, std::complex<double>);
-#endif
+#  endif
 
-#undef TEMPL_COPY_CONSTRUCTOR
+#  undef TEMPL_COPY_CONSTRUCTOR
 
     template class Vector<float, ::dealii::MemorySpace::Default>;
     template class Vector<double, ::dealii::MemorySpace::Default>;
 
-#ifndef DOXYGEN
     template void
     Vector<float, ::dealii::MemorySpace::Host>::import_elements<
       ::dealii::MemorySpace::Default>(

--- a/source/lac/read_write_vector.cc
+++ b/source/lac/read_write_vector.cc
@@ -25,21 +25,23 @@ namespace LinearAlgebra
   // two template arguments that need to be different (the case of same
   // arguments is covered by the default copy constructor and copy operator that
   // is declared separately)
+#ifndef DOXYGEN
 
-#define TEMPL_COPY_CONSTRUCTOR(S1, S2)                         \
-  template ReadWriteVector<S1> &ReadWriteVector<S1>::operator= \
-    <S2>(const ReadWriteVector<S2> &)
+#  define TEMPL_COPY_CONSTRUCTOR(S1, S2)                         \
+    template ReadWriteVector<S1> &ReadWriteVector<S1>::operator= \
+      <S2>(const ReadWriteVector<S2> &)
 
   TEMPL_COPY_CONSTRUCTOR(double, float);
   TEMPL_COPY_CONSTRUCTOR(float, double);
-#ifdef DEAL_II_WITH_COMPLEX_VALUES
+#  ifdef DEAL_II_WITH_COMPLEX_VALUES
   TEMPL_COPY_CONSTRUCTOR(std::complex<double>, std::complex<float>);
   TEMPL_COPY_CONSTRUCTOR(std::complex<float>, std::complex<double>);
-#endif
+#  endif
 
-#undef TEMPL_COPY_CONSTRUCTOR
+#  undef TEMPL_COPY_CONSTRUCTOR
 
-#ifndef DOXYGEN
+
+
   template void
   ReadWriteVector<float>::import_elements(
     const distributed::Vector<float, ::dealii::MemorySpace::Host> &,


### PR DESCRIPTION
See
https://dealii.org/developer/doxygen/deal.II/namespaceLinearAlgebra.html for example.