### PR TITLE
Get rid of one place where we use GeometryInfo.

### DIFF
--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -816,24 +816,30 @@ FlatManifold<3>::get_normals_at_vertices(
   const Triangulation<3>::face_iterator &face,
   Manifold<3, 3>::FaceVertexNormals     &face_vertex_normals) const
 {
-  const unsigned int vertices_per_face = GeometryInfo<3>::vertices_per_face;
-
-  static const unsigned int neighboring_vertices[4][2] = {{1, 2},
-                                                          {3, 0},
-                                                          {0, 3},
-                                                          {2, 1}};
-  for (unsigned int vertex = 0; vertex < vertices_per_face; ++vertex)
+  if (face->reference_cell() == ReferenceCells::Quadrilateral)
     {
-      // first define the two tangent vectors at the vertex by using the
-      // two lines radiating away from this vertex
-      const Tensor<1, 3> tangents[2] = {
-        face->vertex(neighboring_vertices[vertex][0]) - face->vertex(vertex),
-        face->vertex(neighboring_vertices[vertex][1]) - face->vertex(vertex)};
+      static const unsigned int neighboring_vertices[4][2] = {{1, 2},
+                                                              {3, 0},
+                                                              {0, 3},
+                                                              {2, 1}};
+      for (unsigned int vertex = 0; vertex < face->n_vertices(); ++vertex)
+        {
+          // first define the two tangent vectors at the vertex by using the
+          // two lines radiating away from this vertex
+          const Tensor<1, 3> tangents[2] = {
+            face->vertex(neighboring_vertices[vertex][0]) -
+              face->vertex(vertex),
+            face->vertex(neighboring_vertices[vertex][1]) -
+              face->vertex(vertex)};
 
-      // then compute the normal by taking the cross product. since the
-      // normal is not required to be normalized, no problem here
-      face_vertex_normals[vertex] = cross_product_3d(tangents[0], tangents[1]);
+          // then compute the normal by taking the cross product. since the
+          // normal is not required to be normalized, no problem here
+          face_vertex_normals[vertex] =
+            cross_product_3d(tangents[0], tangents[1]);
+        }
     }
+  else
+    DEAL_II_NOT_IMPLEMENTED();
 }
 
 


### PR DESCRIPTION
In the spirit of the discussion on Element, here's a patch that removes one of the ~1500 places where we still use `GeometryInfo` :-) It doesn't actually resolve the issue that the function isn't implemented for triangles, but at least it now gives an error, and it removes the use of `GeometryInfo` in the implemented part.

Part of #11879 .