### PR TITLE
Clean up how we handle functions which use GMSH's API.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -820,6 +820,21 @@ namespace StandardExceptions
     "looking at the summary printed at the end of the cmake "
     "output.");
 
+  /**
+   * This function requires support for the GMSH API.
+   */
+  DeclExceptionMsg(
+    ExcNeedsGMSHAPI,
+    "You are attempting to use functionality that is only available if deal.II "
+    "was configured to use GMSH's API, but cmake did not find a valid GMSH "
+    "library."
+    "\n\n"
+    "You will have to ensure that your system has a usable GMSH "
+    "installation (including both the gmsh executable and the GMSH library) "
+    "and re-install deal.II, making sure that cmake finds the GMSH "
+    "installation. You can check this by looking at the summary printed at the "
+    "end of the cmake output.");
+
 #ifdef DEAL_II_WITH_MPI
   /**
    * Exception for MPI errors. This exception is only defined if

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -502,7 +502,6 @@ public:
   void
   read_msh(std::istream &in);
 
-#ifdef DEAL_II_GMSH_WITH_API
   /**
    * Read grid data using Gmsh API. Any file supported by Gmsh can be passed as
    * argument. The format is deduced from the filename extension.
@@ -556,14 +555,13 @@ public:
    * as a boundary or material id.  Physical surface numbers created in Gmsh,
    * which can be seen in the .geo file, become material IDs.
    *
-   *
    * Also see
    * @ref simplex "Simplex support".
+   *
+   * @note This function requires the GMSH API.
    */
   void
   read_msh(const std::string &filename);
-#endif
-
 
   /**
    * Read a partitioned GMSH file and create a fully distributed triangulation
@@ -622,11 +620,12 @@ public:
    * cells) or as @ref GlossMaterialId "material indicators" (for cells). It
    * does not set manifold ids, and it does not attach manifold descriptions to
    * the triangulation.
+   *
+   * @note This function requires the GMSH API.
    */
   void
   read_partitioned_msh(const std::string &file_prefix,
                        const std::string &file_suffix = "msh");
-
 
   /**
    * Read grid data from a `.mphtxt` file. `.mphtxt` is one of the file formats

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -1098,7 +1098,6 @@ public:
   void
   write_msh(const Triangulation<dim, spacedim> &tria, std::ostream &out) const;
 
-#ifdef DEAL_II_GMSH_WITH_API
   /**
    * Write the triangulation in any format supported by gmsh API.
    *
@@ -1138,12 +1137,13 @@ public:
    * The special boundary id `-1` is used to indicate internal boundaries. The
    * internal boundaries must be specified whenever it is necessary to specify
    * a non-flat manifold id.
+   *
+   * @note This function requires the GMSH API.
    */
   template <int dim, int spacedim>
   void
   write_msh(const Triangulation<dim, spacedim> &tria,
             const std::string                  &filename) const;
-#endif
 
   /**
    * Write the triangulation in the ucd format.

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2911,11 +2911,11 @@ GridIn<dim, spacedim>::read_msh(std::istream &input_stream)
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
 template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::read_msh(const std::string &fname)
 {
+#ifdef DEAL_II_GMSH_WITH_API
   Assert(tria != nullptr, ExcNoTriangulationSelected());
   // gmsh -> deal.II types
   const std::map<int, std::uint8_t> gmsh_to_dealii_type = {
@@ -3143,17 +3143,20 @@ GridIn<dim, spacedim>::read_msh(const std::string &fname)
 
   gmsh::clear();
   gmsh::finalize();
-}
+#else
+  (void)fname;
+  AssertThrow(false, ExcNeedsGMSHAPI());
 #endif
+}
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
 template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::read_partitioned_msh(const std::string &file_prefix,
                                             const std::string &file_suffix)
 {
+#ifdef DEAL_II_GMSH_WITH_API
   auto *parallel_tria =
     dynamic_cast<parallel::fullydistributed::Triangulation<dim, spacedim> *>(
       tria.get());
@@ -3512,20 +3515,12 @@ GridIn<dim, spacedim>::read_partitioned_msh(const std::string &file_prefix,
 
   gmsh::clear();
   gmsh::finalize();
-}
 #else
-template <int dim, int spacedim>
-void
-GridIn<dim, spacedim>::read_partitioned_msh(const std::string &,
-                                            const std::string &)
-{
-  AssertThrow(
-    false,
-    ExcMessage(
-      "GridIn::read_partitioned_msh() requires the Gmsh API "
-      "to be installed, but it was not found when configuring deal.II."));
+  (void)file_prefix;
+  (void)file_suffix;
+  AssertThrow(false, ExcNeedsGMSHAPI());
+#endif
 }
-#endif // DEAL_II_GMSH_WITH_API
 
 
 template <int dim, int spacedim>

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1442,12 +1442,12 @@ GridOut::write_xfig(const Triangulation<2> &tria,
 
 
 
-#ifdef DEAL_II_GMSH_WITH_API
 template <int dim, int spacedim>
 void
 GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
                    const std::string                  &filename) const
 {
+#ifdef DEAL_II_GMSH_WITH_API
   // mesh Type renumbering
   const std::array<int, 8> dealii_to_gmsh_type = {{15, 1, 2, 3, 4, 7, 6, 5}};
 
@@ -1638,8 +1638,12 @@ GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
   gmsh::write(filename);
   gmsh::clear();
   gmsh::finalize();
-}
+#else
+  (void)tria;
+  (void)filename;
+  AssertThrow(false, ExcNeedsGMSHAPI());
 #endif
+}
 
 
 

--- a/source/grid/grid_out.inst.in
+++ b/source/grid/grid_out.inst.in
@@ -25,10 +25,9 @@ for (deal_II_dimension : DIMENSIONS)
 
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      std::ostream &) const;
-#ifdef DEAL_II_GMSH_WITH_API
+
     template void GridOut::write_msh(const Triangulation<deal_II_dimension> &,
                                      const std::string &) const;
-#endif
 
 #if deal_II_dimension != 2
     template void GridOut::write_xfig(
@@ -86,11 +85,9 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
     template void GridOut::write_msh(
       const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
       std::ostream &) const;
-#  ifdef DEAL_II_GMSH_WITH_API
     template void GridOut::write_msh(
       const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
       const std::string &) const;
-#  endif
     template void GridOut::write_ucd(
       const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
       std::ostream &) const;


### PR DESCRIPTION
Since our public APIs don't require GMSH types we should always compile these and unconditionally throw exceptions when GMSH's API isn't available: that's the way we typically handle internal dependencies (e.g., Zoltan, ExodusII, etc.).

Inspired by #18632.