### PR TITLE
Allow users to edit the team_size of the Kokkos TeamPolicy objects inside Portable::MatrixFree

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -219,11 +219,13 @@ namespace Portable
                                                  update_quadrature_points,
         const bool         use_coloring                      = false,
         const bool         overlap_communication_computation = false,
-        const unsigned int mg_level = numbers::invalid_unsigned_int)
+        const unsigned int mg_level  = numbers::invalid_unsigned_int,
+        const unsigned int team_size = numbers::invalid_unsigned_int)
         : mapping_update_flags(mapping_update_flags)
         , use_coloring(use_coloring)
         , overlap_communication_computation(overlap_communication_computation)
         , mg_level(mg_level)
+        , team_size(team_size)
       {
 #ifndef DEAL_II_MPI_WITH_DEVICE_SUPPORT
         AssertThrow(
@@ -269,6 +271,12 @@ namespace Portable
        * gone through, otherwise the cells in the given local smoothing level.
        */
       unsigned int mg_level;
+
+      /**
+       * The team size used by the underlying kokkos team policy. If -1 is
+       * provided then Kokkos::AUTO will be used.
+       */
+      unsigned int team_size;
     };
 
     /**
@@ -698,6 +706,12 @@ namespace Portable
      * If set to numbers::invalid_unsigned_int, this operates on active cells.
      */
     unsigned int mg_level;
+
+    /**
+     * The team size used by the underlying kokkos team policy. If -1 is
+     * provided then Kokkos::AUTO will be used.
+     */
+    unsigned int team_size;
 
     /**
      * Store data that is specific to each DoFHandler.

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -770,9 +770,13 @@ namespace Portable
             colored_data[di] = get_data(di, color);
 
           MemorySpace::Default::kokkos_space::execution_space exec;
-          Kokkos::TeamPolicy<
-            MemorySpace::Default::kokkos_space::execution_space>
-            team_policy(exec, n_cells[color], Kokkos::AUTO);
+
+          using TeamPolicy = Kokkos::TeamPolicy<
+            MemorySpace::Default::kokkos_space::execution_space>;
+          auto team_policy =
+            (this->team_size == numbers::invalid_unsigned_int) ?
+              TeamPolicy(exec, n_cells[color], Kokkos::AUTO) :
+              TeamPolicy(exec, n_cells[color], this->team_size);
 
           Kokkos::parallel_for(
             "dealii::MatrixFree::evaluate_coeff_cell_loop color " +
@@ -908,6 +912,7 @@ namespace Portable
       update_flags |= update_JxW_values;
 
     this->use_coloring = additional_data.use_coloring;
+    this->team_size    = additional_data.team_size;
     this->overlap_communication_computation =
       additional_data.overlap_communication_computation;
     this->mg_level = additional_data.mg_level;
@@ -1287,9 +1292,12 @@ namespace Portable
         {
           MemorySpace::Default::kokkos_space::execution_space exec;
 
-          Kokkos::TeamPolicy<
-            MemorySpace::Default::kokkos_space::execution_space>
-            team_policy(exec, n_cells[color], Kokkos::AUTO);
+          using TeamPolicy = Kokkos::TeamPolicy<
+            MemorySpace::Default::kokkos_space::execution_space>;
+          auto team_policy =
+            (this->team_size == numbers::invalid_unsigned_int) ?
+              TeamPolicy(exec, n_cells[color], Kokkos::AUTO) :
+              TeamPolicy(exec, n_cells[color], this->team_size);
 
           for (unsigned int di = 0; di < dof_handler_data.size(); ++di)
             colored_data[di] = get_data(di, color);
@@ -1349,9 +1357,12 @@ namespace Portable
           {
             // helper to process one color
             auto do_color = [&](const unsigned int color) {
-              Kokkos::TeamPolicy<
-                MemorySpace::Default::kokkos_space::execution_space>
-                team_policy(exec, n_cells[color], Kokkos::AUTO);
+              using TeamPolicy = Kokkos::TeamPolicy<
+                MemorySpace::Default::kokkos_space::execution_space>;
+              auto team_policy =
+                (this->team_size == numbers::invalid_unsigned_int) ?
+                  TeamPolicy(exec, n_cells[color], Kokkos::AUTO) :
+                  TeamPolicy(exec, n_cells[color], this->team_size);
 
               for (unsigned int di = 0; di < dof_handler_data.size(); ++di)
                 colored_data[di] = get_data(di, color);
@@ -1402,9 +1413,12 @@ namespace Portable
             for (unsigned int color = 0; color < n_colors; ++color)
               if (n_cells[color] > 0)
                 {
-                  Kokkos::TeamPolicy<
-                    MemorySpace::Default::kokkos_space::execution_space>
-                    team_policy(exec, n_cells[color], Kokkos::AUTO);
+                  using TeamPolicy = Kokkos::TeamPolicy<
+                    MemorySpace::Default::kokkos_space::execution_space>;
+                  auto team_policy =
+                    (this->team_size == numbers::invalid_unsigned_int) ?
+                      TeamPolicy(exec, n_cells[color], Kokkos::AUTO) :
+                      TeamPolicy(exec, n_cells[color], this->team_size);
 
                   for (unsigned int di = 0; di < dof_handler_data.size(); ++di)
                     colored_data[di] = get_data(di, color);
@@ -1441,9 +1455,12 @@ namespace Portable
         for (unsigned int color = 0; color < n_colors; ++color)
           if (n_cells[color] > 0)
             {
-              Kokkos::TeamPolicy<
-                MemorySpace::Default::kokkos_space::execution_space>
-                team_policy(exec, n_cells[color], Kokkos::AUTO);
+              using TeamPolicy = Kokkos::TeamPolicy<
+                MemorySpace::Default::kokkos_space::execution_space>;
+              auto team_policy =
+                (this->team_size == numbers::invalid_unsigned_int) ?
+                  TeamPolicy(exec, n_cells[color], Kokkos::AUTO) :
+                  TeamPolicy(exec, n_cells[color], this->team_size);
 
               for (unsigned int di = 0; di < dof_handler_data.size(); ++di)
                 colored_data[di] = get_data(di, color);


### PR DESCRIPTION
Currently all TeamPolicy objects inside Portable::MatrixFree use Kokkos::AUTO. In the Kokkos tutorials it is mentioned that generally speaking Kokkos::AUTO is not optimal and indeed can be quite far from optimal. This change adds a team_size option to the AdditionalData object inside Portable::MatrixFree which will allow users to manually adjust this team size if this makes a large difference for their code.

A future goal could be to improve the default we use from Kokkos::AUTO to something more sensible based on the information we have at runtime. 