### PR TITLE
Adjust a reference to a namespace in FETools

### DIFF
--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -1130,7 +1130,7 @@ namespace FETools
      * individual shape functions that do not depend on whether the
      * composed element uses the tensor product or combination
      * strategy outlined in the documentation of the
-     * FETools::Composition namespace. Consequently, this function
+     * FETools::Compositing namespace. Consequently, this function
      * does not have a @p do_tensor_product argument.
      */
     template <int dim, int spacedim>
@@ -1162,7 +1162,7 @@ namespace FETools
      * individual shape functions that do not depend on whether the
      * composed element uses the tensor product or combination
      * strategy outlined in the documentation of the
-     * FETools::Composition namespace. Consequently, this function
+     * FETools::Compositing namespace. Consequently, this function
      * does not have a @p do_tensor_product argument.
      *
      * @deprecated Use the versions of this function that take a


### PR DESCRIPTION
The name is `Compositing`, not `Composition`, see https://github.com/dealii/dealii/blob/22f76a9aee555dd9c6e62b6ca67ecde26099e6ff/include/deal.II/fe/fe_tools.h#L1068-L1070