### PR TITLE
gh-actions: Also build on windows-2025.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022]
+        os: [windows-2022, windows-2025]
 
     steps:
     - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
         ctest --test-dir build --build-config Debug --extra-verbose
     - name: upload library
       # run only if a PR is merged into master
-      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2022' }}
+      if: ${{ github.ref == 'refs/heads/master' && matrix.os == 'windows-2025' }}
       uses: actions/upload-artifact@v4
       with:
         name: dealii-${{ matrix.os }}


### PR DESCRIPTION
`windows-latest` will be migrated to `windows-2025` beginning September 2, 2025. [1]

So let's also build on `windows-2025` again, after we previously disabled it in #18558. I assume that their image is stable now. 

[1] -- https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration