### PR TITLE
vector_data_exchange: avoid uninitialized variable

### DIFF
--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -1088,7 +1088,7 @@ namespace internal
         requests.resize(sm_ghost_ranks.size() + sm_import_ranks.size() +
                         ghost_targets_data.size() + import_targets_data.size());
 
-        int dummy;
+        int dummy = 0;
         for (unsigned int i = 0; i < sm_ghost_ranks.size(); ++i)
           {
             const int ierr = MPI_Isend(&dummy,


### PR DESCRIPTION
clang-21 complains here that the variable "dummy" variable is not initialized. Let's simply initialize it to zero.
