### PR TITLE
Simplify static assertions and condition checks

### DIFF
--- a/include/deal.II/differentiation/ad/adolc_number_types.h
+++ b/include/deal.II/differentiation/ad/adolc_number_types.h
@@ -332,7 +332,7 @@ namespace Differentiation
     {
       static_assert(std::is_same_v<ad_type, adouble>,
                     "Incorrect template type selected for taped ad_type");
-      static_assert(is_taped == true, "Incorrect setting for taping");
+      static_assert(is_taped, "Incorrect setting for taping");
     };
 
 
@@ -354,7 +354,7 @@ namespace Differentiation
     {
       static_assert(std::is_same_v<ad_type, std::complex<adouble>>,
                     "Incorrect template type selected for taped ad_type");
-      static_assert(is_taped == true, "Incorrect setting for taping");
+      static_assert(is_taped, "Incorrect setting for taping");
     };
 
 
@@ -375,7 +375,7 @@ namespace Differentiation
     {
       static_assert(std::is_same_v<ad_type, adtl::adouble>,
                     "Incorrect template type selected for tapeless ad_type");
-      static_assert(is_tapeless == true, "Incorrect setting for taping");
+      static_assert(is_tapeless, "Incorrect setting for taping");
     };
 
 
@@ -398,7 +398,7 @@ namespace Differentiation
     {
       static_assert(std::is_same_v<ad_type, std::complex<adtl::adouble>>,
                     "Incorrect template type selected for tapeless ad_type");
-      static_assert(is_tapeless == true, "Incorrect setting for taping");
+      static_assert(is_tapeless, "Incorrect setting for taping");
     };
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -15844,7 +15844,7 @@ void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
   // some difficulty in the past (see the
   // deal.II/coarsening_* tests)
   if (smooth_grid & limit_level_difference_at_vertices)
-    Assert(satisfies_level1_at_vertex_rule(*this) == true, ExcInternalError());
+    Assert(satisfies_level1_at_vertex_rule(*this), ExcInternalError());
 
   // Inform all listeners about beginning of refinement.
   signals.pre_refinement();

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -1040,7 +1040,7 @@ namespace TrilinosWrappers
   void
   SparsityPattern::print_gnuplot(std::ostream &out) const
   {
-    Assert(graph->Filled() == true, ExcInternalError());
+    Assert(graph->Filled(), ExcInternalError());
     for (dealii::types::global_dof_index row = 0; row < local_size(); ++row)
       {
         int *indices;

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -1032,7 +1032,7 @@ namespace LinearAlgebra
     void
     SparsityPattern<MemorySpace>::print_gnuplot(std::ostream &out) const
     {
-      Assert(graph->isFillComplete() == true, ExcInternalError());
+      Assert(graph->isFillComplete(), ExcInternalError());
 
       for (unsigned int row = 0; row < local_size(); ++row)
         {


### PR DESCRIPTION
Static assertions and condition checks:  remove unnecessary comparisons with `true`.