### PR TITLE
Add a check in Portable::MatrixFree get_data if MPI process owns cells of given color

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -525,9 +525,9 @@ namespace Portable
   typename MatrixFree<dim, Number>::PrecomputedData
   MatrixFree<dim, Number>::get_data(unsigned int color) const
   {
-    AssertThrow(n_cells[color] > 0,
-      ExcMessage("Current MPI process does not own any cells "
-                                        "of the given color."));
+    Assert(n_cells[color] > 0,
+           ExcMessage(
+             "Current MPI process does not own any cells of the given color."));
     PrecomputedData data_copy;
     if (q_points.size() > 0)
       data_copy.q_points = q_points[color];


### PR DESCRIPTION
 
When accessing `get_data(color)` in `Portable::MatrixFree` in parallel, a segmentation fault is encountered if the process does not own cells of the given color.  

Context: I've been implementing a cell loop with a different signature than the one currently available in `Portable::MatrixFree`, where  `std::vector<unsigned int> n_cells` is a private attribute. I was accessing public attribute `matrix_free.get_data(color).n_cells`  to check if the cells are owned by the current MPI process,  but it was giving a segmentation fault as some of the fields in `PrecomputedData` are not (seemingly) initialized. The workaround is simple `n_colors > 0 && colored_graph[color].size() > 0`, but it took a while to understand where the issue was. 

 The solution I pushed is not _the_ solution, so I would like to ask for advice on how you'd like to address this issue (_if_ you want to address it). I'm available to work on that with some of your guidance if you'd like that :)