### PR TITLE
Pass constraints to the Chebyshev smoother in step64

### DIFF
--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -601,6 +601,7 @@ namespace Step64
     additional_data.smoothing_range     = 15.;
     additional_data.degree              = 5;
     additional_data.eig_cg_n_iterations = 10;
+    additional_data.constraints.copy_from(constraints);
     additional_data.preconditioner =
       system_matrix_dev->get_matrix_diagonal_inverse();
 


### PR DESCRIPTION

<img width="1920" height="1200" alt="step64" src="https://github.com/user-attachments/assets/ea3a418e-34f4-47df-9f01-0f07c0114a34" />
When solving problems with Dirichlet BCs, the constraints should be passed to the Chebyshev smoother. The constraints are applied to the initial guess, which is of great importance for the smoother to damp the eigenvalues. The effect is seen mostly in 2D and on coarser meshes, as the ratio of the boundary DoFs is much higher. In 3D, it is invisible in the iteration count. 

In the image (left- without constraints, right - with), you can see the number of iterations and the eigenvalue estimates done by the Chebyshev smoother with `dim=2, fe_degree=3`. The iteration count and the damping eigenvalue effect differ quite a bit.  

I will rerun the simulation and can adapt the documentation if I see this difference for the test case reported in the tutorial documentation. Also, when I figure out how to do this ;) 

Regarding the documentation: Would there be interest in adding a simple note on that in the documentation? It is not relevant for step-64, but might help another poor researcher like myself save a couple of days looking for _why_ ;)

@kronbichler, with this my p-MG now works as expected ;)
