### PR TITLE
fix warning in `TableHandler` via `emplace_back()`

### DIFF
--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -960,7 +960,7 @@ TableHandler::add_value(const std::string &key, const T value)
 
       while (columns[key].entries.size() + 1 < max_col_length)
         {
-          columns[key].entries.push_back(internal::TableEntry(T()));
+          columns[key].entries.emplace_back(T());
           const internal::TableEntry &entry = columns[key].entries.back();
           entry.cache_string(columns[key].scientific, columns[key].precision);
           columns[key].max_length =
@@ -971,7 +971,7 @@ TableHandler::add_value(const std::string &key, const T value)
     }
 
   // now push the value given to this function
-  columns[key].entries.push_back(internal::TableEntry(value));
+  columns[key].entries.emplace_back(value);
   const internal::TableEntry &entry = columns[key].entries.back();
   entry.cache_string(columns[key].scientific, columns[key].precision);
   columns[key].max_length =


### PR DESCRIPTION
This is a little workaround for a GCC 13.3 warning
`may be used uninitialized [-Wmaybe-uninitialized]`
due to GCC mis-tracking the initialization path through the variant using `push_back()`.

We can just use `emplace_back()`, which finds the suitable constructor for `internal::TableEntry`.