### PR TITLE
Fix default for MatrixOut.

### DIFF
--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -166,8 +166,9 @@ public:
    * been built, you can use the functions of the base class to write the data
    * into a files, using one of the supported output formats.
    *
-   * You may give a structure holding various options. See the description of
-   * the fields of this structure for more information.
+   * The last argument provides customization choices for how output
+   * is to be produced. See the description of the fields of the
+   * Options structure for more information.
    *
    * Note that this function requires that we can extract elements of the
    * matrix, which is done using the get_element() function declared in an
@@ -181,7 +182,7 @@ public:
   void
   build_patches(const Matrix      &matrix,
                 const std::string &name,
-                const Options      options = Options(false, 1, false, false));
+                const Options      options = Options());
 
 private:
   /**

--- a/tests/lac/matrix_out.cc
+++ b/tests/lac/matrix_out.cc
@@ -34,7 +34,9 @@ main()
         full_matrix(i, i) = 1;
 
       MatrixOut matrix_out;
-      matrix_out.build_patches(full_matrix, "full_matrix");
+      matrix_out.build_patches(full_matrix,
+                               "full_matrix",
+                               {false, 1, false, false});
       matrix_out.write_gnuplot(logfile);
     };
 


### PR DESCRIPTION
We describe in the release paper that the default for `MatrixOut` is now sparse output, but I messed that up in #18377: I only switched the default for the `MatrixOut::Options` struct, but not for the default value in `build_patches()` where we unfortunately list defaulted arguments again -- and these continue to describe dense output. I think that qualifies as a bug if we consider the release paper as the normative source, so I would suggest we fix it as done here, and pull the commit onto the release branch as well. Thoughts?