### PR TITLE
Test parsing trailing separator characters for parsed function

### DIFF
--- a/tests/bits/parsed_function_02.cc
+++ b/tests/bits/parsed_function_02.cc
@@ -1,0 +1,75 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 - by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// This program tests that we ignore a trailing comma in function constants
+// and a trailing semicolon in function expressions.
+
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/parsed_function.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include "../tests.h"
+
+template <int dim>
+void
+Test()
+{
+  // A parameter handler
+  ParameterHandler prm;
+
+  // Test vector declaration
+  for (unsigned int i = 0; i < dim; ++i)
+    {
+      const std::string id = "Function " + Utilities::int_to_string(dim) +
+                             " - " + Utilities::int_to_string(i);
+      prm.enter_subsection(id);
+
+      Functions::ParsedFunction<dim>::declare_parameters(prm, i + 1);
+      prm.set("Function constants",
+              "f=" + Utilities::int_to_string(i + 1) + ",");
+
+      std::string expr;
+
+      for (unsigned int j = 0; j < i + 1; ++j)
+        {
+          expr += "f + 0.5;";
+        }
+
+      prm.set("Function expression", expr);
+
+      Functions::ParsedFunction<dim> function(i + 1);
+      function.parse_parameters(prm);
+
+      prm.leave_subsection();
+
+      deallog << "Dim: " << dim << ". Components: " << i
+              << ". Value: " << function.value(Point<dim>()) << std::endl;
+    }
+
+  deallog << "Tested on: " << std::endl;
+  prm.log_parameters(deallog);
+}
+
+int
+main()
+{
+  initlog();
+
+  Test<1>();
+  Test<2>();
+  Test<3>();
+}

--- a/tests/bits/parsed_function_02.with_muparser=true.output
+++ b/tests/bits/parsed_function_02.with_muparser=true.output
@@ -1,0 +1,28 @@
+
+DEAL::Dim: 1. Components: 0. Value: 1.50000
+DEAL::Tested on: 
+DEAL:parameters:Function 1 - 0::Function constants: f=1
+DEAL:parameters:Function 1 - 0::Function expression: f + 0.5
+DEAL:parameters:Function 1 - 0::Variable names: x,t
+DEAL::Dim: 2. Components: 0. Value: 1.50000
+DEAL::Dim: 2. Components: 1. Value: 2.50000
+DEAL::Tested on: 
+DEAL:parameters:Function 2 - 0::Function constants: f=1
+DEAL:parameters:Function 2 - 0::Function expression: f + 0.5
+DEAL:parameters:Function 2 - 0::Variable names: x,y,t
+DEAL:parameters:Function 2 - 1::Function constants: f=2
+DEAL:parameters:Function 2 - 1::Function expression: f + 0.5; f + 0.5
+DEAL:parameters:Function 2 - 1::Variable names: x,y,t
+DEAL::Dim: 3. Components: 0. Value: 1.50000
+DEAL::Dim: 3. Components: 1. Value: 2.50000
+DEAL::Dim: 3. Components: 2. Value: 3.50000
+DEAL::Tested on: 
+DEAL:parameters:Function 3 - 0::Function constants: f=1
+DEAL:parameters:Function 3 - 0::Function expression: f + 0.5
+DEAL:parameters:Function 3 - 0::Variable names: x,y,z,t
+DEAL:parameters:Function 3 - 1::Function constants: f=2
+DEAL:parameters:Function 3 - 1::Function expression: f + 0.5; f + 0.5
+DEAL:parameters:Function 3 - 1::Variable names: x,y,z,t
+DEAL:parameters:Function 3 - 2::Function constants: f=3
+DEAL:parameters:Function 3 - 2::Function expression: f + 0.5; f + 0.5; f + 0.5
+DEAL:parameters:Function 3 - 2::Variable names: x,y,z,t


### PR DESCRIPTION
In geodynamics/aspect#6728 I thought there may be a bug in the function parser that would throw an assert if a constant had a trailing separator character as in `set Function constants  = pi=3.1415926;`. It turns out the function parsing works fine, the problem was that function constants need to be separated by commas not semicolons, while components in function expressions need to be separated by semicolons. So everything is working as expected, except that the error message could be clearer. Since I created a test for the trailing separator characters already, here is the test that proves that the parser works.

There is the separate question of whether to allow semicolons to separate function constants (as we do for the components of function expressions), or at least providing a better error message than [this](https://github.com/geodynamics/aspect/pull/6728#discussion_r2510712417): `Can't convert <3.1415926;> to a double.`. We could for example check the parameter `Function constants` for semicolons and throw an exception if one is found. Is there a preference for one or do you think the current behavior is sufficient and using semicolons for the functions simply a user error?
