### PR TITLE
doxygen: disable the navigation column.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -128,6 +128,10 @@ HTML_COLORSTYLE_SAT    = 200
 HTML_EXTRA_STYLESHEET  = @CMAKE_CURRENT_SOURCE_DIR@/doxygen-awesome.css \
                          @CMAKE_CURRENT_SOURCE_DIR@/custom.css
 
+# disable the navigation column
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = NO
+
 LAYOUT_FILE            = @CMAKE_CURRENT_BINARY_DIR@/DoxygenLayout.xml
 
 


### PR DESCRIPTION
Since doxygen 1.13.0 (see [changelog](https://www.doxygen.nl/manual/changelog.html#log_1_13_0)), the options `DISABLE_INDEX` and `GENERATE_TREEVIEW` are set to `yes`, which adds some sort of navigation columns in the HTML output.

This patch ensures the old behavior. See also other [doxygen customization options](https://www.doxygen.nl/manual/customize.html#minor_tweaks_treeview).

@tamiko -- Does this correspond to the setting we use on our hosted documentation?