### PR TITLE
When reading parameters from a string, don't say 'from file <input string>'.

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1722,8 +1722,9 @@ public:
                  std::string,
                  std::string,
                  << "There are unequal numbers of 'subsection' and 'end' "
-                    "statements in the parameter file <"
-                 << arg1 << ">." << (arg2.size() > 0 ? "\n" + arg2 : ""));
+                    "statements in the parameter file"
+                 << (arg1.empty() ? "" : (" <" + arg1 + ">")) << "."
+                 << (arg2.empty() ? "" : ("\n" + arg2)));
 
   /**
    * Exception for when, during parsing of a parameter file, the parser
@@ -1733,8 +1734,9 @@ public:
                  int,
                  std::string,
                  std::string,
-                 << "Line <" << arg1 << "> of file <" << arg2
-                 << ">: You are trying to enter a subsection '" << arg3
+                 << "Line <" << arg1 << ">"
+                 << (arg2.empty() ? "" : (" of file <" + arg2 + ">"))
+                 << ": You are trying to enter a subsection '" << arg3
                  << "', but the ParameterHandler object does "
                  << "not know of any such subsection.");
 
@@ -1747,7 +1749,9 @@ public:
                  int,
                  std::string,
                  std::string,
-                 << "Line <" << arg1 << "> of file <" << arg2 << ">: " << arg3);
+                 << "Line <" << arg1 << ">"
+                 << (arg2.empty() ? "" : (" of file <" + arg2 + ">")) << ": "
+                 << arg3);
 
   /**
    * Exception for an entry in a parameter file that does not match the
@@ -1760,8 +1764,9 @@ public:
                  std::string,
                  std::string,
                  std::string,
-                 << "Line <" << arg1 << "> of file <" << arg2
-                 << ">:\n"
+                 << "Line <" << arg1 << ">"
+                 << (arg2.empty() ? "" : (" of file <" + arg2 + ">"))
+                 << ":\n"
                     "    The entry value \n"
                  << "        " << arg3 << '\n'
                  << "    for the entry named\n"
@@ -1789,8 +1794,9 @@ public:
     int,
     std::string,
     std::string,
-    << "Line <" << arg1 << "> of file <" << arg2
-    << ">: This line "
+    << "Line <" << arg1 << ">"
+    << (arg2.empty() ? "" : (" of file <" + arg2 + ">"))
+    << ": This line "
        "contains an 'include' or 'INCLUDE' statement, but the given "
        "file to include <"
     << arg3 << "> cannot be opened.");

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -613,7 +613,10 @@ ParameterHandler::parse_input_from_string(const std::string &s,
                                           const bool         skip_undefined)
 {
   std::istringstream input_stream(s);
-  parse_input(input_stream, "input string", last_line, skip_undefined);
+  parse_input(input_stream,
+              /* filename is unknown: */ "",
+              last_line,
+              skip_undefined);
 }
 
 
@@ -2065,9 +2068,11 @@ ParameterHandler::scan_line(std::string        line,
           if (entries->get<std::string>(path + path_separator +
                                         "deprecation_status") == "true")
             {
-              std::cerr << "Warning in line <" << current_line_n
-                        << "> of file <" << input_filename
-                        << ">: You are using the deprecated spelling <"
+              std::cerr << "Warning in line <" << current_line_n << ">"
+                        << (input_filename.empty() ?
+                              "" :
+                              (" of file <" + input_filename + ">"))
+                        << ": You are using the deprecated spelling <"
                         << entry_name << "> of the parameter <"
                         << entries->get<std::string>(path + path_separator +
                                                      "alias")

--- a/tests/parameter_handler/parameter_handler_19.debug.output
+++ b/tests/parameter_handler/parameter_handler_19.debug.output
@@ -14,7 +14,7 @@ Additional information:
 DEAL::
 DEAL::* parse_input with missing 'end':
 DEAL::ExcUnbalancedSubsections(filename, paths_message.str())
-    There are unequal numbers of 'subsection' and 'end' statements in the parameter file <input string>.
+    There are unequal numbers of 'subsection' and 'end' statements in the parameter file.
 DEAL::
 DEAL::Exception 
 --------------------------------------------------------
@@ -32,7 +32,7 @@ DEAL::* Check non empty path before parse_input()
 DEAL::
 DEAL::* Check parse_input() catches messing with path:
 DEAL::ExcUnbalancedSubsections(filename, paths_message.str())
-    There are unequal numbers of 'subsection' and 'end' statements in the parameter file <input string>.
+    There are unequal numbers of 'subsection' and 'end' statements in the parameter file.
 Path before loading input:
     subsection test
 Current path:


### PR DESCRIPTION
When `ParameterHandler` triggers errors, it shows the file name of the file that contained the errors. But when the parameters are read from a string, rather than from a file, it says `... in file <input string>`, which is not particularly clear.  This then looks like this:
```
An error occurred in line <2145> of file </home/bangerth/p/deal.II/1/dealii/source/base/parameter_handler.cc> in function
    void dealii::ParameterHandler::scan_line(std::string, const std::string&, unsigned int, bool)
The violated condition was: 
    skip_undefined
Additional information: 
    Line <8> of file <input string>: No entry with name <Output diectory>
    was declared in the current subsection.
```
This patch rejiggers things in such a way that the confusing naming of an inexistent file name is simply omitted if no file name is available.