### PR TITLE
fe_dgq AssertThrow

### DIFF
--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -374,7 +374,7 @@ FE_DGQ<dim, spacedim>::get_face_interpolation_matrix(
   const unsigned int) const
 {
   // this is only implemented, if the source
-  // FE is also a DGQ element. in that case,
+  // FE is also a DGQ element or FE_Nothing. in that case,
   // both elements have no dofs on their
   // faces and the face interpolation matrix
   // is necessarily empty -- i.e. there isn't
@@ -382,7 +382,9 @@ FE_DGQ<dim, spacedim>::get_face_interpolation_matrix(
   (void)interpolation_matrix;
   using FE = FiniteElement<dim, spacedim>;
   AssertThrow((dynamic_cast<const FE_DGQ<dim, spacedim> *>(&x_source_fe) !=
-               nullptr),
+               nullptr) ||
+                (dynamic_cast<const FE_Nothing<dim, spacedim> *>(
+                   &x_source_fe) != nullptr),
               typename FE::ExcInterpolationNotImplemented());
 
   Assert(interpolation_matrix.m() == 0,
@@ -402,7 +404,7 @@ FE_DGQ<dim, spacedim>::get_subface_interpolation_matrix(
   const unsigned int) const
 {
   // this is only implemented, if the source
-  // FE is also a DGQ element. in that case,
+  // FE is also a DGQ element or FE_Nothing. in that case,
   // both elements have no dofs on their
   // faces and the face interpolation matrix
   // is necessarily empty -- i.e. there isn't
@@ -410,7 +412,9 @@ FE_DGQ<dim, spacedim>::get_subface_interpolation_matrix(
   (void)interpolation_matrix;
   using FE = FiniteElement<dim, spacedim>;
   AssertThrow((dynamic_cast<const FE_DGQ<dim, spacedim> *>(&x_source_fe) !=
-               nullptr),
+               nullptr) ||
+                (dynamic_cast<const FE_Nothing<dim, spacedim> *>(
+                   &x_source_fe) != nullptr),
               typename FE::ExcInterpolationNotImplemented());
 
   Assert(interpolation_matrix.m() == 0,


### PR DESCRIPTION
related to https://github.com/dealii/dealii/issues/18889, as suggested by @bangerth, we modified the assert so that it checks
 (i) the other element is also an FE_DGQ, or (ii) the other element is FE_Nothing. 
