### PR TITLE
Portable::MatrixFree: remove n_local_dofs member

### DIFF
--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -73,11 +73,9 @@ namespace Step64
                const unsigned int                                      q) const;
 
     // Since Portable::MatrixFree::Data doesn't know about the size of its
-    // arrays, we need to store the number of quadrature points and the
-    // number of degrees of freedom in this class to do necessary index
-    // conversions.
-    static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-    static const unsigned int n_q_points   = Utilities::pow(fe_degree + 1, dim);
+    // arrays, we need to store the number of quadrature points in this class
+    // to be able to do necessary index conversions.
+    static const unsigned int n_q_points = Utilities::pow(fe_degree + 1, dim);
 
   private:
     double *coef;
@@ -135,8 +133,6 @@ namespace Step64
     static const unsigned int n_q_points =
       dealii::Utilities::pow(fe_degree + 1, dim);
 
-    static const unsigned int n_local_dofs = n_q_points;
-
   private:
     double *coef;
   };
@@ -179,10 +175,8 @@ namespace Step64
   {
   public:
     // Again, the Portable::MatrixFree object doesn't know about the number
-    // of degrees of freedom and the number of quadrature points so we need
-    // to store these for index calculations in the call operator.
-    static constexpr unsigned int n_local_dofs =
-      Utilities::pow(fe_degree + 1, dim);
+    // of quadrature points so we need to store these for index calculations
+    // in the call operator.
     static constexpr unsigned int n_q_points =
       Utilities::pow(fe_degree + 1, dim);
 

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -488,7 +488,6 @@ namespace Portable
      *   const typename Portable::MatrixFree<dim, Number>::Data *data,
      *   const DeviceVector<Number>                             &src,
      *   DeviceVector<Number>                                   &dst) const;
-     *   static const unsigned int n_local_dofs;
      *   static const unsigned int n_q_points;
      * \endcode
      */
@@ -508,7 +507,6 @@ namespace Portable
      * \code
      *  DEAL_II_HOST_DEVICE void operator()(
      *    const typename Portable::MatrixFree<dim, Number>::Data *data);
-     * static const unsigned int n_local_dofs;
      * static const unsigned int n_q_points;
      * \endcode
      */

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1501,8 +1501,6 @@ namespace MatrixFreeTools
           }
       };
 
-      static constexpr unsigned int n_local_dofs =
-        dealii::Utilities::pow(fe_degree + 1, dim) * n_components;
       static constexpr unsigned int n_q_points =
         dealii::Utilities::pow(n_q_points_1d, dim);
 

--- a/tests/matrix_free_kokkos/cell_loop_block_01.cc
+++ b/tests/matrix_free_kokkos/cell_loop_block_01.cc
@@ -34,8 +34,7 @@ template <int dim,
 class MatrixFreeTest
 {
 public:
-  static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-  static const unsigned int n_q_points   = Utilities::pow(n_q_points_1d, dim);
+  static const unsigned int n_q_points = Utilities::pow(n_q_points_1d, dim);
 
   MatrixFreeTest(const Portable::MatrixFree<dim, Number> &data_in)
     : data(data_in){};
@@ -81,8 +80,7 @@ template <int dim,
 class MatrixFreeTestBlock
 {
 public:
-  static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-  static const unsigned int n_q_points   = Utilities::pow(n_q_points_1d, dim);
+  static const unsigned int n_q_points = Utilities::pow(n_q_points_1d, dim);
 
   MatrixFreeTestBlock(const Portable::MatrixFree<dim, Number> &data_in)
     : data(data_in){};
@@ -124,15 +122,7 @@ protected:
 
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 const unsigned int
-  MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_local_dofs;
-
-template <int dim, int fe_degree, int n_q_points_1d, typename Number>
-const unsigned int
   MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_q_points;
-
-template <int dim, int fe_degree, int n_q_points_1d, typename Number>
-const unsigned int
-  MatrixFreeTestBlock<dim, fe_degree, n_q_points_1d, Number>::n_local_dofs;
 
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 const unsigned int

--- a/tests/matrix_free_kokkos/cell_loop_block_02.cc
+++ b/tests/matrix_free_kokkos/cell_loop_block_02.cc
@@ -34,8 +34,7 @@ template <int dim,
 class MatrixFreeTest
 {
 public:
-  static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-  static const unsigned int n_q_points   = Utilities::pow(n_q_points_1d, dim);
+  static const unsigned int n_q_points = Utilities::pow(n_q_points_1d, dim);
 
   MatrixFreeTest(const Portable::MatrixFree<dim, Number> &data_in)
     : data(data_in){};
@@ -81,8 +80,7 @@ template <int dim,
 class MatrixFreeTestBlock
 {
 public:
-  static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-  static const unsigned int n_q_points   = Utilities::pow(n_q_points_1d, dim);
+  static const unsigned int n_q_points = Utilities::pow(n_q_points_1d, dim);
 
   MatrixFreeTestBlock(const Portable::MatrixFree<dim, Number> &data_in)
     : data(data_in){};
@@ -130,15 +128,7 @@ protected:
 
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 const unsigned int
-  MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_local_dofs;
-
-template <int dim, int fe_degree, int n_q_points_1d, typename Number>
-const unsigned int
   MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_q_points;
-
-template <int dim, int fe_degree, int n_q_points_1d, typename Number>
-const unsigned int
-  MatrixFreeTestBlock<dim, fe_degree, n_q_points_1d, Number>::n_local_dofs;
 
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 const unsigned int

--- a/tests/matrix_free_kokkos/coefficient_eval_device.cc
+++ b/tests/matrix_free_kokkos/coefficient_eval_device.cc
@@ -40,8 +40,6 @@ public:
              const Portable::DeviceVector<double>                   &src,
              Portable::DeviceVector<double>                         &dst) const;
 
-  static const unsigned int n_local_dofs =
-    dealii::Utilities::pow(fe_degree + 1, dim);
   static const unsigned int n_q_points =
     dealii::Utilities::pow(fe_degree + 1, dim);
 };

--- a/tests/matrix_free_kokkos/compute_diagonal_util.h
+++ b/tests/matrix_free_kokkos/compute_diagonal_util.h
@@ -61,9 +61,6 @@ public:
 
   static const unsigned int n_q_points =
     dealii::Utilities::pow(fe_degree + 1, dim);
-
-  static const unsigned int n_local_dofs =
-    dealii::Utilities::pow(fe_degree + 1, dim);
 };
 
 

--- a/tests/matrix_free_kokkos/matrix_free_device_no_index_initialize.cc
+++ b/tests/matrix_free_kokkos/matrix_free_device_no_index_initialize.cc
@@ -32,8 +32,7 @@ template <int dim,
 class MatrixFreeTest
 {
 public:
-  static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-  static const unsigned int n_q_points   = Utilities::pow(n_q_points_1d, dim);
+  static const unsigned int n_q_points = Utilities::pow(n_q_points_1d, dim);
 
   MatrixFreeTest(const Portable::MatrixFree<dim, Number> &data_in)
     : data(data_in){};
@@ -45,6 +44,8 @@ public:
   {
     Portable::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> fe_eval(
       data);
+
+    const unsigned int n_local_dofs = decltype(fe_eval)::tensor_dofs_per_cell;
 
     // set to unit vector
     auto fe_eval_ptr = &fe_eval;
@@ -91,9 +92,7 @@ protected:
   const Portable::MatrixFree<dim, Number> &data;
 };
 
-template <int dim, int fe_degree, int n_q_points_1d, typename Number>
-const unsigned int
-  MatrixFreeTest<dim, fe_degree, n_q_points_1d, Number>::n_local_dofs;
+
 
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 const unsigned int

--- a/tests/matrix_free_kokkos/matrix_free_mg_level_01.cc
+++ b/tests/matrix_free_kokkos/matrix_free_mg_level_01.cc
@@ -81,8 +81,6 @@ template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 class LaplaceOperator
 {
 public:
-  static const unsigned int n_local_dofs =
-    dealii::Utilities::pow(fe_degree + 1, dim);
   static const unsigned int n_q_points =
     dealii::Utilities::pow(n_q_points_1d, dim);
 

--- a/tests/matrix_free_kokkos/matrix_free_mg_level_02.cc
+++ b/tests/matrix_free_kokkos/matrix_free_mg_level_02.cc
@@ -79,8 +79,6 @@ template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 class LaplaceOperator
 {
 public:
-  static const unsigned int n_local_dofs =
-    dealii::Utilities::pow(fe_degree + 1, dim);
   static const unsigned int n_q_points =
     dealii::Utilities::pow(n_q_points_1d, dim);
 

--- a/tests/matrix_free_kokkos/matrix_vector_device_mf.h
+++ b/tests/matrix_free_kokkos/matrix_vector_device_mf.h
@@ -67,8 +67,6 @@ template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 class HelmholtzOperator
 {
 public:
-  static const unsigned int n_local_dofs =
-    dealii::Utilities::pow(fe_degree + 1, dim);
   static const unsigned int n_q_points =
     dealii::Utilities::pow(n_q_points_1d, dim);
 
@@ -119,8 +117,6 @@ public:
              const unsigned int                                      q) const;
 
   static const unsigned int n_dofs_1d = fe_degree + 1;
-  static const unsigned int n_local_dofs =
-    dealii::Utilities::pow(fe_degree + 1, dim);
   static const unsigned int n_q_points =
     dealii::Utilities::pow(n_q_points_1d, dim);
 

--- a/tests/matrix_free_kokkos/matrix_vector_host_device_multi_component.cc
+++ b/tests/matrix_free_kokkos/matrix_vector_host_device_multi_component.cc
@@ -193,8 +193,6 @@ public:
 
     phi.distribute_local_to_global(dst);
   }
-  static const unsigned int n_local_dofs =
-    Utilities::pow(fe_degree + 1, dim) * n_components;
   static const unsigned int n_q_points = Utilities::pow(fe_degree + 1, dim);
 
 private:

--- a/tests/matrix_free_kokkos/transfer_matrix_free_copy_to_host_01.cc
+++ b/tests/matrix_free_kokkos/transfer_matrix_free_copy_to_host_01.cc
@@ -213,8 +213,6 @@ public:
     phi.distribute_local_to_global(dst);
   }
 
-  static const unsigned int n_local_dofs =
-    Utilities::pow(fe_degree + 1, dim) * n_components;
   static const unsigned int n_q_points = Utilities::pow(fe_degree + 1, dim);
 };
 


### PR DESCRIPTION
This static member used to be necessary, but is no longer used. Remove it from tests and documentation.