### PR TITLE
Improve the formatting of an error message.

### DIFF
--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1758,21 +1758,19 @@ public:
    * provided pattern. The arguments are, in order, the line number, file
    * name, entry value, entry name, and a description of the pattern.
    */
-  DeclException5(ExcInvalidEntryForPattern,
-                 int,
-                 std::string,
-                 std::string,
-                 std::string,
-                 std::string,
-                 << "Line <" << arg1 << ">"
-                 << (arg2.empty() ? "" : (" of file <" + arg2 + ">"))
-                 << ":\n"
-                    "    The entry value \n"
-                 << "        " << arg3 << '\n'
-                 << "    for the entry named\n"
-                 << "        " << arg4 << '\n'
-                 << "    does not match the given pattern:\n"
-                 << "        " << arg5);
+  DeclException5(
+    ExcInvalidEntryForPattern,
+    int,
+    std::string,
+    std::string,
+    std::string,
+    std::string,
+    << "In line <" << arg1 << ">"
+    << (arg2.empty() ? "" : (" of file <" + arg2 + ">")) << ": The value <"
+    << arg3 << "> for the parameter entry named <" << arg4
+    << "> does not match the pattern expected for this parameter.\n"
+       "The expected pattern for this parameter is:\n"
+    << arg5);
 
   /**
    * Exception for when an XML file cannot be read at all. This happens when

--- a/tests/parameter_handler/parameter_handler_10.output
+++ b/tests/parameter_handler/parameter_handler_10.output
@@ -1,9 +1,5 @@
 
-DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
-Line <1> of file <input file>:
-    The entry value 
-        3.1415
-    for the entry named
-        test_1
-    does not match the given pattern:
-        [Integer range -2147483648...2147483647 (inclusive)]
+DEAL::ExcInvalidEntryForPattern( current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
+    In line <1> of file <input file>: The value <3.1415> for the parameter entry named <test_1> does not match the pattern expected for this parameter.
+The expected pattern for this parameter is:
+[Integer range -2147483648...2147483647 (inclusive)]

--- a/tests/parameter_handler/parameter_handler_11.output
+++ b/tests/parameter_handler/parameter_handler_11.output
@@ -1,9 +1,5 @@
 
-DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
-Line <1> of file <input file>:
-    The entry value 
-        3.1415 something
-    for the entry named
-        test_1
-    does not match the given pattern:
-        [Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]
+DEAL::ExcInvalidEntryForPattern( current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
+    In line <1> of file <input file>: The value <3.1415 something> for the parameter entry named <test_1> does not match the pattern expected for this parameter.
+The expected pattern for this parameter is:
+[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]

--- a/tests/parameter_handler/parameter_handler_backslash_03.output
+++ b/tests/parameter_handler/parameter_handler_backslash_03.output
@@ -1,17 +1,9 @@
 
-DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
-Line <4> of file <prm/parameter_handler_backslash_03.prm>:
-    The entry value
-        a,\
-    for the entry named
-        Function
-    does not match the given pattern:
-        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
-DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
-Line <4> of file <input file>:
-    The entry value
-        a,\
-    for the entry named
-        Function
-    does not match the given pattern:
-        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+DEAL::ExcInvalidEntryForPattern( current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
+    In file <parameter_handler_backslash_03.prm>: The value <a,\> for the parameter entry named <Function> does not match the pattern expected for this parameter.
+The expected pattern for this parameter is:
+[List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+DEAL::ExcInvalidEntryForPattern( current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
+    In line <4> of file <input file>: The value <a,\> for the parameter entry named <Function> does not match the pattern expected for this parameter.
+The expected pattern for this parameter is:
+[List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]

--- a/tests/parameter_handler/parameter_handler_backslash_04.output
+++ b/tests/parameter_handler/parameter_handler_backslash_04.output
@@ -1,17 +1,9 @@
 
-DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
-Line <4> of file <prm/parameter_handler_backslash_04.prm>:
-    The entry value
-        a,\ b,
-    for the entry named
-        Function
-    does not match the given pattern:
-        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
-DEAL::ExcInvalidEntryForPattern (current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
-Line <4> of file <input file>:
-    The entry value
-        a,\ b,
-    for the entry named
-        Function
-    does not match the given pattern:
-        [List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+DEAL::ExcInvalidEntryForPattern( current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
+    In file <parameter_handler_backslash_04.prm>: The value <a,\ b,> for the parameter entry named <Function> does not match the pattern expected for this parameter.
+The expected pattern for this parameter is:
+[List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]
+DEAL::ExcInvalidEntryForPattern( current_line_n, input_filename, entry_value, entry_name, patterns[pattern_index]->description())
+    In line <4> of file <input file>: The value <a,\ b,> for the parameter entry named <Function> does not match the pattern expected for this parameter.
+The expected pattern for this parameter is:
+[List of <[Selection a|b|c|d|e|f|g|h ]> of length 0...4294967295 (inclusive)]


### PR DESCRIPTION
Trying something with ASPECT, I got this slightly awkwardly-formatted error message:
```
An error occurred in line <2098> of file </tempest/a/accounts/bangerth/p/deal.II/1/dealii/source/base/parameter_handler.cc> in function
    void dealii::ParameterHandler::scan_line(std::string, const std::string&, unsigned int, bool)
The violated condition was: 
    patterns[pattern_index]->match(entry_value)
Additional information: 
    Line <171>:
    The entry value
    tidal heating2
    for the entry named
    List of model names
    does not match the given pattern:
    [MultipleSelection adiabatic heating|adiabatic heating of
    melt|compositional heating|constant heating|function|latent
    heat|latent heat melt|radioactive decay|shear heating|shear heating
    with melt|tidal heating ]
```
The short lines are because we used to have the formatting as part of the exception message, but these days we wrap all errors to 70 characters and prepend two spaces at the front. That means that any manual formatting is lost. This patch removes manual formatting from one of the more often triggered error messages involving `ParameterHandler`. This now looks as follows:
```
An error occurred in line <2098> of file </tempest/a/accounts/bangerth/p/deal.II/1/dealii/source/base/parameter_handler.cc> in function
    void dealii::ParameterHandler::scan_line(std::string, const std::string&, unsigned int, bool)
The violated condition was: 
    patterns[pattern_index]->match(entry_value)
Additional information: 
    In line <171>: The value <tidal heating2> for the parameter entry
    named <List of model names> does not match the pattern expected for
    this parameter.
    The expected pattern for this parameter is:
    [MultipleSelection adiabatic heating|adiabatic heating of
    melt|compositional heating|constant heating|function|latent
    heat|latent heat melt|radioactive decay|shear heating|shear heating
    with melt|tidal heating ]
```
