### PR TITLE
Clean up matrix_free_kokkos tests

### DIFF
--- a/tests/matrix_free_kokkos/matrix_vector_device_mf.h
+++ b/tests/matrix_free_kokkos/matrix_vector_device_mf.h
@@ -42,9 +42,7 @@ public:
     dealii::Utilities::pow(n_q_points_1d, dim);
 
 private:
-  const typename Portable::MatrixFree<dim, Number>::Data *gpu_data;
-  Number                                                 *coef;
-  int                                                     cell;
+  Number *coef;
 };
 
 
@@ -135,8 +133,6 @@ VaryingCoefficientFunctor<dim, fe_degree, Number, n_q_points_1d>::operator()(
 {
   const unsigned int pos     = gpu_data->local_q_point_id(cell, q);
   const auto         q_point = gpu_data->get_quadrature_point(cell, q);
-
-
 
   Number p_square = 0.;
   for (unsigned int i = 0; i < dim; ++i)

--- a/tests/matrix_free_kokkos/stokes_01.cc
+++ b/tests/matrix_free_kokkos/stokes_01.cc
@@ -141,10 +141,6 @@ public:
     Portable::FEEvaluation<dim, degree_u, n_q_points_1d, dim, Number> &fe_u,
     Portable::FEEvaluation<dim, degree_p, n_q_points_1d, 1, Number>   &fe_p,
     int q_point) const;
-
-private:
-  const typename Portable::MatrixFree<dim, Number>::Data *gpu_data;
-  int                                                     cell;
 };
 
 


### PR DESCRIPTION
The `*Quad` operators don't use the `cell` and `gpu_data` members (which are also not initialized) but would get the corresponding infomation from the `Portable::FEEvaluation` argument.
Even if these are just tests, I find it helpful to clean it up to clarify the intended interface.