### PR TITLE
Add alpha in step-7.

### DIFF
--- a/examples/step-7/doc/intro.dox
+++ b/examples/step-7/doc/intro.dox
@@ -118,7 +118,7 @@ Using the above definitions, we can state the weak formulation of the
 equation, which reads: find $u\in H^1_g=\{v\in H^1: v|_{\Gamma_1}=g_1\}$ such
 that
 @f[
-  {(\nabla v, \nabla u)}_\Omega + {(v,u)}_\Omega
+  {(\nabla v, \nabla u)}_\Omega + \alpha {(v,u)}_\Omega
   =
   {(v,f)}_\Omega + {(v,g_2)}_{\Gamma_2}
 @f]
@@ -129,7 +129,7 @@ matrices and vectors which we use to build the global matrices and right hand
 side vectors in the discrete formulation therefore look like this:
 @f{eqnarray*}{
   A_{ij}^K &=& \left(\nabla \varphi_i, \nabla \varphi_j\right)_K
-              +\left(\varphi_i, \varphi_j\right)_K,
+              +\alpha \left(\varphi_i, \varphi_j\right)_K,
   \\
   F_i^K &=& \left(\varphi_i, f\right)_K
            +\left(\varphi_i, g_2\right)_{\partial K\cap \Gamma_2}.
@@ -168,7 +168,7 @@ where the centers $x_i$ of the exponentials are
 and the half width is set to $\sigma=\frac {1}{8}$. The method of manufactured
 solution then says: choose
 @f{align*}{
-  f &= -\Delta \bar u + \bar u, \\
+  f &= -\Delta \bar u + \alpha \bar u, \\
   g_1 &= \bar u|_{\Gamma_1}, \\
   g_2 &= {\mathbf n}\cdot \nabla\bar u|_{\Gamma_2}.
 @f}

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -600,13 +600,14 @@ namespace Step7
                   // equation, including the coefficient $\alpha=1$:
                   const double alpha = 1;
                   cell_matrix(i, j) +=
-                    ((fe_values.shape_grad(i, q_point) * // (grad phi_i(x_q)
-                        fe_values.shape_grad(j, q_point) //  * grad phi_j(x_q)
-                      +                                  //
-                      alpha *                            //  alpha
-                        fe_values.shape_value(i, q_point) *  //  * phi_i(x_q)
-                        fe_values.shape_value(j, q_point)) * //  * phi_j(x_q))
-                     fe_values.JxW(q_point));                // *dx
+                    (fe_values.shape_grad(i, q_point)      // [grad phi_i(x_q)
+                       * fe_values.shape_grad(j, q_point)  //  * grad phi_j(x_q)
+                     +                                     //
+                     alpha                                 //  alpha
+                       * fe_values.shape_value(i, q_point) //  * phi_i(x_q)
+                       * fe_values.shape_value(j, q_point) //  * phi_j(x_q)]
+                     ) *
+                    fe_values.JxW(q_point); // * dx
                 }
 
               cell_rhs(i) += (fe_values.shape_value(i, q_point) * // phi_i(x_q)

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -594,17 +594,20 @@ namespace Step7
           for (unsigned int i = 0; i < dofs_per_cell; ++i)
             {
               for (unsigned int j = 0; j < dofs_per_cell; ++j)
-                // The first thing that has changed is the bilinear form. It
-                // now contains the additional term from the Helmholtz
-                // equation:
-                cell_matrix(i, j) +=
-                  ((fe_values.shape_grad(i, q_point) *     // grad phi_i(x_q)
-                      fe_values.shape_grad(j, q_point)     // grad phi_j(x_q)
-                    +                                      //
-                    fe_values.shape_value(i, q_point) *    // phi_i(x_q)
-                      fe_values.shape_value(j, q_point)) * // phi_j(x_q)
-                   fe_values.JxW(q_point));                // dx
-
+                {
+                  // The first thing that has changed is the bilinear form. It
+                  // now contains the additional term from the Helmholtz
+                  // equation, including the coefficient $\alpha=1$:
+                  const double alpha = 1;
+                  cell_matrix(i, j) +=
+                    ((fe_values.shape_grad(i, q_point) * // (grad phi_i(x_q)
+                        fe_values.shape_grad(j, q_point) //  * grad phi_j(x_q)
+                      +                                  //
+                      alpha *                            //  alpha
+                        fe_values.shape_value(i, q_point) *  //  * phi_i(x_q)
+                        fe_values.shape_value(j, q_point)) * //  * phi_j(x_q))
+                     fe_values.JxW(q_point));                // *dx
+                }
 
               cell_rhs(i) += (fe_values.shape_value(i, q_point) * // phi_i(x_q)
                               rhs_values[q_point] *               // f(x_q)


### PR DESCRIPTION
The equation shown at the top of the step-7 introduction has a coefficient alpha=1. The rest of the program, however, omits this coefficient (presumably because we have assumed it to be equal to 1). I think the coefficient is useful, however, primarily because it carries physical units that make sure this term can be added to the other terms.

This patch adds the coefficient throughout.