### PR TITLE
tests/performance/timing_matrix_free_kokkos: remove unused var

### DIFF
--- a/tests/performance/timing_matrix_free_kokkos.cc
+++ b/tests/performance/timing_matrix_free_kokkos.cc
@@ -144,9 +144,8 @@ public:
     fe_eval.integrate(EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }
-  static const unsigned int n_dofs_1d    = fe_degree + 1;
-  static const unsigned int n_local_dofs = Utilities::pow(fe_degree + 1, dim);
-  static const unsigned int n_q_points   = Utilities::pow(fe_degree + 1, dim);
+  static const unsigned int n_dofs_1d  = fe_degree + 1;
+  static const unsigned int n_q_points = Utilities::pow(fe_degree + 1, dim);
 };
 
 template <int dim, int fe_degree, typename Number>


### PR DESCRIPTION
n_local_dofs is no longer used