### PR TITLE
Fix documentation of GridGenerator::subdivided_hyper_cube_with_simplices().

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -2776,9 +2776,9 @@ namespace GridGenerator
    * each cell divided into simplices.
    *
    * The hypercube volume is the tensor product interval
-   * $[left,right]^{\text{dim}}$ in the present number of dimensions, where
-   * the limits are given as arguments. They default to zero and unity, then
-   * producing the unit hypercube.
+   * $[\text{left},\text{right}]^{\text{dim}}$ in the present number of
+   * dimensions, where the limits are given as arguments. They default to zero
+   * and one, then producing the unit hypercube.
    *
    * @note This function takes the mesh produced by subdivided_hyper_cube()
    * and further subdivides each cell into 2 triangles (for @p dim 2) or
@@ -2791,8 +2791,8 @@ namespace GridGenerator
   void
   subdivided_hyper_cube_with_simplices(Triangulation<dim, spacedim> &tria,
                                        const unsigned int repetitions,
-                                       const double       p1       = 0.0,
-                                       const double       p2       = 1.0,
+                                       const double       left     = 0.0,
+                                       const double       right    = 1.0,
                                        const bool         colorize = false);
 
   /** @} */

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -9465,22 +9465,25 @@ namespace GridGenerator
   void
   subdivided_hyper_cube_with_simplices(Triangulation<dim, spacedim> &tria,
                                        const unsigned int repetitions,
-                                       const double       p1,
-                                       const double       p2,
+                                       const double       left,
+                                       const double       right,
                                        const bool         colorize)
   {
     if (dim == 2)
       {
-        subdivided_hyper_rectangle_with_simplices(
-          tria, {{repetitions, repetitions}}, {p1, p1}, {p2, p2}, colorize);
+        subdivided_hyper_rectangle_with_simplices(tria,
+                                                  {{repetitions, repetitions}},
+                                                  {left, left},
+                                                  {right, right},
+                                                  colorize);
       }
     else if (dim == 3)
       {
         subdivided_hyper_rectangle_with_simplices(
           tria,
           {{repetitions, repetitions, repetitions}},
-          {p1, p1, p1},
-          {p2, p2, p2},
+          {left, left, left},
+          {right, right, right},
           colorize);
       }
     else


### PR DESCRIPTION
The function documentation talks about `left` and `right` (which would be scalar), but the function arguments are actually called `p1,p2` (indeed scalars, but by their names suggesting that they are points). Fix this discrepancy.