### PR TITLE
Added mask to ROL Wrapper.

### DIFF
--- a/doc/news/changes/minor/20251120Fehling
+++ b/doc/news/changes/minor/20251120Fehling
@@ -1,0 +1,5 @@
+New: You can now mask vector elements in TrilinosWrappers::ROLVector to
+reduce the size of the optimization space. This is useful for excluding
+constrained degrees of freedom from the optimization process.
+<br>
+(Marc Fehling, 2025/11/20)

--- a/tests/rol/rolvector_basis_01.cc
+++ b/tests/rol/rolvector_basis_01.cc
@@ -1,0 +1,62 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Check ROLVector::basis() on a distributed vector.
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/signaling_nan.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/trilinos/rol_vector.h>
+
+#include "../tests.h"
+
+
+template <typename VectorType>
+void
+test()
+{
+  // set up distributed vector
+  const unsigned int nprocs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const unsigned int myid   = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  IndexSet owned(nprocs);
+  owned.add_index(myid);
+
+  VectorType v(owned, MPI_COMM_WORLD);
+  v[myid] = myid;
+
+  // wrap for ROL
+  TrilinosWrappers::ROLVector<VectorType> rol_v(ROL::makePtrFromRef(v));
+
+  // get all basis vectors
+  for (unsigned int b = 0; b < nprocs; ++b)
+    {
+      const auto basis = rol_v.basis(b);
+      basis->print(deallog.get_file_stream());
+    }
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test<TrilinosWrappers::MPI::Vector>();
+  test<LinearAlgebra::distributed::Vector<double>>();
+}

--- a/tests/rol/rolvector_basis_01.mpirun=2.output
+++ b/tests/rol/rolvector_basis_01.mpirun=2.output
@@ -1,0 +1,27 @@
+
+size:2 locally_owned_size:1 :
+[0]: 1.000e+00
+size:2 locally_owned_size:1 :
+[0]: 0.000e+00
+Process #0
+Local range: [0, 1), global size: 2
+Vector data:
+1.000e+00 
+Process #0
+Local range: [0, 1), global size: 2
+Vector data:
+0.000e+00 
+
+size:2 locally_owned_size:1 :
+[1]: 0.000e+00
+size:2 locally_owned_size:1 :
+[1]: 1.000e+00
+Process #1
+Local range: [1, 2), global size: 2
+Vector data:
+0.000e+00 
+Process #1
+Local range: [1, 2), global size: 2
+Vector data:
+1.000e+00 
+

--- a/tests/rol/rolvector_indexset_01.cc
+++ b/tests/rol/rolvector_indexset_01.cc
@@ -1,0 +1,78 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Check ROLVector with an IndexSet mask.
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/signaling_nan.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/trilinos/rol_vector.h>
+
+#include <ROL_Vector.hpp>
+
+#include "../tests.h"
+
+
+template <typename VectorType>
+void
+test()
+{
+  const unsigned int size = 5;
+
+  VectorType u(size);
+  VectorType v(size);
+  VectorType w(size);
+
+  // mask excludes first and last indices
+  IndexSet mask(size);
+  mask.add_range(1, size - 1);
+
+  // fill masked parts of vectors with some numbers, and the other parts with
+  // signaling nans
+  unsigned int tmp = 0;
+  for (unsigned int i = 0; i < size; ++i)
+    {
+      if (mask.is_element(i))
+        {
+          u[i] = ++tmp;
+          v[i] = ++tmp;
+          w[i] = ++tmp;
+        }
+      else
+        {
+          u[i] = numbers::signaling_nan<typename VectorType::value_type>();
+          v[i] = numbers::signaling_nan<typename VectorType::value_type>();
+          w[i] = numbers::signaling_nan<typename VectorType::value_type>();
+        }
+    }
+
+  // wrap for ROL
+  TrilinosWrappers::ROLVector<VectorType> u_rol(ROL::makePtrFromRef(u), mask);
+  TrilinosWrappers::ROLVector<VectorType> v_rol(ROL::makePtrFromRef(v), mask);
+  TrilinosWrappers::ROLVector<VectorType> w_rol(ROL::makePtrFromRef(w), mask);
+
+  // let ROL do some checks
+  u_rol.checkVector(v_rol, w_rol, true, deallog.get_file_stream());
+}
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  test<Vector<double>>();
+}

--- a/tests/rol/rolvector_indexset_01.output
+++ b/tests/rol/rolvector_indexset_01.output
@@ -1,0 +1,19 @@
+
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+

--- a/tests/rol/rolvector_indexset_01.output.1
+++ b/tests/rol/rolvector_indexset_01.output.1
@@ -1,0 +1,20 @@
+
+
+********** Begin verification of linear algebra. *********************************************
+
+Commutativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Associativity of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Inverse elements of addition. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Identity element of scalar multiplication. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication with field multiplication. Consistency error: >>>>>>>>>>> 0
+Distributivity of scalar multiplication with respect to field addition. Consistency error: >>> 0
+Distributivity of scalar multiplication with respect to vector addition. Consistency error: >> 0
+Commutativity of dot (inner) product over the field of reals. Consistency error: >>>>>>>>>>>>> 0
+Additivity of dot (inner) product. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of scalar multiplication and norm. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Reflexivity. Consistency error: >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+Consistency of apply and dual:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 0
+
+********** End verification of linear algebra. ***********************************************
+


### PR DESCRIPTION
~Blocked by #19002 and #19012 (only https://github.com/dealii/dealii/commit/e961836fd0606f4e2d8689f8a2965315125aa8b5 contains the actual patch for this PR).~ (EDIT: Dependent patches have been merged.)

As discussed on element, masking a vector of a finite element discretization is useful in context of numerical optimization to exclude constrained degrees of freedom from the optimization space (boundary, hanging nodes). This patch implements such a feature.

The implementation uses index-based access to the wrapped vector, which is potentially slow. It replaces the previous, vectorized operations. However, I did not encounter any performance bottlenecks from the basic vector operations in this wrapper class (as evaluating global integrals through quadrature is almost always more expensive). I suggest we revisit the implementation once we do encounter bottlenecks.