### PR TITLE
Add a getter for overlap_communication_computation in P::MF

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -627,6 +627,14 @@ namespace Portable
     get_mg_level() const;
 
     /**
+     * Return the flag indicating whether overlap MPI communication with
+     * computation is used as was set by
+     * AdditionalData::overlap_communication_computation.
+     */
+    bool
+    use_overlap_communication_computation() const;
+
+    /**
      * Return an approximation of the memory consumption of this class in bytes.
      */
     std::size_t
@@ -1129,6 +1137,15 @@ namespace Portable
   MatrixFree<dim, Number>::get_mg_level() const
   {
     return mg_level;
+  }
+
+
+
+  template <int dim, typename Number>
+  inline bool
+  MatrixFree<dim, Number>::use_overlap_communication_computation() const
+  {
+    return overlap_communication_computation;
   }
 
 #endif


### PR DESCRIPTION
This PR adds a getter for `overlap_communication_computation` in `Portable::MatrixFree`.

Right now, to be able to perform MPI-aware overlapping computation in custom codes, the flag `overlap_communication_computation` should either be passed in the constructors to all nested classes (very prone to bugs) or an option I've been using is templating the class with an additional `bool` value (bulky code, and honestly quite annoying ;) ). 