### PR TITLE
Shorten documentation of ParsedFunction.

### DIFF
--- a/doc/news/changes/minor/20251121LucaHeltai
+++ b/doc/news/changes/minor/20251121LucaHeltai
@@ -1,0 +1,3 @@
+Fix: Shorten documentation of ParsedFunction that is printed to parameter files.
+<br>
+(Luca Heltai, 2025/11/21)

--- a/include/deal.II/base/parsed_function.h
+++ b/include/deal.II/base/parsed_function.h
@@ -142,9 +142,11 @@ namespace Functions
      *  @endcode
      *
      * These constants can be used in the declaration of the function
-     * expression, which follows the convention of the FunctionParser class.
-     * In order to specify vector functions, semicolons have to be used to
-     * separate the different components, e.g.:
+     * expression, which follows the convention of the FunctionParser class. The
+     * constants `pi`, `PI`, `Pi`, (for the value of π) and `E` (for the Nepero
+     * number) are predefined. If want to override these constants, you can do
+     * so in the Function constants entry. In order to specify vector functions,
+     * semicolons have to be used to separate the different components, e.g.:
      *
      *  @code
      *

--- a/source/base/parsed_function.cc
+++ b/source/base/parsed_function.cc
@@ -57,17 +57,7 @@ namespace Functions
       "Variable names",
       vnames,
       Patterns::Anything(),
-      "The names of the variables as they will be used in the "
-      "function, separated by commas. By default, the names of variables "
-      "at which the function will be evaluated are `x' (in 1d), `x,y' (in 2d) or "
-      "`x,y,z' (in 3d) for spatial coordinates and `t' for time. You can then "
-      "use these variable names in your function expression and they will be "
-      "replaced by the values of these variables at which the function is "
-      "currently evaluated. However, you can also choose a different set "
-      "of names for the independent variables at which to evaluate your function "
-      "expression. For example, if you work in spherical coordinates, you may "
-      "wish to set this input parameter to `r,phi,theta,t' and then use these "
-      "variable names in your function expression.");
+      "Names of the independent variables, separated by commas.");
 
     // The expression of the function
     // If the string is an empty string, 0 is set for each components.
@@ -91,33 +81,14 @@ namespace Functions
       "Function expression",
       expr,
       Patterns::Anything(),
-      "The formula that denotes the function you want to evaluate for "
-      "particular values of the independent variables. This expression "
-      "may contain any of the usual operations such as addition or "
-      "multiplication, as well as all of the common functions such as "
-      "`sin' or `cos'. In addition, it may contain expressions like "
-      "`if(x>0, 1, -1)' where the expression evaluates to the second "
-      "argument if the first argument is true, and to the third argument "
-      "otherwise. For a full overview of possible expressions accepted "
-      "see the documentation of the muparser library at http://muparser.beltoforion.de/."
-      "\n\n"
-      "If the function you are describing represents a vector-valued "
-      "function with multiple components, then separate the expressions "
-      "for individual components by a semicolon.");
+      "Semicolon-separated formulas for the function components. Supports standard "
+      "operations, functions `sin`, `cos`, etc., and conditionals `if(x>0, 1, -1)`.");
     prm.declare_entry(
       "Function constants",
       "",
       Patterns::Anything(),
-      "Sometimes it is convenient to use symbolic constants in the "
-      "expression that describes the function, rather than having to "
-      "use its numeric value everywhere the constant appears. These "
-      "values can be defined using this parameter, in the form "
-      "`var1=value1, var2=value2, ...'."
-      "\n\n"
-      "A typical example would be to set this runtime parameter to "
-      "`pi=3.1415926536' and then use `pi' in the expression of the "
-      "actual formula. (That said, for convenience this class actually "
-      "defines both `pi' and `Pi' by default, but you get the idea.)");
+      "Symbolic constants for the function expression, in the form "
+      "'var1=value1, var2=value2, ...'. Note: 'pi', 'Pi', 'PI', and 'E' are predefined.");
   }
 
 
@@ -133,6 +104,14 @@ namespace Functions
     std::vector<std::string> const_list =
       Utilities::split_string_list(constants_list, ',');
     std::map<std::string, double> constants;
+
+    // set pi, Pi, and PI as synonyms for the corresponding value, and set the
+    // Nepero number E.
+    constants["pi"] = numbers::PI;
+    constants["Pi"] = numbers::PI;
+    constants["PI"] = numbers::PI;
+    constants["E"]  = numbers::E;
+
     for (const auto &constant : const_list)
       {
         std::vector<std::string> this_c =
@@ -143,11 +122,6 @@ namespace Functions
                                "entries of the form 'name=value'."));
         constants[this_c[0]] = Utilities::string_to_double(this_c[1]);
       }
-
-    // set pi and Pi as synonyms for the corresponding value. note that
-    // this overrides any value a user may have given
-    constants["pi"] = numbers::PI;
-    constants["Pi"] = numbers::PI;
 
     const unsigned int nn = (Utilities::split_string_list(vnames)).size();
     switch (nn)


### PR DESCRIPTION
This PR shortens the documentation of the `ParsedFunction` class that gets written to the parameter file.

Whenever we create a new object (and one may have in the order of 10 such guys in a parameter files), we get this:

```bash
subsection Exact solution
  # Sometimes it is convenient to use symbolic constants in the expression
  # that describes the function, rather than having to use its numeric value
  # everywhere the constant appears. These values can be defined using this
  # parameter, in the form `var1=value1, var2=value2, ...'.
  #
  # A typical example would be to set this runtime parameter to
  # `pi=3.1415926536' and then use `pi' in the expression of the actual
  # formula. (That said, for convenience this class actually defines both `pi'
  # and `Pi' by default, but you get the idea.)
  set Function constants  =

  # The formula that denotes the function you want to evaluate for particular
  # values of the independent variables. This expression may contain any of
  # the usual operations such as addition or multiplication, as well as all of
  # the common functions such as `sin' or `cos'. In addition, it may contain
  # expressions like `if(x>0, 1, -1)' where the expression evaluates to the
  # second argument if the first argument is true, and to the third argument
  # otherwise. For a full overview of possible expressions accepted see the
  # documentation of the muparser library at http://muparser.beltoforion.de/.
  #
  # If the function you are describing represents a vector-valued function
  # with multiple components, then separate the expressions for individual
  # components by a semicolon.
  set Function expression = 0

  # The names of the variables as they will be used in the function, separated
  # by commas. By default, the names of variables at which the function will
  # be evaluated are `x' (in 1d), `x,y' (in 2d) or `x,y,z' (in 3d) for spatial
  # coordinates and `t' for time. You can then use these variable names in
  # your function expression and they will be replaced by the values of these
  # variables at which the function is currently evaluated. However, you can
  # also choose a different set of names for the independent variables at
  # which to evaluate your function expression. For example, if you work in
  # spherical coordinates, you may wish to set this input parameter to
  # `r,phi,theta,t' and then use these variable names in your function
  # expression.
  set Variable names      = x,y,z,t
end
```

This PR modifies the codes that outputs the documentation and creates a minimalist parameter file which is much shorter, yet understandable:

```bash
subsection Exact solution
  # Symbolic constants for the function expression, in the form
  # 'var1=value1, var2=value2, ...'. Note: 'pi', 'Pi', 'PI', and 'E' are predefined.
  set Function constants  =

  # Semicolon-separated formulas for the function components. Supports standard
  # operations, functions `sin`, `cos`, etc., and conditionals `if(x>0, 1, -1)`.
  set Function expression = 0

  # Names of the independent variables, separated by commas.
  set Variable names      = x,y,z,t
end
```