### PR TITLE
Update reference Kinnewig:2023

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -2853,14 +2853,17 @@ doi = {10.1137/24M1653689}
   pages  = {41--54}
 }
 
-@misc{Kinnewig2023,
-  author = {Kinnewig, Sebastian and Wick, Thomas and Beuchler, Sven},
-  title  = {Algorithmic realization of the solution to the sign conflict problem for hanging nodes on hp-hexahedral N{\'e}d{\'e}lec elements},
-  doi    = {10.48550/ARXIV.2306.01416},
-  url    = {https://arxiv.org/abs/2306.01416},
-  publisher = {arXiv},
-  year   = 2023,
-  copyright = {Creative Commons Attribution Non Commercial No Derivatives 4.0 International}
+@article{Kinnewig2023,
+  author    = {Kinnewig, Sebastian and Wick, Thomas and Beuchler, Sven},
+  title     = {Algorithmic Realization of the Solution to the Sign Conflict Problem for Hanging Nodes on Hp-Hexahedral N\'{e}d\'{e}lec Elements},
+  year      = {2025},
+  publisher = {Association for Computing Machinery},
+  address   = {New York, NY, USA},
+  issn      = {0098-3500},
+  url       = {https://doi.org/10.1145/3766903},
+  doi       = {10.1145/3766903},
+  journal   = {ACM Trans. Math. Softw.},
+  month     = sep,
 }
 
 @article{Farrell2021,


### PR DESCRIPTION
After nearly two years, the paper "Algorithmic Realization of the Solution to the Sign Conflict Problem for Hanging Nodes on Hp-Hexahedral N\'{e}d\'{e}lec Elements" was finally published. Therefore, I would like to replace the preprint with the actual publication.

The publication is also open access, so replacing the arXiv link with the official link does not limit accessibility.