### PR TITLE
gh-actions: Also build in C++20 mode on macos.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -56,7 +56,7 @@ jobs:
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
-              -D DEAL_II_CXX_FLAGS='-Werror' \
+              -D DEAL_II_CXX_FLAGS='-Werror -std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               ..
     - name: print detailed.log
@@ -111,7 +111,7 @@ jobs:
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
               -D DEAL_II_WITH_64BIT_INDICES=ON \
-              -D DEAL_II_CXX_FLAGS='-Werror' \
+              -D DEAL_II_CXX_FLAGS='-Werror -std=c++20' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -D DEAL_II_WITH_MPI=ON \
               ..


### PR DESCRIPTION
We build with `std=c++20` on the linux and windows workflows.

I see no reason why not to do the same on the macos workflows.