### PR TITLE
Suppress warnings when compiling backward compatibility headers as modules.

### DIFF
--- a/include/deal.II/base/std_cxx17/algorithm.h
+++ b/include/deal.II/base/std_cxx17/algorithm.h
@@ -19,8 +19,10 @@
 
 #include <algorithm>
 
+#ifndef DEAL_II_BUILDING_CXX20_MODULE
 DEAL_II_WARNING("This file is deprecated."
                 "Use the corresponding C++17 header algorithm instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17

--- a/include/deal.II/base/std_cxx17/optional.h
+++ b/include/deal.II/base/std_cxx17/optional.h
@@ -19,8 +19,10 @@
 
 #include <optional>
 
+#ifndef DEAL_II_BUILDING_CXX20_MODULE
 DEAL_II_WARNING("This file is deprecated."
                 "Use the corresponding C++17 header optional instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17

--- a/include/deal.II/base/std_cxx17/tuple.h
+++ b/include/deal.II/base/std_cxx17/tuple.h
@@ -19,8 +19,10 @@
 
 #include <tuple>
 
+#ifndef DEAL_II_BUILDING_CXX20_MODULE
 DEAL_II_WARNING("This file is deprecated."
                 "Use the corresponding C++17 header tuple instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17

--- a/include/deal.II/base/std_cxx17/variant.h
+++ b/include/deal.II/base/std_cxx17/variant.h
@@ -19,8 +19,10 @@
 
 #include <variant>
 
+#ifndef DEAL_II_BUILDING_CXX20_MODULE
 DEAL_II_WARNING("This file is deprecated."
                 "Use the corresponding C++17 header variant instead.")
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17


### PR DESCRIPTION
We convert all headers to module interface units and compile them. But we have a few deprecated headers that when converted and compiled trigger warnings. We could write some logic to just not compile those, but this would require special-casing directory names or file names. The easier way is to simply disable the warning if we are compiling modules (as opposed to someone `#include`ing these files).

Part of #18071.