### PR TITLE
Use uint8_t instead of unsigned char for geometric_orientation.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -37,7 +37,7 @@ namespace types
    * @ref GlossCombinedOrientation "glossary"
    * for more information.
    */
-  using geometric_orientation = unsigned char;
+  using geometric_orientation = std::uint8_t;
 
   /**
    * The type used to denote subdomain_ids of cells.


### PR DESCRIPTION
@drwells Reading through the release paper, I decided to look up the typedef for `types::geometric_orientation`. It is `unsigned char`, which is historically correct. What do you think of changing it to `std::uint8_t`, which I think more correctly represents the *intent*?