### PR TITLE
Geometric multigrid transfer: Fix bug of 64 -> 32 bit narrowing

### DIFF
--- a/include/deal.II/matrix_free/constraint_info.h
+++ b/include/deal.II/matrix_free/constraint_info.h
@@ -157,9 +157,9 @@ namespace internal
 
     private:
       // for setup
-      ConstraintValues<double>               constraint_values;
-      std::vector<std::vector<unsigned int>> dof_indices_per_cell;
-      std::vector<std::vector<unsigned int>> plain_dof_indices_per_cell;
+      ConstraintValues<double>            constraint_values;
+      std::vector<std::vector<IndexType>> dof_indices_per_cell;
+      std::vector<std::vector<IndexType>> plain_dof_indices_per_cell;
       std::vector<std::vector<std::pair<unsigned short, unsigned short>>>
         constraint_indicator_per_cell;
 
@@ -619,6 +619,7 @@ namespace internal
       AssertDimension(constraint_pool_data.size(), length);
 
       this->dof_indices_per_cell.clear();
+      this->plain_dof_indices_per_cell.clear();
       constraint_indicator_per_cell.clear();
 
       if (hanging_nodes &&
@@ -749,6 +750,7 @@ namespace internal
       AssertDimension(constraint_pool_data.size(), length);
 
       this->dof_indices_per_cell.clear();
+      this->plain_dof_indices_per_cell.clear();
       constraint_indicator_per_cell.clear();
 
       if (hanging_nodes &&


### PR DESCRIPTION
When using multigrid with more than 4b DoFs, the solver would either not converge at all or converge very slowly, with no warning or error in either release or debug mode. After searching among smoothers, operators and mg transfer I identified the MG transfer and the reason: Running big multigrid cases (at least with h multigrid on finer leves) was broken in deal.II since #18859, where the functionality was moved to the newer `MGTwoLevelTransfer`, but the bug likely existed there for longer.

I tried to find a way to test this but I could not, because one necessarily needs more than 2^32 dofs and there is no way to shift indices of a DoFHandler (or at least level dofs) to higher numbers. So I only added an assertion that eventually helped me to narrow down it. I stared at a lot of code, and went through all 609 warnings I got with `-Wimplicit-int-conversion` to find the two or three warnings that finally showed where the narrowing happened.