### PR TITLE
doc: RemotePointEvaluation: promise no concurrent call-back

### DIFF
--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -326,6 +326,9 @@ namespace Utilities
        *   specify the number of components @p n_components. This allows to
        *   provide unrolled tensors, which is useful, e.g., if its dimension
        *   and its rank is not known at compile time.
+       *
+       * @note The @p evaluation_function will be called sequentially and not
+       * from multiple threads at the same time.
        */
       template <typename DataType, unsigned int n_components = 1>
       void
@@ -360,6 +363,9 @@ namespace Utilities
        *   specify the number of components @p n_components. This allows to
        *   provide unrolled tensors, which is useful, e.g., if its dimension
        *   and its rank is not known at compile time.
+       *
+       * @note The @p evaluation_function will be called sequentially and not
+       * from multiple threads at the same time.
        */
       template <typename DataType, unsigned int n_components = 1>
       void


### PR DESCRIPTION
Document that the lambda provided will not be called concurrently, which would make it difficult to capture and store any data due to potential write race conditions.

FYI @bangerth 