### PR TITLE
Doc: fix ParameterHandler example

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -626,7 +626,7 @@ class MultipleParameterLoop;
  *     prm.parse_input ("prmtest.prm");
  *     // print parameters to std::cout as ASCII text
  *     std::cout << "\n\n";
- *     prm.print_parameters (std::cout, ParameterHandler::Text);
+ *     prm.print_parameters (std::cout, ParameterHandler::PRM);
  *     // get parameters into the program
  *     std::cout << "\n\n" << "Getting parameters:" << std::endl;
  *     p.get_parameters (prm);


### PR DESCRIPTION
The ::Text option has been deprecated in 9.6 and removed in 9.7