### PR TITLE
Disallow TimerOutput output while running

### DIFF
--- a/doc/news/changes/incompatibilities/20251002Gassmoeller
+++ b/doc/news/changes/incompatibilities/20251002Gassmoeller
@@ -1,0 +1,4 @@
+Changed: The TimerOutput class no longer supports producing output while actively timing a subsection.
+This feature was removed to simplify internal data storage and to avoid inconsistencies in parallel computations.
+<br>
+(Rene Gassmoeller, 2025/10/02)

--- a/doc/news/changes/minor/20250924Gassmoeller
+++ b/doc/news/changes/minor/20250924Gassmoeller
@@ -1,7 +1,5 @@
-Changed: The TimerOutput class now includes run time spent in currently active
-subsections in its reports. Previously it would only report time spent in
-sections that had already been left. Additionally, CPU time spent in sections
-is now reported as the sum over all processes in the given MPI communicator.
+Changed: The TimerOutput class now reports CPU time spent in sections
+as the sum over all processes in the given MPI communicator.
 Previously, it would only report for each section the CPU time on the current
 process. This meant the time spent in sections would not add up to the total
 CPU time, which was always reported as the sum over all MPI processes.

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -397,8 +397,13 @@ private:
  * sections that perform certain aspects of the program. A section can be
  * entered several times. By changing the options in OutputFrequency and
  * OutputType, the user can choose whether output should be generated every
- * time a section is joined or just in the end of the program. Moreover, it is
+ * time a section is joined or just at the end of the program. Moreover, it is
  * possible to show CPU times, wall times, or both.
+ *
+ * To ensure output from this class is properly synchronized in parallel
+ * programs and to simplify internal data handling, output from this class can
+ * only be generated, if no subsection is currently being timed. I.e. all
+ * subsections have to be closed before producing output or accessing data.
  *
  * The class is used in a substantial number of tutorial programs that collect
  * timing data. step-77 is an example of a relatively simple sequential program
@@ -447,7 +452,7 @@ private:
  * | Setup dof system                |         1 |      3.97s |       4.5% |
  * +---------------------------------+-----------+------------+------------+
  * @endcode
- * The output will see that we entered the assembly and solve section twice,
+ * The output shows that we entered the assembly and solve section twice,
  * and reports how much time we spent there. Moreover, the class measures the
  * total time spent from start to termination of the TimerOutput object. In
  * this case, we did a lot of other stuff, so that the time proportions of the

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -501,6 +501,11 @@ TimerOutput::leave_subsection(const std::string &section_name)
 std::map<std::string, double>
 TimerOutput::get_summary_data(const OutputData kind) const
 {
+  Assert(
+    active_sections.empty(),
+    ExcMessage(
+      "Cannot access data from TimerOutput while inside a timed section."));
+
   std::map<std::string, double> output;
   for (const auto &section : sections)
     {
@@ -527,6 +532,10 @@ TimerOutput::get_summary_data(const OutputData kind) const
 void
 TimerOutput::print_summary() const
 {
+  Assert(active_sections.empty(),
+         ExcMessage(
+           "Cannot print data from TimerOutput while inside a timed section."));
+
   // we are going to change the precision and width of output below. store the
   // old values so the get restored when exiting this function
   const boost::io::ios_base_all_saver restore_stream(out_stream.get_stream());
@@ -838,6 +847,10 @@ void
 TimerOutput::print_wall_time_statistics(const MPI_Comm mpi_comm,
                                         const double   quantile) const
 {
+  Assert(active_sections.empty(),
+         ExcMessage(
+           "Cannot print data from TimerOutput while inside a timed section."));
+
   // we are going to change the precision and width of output below. store the
   // old values so the get restored when exiting this function
   const boost::io::ios_base_all_saver restore_stream(out_stream.get_stream());


### PR DESCRIPTION
This PR sits on top of #18866 and should only be merged after that one. It changes the TimerOutput class so that no output or access to internal data is allowed while a subsection is active. I looked through the examples and didnt see a case where we output before leaving all subsections, but we should nevertheless make sure this is tested, because it is an incompatible change (it prevents behavior that was previously allowed).