### PR TITLE
ReferenceCell: let vertices have one child.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -2079,7 +2079,7 @@ ReferenceCell::n_isotropic_children() const
   switch (this->kind)
     {
       case ReferenceCells::Vertex:
-        return 0;
+        return 1;
       case ReferenceCells::Line:
         return 2;
       case ReferenceCells::Triangle:


### PR DESCRIPTION
This makes things consistent with `GeometryInfo<0>::max_children_per_cell`.

Fixes #14667. There are some other odd inconsistencies around `GeometryInfo<0>` (like `GeometryInfo<0>::n_children()` returns `0`) but that's something we should gradually address as we retire `GeometryInfo`.