### PR TITLE
Simplify handling of timer overhead in TimerOutput

### DIFF
--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -301,6 +301,8 @@ TimerOutput::TimerOutput(std::ostream         &stream,
                          const OutputType      output_type)
   : output_frequency(output_frequency)
   , output_type(output_type)
+  , timer_all()
+  , sections()
   , out_stream(stream, true)
   , output_is_enabled(true)
   , mpi_communicator(MPI_COMM_SELF)
@@ -313,6 +315,8 @@ TimerOutput::TimerOutput(ConditionalOStream   &stream,
                          const OutputType      output_type)
   : output_frequency(output_frequency)
   , output_type(output_type)
+  , timer_all()
+  , sections()
   , out_stream(stream)
   , output_is_enabled(true)
   , mpi_communicator(MPI_COMM_SELF)
@@ -326,6 +330,8 @@ TimerOutput::TimerOutput(const MPI_Comm        mpi_communicator,
                          const OutputType      output_type)
   : output_frequency(output_frequency)
   , output_type(output_type)
+  , timer_all(mpi_communicator, /* sync_lap_times */ false)
+  , sections()
   , out_stream(stream, true)
   , output_is_enabled(true)
   , mpi_communicator(mpi_communicator)
@@ -339,6 +345,8 @@ TimerOutput::TimerOutput(const MPI_Comm        mpi_communicator,
                          const OutputType      output_type)
   : output_frequency(output_frequency)
   , output_type(output_type)
+  , timer_all(mpi_communicator, /* sync_lap_times */ false)
+  , sections()
   , out_stream(stream)
   , output_is_enabled(true)
   , mpi_communicator(mpi_communicator)
@@ -546,19 +554,19 @@ TimerOutput::print_summary() const
       // in case we want to write CPU times
       if (output_type != wall_times)
         {
-          double total_cpu_time =
-            Utilities::MPI::sum(timer_all.cpu_time(), mpi_communicator);
+          double total_cpu_time = timer_all.cpu_time();
 
-          // check that the sum of all times is less or equal than the total
-          // time. otherwise, we might have generated a lot of overhead in this
-          // function.
-          double check_time = 0.;
+          // check that the sum of all section times is less or equal than the
+          // total time. otherwise, we might have generated a lot of overhead in
+          // this function.
+          double total_cpu_time_in_sections = 0.;
           for (const auto &i : sections)
-            check_time += i.second.total_cpu_time;
+            total_cpu_time_in_sections += i.second.total_cpu_time;
 
-          const double time_gap = check_time - total_cpu_time;
-          if (time_gap > 0.0)
-            total_cpu_time = check_time;
+          const double section_overhead =
+            total_cpu_time_in_sections - total_cpu_time;
+          if (section_overhead > 0.0)
+            total_cpu_time = total_cpu_time_in_sections;
 
           // generate a nice table
           out_stream << "\n\n"
@@ -624,10 +632,10 @@ TimerOutput::print_summary() const
                      << "------------+------------+\n"
                      << std::endl;
 
-          if (time_gap > 0.0)
+          if (section_overhead > 0.0)
             out_stream
               << std::endl
-              << "Note: The sum of counted times is " << time_gap
+              << "Note: The sum of section times is " << section_overhead
               << " seconds larger than the total time.\n"
               << "(Timer function may have introduced too much overhead, or different\n"
               << "section timers may have run at the same time.)" << std::endl;
@@ -636,7 +644,7 @@ TimerOutput::print_summary() const
       // in case we want to write out wallclock times
       if (output_type != cpu_times)
         {
-          double total_wall_time = timer_all.wall_time();
+          const double total_wall_time = timer_all.wall_time();
 
           // now generate a nice table
           out_stream << "\n\n"
@@ -707,19 +715,18 @@ TimerOutput::print_summary() const
     // output_type == cpu_and_wall_times_grouped
     {
       const double total_wall_time = timer_all.wall_time();
-      double       total_cpu_time =
-        Utilities::MPI::sum(timer_all.cpu_time(), mpi_communicator);
+      double       total_cpu_time  = timer_all.cpu_time();
 
       // check that the sum of all times is less or equal than the total time.
       // otherwise, we might have generated a lot of overhead in this function.
-      double check_time = 0.;
-
+      double total_cpu_time_in_sections = 0.;
       for (const auto &i : sections)
-        check_time += i.second.total_cpu_time;
+        total_cpu_time_in_sections += i.second.total_cpu_time;
 
-      const double time_gap = check_time - total_cpu_time;
-      if (time_gap > 0.0)
-        total_cpu_time = check_time;
+      const double section_overhead =
+        total_cpu_time_in_sections - total_cpu_time;
+      if (section_overhead > 0.0)
+        total_cpu_time = total_cpu_time_in_sections;
 
       // generate a nice table
       out_stream << "\n\n+---------------------------------------------"
@@ -820,10 +827,10 @@ TimerOutput::print_summary() const
                  << "------------+------------+" << std::endl
                  << std::endl;
 
-      if (output_type != wall_times && time_gap > 0.0)
+      if (output_type != wall_times && section_overhead > 0.0)
         out_stream
           << std::endl
-          << "Note: The sum of counted times is " << time_gap
+          << "Note: The sum of section times is " << section_overhead
           << " seconds larger than the total time.\n"
           << "(Timer function may have introduced too much overhead, or different\n"
           << "section timers may have run at the same time.)" << std::endl;


### PR DESCRIPTION
Part 3 of splitting #18866.

This PR improves readability of the TimerOutput class and resolves an apparent (but not actual) contradiction between the documentation of the `timer_all` member variable and its use in the class. The documentation of `timer_all` states: 
```
   * A timer object for the overall run time. If we are using MPI, this timer
   * also accumulates over all MPI processes.
```

But in the code it is not initialized with an MPI communicator. This looks like a bug, except in the places where it is used, we manually perform an `MPI::sum` over all CPU times reported by the timer_all objects. If the objects are initialized with an MPI communicator instead this will just happen inside the `cpu_time()` function. Therefore initializing `timer_all` with the MPI communicator is more in line with the documentation and does not change its behavior for the cases we use it for.

I also improved the naming of some variables that are filled with the information from timer_all. `check_time` and `time_gap` are not explaining well what they actually mean, so I renamed them into `total_cpu_time_in_sections` and `section_overhead`.

This PR should not change any functionality.