### PR TITLE
Add get_cell_iterator to P::MF

### DIFF
--- a/doc/news/changes/minor/20251112Wichrowski
+++ b/doc/news/changes/minor/20251112Wichrowski
@@ -1,0 +1,3 @@
+New: In Portable::MatrixFree the method get_cell_iterator() has been added.
+<br>
+(Michał Wichrowski, 2025/11/11)

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -607,9 +607,21 @@ namespace Portable
 
     /**
      * Return the colored graph of locally owned active cells.
+     *
+     * @warning if MatrixFree is initialized for a specific multigrid level,
+     * this function will throw an exception.
      */
     const std::vector<std::vector<CellFilter>> &
     get_colored_graph() const;
+
+    /**
+     * Return the colored graph of locally owned level cells.
+     *
+     * @warning if MatrixFree is initialized for active cells,
+     * this function will throw an exception.
+     */
+    const std::vector<std::vector<LevelCellFilter>> &
+    get_colored_level_graph() const;
 
     /**
      * Return the partitioner that represents the locally owned data and the
@@ -637,6 +649,24 @@ namespace Portable
      */
     unsigned int
     get_mg_level() const;
+
+    /**
+     * Return the cell iterator given the index within the color.
+     *
+     * @param color The color index
+     * @param index The index within the color
+     * @param dof_handler_index Index of the DoFHandler (default 0)
+     */
+    typename DoFHandler<dim>::cell_iterator
+    get_cell_iterator(const unsigned int color,
+                      const unsigned int index,
+                      const unsigned int dof_handler_index = 0) const;
+
+    /**
+     * Return the entries (cells) per color.
+     */
+    unsigned int
+    n_cells_per_color(const unsigned int color) const;
 
     /**
      * Return the flag indicating whether overlap MPI communication with
@@ -1114,7 +1144,28 @@ namespace Portable
     FilteredIterator<typename DoFHandler<dim>::active_cell_iterator>>> &
   MatrixFree<dim, Number>::get_colored_graph() const
   {
+    AssertThrow(
+      mg_level == numbers::invalid_unsigned_int,
+      ExcMessage(
+        "The MatrixFree object has been initialized for a specific "
+        "multigrid level. This function is only available when working "
+        "on active cells."));
     return graph;
+  }
+
+
+
+  template <int dim, typename Number>
+  inline const std::vector<std::vector<
+    FilteredIterator<typename DoFHandler<dim>::level_cell_iterator>>> &
+  MatrixFree<dim, Number>::get_colored_level_graph() const
+  {
+    AssertThrow(
+      mg_level != numbers::invalid_unsigned_int,
+      ExcMessage("The MatrixFree object has been initialized for active cells. "
+                 "This function is only available when working on a specific "
+                 "multigrid level."));
+    return level_graph;
   }
 
 
@@ -1132,6 +1183,15 @@ namespace Portable
 
 
   template <int dim, typename Number>
+  inline unsigned int
+  MatrixFree<dim, Number>::get_mg_level() const
+  {
+    return mg_level;
+  }
+
+
+
+  template <int dim, typename Number>
   inline const DoFHandler<dim> &
   MatrixFree<dim, Number>::get_dof_handler(
     const unsigned int dof_handler_index) const
@@ -1143,12 +1203,51 @@ namespace Portable
   }
 
 
+  template <int dim, typename Number>
+  typename DoFHandler<dim>::cell_iterator
+  MatrixFree<dim, Number>::get_cell_iterator(
+    const unsigned int color,
+    const unsigned int index,
+    const unsigned int dof_handler_index) const
+  {
+    if (mg_level == numbers::invalid_unsigned_int)
+      {
+        const unsigned int cell_level =
+          get_colored_graph()[color][index]->level();
+
+        const unsigned int cell_index =
+          get_colored_graph()[color][index]->index();
+
+        return typename DoFHandler<dim>::cell_iterator(
+          &(get_dof_handler(dof_handler_index).get_triangulation()),
+          cell_level,
+          cell_index,
+          &get_dof_handler(dof_handler_index));
+      }
+    else
+      {
+        const unsigned int cell_level =
+          get_colored_level_graph()[color][index]->level();
+
+        const unsigned int cell_index =
+          get_colored_level_graph()[color][index]->index();
+
+        return typename DoFHandler<dim>::cell_iterator(
+          &(get_dof_handler(dof_handler_index).get_triangulation()),
+          cell_level,
+          cell_index,
+          &get_dof_handler(dof_handler_index));
+      }
+  }
+
+
 
   template <int dim, typename Number>
   inline unsigned int
-  MatrixFree<dim, Number>::get_mg_level() const
+  MatrixFree<dim, Number>::n_cells_per_color(const unsigned int color) const
   {
-    return mg_level;
+    AssertIndexRange(color, n_cells.size());
+    return n_cells[color];
   }
 
 

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_01.cc
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_01.cc
@@ -1,0 +1,195 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// test Portable::MatrixFree::get_cell_iterator()
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include <deal.II/matrix_free/portable_matrix_free.h>
+#include <deal.II/matrix_free/portable_matrix_free.templates.h>
+
+#include <Kokkos_Core.hpp>
+
+#include "../tests.h"
+
+
+// Device functor to compute cell centers on GPU
+template <int dim>
+struct CellCenterKernel
+{
+  // Store computed centers: centers_out[color * max_cells_per_color * dim +
+  // cell_id * dim + d]
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> centers_out;
+  unsigned int max_cells_per_color;
+
+  static constexpr unsigned int n_q_points = (1u << dim);
+
+  KOKKOS_FUNCTION void
+  operator()(const typename Portable::MatrixFree<dim, double>::Data *data,
+             const Portable::DeviceVector<double> &,
+             Portable::DeviceVector<double> &) const
+  {
+    const unsigned int cell_id = data->cell_index;
+    const unsigned int color   = data->precomputed_data[0].row_start /
+                               data->precomputed_data[0].padding_length;
+
+    Point<dim, double> cell_center;
+    for (unsigned int d = 0; d < dim; ++d)
+      cell_center[d] = 0.0;
+
+    // Average all quadrature points to get cell center
+    for (unsigned int q = 0; q < n_q_points; ++q)
+      {
+        const Point<dim, double> &q_point =
+          data->get_quadrature_point(cell_id, q);
+        for (unsigned int d = 0; d < dim; ++d)
+          cell_center[d] += q_point[d];
+      }
+
+    for (unsigned int d = 0; d < dim; ++d)
+      cell_center[d] /= n_q_points;
+
+    // Store in output array
+    const unsigned int base_idx =
+      color * max_cells_per_color * dim + cell_id * dim;
+    for (unsigned int d = 0; d < dim; ++d)
+      centers_out[base_idx + d] = cell_center[d];
+  }
+};
+
+template <int dim>
+void
+test(const unsigned int level = numbers::invalid_unsigned_int)
+{
+  Triangulation<dim> tria(
+    Triangulation<dim>::limit_level_difference_at_vertices);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+  dof_handler.distribute_mg_dofs();
+
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  const QGauss<1> quad(2);
+
+  Portable::MatrixFree<dim, double> mf_data;
+
+  typename Portable::MatrixFree<dim, double>::AdditionalData additional_data;
+  additional_data.mapping_update_flags =
+    update_gradients | update_JxW_values | update_quadrature_points;
+  additional_data.mg_level = level;
+
+  additional_data.use_coloring = false;
+
+  mf_data.reinit(
+    MappingQ1<dim>(), dof_handler, constraints, quad, additional_data);
+
+  const unsigned int n_colors = level == numbers::invalid_unsigned_int ?
+                                  mf_data.get_colored_graph().size() :
+                                  mf_data.get_colored_level_graph().size();
+
+  deallog << "Number of colors: " << n_colors << std::endl;
+
+  // Find maximum cells per color for array allocation
+  unsigned int max_cells_per_color = 0;
+  for (unsigned int color = 0; color < n_colors; ++color)
+    max_cells_per_color =
+      std::max(max_cells_per_color, mf_data.n_cells_per_color(color));
+
+  // Allocate device array to store GPU-computed centers
+  // Layout: centers[color * max_cells_per_color * dim + cell_id * dim + d]
+  using double_view =
+    Kokkos::View<double *, MemorySpace::Default::kokkos_space>;
+  double_view centers_gpu("centers_gpu", n_colors * max_cells_per_color * dim);
+
+  // Run kernel to compute centers on GPU
+  using device_vector_type =
+    LinearAlgebra::distributed::Vector<double, MemorySpace::Default>;
+  device_vector_type src, dst;
+  mf_data.initialize_dof_vector(src);
+  mf_data.initialize_dof_vector(dst);
+
+  CellCenterKernel<dim> kernel{centers_gpu, max_cells_per_color};
+  mf_data.cell_loop(kernel, src, dst);
+
+  // Copy GPU results to host
+  auto centers_gpu_host = Kokkos::create_mirror_view(centers_gpu);
+  Kokkos::deep_copy(centers_gpu_host, centers_gpu);
+
+  // Compare with host-computed centers using get_cell_iterator()
+  unsigned int n_matches    = 0;
+  unsigned int n_mismatches = 0;
+
+  for (unsigned int color = 0; color < n_colors; ++color)
+    {
+      const unsigned int n_cells = mf_data.n_cells_per_color(color);
+      deallog << "Color " << color << " has " << n_cells << " cells"
+              << std::endl;
+
+      for (unsigned int cell_id = 0; cell_id < n_cells; ++cell_id)
+        {
+          // Get cell iterator and compute center on host
+          auto               cell = mf_data.get_cell_iterator(color, cell_id);
+          Point<dim, double> center_host = cell->center();
+
+          // Get GPU-computed center
+          const unsigned int base_idx =
+            color * max_cells_per_color * dim + cell_id * dim;
+          Point<dim, double> center_gpu;
+          for (unsigned int d = 0; d < dim; ++d)
+            center_gpu[d] = centers_gpu_host[base_idx + d];
+
+          if ((center_host - center_gpu).norm() < 1e-8)
+            ++n_matches;
+          else
+            ++n_mismatches;
+        }
+    }
+
+  deallog << "Total cells: " << tria.n_active_cells() << std::endl;
+  deallog << "Matches: " << n_matches << ", Mismatches: " << n_mismatches
+          << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  Kokkos::initialize();
+  {
+    test<2>(1);
+    test<2>(2);
+    test<2>();
+    test<3>(1);
+    test<3>(2);
+    test<3>();
+  }
+  Kokkos::finalize();
+
+  return 0;
+}

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_01.output
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_01.output
@@ -1,0 +1,25 @@
+
+DEAL::Number of colors: 1
+DEAL::Color 0 has 4 cells
+DEAL::Total cells: 16
+DEAL::Matches: 4, Mismatches: 0
+DEAL::Number of colors: 1
+DEAL::Color 0 has 16 cells
+DEAL::Total cells: 16
+DEAL::Matches: 16, Mismatches: 0
+DEAL::Number of colors: 1
+DEAL::Color 0 has 16 cells
+DEAL::Total cells: 16
+DEAL::Matches: 16, Mismatches: 0
+DEAL::Number of colors: 1
+DEAL::Color 0 has 8 cells
+DEAL::Total cells: 64
+DEAL::Matches: 8, Mismatches: 0
+DEAL::Number of colors: 1
+DEAL::Color 0 has 64 cells
+DEAL::Total cells: 64
+DEAL::Matches: 64, Mismatches: 0
+DEAL::Number of colors: 1
+DEAL::Color 0 has 64 cells
+DEAL::Total cells: 64
+DEAL::Matches: 64, Mismatches: 0

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_02.cc
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_02.cc
@@ -1,0 +1,191 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// test Portable::MatrixFree::get_cell_iterator() with coloring enabled
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include <deal.II/matrix_free/portable_matrix_free.h>
+#include <deal.II/matrix_free/portable_matrix_free.templates.h>
+
+#include <Kokkos_Core.hpp>
+
+#include "../tests.h"
+
+
+// Device functor to compute cell centers on GPU
+template <int dim>
+struct CellCenterKernel
+{
+  // Store computed centers: centers_out[global_cell_id * dim + d]
+  Kokkos::View<double *, MemorySpace::Default::kokkos_space> centers_out;
+
+  static constexpr unsigned int n_q_points = (1u << dim);
+
+  KOKKOS_FUNCTION void
+  operator()(const typename Portable::MatrixFree<dim, double>::Data *data,
+             const Portable::DeviceVector<double> &,
+             Portable::DeviceVector<double> &) const
+  {
+    const unsigned int cell_id = data->cell_index;
+    const unsigned int global_cell_id =
+      data->precomputed_data[0].row_start /
+        data->precomputed_data[0].padding_length +
+      cell_id;
+
+    Point<dim, double> cell_center;
+    for (unsigned int d = 0; d < dim; ++d)
+      cell_center[d] = 0.0;
+
+    // Average all quadrature points to get cell center
+    for (unsigned int q = 0; q < n_q_points; ++q)
+      {
+        const Point<dim, double> &q_point =
+          data->get_quadrature_point(cell_id, q);
+        for (unsigned int d = 0; d < dim; ++d)
+          cell_center[d] += q_point[d];
+      }
+
+    for (unsigned int d = 0; d < dim; ++d)
+      cell_center[d] /= n_q_points;
+
+    // Store in output array
+    const unsigned int base_idx = global_cell_id * dim;
+    for (unsigned int d = 0; d < dim; ++d)
+      centers_out[base_idx + d] = cell_center[d];
+  }
+};
+
+template <int dim>
+void
+test(const unsigned int level = numbers::invalid_unsigned_int)
+{
+  Triangulation<dim> tria(
+    Triangulation<dim>::limit_level_difference_at_vertices);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+  dof_handler.distribute_mg_dofs();
+
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  const QGauss<1> quad(2);
+
+  Portable::MatrixFree<dim, double> mf_data;
+
+  typename Portable::MatrixFree<dim, double>::AdditionalData additional_data;
+  additional_data.mapping_update_flags =
+    update_gradients | update_JxW_values | update_quadrature_points;
+  additional_data.mg_level = level;
+
+  additional_data.use_coloring = true;
+
+  mf_data.reinit(
+    MappingQ1<dim>(), dof_handler, constraints, quad, additional_data);
+
+  const unsigned int n_colors = level == numbers::invalid_unsigned_int ?
+                                  mf_data.get_colored_graph().size() :
+                                  mf_data.get_colored_level_graph().size();
+
+  // Calculate total number of cells
+  unsigned int n_total_cells = 0;
+  for (unsigned int color = 0; color < n_colors; ++color)
+    n_total_cells += mf_data.n_cells_per_color(color);
+
+  // Allocate device array to store GPU-computed centers
+  // Layout: centers[global_cell_id * dim + d]
+  using double_view =
+    Kokkos::View<double *, MemorySpace::Default::kokkos_space>;
+  double_view centers_gpu("centers_gpu", n_total_cells * dim);
+
+  // Run kernel to compute centers on GPU
+  using device_vector_type =
+    LinearAlgebra::distributed::Vector<double, MemorySpace::Default>;
+  device_vector_type src, dst;
+  mf_data.initialize_dof_vector(src);
+  mf_data.initialize_dof_vector(dst);
+
+  CellCenterKernel<dim> kernel{centers_gpu};
+  mf_data.cell_loop(kernel, src, dst);
+
+  // Copy GPU results to host
+  auto centers_gpu_host = Kokkos::create_mirror_view(centers_gpu);
+  Kokkos::deep_copy(centers_gpu_host, centers_gpu);
+
+  // Compare with host-computed centers using get_cell_iterator()
+  unsigned int n_matches      = 0;
+  unsigned int n_mismatches   = 0;
+  unsigned int global_cell_id = 0;
+
+  for (unsigned int color = 0; color < n_colors; ++color)
+    {
+      const unsigned int n_cells = mf_data.n_cells_per_color(color);
+
+      for (unsigned int cell_id = 0; cell_id < n_cells; ++cell_id)
+        {
+          // Get cell iterator and compute center on host
+          auto               cell = mf_data.get_cell_iterator(color, cell_id);
+          Point<dim, double> center_host = cell->center();
+
+          // Get GPU-computed center
+          const unsigned int base_idx = global_cell_id * dim;
+          Point<dim, double> center_gpu;
+          for (unsigned int d = 0; d < dim; ++d)
+            center_gpu[d] = centers_gpu_host[base_idx + d];
+
+          if ((center_host - center_gpu).norm() < 1e-8)
+            ++n_matches;
+          else
+            ++n_mismatches;
+
+          global_cell_id++;
+        }
+    }
+
+  deallog << "Total cells: " << tria.n_active_cells() << std::endl;
+  deallog << "Matches: " << n_matches << ", Mismatches: " << n_mismatches
+          << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  Kokkos::initialize();
+  {
+    test<2>(1);
+    test<2>(2);
+    test<2>();
+    test<3>(1);
+    test<3>(2);
+    test<3>();
+  }
+  Kokkos::finalize();
+
+  return 0;
+}

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_02.output
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_02.output
@@ -1,0 +1,13 @@
+
+DEAL::Total cells: 16
+DEAL::Matches: 4, Mismatches: 0
+DEAL::Total cells: 16
+DEAL::Matches: 16, Mismatches: 0
+DEAL::Total cells: 16
+DEAL::Matches: 16, Mismatches: 0
+DEAL::Total cells: 64
+DEAL::Matches: 8, Mismatches: 0
+DEAL::Total cells: 64
+DEAL::Matches: 64, Mismatches: 0
+DEAL::Total cells: 64
+DEAL::Matches: 64, Mismatches: 0


### PR DESCRIPTION
Depends on  #19001 , without it the tests are not going to pass.

The point of this PR is to make the interface of Portable::MatrixFree similar to MatrixFree, so that MGTwoLevelTransfer can be easily ported to the GPU.