### PR TITLE
Nodal variant of Nedelec element

### DIFF
--- a/doc/news/changes/minor/20251205Nebulishvili
+++ b/doc/news/changes/minor/20251205Nebulishvili
@@ -1,0 +1,3 @@
+New: A nodal variant of Nedelec elements, FE_NedelecNodal, has been added.
+<br>
+(Natalia Nebulishvili, Martin Kronbichler, Katharina Kormann 2025/12/05)

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -21,12 +21,15 @@
 #include <deal.II/base/mutex.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_nedelec.h>
+#include <deal.II/base/polynomials_vector_anisotropic.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_poly_tensor.h>
+
+#include <deal.II/matrix_free/shape_info.h>
 
 #include <vector>
 
@@ -653,6 +656,93 @@ private:
   // Allow access from other dimensions.
   template <int dim1>
   friend class FE_Nedelec;
+};
+
+
+
+/**
+ * The N&eacute;d&eacute;lec elements with node functionals defined as point
+ * values in Gauss-Lobatto points.
+ *
+ * <h3>Description of node values</h3>
+ *
+ * For this N&eacute;d&eacute;lec element, the node values are not cell and face
+ * moments with respect to certain polynomials like for FE_NedelecSZ, but the
+ * values at quadrature points. Following the general scheme for numbering
+ * degrees of freedom, the node values on faces (edges in 2d, quads in 3d) are
+ * first, face by face, according to the natural ordering of the faces of a
+ * cell. The interior degrees of freedom are last.
+ *
+ * For an N&eacute;d&eacute;lec-element of degree <i>k</i>, the polynomials are
+ * the tensor product of Lagrange polynomials on the points of a QGaussLobatto
+ * formula with $(k+1)$ points in the normal direction with Lagrange polynomials
+ * on the points of a QGaussLobatto quadrature formula with $(k+2)$ points
+ * in the tangential direction. For degree $k=0$, the midpoint is chosen.
+ * Within each entity (edge, face, volume), these points are ordered
+ * lexicographically.
+ *
+ * @note The degree stored in the member variable
+ * FiniteElementData<dim>::degree is higher by one than the constructor
+ * argument!
+ */
+template <int dim>
+class FE_NedelecNodal : public FE_PolyTensor<dim>
+{
+public:
+  /**
+   * Constructor for the Nedelec element of given @p order. The maximal
+   * polynomial degree of the shape functions is `order+1` (in each variable;
+   * the total polynomial degree may be higher). If `order = 0`, the element is
+   * linear and has degrees of freedom only on the edges. If `order >=1` the
+   * element has degrees of freedom on the edges, faces and volume. For example
+   * the 3d version of FE_Nedelec has 12 degrees of freedom for `order = 0`
+   * and 54 for `degree = 1`.
+   */
+  FE_NedelecNodal(const unsigned int p);
+
+  /**
+   * Return a string that uniquely identifies a finite element. This class
+   * returns <tt>FE_NedelecNodal<dim>(degree)</tt>, with @p dim and @p
+   * degree replaced by appropriate values.
+   */
+  virtual std::string
+  get_name() const override;
+
+  // Documentation inherited from the base class.
+  virtual std::unique_ptr<FiniteElement<dim, dim>>
+  clone() const override;
+
+  // Documentation inherited from the base class.
+  virtual void
+  convert_generalized_support_point_values_to_dof_values(
+    const std::vector<Vector<double>> &support_point_values,
+    std::vector<double>               &nodal_values) const override;
+
+  /**
+   * Compute the lexicographic to hierarchic numbering underlying this class,
+   * necessary for the creation of the respective vector polynomial space.
+   */
+  std::vector<unsigned int>
+  get_lexicographic_numbering(const unsigned int degree) const;
+
+  /**
+   * @copydoc FiniteElement::compare_for_domination()
+   */
+  virtual FiniteElementDomination::Domination
+  compare_for_domination(const FiniteElement<dim> &fe_other,
+                         const unsigned int codim = 0) const override final;
+
+
+  /**
+   * Fills data of univariate shape functions in ShapeInfo through taking
+   * a given one-dimensional quadrature formula. The method evaluates the shape
+   * functions and gradients on the one-dimensional unit cell.
+   */
+  template <typename Number, int dim_q>
+  void
+  fill_shape_info(internal::MatrixFreeFunctions::ShapeInfo<Number> *shape_info,
+                  const Quadrature<dim_q>                          &quad_in,
+                  const unsigned int base_element_number = 0) const;
 };
 
 /* -------------- declaration of explicit specializations ------------- */

--- a/include/deal.II/fe/fe_nedelec.templates.h
+++ b/include/deal.II/fe/fe_nedelec.templates.h
@@ -1,0 +1,103 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_fe_nedelec_templates_h
+#define dealii_fe_nedelec_templates_h
+
+#include <deal.II/fe/fe_nedelec.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+template <int dim>
+template <typename Number, int dim_q>
+void
+FE_NedelecNodal<dim>::fill_shape_info(
+  internal::MatrixFreeFunctions::ShapeInfo<Number> *shape_info,
+  const Quadrature<dim_q>                          &quad_in,
+  const unsigned int                                base_element_number) const
+{
+  const auto quad = quad_in.get_tensor_basis()[0];
+  shape_info->element_type =
+    internal::MatrixFreeFunctions::ElementType::tensor_nedelec;
+
+  const FiniteElement<dim, dim> &fe = this->base_element(base_element_number);
+  shape_info->n_dimensions          = dim;
+  shape_info->n_components          = this->n_components();
+
+  shape_info->data.resize(2);
+  const unsigned int n_q_points_1d = quad.size();
+
+  shape_info->n_q_points      = Utilities::fixed_power<dim>(n_q_points_1d);
+  shape_info->n_q_points_face = Utilities::fixed_power<dim - 1>(n_q_points_1d);
+
+  shape_info->dofs_per_component_on_cell =
+    this->n_dofs_per_cell() / this->n_components();
+
+  // NOTE dofs_per_component_on_face is in tangential direction!
+  shape_info->dofs_per_component_on_face =
+    this->n_dofs_per_face() + Utilities::pow(this->degree, dim - 2);
+  const unsigned int dofs_per_face = this->n_dofs_per_face();
+
+  const unsigned int dofs_per_line = this->n_dofs_per_line();
+
+  // degrees of freedom on (dim-2)-dimensional elements
+  const unsigned int dofs_dim_2 =
+    dim == 3 ? this->n_dofs_per_line() : this->n_dofs_per_vertex();
+
+
+  shape_info->lexicographic_numbering =
+    get_lexicographic_numbering(this->degree - 1);
+
+
+  // To get the right shape_values of the Nedelec element
+  std::vector<unsigned int> lex_normal, lex_tangent;
+  for (unsigned int i = dofs_per_line * 2; i < dofs_per_line * 2 + fe.degree;
+       ++i)
+    lex_normal.push_back(i);
+  lex_tangent.push_back(lex_normal[0]);
+  for (unsigned int i = 4 * dofs_per_face - 4 * dofs_dim_2;
+       i < 4 * dofs_per_face - 4 * dofs_dim_2 + (fe.degree - 1) * fe.degree;
+       i += fe.degree)
+    lex_tangent.push_back(i);
+  lex_tangent.push_back(dofs_per_line * 3);
+
+
+  // 'direction' distinguishes between normal=0 and tangential=1 direction
+  for (unsigned int direction = 0; direction < 2; ++direction)
+    {
+      shape_info->data[direction].element_type =
+        internal::MatrixFreeFunctions::ElementType::tensor_nedelec;
+      shape_info->data[direction].quadrature    = quad;
+      shape_info->data[direction].n_q_points_1d = n_q_points_1d;
+      shape_info->data[direction].fe_degree     = fe.degree - (1 - direction);
+      const std::vector<unsigned int> &lexicographic =
+        direction == 0 ? lex_normal : lex_tangent;
+
+
+      shape_info->data[direction].evaluate_shape_functions(fe,
+                                                           quad,
+                                                           lexicographic,
+                                                           direction);
+      shape_info->data[direction].evaluate_collocation_space(fe,
+                                                             quad,
+                                                             lexicographic,
+                                                             direction);
+
+      shape_info->data[direction].check_and_set_shapes_symmetric();
+    }
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -112,9 +112,16 @@ namespace internal
       tensor_raviart_thomas = 7,
 
       /**
+       * Special case of the FE_NedelecNodal element with anisotropic
+       * tensor product shape functions, i.e degree (k + 1) in tangential
+       * direction, and k in normal direction.
+       */
+      tensor_nedelec = 8,
+
+      /**
        * Shape functions without a tensor product properties.
        */
-      tensor_none = 8
+      tensor_none = 9
 
 
     };

--- a/source/fe/CMakeLists.txt
+++ b/source/fe/CMakeLists.txt
@@ -30,6 +30,7 @@ set(_unity_include_src
   fe_face.cc
   fe_hermite.cc
   fe_nedelec.cc
+  fe_nedelec_nodal.cc
   fe_nedelec_sz.cc
   fe_nothing.cc
   fe_poly.cc
@@ -103,6 +104,7 @@ set(_inst
   fe.inst.in
   fe_hermite.inst.in
   fe_nedelec.inst.in
+  fe_nedelec_nodal.inst.in
   fe_nedelec_sz.inst.in
   fe_nothing.inst.in
   fe_poly.inst.in

--- a/source/fe/fe_nedelec_nodal.cc
+++ b/source/fe/fe_nedelec_nodal.cc
@@ -1,0 +1,427 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#include <deal.II/base/polynomial.h>
+#include <deal.II/base/qprojector.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/fe_nedelec.templates.h>
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_tools.h>
+#include <deal.II/fe/mapping.h>
+
+#include <deal.II/matrix_free/shape_info.templates.h>
+
+#include <memory>
+#include <sstream>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+// ---------------- polynomial class for FE_NedelecNodal ---------------
+
+namespace
+{
+  // Return a vector of "dofs per object" where the components of the returned
+  // vector refer to:
+  // 0 = vertex
+  // 1 = edge
+  // 2 = face (which is a cell in 2d)
+  // 3 = cell.
+  std::vector<unsigned int>
+  get_nedelec_dpo_vector(const unsigned int dim, const unsigned int degree)
+  {
+    std::vector<unsigned int> dpo(dim + 1);
+    dpo[0]                               = 0;
+    dpo[1]                               = degree + 1;
+    unsigned int dofs_per_face_component = degree + 1;
+    for (unsigned int d = 2; d < dim; ++d)
+      dofs_per_face_component *= degree;
+    dpo[dim - 1] = (dim - 1) * dofs_per_face_component;
+    dpo[dim]     = dim * degree * dofs_per_face_component;
+
+    return dpo;
+  }
+
+} // namespace
+
+
+
+// --------------------- actual implementation of element --------------------
+
+template <int dim>
+FE_NedelecNodal<dim>::FE_NedelecNodal(const unsigned int degree)
+  : FE_PolyTensor<dim>(
+      PolynomialsVectorAnisotropic<dim>(degree,
+                                        degree + 1,
+                                        get_lexicographic_numbering(degree)),
+      FiniteElementData<dim>(get_nedelec_dpo_vector(dim, degree),
+                             dim,
+                             degree + 1,
+                             FiniteElementData<dim>::Hcurl),
+      std::vector<bool>(
+        PolynomialsVectorAnisotropic<dim>::n_polynomials(degree, degree + 1),
+        true),
+      std::vector<ComponentMask>(
+        PolynomialsVectorAnisotropic<dim>::n_polynomials(degree, degree + 1),
+        std::vector<bool>(dim, true)))
+{
+  Assert(dim >= 2, ExcImpossibleInDim(dim));
+
+  const std::vector<unsigned int> &renumber =
+    get_lexicographic_numbering(degree);
+  this->mapping_kind = {mapping_nedelec};
+  this->generalized_support_points =
+    PolynomialsVectorAnisotropic<dim>(degree, degree + 1, renumber)
+      .get_polynomial_support_points();
+
+  AssertDimension(this->generalized_support_points.size(),
+                  this->n_dofs_per_cell());
+
+  PolynomialsVectorAnisotropic<dim> polynomials(degree, degree + 1, renumber);
+  QMidpoint<1>                      gauss;
+  QGaussLobatto<1>                  gl(degree + 2);
+  this->unit_support_points.resize(this->dofs_per_cell);
+
+  const unsigned int n_pols = polynomials.n() / dim;
+  for (unsigned int k = 0; k < (dim > 2 ? degree + 2 : 1); ++k)
+    for (unsigned int j = 0; j < (dim > 1 ? degree + 2 : 1); ++j)
+      for (unsigned int i = 0; i < degree + 1; ++i)
+        {
+          this->unit_support_points
+            [renumber[(k * (degree + 2) + j) * (degree + 1) + i]][0] =
+            (degree == 0 ? gauss.point(i)[0] : gl.point(i)[0]);
+          if (dim > 1)
+            this->unit_support_points
+              [renumber[(k * (degree + 2) + j) * (degree + 1) + i]][1] =
+              gl.point(j)[0];
+          if (dim > 2)
+            this->unit_support_points
+              [renumber[(k * (degree + 2) + j) * (degree + 1) + i]][2] =
+              gl.point(k)[0];
+        }
+  if (dim > 1)
+    for (unsigned int k = 0; k < (dim > 2 ? degree + 2 : 1); ++k)
+      for (unsigned int j = 0; j < degree + 1; ++j)
+        for (unsigned int i = 0; i < degree + 2; ++i)
+          {
+            this->unit_support_points
+              [renumber[n_pols + (k * (degree + 1) + j) * (degree + 2) + i]]
+              [0] = gl.point(i)[0];
+            this->unit_support_points
+              [renumber[n_pols + (k * (degree + 1) + j) * (degree + 2) + i]]
+              [1] = (degree == 0 ? gauss.point(j)[0] : gl.point(j)[0]);
+            if (dim > 2)
+              this->unit_support_points
+                [renumber[n_pols + (k * (degree + 1) + j) * (degree + 2) + i]]
+                [2] = gl.point(k)[0];
+          }
+  if (dim > 2)
+    for (unsigned int k = 0; k < degree + 1; ++k)
+      for (unsigned int j = 0; j < degree + 2; ++j)
+        for (unsigned int i = 0; i < degree + 2; ++i)
+          {
+            this->unit_support_points
+              [renumber[2 * n_pols + (k * (degree + 2) + j) * (degree + 2) + i]]
+              [0] = gl.point(i)[0];
+            this->unit_support_points
+              [renumber[2 * n_pols + (k * (degree + 2) + j) * (degree + 2) + i]]
+              [1] = gl.point(j)[0];
+            this->unit_support_points
+              [renumber[2 * n_pols + (k * (degree + 2) + j) * (degree + 2) + i]]
+              [2] = (degree == 0 ? gauss.point(k)[0] : gl.point(k)[0]);
+          }
+}
+
+
+
+template <int dim>
+std::string
+FE_NedelecNodal<dim>::get_name() const
+{
+  /*Note, that the FETools::get_fe_by_name function depends on the particular
+   format of the string this function returns. So, they have to be kept in
+   sync.*/
+
+  // Note, that this->degree is the maximal polynomial degree and is thus one
+  // higher than the argument given to the constructor.
+  return "FE_NedelecNodal<" + std::to_string(dim) + ">(" +
+         std::to_string(this->degree - 1) + ")";
+}
+
+
+template <int dim>
+std::unique_ptr<FiniteElement<dim, dim>>
+FE_NedelecNodal<dim>::clone() const
+{
+  return std::make_unique<FE_NedelecNodal<dim>>(*this);
+}
+
+template <int dim>
+void
+FE_NedelecNodal<dim>::convert_generalized_support_point_values_to_dof_values(
+  const std::vector<Vector<double>> &support_point_values,
+  std::vector<double>               &nodal_values) const
+{
+  Assert(support_point_values.size() == this->generalized_support_points.size(),
+         ExcDimensionMismatch(support_point_values.size(),
+                              this->generalized_support_points.size()));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
+  Assert(support_point_values[0].size() == this->n_components(),
+         ExcDimensionMismatch(support_point_values[0].size(),
+                              this->n_components()));
+
+  // First do interpolation on lines. The component evaluated there depends
+  // on the face direction and orientation.
+  unsigned int base = 0;
+  for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_cell;
+       ++l, base += this->n_dofs_per_line())
+    {
+      for (unsigned int i = 0; i < this->n_dofs_per_line(); ++i)
+        {
+          nodal_values[base + i] =
+            support_point_values[base + i](l < 8 ? ((l % 4) / 2) ^ 1 : 2);
+        }
+    }
+
+  if (dim == 3)
+    {
+      std::vector<unsigned int> componentFreq(dim,
+                                              this->n_dofs_per_quad(0) / 2);
+      unsigned int              index = -1;
+      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        {
+          index                = GeometryInfo<dim>::unit_normal_direction[f];
+          componentFreq[index] = 0;
+          for (unsigned int compInd = 0; compInd < dim; ++compInd)
+            {
+              for (unsigned int compQuant = 0;
+                   compQuant < componentFreq[compInd];
+                   ++compQuant)
+                {
+                  nodal_values[base + compQuant] =
+                    support_point_values[base + compQuant](compInd);
+                }
+              base += componentFreq[compInd];
+            }
+          componentFreq[index] = this->n_dofs_per_quad(f) / 2;
+        }
+    }
+  // The remaining points form dim chunks, one for each component.
+  const unsigned int istep = (this->n_dofs_per_cell() - base) / dim;
+  Assert((this->n_dofs_per_cell() - base) % dim == 0, ExcInternalError());
+
+  int f = 0;
+  while (base < this->n_dofs_per_cell())
+    {
+      for (unsigned int i = 0; i < istep; ++i)
+        {
+          nodal_values[base + i] = support_point_values[base + i](f);
+        }
+      base += istep;
+      ++f;
+    }
+  Assert(base == this->n_dofs_per_cell(), ExcInternalError());
+}
+
+
+
+template <int dim>
+std::vector<unsigned int>
+FE_NedelecNodal<dim>::get_lexicographic_numbering(
+  const unsigned int degree) const
+{
+  const unsigned int n_dofs_edges =
+    (dim == 2) ? 4 * (degree + 1) : 12 * (degree + 1);
+  const unsigned int n_dofs_faces_3D = 2 * 6 * (degree * (degree + 1));
+  const unsigned     n_dofs_per_component_face = degree * (degree + 1);
+  const unsigned int n_dofs_D_1 =
+    (dim == 2) ? n_dofs_edges : n_dofs_edges + n_dofs_faces_3D;
+  std::vector<unsigned int> lexicographic_renumbering(
+    (dim == 2) ? 2 * (degree + 1) * (degree + 2) :
+                 3 * (degree + 1) * (degree + 2) * (degree + 2));
+  unsigned int ind_lex_numbering = 0;
+
+  // Component 1
+  for (unsigned int i = 2 * (degree + 1); i < 3 * (degree + 1); ++i)
+    lexicographic_renumbering[ind_lex_numbering++] = i;
+  const unsigned int n_dofs_before =
+    n_dofs_edges + ((dim == 3) ? 8 * n_dofs_per_component_face : 0);
+  for (unsigned int i = n_dofs_before;
+       i < n_dofs_before + n_dofs_per_component_face;
+       ++i)
+    lexicographic_renumbering[ind_lex_numbering++] = i;
+  for (unsigned int i = 3 * (degree + 1); i < 4 * (degree + 1); ++i)
+    lexicographic_renumbering[ind_lex_numbering++] = i;
+  if (dim == 3)
+    {
+      for (unsigned int i = 0; i < degree; ++i)
+        {
+          for (unsigned int j = 0; j < degree + 1; ++j)
+            lexicographic_renumbering[ind_lex_numbering++] =
+              n_dofs_edges + 4 * n_dofs_per_component_face + i * (degree + 1) +
+              j;
+          for (unsigned int j = 0; j < n_dofs_per_component_face; ++j)
+            lexicographic_renumbering[ind_lex_numbering++] =
+              n_dofs_D_1 + i * n_dofs_per_component_face + j;
+          for (unsigned int j = 0; j < degree + 1; ++j)
+            lexicographic_renumbering[ind_lex_numbering++] =
+              n_dofs_edges + 6 * n_dofs_per_component_face + i * (degree + 1) +
+              j;
+        }
+      for (unsigned int i = 6 * (degree + 1); i < 7 * (degree + 1); ++i)
+        lexicographic_renumbering[ind_lex_numbering++] = i;
+      for (unsigned int i = n_dofs_edges + 10 * n_dofs_per_component_face;
+           i < n_dofs_edges + 11 * n_dofs_per_component_face;
+           ++i)
+        lexicographic_renumbering[ind_lex_numbering++] = i;
+      for (unsigned int i = 7 * (degree + 1); i < 8 * (degree + 1); ++i)
+        lexicographic_renumbering[ind_lex_numbering++] = i;
+    }
+
+  // Component 2
+  unsigned int n_dofs_faces_before =
+    n_dofs_edges + ((dim == 3) ? 9 : 1) * n_dofs_per_component_face;
+  for (unsigned int i = 0; i < degree + 1; ++i)
+    {
+      lexicographic_renumbering[ind_lex_numbering++] = i;
+      for (unsigned int j = n_dofs_faces_before + i * degree;
+           j < n_dofs_faces_before + (i + 1) * degree;
+           ++j)
+        {
+          lexicographic_renumbering[ind_lex_numbering++] = j;
+        }
+      lexicographic_renumbering[ind_lex_numbering++] = (degree + 1) + i;
+    }
+
+  if (dim == 3)
+    {
+      for (unsigned int i = 0; i < n_dofs_per_component_face; ++i)
+        {
+          lexicographic_renumbering[ind_lex_numbering++] = n_dofs_edges + i;
+          for (unsigned int j = 0; j < degree; j++)
+            {
+              lexicographic_renumbering[ind_lex_numbering++] =
+                n_dofs_D_1 + n_dofs_per_component_face * degree + i * degree +
+                j;
+            }
+          lexicographic_renumbering[ind_lex_numbering++] =
+            n_dofs_edges + 2 * n_dofs_per_component_face + i;
+        }
+      unsigned int n_dofs_before = n_dofs_edges + 11 * degree * (degree + 1);
+      for (unsigned int i = 0; i < degree + 1; i++)
+        {
+          lexicographic_renumbering[ind_lex_numbering++] = 4 * (degree + 1) + i;
+          for (unsigned int j = 0; j < degree; j++)
+            {
+              lexicographic_renumbering[ind_lex_numbering++] =
+                n_dofs_before + i * degree + j;
+            }
+          lexicographic_renumbering[ind_lex_numbering++] = 5 * (degree + 1) + i;
+        }
+    }
+  // Component 3
+  if (dim == 3)
+    {
+      for (unsigned int i = 0; i < degree + 1; i++)
+        {
+          lexicographic_renumbering[ind_lex_numbering++] = 8 * (degree + 1) + i;
+          unsigned int n_dofs_before =
+            n_dofs_edges + 5 * n_dofs_per_component_face;
+          for (unsigned int j = 0; j < degree; j++)
+            {
+              lexicographic_renumbering[ind_lex_numbering++] =
+                n_dofs_before + i * degree + j;
+            }
+          lexicographic_renumbering[ind_lex_numbering++] = 9 * (degree + 1) + i;
+          for (unsigned int j = 0; j < degree; ++j)
+            {
+              lexicographic_renumbering[ind_lex_numbering++] =
+                n_dofs_edges + n_dofs_per_component_face + i * degree + j;
+              n_dofs_before = n_dofs_D_1 +
+                              2 * degree * n_dofs_per_component_face +
+                              i * degree * degree + j * degree;
+              for (unsigned int k = 0; k < degree; k++)
+                {
+                  lexicographic_renumbering[ind_lex_numbering++] =
+                    n_dofs_before + k;
+                }
+              lexicographic_renumbering[ind_lex_numbering++] =
+                n_dofs_edges + 3 * n_dofs_per_component_face + i * degree + j;
+            }
+          lexicographic_renumbering[ind_lex_numbering++] =
+            10 * (degree + 1) + i;
+          for (unsigned int j = 0; j < degree; j++)
+            {
+              lexicographic_renumbering[ind_lex_numbering++] =
+                n_dofs_edges + 7 * n_dofs_per_component_face + i * degree + j;
+            }
+          lexicographic_renumbering[ind_lex_numbering++] =
+            11 * (degree + 1) + i;
+        }
+    }
+  return lexicographic_renumbering;
+}
+
+
+template <int dim>
+FiniteElementDomination::Domination
+FE_NedelecNodal<dim>::compare_for_domination(const FiniteElement<dim> &fe_other,
+                                             const unsigned int codim) const
+{
+  Assert(codim <= dim, ExcImpossibleInDim(dim));
+  (void)codim;
+
+  // vertex/line/face/cell domination
+  // --------------------------------
+  if (const FE_NedelecNodal<dim> *fe_nedelec_nodal_other =
+        dynamic_cast<const FE_NedelecNodal<dim> *>(&fe_other))
+    {
+      if (this->degree < fe_nedelec_nodal_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_nedelec_nodal_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
+  else if (const FE_Nothing<dim> *fe_nothing =
+             dynamic_cast<const FE_Nothing<dim> *>(&fe_other))
+    {
+      if (fe_nothing->is_dominating())
+        return FiniteElementDomination::other_element_dominates;
+      else
+        // the FE_Nothing has no degrees of freedom and it is typically used
+        // in a context where we don't require any continuity along the
+        // interface
+        return FiniteElementDomination::no_requirements;
+    }
+
+  DEAL_II_NOT_IMPLEMENTED();
+  return FiniteElementDomination::neither_element_dominates;
+}
+
+
+// explicit instantiations
+#include "fe/fe_nedelec_nodal.inst"
+
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/fe/fe_nedelec_nodal.inst.in
+++ b/source/fe/fe_nedelec_nodal.inst.in
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 1998 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+    template class FE_NedelecNodal<deal_II_dimension>;
+  }
+
+for (deal_II_scalar : REAL_SCALARS)
+  {
+    template struct internal::MatrixFreeFunctions::UnivariateShapeData<
+      deal_II_scalar>;
+  }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_scalar : REAL_SCALARS)
+  {
+    template void FE_NedelecNodal<deal_II_dimension>::fill_shape_info(
+      internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar> *,
+      const Quadrature<deal_II_dimension> &,
+      const unsigned int) const;
+  }


### PR DESCRIPTION
This PR implements the nodal variant of the Nedelec elements. It is one of the steps towards the matrix-free evaluators for the Nedelec elements. We have additional functionality added to the element itself `fill_shape_info`, which fills the data of `ShapeInfo` from the element directly. The logic can be further extended to other elements too and it will allow to remove significant amount of the code from `shape_info.templates.h`
The implementation of the matrix-free evaluators  with the corresponding evaluation kernels will be added with the separate PR.