### PR TITLE
Add `numbers::invalid_geometric_orientation`.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -366,6 +366,20 @@ namespace numbers
     static_cast<types::geometric_orientation>(0b001);
 
   /**
+   * Value indicating an invalid or unset orientation.
+   *
+   * This value is an example of an
+   * @ref GlossInvalidValue "invalid value".
+   * See there for more information.
+   *
+   * See the
+   * @ref GlossCombinedOrientation "glossary"
+   * for more information.
+   */
+  constexpr types::geometric_orientation invalid_geometric_orientation =
+    static_cast<types::geometric_orientation>(-1);
+
+  /**
    * A special id for an invalid subdomain id. This value may not be used as a
    * valid id but is used, for example, for default arguments to indicate a
    * subdomain id that is not to be used.

--- a/include/deal.II/grid/tria_orientation.h
+++ b/include/deal.II/grid/tria_orientation.h
@@ -44,11 +44,16 @@ namespace internal
    */
   inline std::tuple<bool, bool, bool>
   split_face_orientation(
-    const types::geometric_orientation combined_face_orientation)
+    const types::geometric_orientation combined_orientation)
   {
-    return {!Utilities::get_bit(combined_face_orientation, 0),
-            Utilities::get_bit(combined_face_orientation, 1),
-            Utilities::get_bit(combined_face_orientation, 2)};
+    Assert(combined_orientation != numbers::invalid_geometric_orientation,
+           ExcMessage(
+             "The provided orientation value is not valid. This typically "
+             "means this value was initialized to an invalid value and not "
+             "correctly set later."));
+    return {!Utilities::get_bit(combined_orientation, 0),
+            Utilities::get_bit(combined_orientation, 1),
+            Utilities::get_bit(combined_orientation, 2)};
   }
 
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7477,9 +7477,10 @@ FEFaceEvaluation<dim,
 
           if (face_index == numbers::invalid_unsigned_int)
             {
-              this->cell_ids[i]          = numbers::invalid_unsigned_int;
-              this->face_numbers[i]      = static_cast<std::uint8_t>(-1);
-              this->face_orientations[i] = static_cast<std::uint8_t>(-1);
+              this->cell_ids[i]     = numbers::invalid_unsigned_int;
+              this->face_numbers[i] = static_cast<std::uint8_t>(-1);
+              this->face_orientations[i] =
+                numbers::invalid_geometric_orientation;
               continue; // invalid face ID: no neighbor on boundary
             }
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7508,7 +7508,8 @@ FEFaceEvaluation<dim,
             }
 
           const bool orientation_interior_face = faces.face_orientation >= 8;
-          auto       face_orientation          = faces.face_orientation % 8;
+          types::geometric_orientation face_orientation =
+            faces.face_orientation % 8;
           if (face_identifies_as_interior != orientation_interior_face)
             {
               Assert(this->matrix_free->get_cell_iterator(cell_index, i)
@@ -7524,7 +7525,7 @@ FEFaceEvaluation<dim,
     }
   else
     {
-      this->face_orientations[0] = 0;
+      this->face_orientations[0] = numbers::default_geometric_orientation;
       this->face_numbers[0]      = face_number;
       if (this->matrix_free->n_active_entries_per_cell_batch(this->cell) ==
           n_lanes)

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -955,7 +955,7 @@ protected:
    * @note Only available for `dof_access_index == dof_access_cell` and
    * `is_interior_face == false`.
    */
-  std::array<std::uint8_t, n_lanes> face_orientations;
+  std::array<types::geometric_orientation, n_lanes> face_orientations;
 
   /**
    * Stores the subface index of the given face. Usually, this variable takes
@@ -1184,7 +1184,7 @@ FEEvaluationData<dim, Number, is_face>::operator=(const FEEvaluationData &other)
          internal::MatrixFreeFunctions::DoFInfo::dof_access_face_exterior) :
       internal::MatrixFreeFunctions::DoFInfo::dof_access_cell;
   face_numbers[0]         = 0;
-  face_orientations[0]    = 0;
+  face_orientations[0]    = numbers::default_geometric_orientation;
   subface_index           = 0;
   cell_type               = internal::MatrixFreeFunctions::general;
   divergence_is_requested = false;
@@ -1275,7 +1275,7 @@ FEEvaluationData<dim, Number, is_face>::reinit_face(
   // internal::MatrixFreeFunctions::FaceToCellTopology::face_orientation.
   face_orientations[0] = (is_interior_face() == (face.face_orientation >= 8)) ?
                            (face.face_orientation % 8) :
-                           0;
+                           numbers::default_geometric_orientation;
 
   if (is_interior_face())
     cell_ids = face.cells_interior;


### PR DESCRIPTION
I also used it in a place instead of `static_cast<T>(-1)`.