### PR TITLE
Query number of vertices from ReferenceCell.

### DIFF
--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -1075,7 +1075,9 @@ namespace internal
 
                   ++n_unique_entities;
                   n_unique_entity_vertices +=
-                    cell_types[ad_entity_types[offset_i]]->n_entities(0);
+                    cell_types[ad_entity_types[offset_i]]
+                      ->get_reference_cell()
+                      .n_vertices();
 
                   new_key = ad_compatibility[offset_i];
                 }


### PR DESCRIPTION
For #19072. Like #19074 and #19078 and #19082.

The `n_entities()` function is called in other contexts with a variable argument, and I'll tackle that separately. But this one seemed simple enough.