### PR TITLE
Do not use memset(..., 0) for complex data types.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1005,9 +1005,10 @@ namespace LinearAlgebra
       // Avoid some overhead, especially on Kokkos versions before 4.6,
       // in Kokkos::deep_copy, by directly calling (sequential) memset.
       if (std::is_same_v<MemorySpaceType, MemorySpace::Host>)
-        std::memset(data.values.data() + partitioner->locally_owned_size(),
-                    0,
-                    partitioner->n_ghost_indices() * sizeof(Number));
+        std::fill(data.values.data() + partitioner->locally_owned_size(),
+                  data.values.data() + partitioner->locally_owned_size() +
+                    partitioner->n_ghost_indices(),
+                  Number(0));
       else
         {
           Kokkos::pair<size_type, size_type> range(


### PR DESCRIPTION
I (correctly!) get this warning:
```
/home/bangerth/p/deal.II/1/dealii/include/deal.II/lac/la_parallel_vector.templates.h:1008:20: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘using value_type = using value_type = using value_type = using value_type = class std::complex<float>’ {aka ‘class std::complex<float>’}; use assignment or value-initialization instead [-Wclass-memaccess]
 1008 |         std::memset(data.values.data() + partitioner->locally_owned_size(),
      |         ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1009 |                     0,
      |                     ~~
 1010 |                     partitioner->n_ghost_indices() * sizeof(Number));
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Here, we are using `memset(dst, 0, size)` to initialize floating point objects, which really only works because the bit pattern of all zeros is, indeed, interpreted as the floating point number `0.0d` or `0.0f`. That is certainly not portable. I think the compiler warning is warranted.

This patch just uses `std::fill`, which any reasonable compiler will internally turn into something that is equally efficient as the `std::memset` call.