### PR TITLE
PETSc: support multithreaded read of ghosted vector

### DIFF
--- a/doc/news/changes/major/20251123tjhei
+++ b/doc/news/changes/major/20251123tjhei
@@ -1,0 +1,3 @@
+New: PETSc linear algebra now supports multi-threaded assembly and reading from ghost vectors.
+<br>
+(Timo Heister, 2025/11/23)

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -126,6 +126,9 @@ namespace PETScWrappers
                    true);
         }
 
+      if (ghosted)
+        release_ghost_form();
+
       PetscErrorCode ierr = VecCopy(v.vector, vector);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
 
@@ -135,6 +138,8 @@ namespace PETScWrappers
           AssertThrow(ierr == 0, ExcPETScError(ierr));
           ierr = VecGhostUpdateEnd(vector, INSERT_VALUES, SCATTER_FORWARD);
           AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+          acquire_ghost_form();
         }
       return *this;
     }
@@ -166,6 +171,9 @@ namespace PETScWrappers
 
       if (update_size || has_ghost_elements())
         {
+          if (has_ghost_elements())
+            release_ghost_form();
+
           // PETSc doesn't support resizing non-empty vectors so create a new
           // one:
           const PetscErrorCode ierr = VecDestroy(&vector);
@@ -178,6 +186,9 @@ namespace PETScWrappers
       // desired
       if (omit_zeroing_entries == false)
         *this = 0;
+
+      if (has_ghost_elements())
+        acquire_ghost_form();
     }
 
 
@@ -210,6 +221,9 @@ namespace PETScWrappers
                    const IndexSet &ghost,
                    const MPI_Comm  comm)
     {
+      if (ghosted)
+        release_ghost_form();
+
       const PetscErrorCode ierr = VecDestroy(&vector);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
 
@@ -224,6 +238,9 @@ namespace PETScWrappers
     void
     Vector::reinit(const IndexSet &local, const MPI_Comm comm)
     {
+      if (ghosted)
+        release_ghost_form();
+
       const PetscErrorCode ierr = VecDestroy(&vector);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
 
@@ -331,6 +348,8 @@ namespace PETScWrappers
                           end - begin +
                             static_cast<PetscInt>(ghost_indices.n_elements()));
         }
+
+      acquire_ghost_form();
     }
 
 

--- a/tests/petsc/step-40-multithreading.cc
+++ b/tests/petsc/step-40-multithreading.cc
@@ -1,0 +1,390 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Test multithreading in PETSc with ghosted vectors. Variant of step-40.
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/timer.h>
+
+#include <deal.II/lac/generic_linear_algebra.h>
+
+#include "../tests.h"
+
+namespace LA
+{
+  using namespace dealii::LinearAlgebraPETSc;
+}
+
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/error_estimator.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <fstream>
+#include <iostream>
+
+namespace Step40
+{
+  using namespace dealii;
+
+  template <int dim>
+  class LaplaceProblem
+  {
+  public:
+    LaplaceProblem();
+
+    void
+    run();
+
+  private:
+    void
+    setup_system();
+    void
+    assemble_system();
+    void
+    solve();
+    void
+    refine_grid();
+    void
+    output_results(const unsigned int cycle);
+
+    MPI_Comm mpi_communicator;
+
+    parallel::distributed::Triangulation<dim> triangulation;
+
+    const FE_Q<dim> fe;
+    DoFHandler<dim> dof_handler;
+
+    IndexSet locally_owned_dofs;
+    IndexSet locally_relevant_dofs;
+
+    AffineConstraints<double> constraints;
+
+    LA::MPI::SparseMatrix system_matrix;
+    LA::MPI::Vector       locally_relevant_solution;
+    LA::MPI::Vector       system_rhs;
+
+    TimerOutput computing_timer;
+  };
+
+
+  template <int dim>
+  LaplaceProblem<dim>::LaplaceProblem()
+    : mpi_communicator(MPI_COMM_WORLD)
+    , triangulation(mpi_communicator,
+                    typename Triangulation<dim>::MeshSmoothing(
+                      Triangulation<dim>::smoothing_on_refinement |
+                      Triangulation<dim>::smoothing_on_coarsening))
+    , fe(2)
+    , dof_handler(triangulation)
+    , computing_timer(mpi_communicator,
+                      deallog.get_file_stream(),
+                      TimerOutput::never,
+                      TimerOutput::wall_times)
+  {}
+
+
+
+  template <int dim>
+  void
+  LaplaceProblem<dim>::setup_system()
+  {
+    TimerOutput::Scope t(computing_timer, "setup");
+
+    dof_handler.distribute_dofs(fe);
+
+    deallog << "   Number of active cells:       "
+            << triangulation.n_global_active_cells() << std::endl
+            << "   Number of degrees of freedom: " << dof_handler.n_dofs()
+            << std::endl;
+
+
+    locally_owned_dofs = dof_handler.locally_owned_dofs();
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
+
+    locally_relevant_solution.reinit(locally_owned_dofs,
+                                     locally_relevant_dofs,
+                                     mpi_communicator);
+    system_rhs.reinit(locally_owned_dofs, mpi_communicator);
+
+    constraints.clear();
+    constraints.reinit(locally_owned_dofs, locally_relevant_dofs);
+    DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+    VectorTools::interpolate_boundary_values(dof_handler,
+                                             0,
+                                             Functions::ZeroFunction<dim>(),
+                                             constraints);
+    constraints.close();
+
+    DynamicSparsityPattern dsp(locally_relevant_dofs);
+
+    DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               dof_handler.locally_owned_dofs(),
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
+
+    system_matrix.reinit(locally_owned_dofs,
+                         locally_owned_dofs,
+                         dsp,
+                         mpi_communicator);
+  }
+
+
+
+  template <int dim>
+  void
+  LaplaceProblem<dim>::assemble_system()
+  {
+    TimerOutput::Scope t(computing_timer, "assembly");
+
+    const QGauss<dim> quadrature_formula(fe.degree + 1);
+
+    FEValues<dim> fe_values(fe,
+                            quadrature_formula,
+                            update_values | update_gradients |
+                              update_quadrature_points | update_JxW_values);
+
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
+    const unsigned int n_q_points    = quadrature_formula.size();
+
+    FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>     cell_rhs(dofs_per_cell);
+
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+    for (const auto &cell : dof_handler.active_cell_iterators())
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+
+          cell_matrix = 0.;
+          cell_rhs    = 0.;
+
+          for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+            {
+              const double rhs_value =
+                (fe_values.quadrature_point(q_point)[1] >
+                     0.5 +
+                       0.25 * std::sin(4.0 * numbers::PI *
+                                       fe_values.quadrature_point(q_point)[0]) ?
+                   1. :
+                   -1.);
+
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                {
+                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                    cell_matrix(i, j) += fe_values.shape_grad(i, q_point) *
+                                         fe_values.shape_grad(j, q_point) *
+                                         fe_values.JxW(q_point);
+
+                  cell_rhs(i) += rhs_value * fe_values.shape_value(i, q_point) *
+                                 fe_values.JxW(q_point);
+                }
+            }
+
+          cell->get_dof_indices(local_dof_indices);
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 system_matrix,
+                                                 system_rhs);
+        }
+
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
+  }
+
+
+
+  template <int dim>
+  void
+  LaplaceProblem<dim>::solve()
+  {
+    TimerOutput::Scope t(computing_timer, "solve");
+
+    LA::MPI::Vector completely_distributed_solution(locally_owned_dofs,
+                                                    mpi_communicator);
+
+    SolverControl solver_control(dof_handler.n_dofs(),
+                                 1e-6 * system_rhs.l2_norm());
+    LA::SolverCG  solver(solver_control);
+
+
+    LA::MPI::PreconditionAMG::AdditionalData data;
+    data.symmetric_operator = true;
+    LA::MPI::PreconditionAMG preconditioner;
+    preconditioner.initialize(system_matrix, data);
+
+    check_solver_within_range(solver.solve(system_matrix,
+                                           completely_distributed_solution,
+                                           system_rhs,
+                                           preconditioner),
+                              solver_control.last_step(),
+                              5,
+                              10);
+
+
+    constraints.distribute(completely_distributed_solution);
+
+    locally_relevant_solution = completely_distributed_solution;
+  }
+
+
+
+  template <int dim>
+  void
+  LaplaceProblem<dim>::refine_grid()
+  {
+    TimerOutput::Scope t(computing_timer, "refine");
+
+    Vector<float> estimated_error_per_cell(triangulation.n_active_cells());
+    KellyErrorEstimator<dim>::estimate(
+      dof_handler,
+      QGauss<dim - 1>(fe.degree + 1),
+      std::map<types::boundary_id, const Function<dim> *>(),
+      locally_relevant_solution,
+      estimated_error_per_cell);
+    parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
+      triangulation, estimated_error_per_cell, 0.3, 0.03);
+    triangulation.execute_coarsening_and_refinement();
+  }
+
+
+
+  template <int dim>
+  void
+  LaplaceProblem<dim>::output_results(const unsigned int cycle)
+  {
+    TimerOutput::Scope t(computing_timer, "output");
+
+    DataOut<dim> data_out;
+    data_out.attach_dof_handler(dof_handler);
+    data_out.add_data_vector(locally_relevant_solution, "u");
+
+    Vector<float> subdomain(triangulation.n_active_cells());
+    for (unsigned int i = 0; i < subdomain.size(); ++i)
+      subdomain(i) = triangulation.locally_owned_subdomain();
+    data_out.add_data_vector(subdomain, "subdomain");
+
+    data_out.build_patches();
+
+    data_out.write_vtu_with_pvtu_record(
+      "./", "solution", cycle, mpi_communicator, 2, 8);
+  }
+
+
+
+  template <int dim>
+  void
+  LaplaceProblem<dim>::run()
+  {
+    deallog << "Running on "
+            << Utilities::MPI::n_mpi_processes(mpi_communicator)
+            << " MPI rank(s)..." << std::endl;
+
+    const unsigned int n_cycles = 2;
+    for (unsigned int cycle = 0; cycle < n_cycles; ++cycle)
+      {
+        deallog << "Cycle " << cycle << ':' << std::endl;
+
+        if (cycle == 0)
+          {
+            GridGenerator::hyper_cube(triangulation);
+            triangulation.refine_global(5);
+          }
+        else
+          refine_grid();
+
+        setup_system();
+        assemble_system();
+        solve();
+        output_results(cycle);
+
+        computing_timer.reset();
+
+        deallog << std::endl;
+      }
+  }
+} // namespace Step40
+
+
+int
+main(int argc, char *argv[])
+{
+  try
+    {
+      using namespace dealii;
+      using namespace Step40;
+
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(
+        argc, argv, numbers::invalid_unsigned_int);
+      MPILogInitAll all;
+
+      LaplaceProblem<2> laplace_problem_2d;
+      laplace_problem_2d.run();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/petsc/step-40-multithreading.with_p4est=true.mpirun=2.output
+++ b/tests/petsc/step-40-multithreading.with_p4est=true.mpirun=2.output
@@ -1,0 +1,25 @@
+
+DEAL:0::Running on 2 MPI rank(s)...
+DEAL:0::Cycle 0:
+DEAL:0::   Number of active cells:       1024
+DEAL:0::   Number of degrees of freedom: 4225
+DEAL:0::Solver stopped within 5 - 10 iterations
+DEAL:0::
+DEAL:0::Cycle 1:
+DEAL:0::   Number of active cells:       1966
+DEAL:0::   Number of degrees of freedom: 8453
+DEAL:0::Solver stopped within 5 - 10 iterations
+DEAL:0::
+
+DEAL:1::Running on 2 MPI rank(s)...
+DEAL:1::Cycle 0:
+DEAL:1::   Number of active cells:       1024
+DEAL:1::   Number of degrees of freedom: 4225
+DEAL:1::Solver stopped within 5 - 10 iterations
+DEAL:1::
+DEAL:1::Cycle 1:
+DEAL:1::   Number of active cells:       1966
+DEAL:1::   Number of degrees of freedom: 8453
+DEAL:1::Solver stopped within 5 - 10 iterations
+DEAL:1::
+


### PR DESCRIPTION
This implements the suggestion in #18886 to avoid the race condition. Now, ghosted vectors always have the ghost form acquired.

fixes #18886
