### PR TITLE
Add time information to pvtu output

### DIFF
--- a/doc/news/changes/minor/20251108floschulze
+++ b/doc/news/changes/minor/20251108floschulze
@@ -1,0 +1,6 @@
+Changed: Time step information is saved for pvtu output. In addition the default
+value of VtkFlags::cycle is changed to numbers::invalid_unsigned_int and
+VtkFlags::time to std::numeric_limits<double>::lowest() to ensure it is added to
+the output at the first time step (cycle=0).
+<br>
+(Florian Schulze, 2025/11/08)

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -20,6 +20,7 @@
 
 #include <deal.II/base/geometry_info.h>
 #include <deal.II/base/mpi_stub.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/table.h>
 
@@ -1145,7 +1146,7 @@ namespace DataOutBase
      * the instructions provided in
      * http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
      * unless it is at its default value of
-     * @verbatim std::numeric_limits<unsigned int>::min() @endverbatim.
+     * @verbatim numbers::invalid_unsigned_int @endverbatim.
      */
     unsigned int cycle;
 
@@ -1210,8 +1211,8 @@ namespace DataOutBase
      * to the argument names of this function.
      */
     explicit VtkFlags(
-      const double           time  = std::numeric_limits<double>::min(),
-      const unsigned int     cycle = std::numeric_limits<unsigned int>::min(),
+      const double           time  = std::numeric_limits<double>::lowest(),
+      const unsigned int     cycle = numbers::invalid_unsigned_int,
       const bool             print_date_and_time = true,
       const CompressionLevel compression_level   = CompressionLevel::best_speed,
       const bool             write_higher_order_cells          = false,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi_large_count.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
@@ -4998,17 +4999,17 @@ namespace DataOutBase
     // http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
     {
       const unsigned int n_metadata =
-        ((flags.cycle != std::numeric_limits<unsigned int>::min() ? 1 : 0) +
-         (flags.time != std::numeric_limits<double>::min() ? 1 : 0));
+        ((flags.cycle != numbers::invalid_unsigned_int ? 1 : 0) +
+         (flags.time != std::numeric_limits<double>::lowest() ? 1 : 0));
       if (n_metadata > 0)
         {
           out << "FIELD FieldData " << n_metadata << '\n';
 
-          if (flags.cycle != std::numeric_limits<unsigned int>::min())
+          if (flags.cycle != numbers::invalid_unsigned_int)
             {
               out << "CYCLE 1 1 int\n" << flags.cycle << '\n';
             }
-          if (flags.time != std::numeric_limits<double>::min())
+          if (flags.time != std::numeric_limits<double>::lowest())
             {
               out << "TIME 1 1 double\n" << flags.time << '\n';
             }
@@ -5352,18 +5353,18 @@ namespace DataOutBase
     // http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
     {
       const unsigned int n_metadata =
-        ((flags.cycle != std::numeric_limits<unsigned int>::min() ? 1 : 0) +
-         (flags.time != std::numeric_limits<double>::min() ? 1 : 0));
+        ((flags.cycle != numbers::invalid_unsigned_int ? 1 : 0) +
+         (flags.time != std::numeric_limits<double>::lowest() ? 1 : 0));
       if (n_metadata > 0)
         out << "<FieldData>\n";
 
-      if (flags.cycle != std::numeric_limits<unsigned int>::min())
+      if (flags.cycle != numbers::invalid_unsigned_int)
         {
           out
             << "<DataArray type=\"Float32\" Name=\"CYCLE\" NumberOfTuples=\"1\" format=\"ascii\">"
             << flags.cycle << "</DataArray>\n";
         }
-      if (flags.time != std::numeric_limits<double>::min())
+      if (flags.time != std::numeric_limits<double>::lowest())
         {
           out
             << "<DataArray type=\"Float32\" Name=\"TIME\" NumberOfTuples=\"1\" format=\"ascii\">"
@@ -6155,18 +6156,18 @@ namespace DataOutBase
     // http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
     {
       const unsigned int n_metadata =
-        ((flags.cycle != std::numeric_limits<unsigned int>::min() ? 1 : 0) +
-         (flags.time != std::numeric_limits<double>::min() ? 1 : 0));
+        ((flags.cycle != numbers::invalid_unsigned_int ? 1 : 0) +
+         (flags.time != std::numeric_limits<double>::lowest() ? 1 : 0));
       if (n_metadata > 0)
         out << "    <FieldData>\n";
 
-      if (flags.cycle != std::numeric_limits<unsigned int>::min())
+      if (flags.cycle != numbers::invalid_unsigned_int)
         {
           out
             << "    <DataArray type=\"Float32\" Name=\"CYCLE\" NumberOfTuples=\"1\" format=\"ascii\">"
             << flags.cycle << "</DataArray>\n";
         }
-      if (flags.time != std::numeric_limits<double>::min())
+      if (flags.time != std::numeric_limits<double>::lowest())
         {
           out
             << "    <DataArray type=\"Float32\" Name=\"TIME\" NumberOfTuples=\"1\" format=\"ascii\">"

--- a/tests/data_out/data_out_base_pvtu.cc
+++ b/tests/data_out/data_out_base_pvtu.cc
@@ -59,7 +59,9 @@ check(std::ostream &out)
 
   std::vector<std::string> filenames = names;
 
-  DataOutX x;
+  DataOutX              x;
+  DataOutBase::VtkFlags vtk_flags(0., 0);
+  x.set_flags(vtk_flags);
   x.write_pvtu_record(out, filenames);
 }
 

--- a/tests/data_out/data_out_base_pvtu.output
+++ b/tests/data_out/data_out_base_pvtu.output
@@ -4,6 +4,10 @@
 -->
 <VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
   <PUnstructuredGrid GhostLevel="0">
+    <FieldData>
+    <DataArray type="Float32" Name="CYCLE" NumberOfTuples="1" format="ascii">0</DataArray>
+    <DataArray type="Float32" Name="TIME" NumberOfTuples="1" format="ascii">0</DataArray>
+    </FieldData>
     <PPointData Scalars="scalars">
     <PDataArray type="Float32" Name="x1" format="ascii"/>
     <PDataArray type="Float32" Name="x2" format="ascii"/>


### PR DESCRIPTION
Add time step information to `.pvtu` output.
In addition, the default value for `VtkFlags.cycle` is changed to `numbers::invalid_unsigned_int`. This ensures that it is added to the output for the first time step of time dependent simulations, `cycle = 0`.

This fixes the problem described in #19053 