### PR TITLE
introduce Portable::MatrixFree::Data::for_each_quad_point()

### DIFF
--- a/examples/step-64/step-64.cc
+++ b/examples/step-64/step-64.cc
@@ -208,8 +208,11 @@ namespace Step64
       data);
     fe_eval.read_dof_values(src);
     fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
-    fe_eval.apply_for_each_quad_point(
-      HelmholtzOperatorQuad<dim, fe_degree>(coef));
+
+    HelmholtzOperatorQuad<dim, fe_degree> quad(coef);
+    data->for_each_quad_point(
+      [&](const int &q_point) { quad(&fe_eval, q_point); });
+
     fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }

--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -268,10 +268,12 @@ namespace Portable
      *   Portable::FEEvaluation<dim, fe_degree, n_q_points_1d, n_components, Number> *fe_eval,
      *   int q_point) const;
      * \endcode
+     *
+     * @deprecated Use MatrixFree::Data::for_each_quad_point() instead.
      */
     // clang-format on
     template <typename Functor>
-    DEAL_II_HOST_DEVICE void
+    DEAL_II_DEPRECATED DEAL_II_HOST_DEVICE void
     apply_for_each_quad_point(const Functor &func);
 
   private:

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -463,6 +463,23 @@ namespace Portable
                ExcInternalError());
         return precomputed_data[0].q_points(q_point, cell);
       }
+
+      /**
+       * Apply the given functor to each quadrature point in parallel.
+       *
+       * @p func needs to define
+       * \code
+       * DEAL_II_HOST_DEVICE void operator()(const int &q_point) const;
+       * \endcode
+       */
+      template <typename Functor>
+      DEAL_II_HOST_DEVICE void
+      for_each_quad_point(const Functor &func) const
+      {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, n_q_points),
+                             [&](const int &q) { func(q); });
+        team_member.team_barrier();
+      }
     };
 
     /**

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1453,7 +1453,8 @@ namespace MatrixFreeTools
                                 c));
 
             fe_eval.evaluate(m_evaluation_flags);
-            fe_eval.apply_for_each_quad_point(m_quad_operation);
+            data->for_each_quad_point(
+              [&](const int &q_point) { m_quad_operation(&fe_eval, q_point); });
             fe_eval.integrate(m_integration_flags);
 
             Portable::internal::

--- a/tests/matrix_free_kokkos/matrix_free_mg_level_01.cc
+++ b/tests/matrix_free_kokkos/matrix_free_mg_level_01.cc
@@ -96,8 +96,11 @@ public:
       data);
     fe_eval.read_dof_values(src);
     fe_eval.evaluate(EvaluationFlags::gradients);
-    fe_eval.apply_for_each_quad_point(
-      LaplaceOperatorQuad<dim, fe_degree, Number, n_q_points_1d>());
+
+    LaplaceOperatorQuad<dim, fe_degree, Number, n_q_points_1d> quad;
+    data->for_each_quad_point(
+      [&](const int &q_point) { quad(&fe_eval, q_point); });
+
     fe_eval.integrate(EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }

--- a/tests/matrix_free_kokkos/matrix_free_mg_level_02.cc
+++ b/tests/matrix_free_kokkos/matrix_free_mg_level_02.cc
@@ -94,8 +94,11 @@ public:
       data);
     fe_eval.read_dof_values(src);
     fe_eval.evaluate(EvaluationFlags::gradients);
-    fe_eval.apply_for_each_quad_point(
-      LaplaceOperatorQuad<dim, fe_degree, Number, n_q_points_1d>());
+
+    LaplaceOperatorQuad<dim, fe_degree, Number, n_q_points_1d> quad;
+    data->for_each_quad_point(
+      [&](const int &q_point) { quad(&fe_eval, q_point); });
+
     fe_eval.integrate(EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }

--- a/tests/matrix_free_kokkos/matrix_free_mg_level_03.cc
+++ b/tests/matrix_free_kokkos/matrix_free_mg_level_03.cc
@@ -96,8 +96,11 @@ public:
       data);
     fe_eval.read_dof_values(src);
     fe_eval.evaluate(EvaluationFlags::gradients);
-    fe_eval.apply_for_each_quad_point(
-      LaplaceOperatorQuad<dim, fe_degree, Number, n_q_points_1d>());
+
+    LaplaceOperatorQuad<dim, fe_degree, Number, n_q_points_1d> quad;
+    data->for_each_quad_point(
+      [&](const int &q_point) { quad(&fe_eval, q_point); });
+
     fe_eval.integrate(EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }

--- a/tests/matrix_free_kokkos/matrix_vector_device_mf.h
+++ b/tests/matrix_free_kokkos/matrix_vector_device_mf.h
@@ -93,8 +93,11 @@ HelmholtzOperator<dim, fe_degree, Number, n_q_points_1d>::operator()(
                                                                            0);
   fe_eval.read_dof_values(src);
   fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
-  fe_eval.apply_for_each_quad_point(
-    HelmholtzOperatorQuad<dim, fe_degree, Number, n_q_points_1d>(coef));
+
+  HelmholtzOperatorQuad<dim, fe_degree, Number, n_q_points_1d> quad(coef);
+  data->for_each_quad_point(
+    [&](const int &q_point) { quad(&fe_eval, q_point); });
+
   fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
   fe_eval.distribute_local_to_global(dst);
 }

--- a/tests/matrix_free_kokkos/transfer_matrix_free_copy_to_host_01.cc
+++ b/tests/matrix_free_kokkos/transfer_matrix_free_copy_to_host_01.cc
@@ -207,8 +207,10 @@ public:
       phi(data);
     phi.read_dof_values(src);
     phi.evaluate(EvaluationFlags::gradients);
-    phi.apply_for_each_quad_point(
-      LaplaceOperatorQuad<dim, fe_degree, n_components, Number>());
+
+    LaplaceOperatorQuad<dim, fe_degree, n_components, Number> quad;
+    data->for_each_quad_point([&](const int &q_point) { quad(&phi, q_point); });
+
     phi.integrate(EvaluationFlags::gradients);
     phi.distribute_local_to_global(dst);
   }

--- a/tests/performance/timing_matrix_free_kokkos.cc
+++ b/tests/performance/timing_matrix_free_kokkos.cc
@@ -139,8 +139,11 @@ public:
       gpu_data);
     fe_eval.read_dof_values(src);
     fe_eval.evaluate(EvaluationFlags::gradients);
-    fe_eval.apply_for_each_quad_point(
-      LaplaceOperatorQuad<dim, fe_degree, Number>());
+
+    LaplaceOperatorQuad<dim, fe_degree, Number> quad;
+    gpu_data->for_each_quad_point(
+      [&](const int &q_point) { quad(&fe_eval, q_point); });
+
     fe_eval.integrate(EvaluationFlags::gradients);
     fe_eval.distribute_local_to_global(dst);
   }


### PR DESCRIPTION
apply_for_each_quad_point() only works for a single Portable::FEEvaluation object. Instead, I opted for a function in MatrixFree::Data.