### PR TITLE
Fix typo in constraints.h documentation

### DIFF
--- a/doc/doxygen/headers/constraints.h
+++ b/doc/doxygen/headers/constraints.h
@@ -39,7 +39,7 @@
  *   VectorTools::compute_no_normal_flux_constraints function) or
  *   prescribed tangential components, $\mathbf{n}\times\mathbf{u}=
  *   \mathbf{n}\times\mathbf{f}$ (as happens in electromagnetic problems and
- *   is handled by the VectorTools::project_boundary_values_curl_conforming
+ *   is handled by the VectorTools::project_boundary_values_curl_conforming_l2
  *   function). For the former case, imagine for example that we are at
  *   at vertex where the normal vector has the form $\frac 1{\sqrt{14}}
  *   (1,2,3)^T$ and that the $x$-, $y$- and $z$-components of the flow


### PR DESCRIPTION
Fix #18823

Replace references to the deprecated `VectorTools::project_boundary_values_curl_conforming` with the correct `VectorTools::project_boundary_values_curl_conforming_l2` in constraints.h documentation.