### PR TITLE
Move logic from setup() into initialize in all petsc preconditioners.

### DIFF
--- a/doc/news/changes/incompatibilities/20250918Moulday
+++ b/doc/news/changes/incompatibilities/20250918Moulday
@@ -1,0 +1,3 @@
+Removed: The `setup` function for all preconditioners in the `PETScWrappers` namespace has been deprecated. Its action is now automatically performed during `initialize`.
+<br>
+(Ryan Moulday, 2025/09/18)

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -98,7 +98,10 @@ namespace PETScWrappers
     /**
      * Explicitly call setup. This is usually not needed since PETSc will
      * automatically call the setup function when needed.
+     *
+     * @deprecated setup() is now explicitly called during initialize().
      */
+    DEAL_II_DEPRECATED_EARLY
     void
     setup();
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -82,12 +82,7 @@ namespace PETScWrappers
 
   void
   PreconditionBase::setup()
-  {
-    AssertThrow(pc != nullptr, StandardExceptions::ExcInvalidState());
-
-    PetscErrorCode ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-  }
+  {}
 
   MPI_Comm
   PreconditionBase::get_mpi_communicator() const
@@ -183,6 +178,9 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
+
+    PetscErrorCode ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -239,6 +237,9 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
+
+    PetscErrorCode ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -282,6 +283,9 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -331,6 +335,9 @@ namespace PETScWrappers
 
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -375,6 +382,9 @@ namespace PETScWrappers
 
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -418,6 +428,9 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -670,6 +683,7 @@ namespace PETScWrappers
 
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
+
 #  else
     Assert(false,
            ExcMessage("Your PETSc installation does not include a copy of "
@@ -690,6 +704,9 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
+
+    PetscErrorCode ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
 
 #  else // DEAL_II_PETSC_WITH_HYPRE
     (void)matrix_;
@@ -805,6 +822,9 @@ namespace PETScWrappers
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
+    ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
 #  else // DEAL_II_PETSC_WITH_HYPRE
     (void)matrix_;
     Assert(false,
@@ -844,6 +864,9 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -898,6 +921,9 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1046,6 +1072,9 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
+
+    PetscErrorCode ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
   /* ----------------- PreconditionShell -------------------- */
@@ -1091,6 +1120,9 @@ namespace PETScWrappers
     initialize(matrix.get_mpi_communicator());
     PetscErrorCode ierr;
     ierr = PCSetOperators(pc, matrix, matrix);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 


### PR DESCRIPTION
This implements the eager construction of PETSc preconditioners as mentioned in #18856 
