### PR TITLE
gh-actions: Use most recent dependencies image, and explicitly specify its version.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -51,7 +51,7 @@ jobs:
         ubuntu_version: [jammy, noble]
 
     container:
-      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.6.0
+      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.7.1
       options: --user root
 
     steps:
@@ -119,7 +119,7 @@ jobs:
             flags: -mno-outline-atomics
 
     container:
-      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.6.0
+      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.7.1
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
     steps:
@@ -187,7 +187,7 @@ jobs:
         ubuntu_version: [jammy, noble]
 
     container:
-      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.6.0
+      image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.7.1
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
     steps:


### PR DESCRIPTION
This reverts commit 5b9de0dbdb772b9fa26e13a63a2d5de6b6f1d1a3.

In reference to #18934, #18935.