### PR TITLE
URGENT: Fix deal.II compilation

### DIFF
--- a/source/lac/matrix_scaling.cc
+++ b/source/lac/matrix_scaling.cc
@@ -24,6 +24,8 @@
 #include <deal.II/lac/sparse_matrix_ez.h>
 #include <deal.II/lac/vector.h>
 
+#include <boost/serialization/utility.hpp>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace TrilinosWrappers


### PR DESCRIPTION
Deal.II somehow does not compile after updating to the most recent version.
The error I have on my machine:

/scratch/mwichro/dealii/bundled/boost-1.84.0/include/boost/serialization/access.hpp:116:11: error: ‘struct std::pair<unsigned int, double>’ has no member named ‘serialize’

 `boost` serialize causes the problem; one header is missing. This PR fixes that (adds one header).
 
 The problem occurred during the last 90 commits. 
 
 @bangerth 