### PR TITLE
Add get_dof_handler_fine() to MGTwoLevelTransferBase.

### DIFF
--- a/doc/news/changes/incompatibilities/20251110Moulday
+++ b/doc/news/changes/incompatibilities/20251110Moulday
@@ -1,0 +1,3 @@
+Changed: A template parameter for dim has been added to MGTwoLevelTransferBase.
+<br>
+(Ryan Moulday, 2025/11/10)

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -112,7 +112,7 @@ namespace mg
 /**
  * An abstract base class for transfer operators between two multigrid levels.
  */
-template <typename VectorType>
+template <int dim, typename VectorType>
 class MGTwoLevelTransferBase : public EnableObserverPointer
 {
 public:
@@ -177,6 +177,13 @@ public:
    */
   virtual std::size_t
   memory_consumption() const = 0;
+
+
+  /**
+   * Return the DoFHandler associated with the fine level and the level index.
+   */
+  virtual std::pair<const DoFHandler<dim> *, unsigned int>
+  get_dof_handler_fine() const = 0;
 };
 
 
@@ -186,8 +193,8 @@ namespace internal
   /**
    * Base class for MGTwoLevelTransferNonNested and MGTwoLevelTransfer.
    */
-  template <typename VectorType>
-  class MGTwoLevelTransferCore : public MGTwoLevelTransferBase<VectorType>
+  template <int dim, typename VectorType>
+  class MGTwoLevelTransferCore : public MGTwoLevelTransferBase<dim, VectorType>
   {
   public:
     /**
@@ -254,7 +261,7 @@ namespace internal
      * Enable inplace vector operations if external and internal vectors
      * are compatible.
      */
-    template <int dim, std::size_t width, typename IndexType>
+    template <std::size_t width, typename IndexType>
     std::pair<bool, bool>
     internal_enable_inplace_operations_if_possible(
       const std::shared_ptr<const Utilities::MPI::Partitioner>
@@ -351,7 +358,8 @@ namespace internal
  * point, and we fall back to the first option in such a case.
  */
 template <int dim, typename VectorType>
-class MGTwoLevelTransfer : public internal::MGTwoLevelTransferCore<VectorType>
+class MGTwoLevelTransfer
+  : public internal::MGTwoLevelTransferCore<dim, VectorType>
 {
 public:
   static_assert(
@@ -485,6 +493,12 @@ public:
    */
   std::size_t
   memory_consumption() const override;
+
+  /**
+   * Return the DoFHandler associated with the fine level and the level index.
+   */
+  std::pair<const DoFHandler<dim> *, unsigned int>
+  get_dof_handler_fine() const override;
 
 protected:
   void
@@ -663,7 +677,8 @@ private:
  * host.
  */
 template <int dim, typename VectorType>
-class MGTwoLevelTransferCopyToHost : public MGTwoLevelTransferBase<VectorType>
+class MGTwoLevelTransferCopyToHost
+  : public MGTwoLevelTransferBase<dim, VectorType>
 {
 public:
   static_assert(
@@ -753,6 +768,12 @@ public:
   std::size_t
   memory_consumption() const override;
 
+  /**
+   * Return the DoFHandler associated with the fine level and the level index.
+   */
+  std::pair<const DoFHandler<dim> *, unsigned int>
+  get_dof_handler_fine() const override;
+
 private:
   /**
    * The internal transfer defined on the host which handles all operations.
@@ -795,7 +816,7 @@ private:
  */
 template <int dim, typename VectorType>
 class MGTwoLevelTransferNonNested
-  : public internal::MGTwoLevelTransferCore<VectorType>
+  : public internal::MGTwoLevelTransferCore<dim, VectorType>
 {
 private:
   static_assert(
@@ -903,6 +924,12 @@ public:
    */
   std::size_t
   memory_consumption() const override;
+
+  /**
+   * Return the DoFHandler associated with the fine level and the level index.
+   */
+  std::pair<const DoFHandler<dim> *, unsigned int>
+  get_dof_handler_fine() const override;
 
   /**
    * Connect a function to mg::SignalsNonNested::prolongation_cell_loop.
@@ -1377,7 +1404,8 @@ private:
   /**
    * Collection of the two-level transfer operators.
    */
-  MGLevelObject<ObserverPointer<MGTwoLevelTransferBase<VectorType>>> transfer;
+  MGLevelObject<ObserverPointer<MGTwoLevelTransferBase<dim, VectorType>>>
+    transfer;
 
   /**
    * External partitioners used during initialize_dof_vector().
@@ -1736,6 +1764,14 @@ MGTwoLevelTransferCopyToHost<dim, VectorType>::memory_consumption() const
 }
 
 template <int dim, typename VectorType>
+std::pair<const DoFHandler<dim> *, unsigned int>
+MGTwoLevelTransferCopyToHost<dim, VectorType>::get_dof_handler_fine() const
+{
+  return host_transfer.get_dof_handler_fine();
+}
+
+
+template <int dim, typename VectorType>
 void
 MGTwoLevelTransferCopyToHost<dim, VectorType>::copy_to_host(
   VectorTypeHost   &dst,
@@ -1803,8 +1839,8 @@ MGTransferMatrixFree<dim, Number, MemorySpace>::initialize_transfer_references(
 
   // Note that transfer[min_level] is empty and never used:
   for (unsigned int l = min_level + 1; l <= max_level; ++l)
-    this->transfer[l] = &const_cast<MGTwoLevelTransferBase<VectorType> &>(
-      static_cast<const MGTwoLevelTransferBase<VectorType> &>(
+    this->transfer[l] = &const_cast<MGTwoLevelTransferBase<dim, VectorType> &>(
+      static_cast<const MGTwoLevelTransferBase<dim, VectorType> &>(
         Utilities::get_underlying_value(transfer[l])));
 }
 

--- a/source/multigrid/mg_transfer_matrix_free.inst.in
+++ b/source/multigrid/mg_transfer_matrix_free.inst.in
@@ -12,18 +12,15 @@
 //
 // ------------------------------------------------------------------------
 
-
-for (S1 : REAL_SCALARS)
+for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
   {
     namespace internal
     \{
       template class MGTwoLevelTransferCore<
+        deal_II_dimension,
         LinearAlgebra::distributed::Vector<S1, ::dealii::MemorySpace::Host>>;
     \}
-  }
 
-for (deal_II_dimension : DIMENSIONS; S1 : REAL_SCALARS)
-  {
     template class MGTwoLevelTransfer<deal_II_dimension,
                                       LinearAlgebra::distributed::Vector<S1>>;
     template class MGTwoLevelTransferNonNested<

--- a/tests/matrix_free_kokkos/mg_transfer_copy_to_host_a_06.cc
+++ b/tests/matrix_free_kokkos/mg_transfer_copy_to_host_a_06.cc
@@ -67,6 +67,7 @@ template <int dim, typename Number, typename MemorySpace, typename MeshType>
 void
 test_interpolation(
   const MGTwoLevelTransferBase<
+    dim,
     LinearAlgebra::distributed::Vector<Number, MemorySpace>> &transfer,
   const MeshType                                             &dof_handler_fine,
   const MeshType              &dof_handler_coarse,

--- a/tests/matrix_free_kokkos/mg_transfer_copy_to_host_a_07.cc
+++ b/tests/matrix_free_kokkos/mg_transfer_copy_to_host_a_07.cc
@@ -66,6 +66,7 @@ template <int dim, typename Number, typename MemorySpace, typename MeshType>
 void
 test_interpolation(
   const MGTwoLevelTransferBase<
+    dim,
     LinearAlgebra::distributed::Vector<Number, MemorySpace>> &transfer,
   const MeshType                                             &dof_handler_fine,
   const MeshType              &dof_handler_coarse,

--- a/tests/multigrid-global-coarsening/mg_transfer_a_06.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_06.cc
@@ -69,7 +69,7 @@ public:
 template <int dim, typename Number, typename MeshType>
 void
 test_interpolation(
-  const MGTwoLevelTransferBase<LinearAlgebra::distributed::Vector<Number>>
+  const MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
                               &transfer,
   const MeshType              &dof_handler_fine,
   const MeshType              &dof_handler_coarse,

--- a/tests/multigrid-global-coarsening/mg_transfer_a_07.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_07.cc
@@ -65,7 +65,7 @@ public:
 template <int dim, typename Number, typename MeshType>
 void
 test_interpolation(
-  const MGTwoLevelTransferBase<LinearAlgebra::distributed::Vector<Number>>
+  const MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
                               &transfer,
   const MeshType              &dof_handler_fine,
   const MeshType              &dof_handler_coarse,

--- a/tests/multigrid-global-coarsening/mg_transfer_util.h
+++ b/tests/multigrid-global-coarsening/mg_transfer_util.h
@@ -192,7 +192,7 @@ test_transfer_operator(
 template <int dim, typename Number, typename MeshType>
 void
 test_non_nested_transfer(
-  const MGTwoLevelTransferBase<LinearAlgebra::distributed::Vector<Number>>
+  const MGTwoLevelTransferBase<dim, LinearAlgebra::distributed::Vector<Number>>
                               &transfer,
   const MeshType              &dof_handler_fine,
   const MeshType              &dof_handler_coarse,

--- a/tests/performance/timing_mg_glob_coarsen.cc
+++ b/tests/performance/timing_mg_glob_coarsen.cc
@@ -402,7 +402,7 @@ private:
     PreconditionChebyshev<LaplaceOperator<dim, float>, VectorTypeMG>;
   mg::SmootherRelaxation<SmootherType, VectorTypeMG> mg_smoother;
 
-  MGLevelObject<std::unique_ptr<MGTwoLevelTransferBase<VectorTypeMG>>>
+  MGLevelObject<std::unique_ptr<MGTwoLevelTransferBase<dim, VectorTypeMG>>>
                                                                  mg_transfers;
   std::unique_ptr<MGTransferGlobalCoarsening<dim, VectorTypeMG>> mg_transfer;
 };


### PR DESCRIPTION
Currently get_dof_handler_fine() inside MGTransferMatrixFree requires a hard-coded dynamic cast for each two level transfer object which is defined in the library. This effectively precludes users from defining their own two level transfer class without editing the library directly. 

This change adds a function get_dof_handler_fine() to the MGTwoLevelTransferBase class and all existing two level transfers which the get_dof_handler_fine() function inside MGTransferMatrixFree now calls instead. This did require adding a template parameter to the base class which necessitated several changes in various tests. Since the base class lacks any functionality it is unlikely (though possible) that this change breaks any real user code, especially given the problem this change is trying to address.