### PR TITLE
Reset FP exception flags at the end of test runs.

### DIFF
--- a/tests/tests.h
+++ b/tests/tests.h
@@ -895,6 +895,25 @@ struct EnableFPE
     feenableexcept(FE_DIVBYZERO | FE_INVALID);
 #endif
   }
+
+  ~EnableFPE()
+  {
+#if defined(DEBUG) && defined(DEAL_II_HAVE_FP_EXCEPTIONS)
+    // Disable floating point exceptions again at the end of the
+    // program run. One would think that this isn't actually
+    // necessary, but CGAL on Mac seems to check at program end that
+    // FP exception flags have been reset to the values it saw at
+    // program start -- see
+    // https://github.com/dealii/dealii/issues/18450. This is done via
+    // a static variable, whose constructor and destructor either
+    // brace the constructor and destructor of the current class, or
+    // the other way around. In either case, if we reset flags in the
+    // destructor here, then CGAL always sees the same values in its
+    // con/destructor.
+    fedisableexcept(FE_DIVBYZERO | FE_INVALID);
+#endif
+  }
+
 } deal_II_enable_fpe;
 
 


### PR DESCRIPTION
This addresses #18450. In ASPECT, we find that CGAL for whatever reason checks that at program end, the FP exception flags have been reset to the value we had at program start. We addressed that through https://github.com/geodynamics/aspect/pull/6634 and https://github.com/geodynamics/aspect/pull/6635. The deal.II library does not actually set FP flags, but we do that in the test suite. Now, I don't know whether we ever run tests on Mac with CGAL enabled, but if we did I would expect that we'd run into the same issue. This patch fixes this by resetting the FP flags at program end to the values we had before.