### PR TITLE
Use host_mirror_type instead of HostMirror when Kokkos 5.0

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -995,50 +995,30 @@ namespace Portable
     /**
      * Kokkos::View of quadrature points on the host.
      */
-#if DEAL_II_KOKKOS_VERSION_GTE(5, 0, 0)
     typename Kokkos::View<Point<dim, Number> **,
                           MemorySpace::Default::kokkos_space>::host_mirror_type
-#else
-    typename Kokkos::View<Point<dim, Number> **,
-                          MemorySpace::Default::kokkos_space>::HostMirror
-#endif
       q_points;
 
     /**
      * Map the position in the local vector to the position in the global
      * vector.
      */
-#if DEAL_II_KOKKOS_VERSION_GTE(5, 0, 0)
     typename Kokkos::View<types::global_dof_index **,
                           MemorySpace::Default::kokkos_space>::host_mirror_type
-#else
-    typename Kokkos::View<types::global_dof_index **,
-                          MemorySpace::Default::kokkos_space>::HostMirror
-#endif
       local_to_global;
 
     /**
      * Kokkos::View of inverse Jacobians on the host.
      */
-#if DEAL_II_KOKKOS_VERSION_GTE(5, 0, 0)
     typename Kokkos::View<Number **[dim][dim],
                           MemorySpace::Default::kokkos_space>::host_mirror_type
-#else
-    typename Kokkos::View<Number **[dim][dim],
-                          MemorySpace::Default::kokkos_space>::HostMirror
-#endif
       inv_jacobian;
 
     /**
      * Kokkos::View of Jacobian times the weights on the host.
      */
-#if DEAL_II_KOKKOS_VERSION_GTE(5, 0, 0)
     typename Kokkos::View<Number **,
                           MemorySpace::Default::kokkos_space>::host_mirror_type
-#else
-    typename Kokkos::View<Number **,
-                          MemorySpace::Default::kokkos_space>::HostMirror
-#endif
       JxW;
 
     /**
@@ -1059,16 +1039,9 @@ namespace Portable
     /**
      * Mask deciding where constraints are set on a given cell.
      */
-#if DEAL_II_KOKKOS_VERSION_GTE(5, 0, 0)
     typename Kokkos::View<
       dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
-      MemorySpace::Default::kokkos_space>::host_mirror_type
-#else
-    typename Kokkos::View<
-      dealii::internal::MatrixFreeFunctions::ConstraintKinds *,
-      MemorySpace::Default::kokkos_space>::HostMirror
-#endif
-      constraint_mask;
+      MemorySpace::Default::kokkos_space>::host_mirror_type constraint_mask;
 
     /**
      * If true, use graph coloring has been used and we can simply add into

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -208,21 +208,12 @@ namespace Portable
       auto constraint_mask_host =
         Kokkos::create_mirror_view(dof_data.constraint_mask[color]);
 
-#if DEAL_II_KOKKOS_VERSION_GTE(5, 0, 0)
       typename std::remove_reference_t<
         decltype(data->q_points[color])>::host_mirror_type q_points_host;
       typename std::remove_reference_t<
         decltype(dof_data.JxW[color])>::host_mirror_type JxW_host;
       typename std::remove_reference_t<decltype(dof_data.inv_jacobian[color])>::
         host_mirror_type inv_jacobian_host;
-#else
-      typename std::remove_reference_t<
-        decltype(data->q_points[color])>::HostMirror q_points_host;
-      typename std::remove_reference_t<
-        decltype(dof_data.JxW[color])>::HostMirror JxW_host;
-      typename std::remove_reference_t<
-        decltype(dof_data.inv_jacobian[color])>::HostMirror inv_jacobian_host;
-#endif
 #if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
       auto local_to_global_host =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing,


### PR DESCRIPTION
`HostMirror` was deprecated in Kokkos 5.0.  Use `host_mirror_type ` instread