### PR TITLE
Portable::MatrixFree: store and use n_q_points

### DIFF
--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -93,7 +93,7 @@ namespace Step64
     const unsigned int                                      cell,
     const unsigned int                                      q) const
   {
-    const unsigned int pos = gpu_data->local_q_point_id(cell, n_q_points, q);
+    const unsigned int pos     = gpu_data->local_q_point_id(cell, q);
     const Point<dim>   q_point = gpu_data->get_quadrature_point(cell, q);
 
     double p_square = 0.;
@@ -154,9 +154,8 @@ namespace Step64
     const typename Portable::MatrixFree<dim, double>::Data *data =
       fe_eval->get_matrix_free_data();
 
-    const unsigned int position =
-      data->local_q_point_id(cell_index, n_q_points, q_point);
-    auto coeff = coef[position];
+    const unsigned int position = data->local_q_point_id(cell_index, q_point);
+    auto               coeff    = coef[position];
 
     auto value = fe_eval->get_value(q_point);
 

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -476,6 +476,7 @@ namespace Portable
         const int cell_index = team_member.league_rank();
 
         typename MatrixFree<dim, Number>::Data data{team_member,
+                                                    Functor::n_q_points,
                                                     n_dof_handler,
                                                     cell_index,
                                                     precomputed_data,
@@ -805,6 +806,7 @@ namespace Portable
                     shared_data;
 
                   Data data{team_member,
+                            n_q_points,
                             n_dof_handler,
                             cell_index,
                             colored_data,

--- a/tests/matrix_free_kokkos/matrix_vector_device_mf.h
+++ b/tests/matrix_free_kokkos/matrix_vector_device_mf.h
@@ -56,7 +56,7 @@ HelmholtzOperatorQuad<dim, fe_degree, Number, n_q_points_1d>::operator()(
   int q_point) const
 {
   unsigned int pos = fe_eval->get_matrix_free_data()->local_q_point_id(
-    fe_eval->get_current_cell_index(), n_q_points, q_point);
+    fe_eval->get_current_cell_index(), q_point);
   fe_eval->submit_value(coef[pos] * fe_eval->get_value(q_point), q_point);
   fe_eval->submit_gradient(fe_eval->get_gradient(q_point), q_point);
 }
@@ -133,7 +133,7 @@ VaryingCoefficientFunctor<dim, fe_degree, Number, n_q_points_1d>::operator()(
   const unsigned int                                      cell,
   const unsigned int                                      q) const
 {
-  const unsigned int pos     = gpu_data->local_q_point_id(cell, n_q_points, q);
+  const unsigned int pos     = gpu_data->local_q_point_id(cell, q);
   const auto         q_point = gpu_data->get_quadrature_point(cell, q);
 
 


### PR DESCRIPTION
By explicitly storing the number of q_points in the data sent to the GPU, we no longer need to ask the user about the value (that could be inconsistent).