### PR TITLE
doxygen: switch dot graphs to svg

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -294,7 +294,7 @@ CALL_GRAPH             = NO
 CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = NO
 DIRECTORY_GRAPH        = YES
-DOT_IMAGE_FORMAT       = png
+DOT_IMAGE_FORMAT       = svg
 MAX_DOT_GRAPH_DEPTH    = 5
 DOT_EDGE_ATTR          = "color=cornflowerblue"
 GENERATE_LEGEND        = YES


### PR DESCRIPTION
Switch dot graphs used for inheritance graphs from png to svg. This makes font rendering more legible and most importantly, disables the current problem where large graphs are zoomed out to fit 100% of the screen with the effect of making them no longer clickable (clickable regions don't line up with the boxes).

For an example see https://dealii.org/developer/doxygen/deal.II/classMapping.html#nested-classes:~:text=Houston%2C%20Chapter%207.-,Definition%20at%20line,-319%20of%20file

before:
<img width="1277" height="614" alt="image" src="https://github.com/user-attachments/assets/4d9e33e5-9bf1-49cf-a248-9b8d416f595d" />


after:
<img width="1276" height="713" alt="image" src="https://github.com/user-attachments/assets/33cbd812-f221-49cd-89f2-8a24d10e3d3d" />
