### PR TITLE
Fix for wrong orientation correction during extraction of new lines created while refining triangular faces as a step to isotopically refine 3d cells.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -6825,9 +6825,9 @@ namespace internal
                                 array<std::array<unsigned int, 3>, 6>
                                   table = {{{{0, 1, 2}}, // 0
                                             {{1, 0, 2}},
-                                            {{1, 2, 0}}, // 2
+                                            {{2, 0, 1}}, // 2
                                             {{0, 2, 1}},
-                                            {{2, 0, 1}}, // 4
+                                            {{1, 2, 0}}, // 4
                                             {{2, 1, 0}}}};
 
                               const auto combined_orientation =


### PR DESCRIPTION
# Fix for wrong orientation _correction_ during extraction of new lines created while refining triangular faces as a step to isotopically refine 3d cells.

During the isotropic refinement of a tetrahedron[^1], the faces are refined first using an algorithm similar to the existing one for 2D cells.

Once the faces are refined, the newly created lines surrounding the center children (child $3$) of the faces are extracted. To ensure this extraction happens in a predictable manner (i.e., the lines consistently appear at the same location within the to be refined 3d reference cell), the orientation of the face must be considered.

This orientation correction is implemented via a lookup table (with the telling name [`table`](https://github.com/AndSte01/dealii/blob/801ee53aab2ca3ac2df8166299c27197a69ac15f/source/grid/tria.cc#L6826-L6831)) that relates the lines of the oriented face $f_\mathrm{oriented}$ to their counterparts on the reference cell face $f_\mathrm{refcell}$.

![Pullrequest_wrong_wedge](https://github.com/user-attachments/assets/8dbff3b3-21b9-4596-bd63-8ebe14ffabc5)

This lookup table is currently wrong because the correct line indices for orientations $2$ and $4$ are switched. This pull request fixes that issue.

## Current situation

The current mistake does not cause an error during standard refinement, but the table nonetheless contains incorrect entries.

The issue was detected when extracting lines from triangles in non-tetrahedral cells (in my case wedges), where it led to errors.

## Testing

This pull request currently lacks an accompanying test. The reason is that, as far as I can determine, the affected list [`relevant_lines`](https://github.com/AndSte01/dealii/blob/801ee53aab2ca3ac2df8166299c27197a69ac15f/source/grid/tria.cc#L6770-L6771), which is currently being constructed incorrectly, cannot be accessed for inspection as it is deeply buried inside [`execute_refinement_isotropic(...)`](https://github.com/AndSte01/dealii/blob/801ee53aab2ca3ac2df8166299c27197a69ac15f/source/grid/tria.cc#L5946-L7118).

However, the correct functionality will be implicitly validated and tested once the implementation for wedge refinement, which depends on the accurate formation of this table, is integrated.

> [!NOTE]
> If this pull request is rejected, I will be required to re-implement the table correctly and use a conditional (an if statement) to select between the correct and incorrect tables based on the reference cell being refined

[^1]: And in the future other reference cells that contain triangles as faces.