### PR TITLE
Matrix-free faces in 1d: Add forgotten changelogs

### DIFF
--- a/doc/news/9.6.0-vs-9.7.0.h
+++ b/doc/news/9.6.0-vs-9.7.0.h
@@ -751,6 +751,14 @@ inconvenience this causes.
  </li>
 
  <li>
+  Fixed: For `dim = 1`, the setup of MatrixFree did not correctly
+  identify faces between cells of different refinement level. This is
+  now fixed.
+  <br>
+  (Sean Johnson, 2024/12/12)
+ </li>
+
+ <li>
   New: Configuration and CI job for pre-commit.
   The tool pre-commit can install hooks into the local git repo.
   These will be run on every call to git commit and perform some quick checks

--- a/doc/news/9.7.0-vs-9.7.1.h
+++ b/doc/news/9.7.0-vs-9.7.1.h
@@ -1,0 +1,40 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+/**
+@page changes_between_9_7_0_and_9_7_1 Changes between Version 9.7.0 and 9.7.1
+
+<p>
+This is the list of changes made since the last release of deal.II.
+All entries are signed with the names of the authors.
+</p>
+
+<!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
+
+<a name="970-971-specific"></a>
+<h3>Specific improvements</h3>
+<ol>
+
+ <li>
+  Fixed: FESystem now populates the
+  adjust_line_dof_index_for_line_orientation_table in 2d, which in turn fixes
+  higher-order simplex elements in 2d.
+  <br>
+  (Arthur Bawin, David Wells, 2025/08/20)
+ </li>
+
+</ol>
+
+*/

--- a/doc/news/9.7.0-vs-9.7.1.h
+++ b/doc/news/9.7.0-vs-9.7.1.h
@@ -35,6 +35,15 @@ All entries are signed with the names of the authors.
   (Arthur Bawin, David Wells, 2025/08/20)
  </li>
 
+ <li>
+  Fixed: The setup of faces of MatrixFree for `dim = 1` across
+  periodic boundaries added some faces twice. This is
+  now fixed.
+  <br>
+  (Martin Kronbichler, Peter Munch, Magdalena Schreter-Fleischhacker,
+  Andreas Koch, 2025/07/25)
+ </li>
+
 </ol>
 
 */


### PR DESCRIPTION
This fixes what was discovered in #18835: We had forgotten to mention the initial bugfix and the later fix addressing it that went to the release branch. I have moved this on top of #18838 because I don't want to create the file another time.