### PR TITLE
[9.7 branch] MappingP1: add default constructor

### DIFF
--- a/include/deal.II/fe/mapping_p1.h
+++ b/include/deal.II/fe/mapping_p1.h
@@ -72,6 +72,11 @@ template <int dim, int spacedim = dim>
 class MappingP1 : public Mapping<dim, spacedim>
 {
 public:
+  /**
+   * Default constructor.
+   */
+  MappingP1() = default;
+
   virtual std::unique_ptr<Mapping<dim, spacedim>>
   clone() const override;
 


### PR DESCRIPTION
Ports #18766 to release branch.

fix nvcc 12.3 warning:
```
source/grid/reference_cell.cc(299): warning #811-D: const variable "mapping" requires an initializer -- class "dealii::MappingP1<1, 1>" has no user-provided default constructor
```