### PR TITLE
gh-actions: fall back to old dependencies image.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -51,7 +51,7 @@ jobs:
         ubuntu_version: [jammy, noble]
 
     container:
-      image: dealii/dependencies:${{ matrix.ubuntu_version }}
+      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.6.0
       options: --user root
 
     steps:
@@ -119,7 +119,7 @@ jobs:
             flags: -mno-outline-atomics
 
     container:
-      image: dealii/dependencies:${{ matrix.ubuntu_version }}
+      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.6.0
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
     steps:
@@ -187,7 +187,7 @@ jobs:
         ubuntu_version: [jammy, noble]
 
     container:
-      image: dealii/dependencies:${{ matrix.ubuntu_version }}
+      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.6.0
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
     steps:


### PR DESCRIPTION
Our CI complains about deprecation warnings for Epetra with Trilinos 16. It seems like https://github.com/dealii/dealii/pull/18643 is without effect on gcc 11.4.0 (jammy).

With this PR, we will again use the dependencies image for the previous 9.6.0 release. Those only feature Trilinos 13 without the deprecation warnings.

@tjhei -- FYI