### PR TITLE
Enable `Taskflow` based parallelization of `apply_to_subranges()`

### DIFF
--- a/doc/news/changes/minor/20251210Shi
+++ b/doc/news/changes/minor/20251210Shi
@@ -1,0 +1,5 @@
+Enable Taskflow-based parallelization of parallel::apply_to_subranges().
+This functionality is missed in the current code, which only supports
+TBB and sequential execution.
+<br>
+(Qingyuan Shi, 2025/12/10)


### PR DESCRIPTION
While testing #19060, I found a few more places where Taskflow should be used but not enabled yet, this is one of them.

If my implementation is correct, I'll continue working on the rest of them, maybe in separate PRs.