### PR TITLE
Provide a better error in a place where something is not implemented.

### DIFF
--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1212,7 +1212,8 @@ GridOut::write_ucd(const Triangulation<dim, spacedim> &tria,
       // May, 1992, p. E6
       //
       // note: vertex numbers are 1-base
-      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
+      Assert(cell->reference_cell().is_hyper_cube(), ExcNotImplemented());
+      for (const unsigned int vertex : cell->vertex_indices())
         out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[vertex]) + 1
             << ' ';
       out << '\n';


### PR DESCRIPTION
I tried to write a file with triangles in UCD format, but one runs into an index error. I don't have the time or motivation to actually fix this, but we should at least provide a reasonable error message. This patch provides this.

For posteriority: The UCD format is documented in a PDF timestamped in 1992, and which can still be found at https://dav.lbl.gov/archive/NERSC/Software/avs5/help/docs/books/devguide.pdf . I don't even know whether the company still exists that wrote the software (AVS Explorer) that used this file format.