### PR TITLE
Export additional symbols from boost.ccm.

### DIFF
--- a/module/interface_module_partitions/boost.ccm
+++ b/module/interface_module_partitions/boost.ccm
@@ -374,4 +374,14 @@ export
     using boost::uintmax_t;
     using boost::variant;
   } // namespace boost
+
+
+  // C++ says that one can overload operator new/delete in the global
+  // namespace, and BOOST does exactly this (for example in
+  // container/detail/placement_new.hpp, which we get through the
+  // various boost.container headers). We need to make sure that these
+  // overloads are also exported so that we can access them through
+  // imports:
+  using ::operator new;
+  using ::operator delete;
 }


### PR DESCRIPTION
It turns out that one can overload `::operator new`, and that BOOST happens to do that. As a consequence, we need to also export these overloads from the BOOST module wrappers.

Part of #18071.