### PR TITLE
ParticleHandler: Add methods to collect particles from active descendant cells

### DIFF
--- a/doc/news/changes/minor/20251217Brotz
+++ b/doc/news/changes/minor/20251217Brotz
@@ -1,0 +1,4 @@
+Add: Extend the ParticleHandler with two new query methods that identify
+particles in descendant active cells of parent cells on arbitrary levels.
+<br>
+(Julian Brotz, Bruno Blais and Magdalena Schreter-Fleischhacker, 2025/12/17)

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -259,6 +259,45 @@ namespace Particles
       const;
 
     /**
+     * This function traverses the cell hierarchy starting from a cell obtained
+     * by moving @p relative_level levels upward from the given @p cell, and collects
+     * particles from all active cells in the resulting subtree.
+     *
+     * If @p relative_level is zero, the traversal starts at @p cell itself.
+     * If the resulting root cell is active, the returned vector contains
+     * exactly one particle range corresponding to that cell similar to calling
+     * particles_in_cell().
+     *
+     * @param cell A cell iterator identifying the reference cell in the triangulation.
+     * @param relative_level A non-negative integer specifying how many parent levels to
+     * move upward from @p cell before collecting particles.
+     *
+     * @return A vector of particle iterator ranges, one for each active descendant cell
+     * in the subtree rooted at the selected cell.
+     */
+    std::vector<particle_iterator_range>
+    particles_in_descendant_active_cells(
+      const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+      const int relative_level) const;
+
+    /**
+     * For each cell on the given refinement level, this function returns a
+     * vector of iterator ranges over all particles that belong to this cell.
+     * The particles may be located in multiple descendant active cells, but are
+     * grouped according to their parent cell on the specified level.
+     *
+     * This function is equivalent to calling
+     * particles_in_descendant_active_cells() for all cells on the given level.
+     *
+     * @param level Refinement level of the parent cells.
+     * @return A map from cells on @p level to vectors of particle iterator ranges
+     * for particles inside the corresponding cells.
+     */
+    std::map<typename Triangulation<dim, spacedim>::cell_iterator,
+             std::vector<particle_iterator_range>>
+    particles_in_active_subtrees_of_parent_cells(const int level) const;
+
+    /**
      * Remove a particle pointed to by the iterator. Note that @p particle
      * and all iterators that point to other particles in the same cell
      * as @p particle will be invalidated during this call.

--- a/tests/particles/particle_handler_serial_09.cc
+++ b/tests/particles/particle_handler_serial_09.cc
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2020 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// This test verifies the correctness of retrieving all particles that belong to
+// a specified parent cell using
+//   Particles::ParticleHandler::particles_in_descendant_active_cells() and
+//   Particles::ParticleHandler::particles_in_active_subtrees_of_level_cells().
+//
+// The test setup consists of a square domain that is refined three times. A
+// fixed number of particles are inserted at random positions in the domain.
+//
+// For each cell on level 1, the test selects one of its descendant active cells
+// on level 3 and queries all particles that belong to the corresponding parent
+// cell on level 1. The retrieved particle IDs are printed. In addition, the
+// test calls
+//   Particles::ParticleHandler::particles_in_active_subtrees_of_level_cells()
+// to obtain a map from level-1 cells to the particles they contain, and prints
+// the particle IDs for each cell.
+
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/cell_id.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/particles/particle.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  using particle_iterator_vector =
+    std::vector<typename Particles::ParticleHandler<dim, spacedim>::
+                  particle_iterator_range>;
+
+  using cell_iterator = typename Triangulation<dim, spacedim>::cell_iterator;
+
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(3);
+
+  Particles::ParticleHandler<dim, spacedim> particle_handler(
+    tria, StaticMappingQ1<dim, spacedim>::mapping);
+
+  const int                    n_particles = 10;
+  std::vector<Point<spacedim>> particles(n_particles);
+
+  for (auto &p : particles)
+    p = random_point<spacedim>();
+
+  particle_handler.insert_particles(particles);
+
+  auto log_particle_ids = [](const particle_iterator_vector &particle_ranges) {
+    for (const auto &particle_range : particle_ranges)
+      for (const auto &particle : particle_range)
+        {
+          deallog << particle.get_id() << " ";
+        }
+  };
+
+  for (const auto &level_1_cell_iterator : tria.cell_iterators_on_level(1))
+    {
+      cell_iterator active_cell = level_1_cell_iterator;
+      while (active_cell->has_children())
+        active_cell = active_cell->child(0);
+
+      particle_iterator_vector particles_in_level_1_parent_cell =
+        particle_handler.particles_in_descendant_active_cells(
+          active_cell, active_cell->level() - 1);
+
+      deallog << "Particles (IDs) in parent cell at level 1 (CellId: "
+              << level_1_cell_iterator->id() << "): " << std::endl;
+      log_particle_ids(particles_in_level_1_parent_cell);
+      deallog << std::endl;
+    }
+
+  std::map<cell_iterator, particle_iterator_vector>
+    all_particles_in_level_1_parent_cell_map =
+      particle_handler.particles_in_active_subtrees_of_parent_cells(1);
+
+  deallog << "Cells and Particles on Level 1: " << std::endl;
+  for (const auto &[cell, particle_ranges] :
+       all_particles_in_level_1_parent_cell_map)
+    {
+      deallog << "CellId: " << cell->id() << ", Particles (IDs): ";
+      log_particle_ids(particle_ranges);
+      deallog << std::endl;
+    }
+}
+
+int
+main()
+{
+  initlog();
+  test<2, 2>();
+}

--- a/tests/particles/particle_handler_serial_09.output
+++ b/tests/particles/particle_handler_serial_09.output
@@ -1,0 +1,14 @@
+
+DEAL::Particles (IDs) in parent cell at level 1 (CellId: 0_1:0): 
+DEAL::
+DEAL::Particles (IDs) in parent cell at level 1 (CellId: 0_1:1): 
+DEAL::2 0 
+DEAL::Particles (IDs) in parent cell at level 1 (CellId: 0_1:2): 
+DEAL::9 4 6 5 3 
+DEAL::Particles (IDs) in parent cell at level 1 (CellId: 0_1:3): 
+DEAL::8 1 7 
+DEAL::Cells and Particles on Level 1: 
+DEAL::CellId: 0_1:0, Particles (IDs): 
+DEAL::CellId: 0_1:1, Particles (IDs): 2 0 
+DEAL::CellId: 0_1:2, Particles (IDs): 9 4 6 5 3 
+DEAL::CellId: 0_1:3, Particles (IDs): 8 1 7 


### PR DESCRIPTION
This PR suggests a first step towards an extension of the ParticleHandler that @bblais, @mschreter and I are planning. The goal is to extend the particle handler to support finite-sized particles, where a single particle can occupy more than one cell in the triangulation.

Conceptually, there are two main challenges: efficiently identifying all cells (at least partially) occupied by a particle, and making this work in parallel by sharing the required particle data as ghost particles across MPI ranks.
Both issues are illustrated in the figure below. The red point marks the particle center and the cell in which it is stored. However, the particle may also overlap neighboring cells, which therefore need to be aware of it. In parallel runs, these cells may lie on different ranks. With only a single ghost-cell layer, the particle center may not fall into a ghost cell, so the particle is not exchanged and neighboring ranks remain unaware of its presence.

<img width="503" height="414" alt="illustration" src="https://github.com/user-attachments/assets/9f0bdc1a-abfb-43b0-8124-9c8cbc326a46" />

As a first step towards this extension of the ParticleHandler, this PR introduces two new methods intended to deal with the former of the two challenges mentioned above.
* particles_in_descendant_active_cells(): This method finds all particles located in a specified cell. Unlike particles_in_cell(), the input cell does not need to be active. To collect all relevant particles, the method recursively traverses the child cells until all active cells that make up the specified cell are reached.
* particles_in_active_subtrees_of_parent_cells(): This method returns a map from cell iterators on a specified level to vectors of particle iterators for all particles in the active subtrees of those cells. The intention is to later use this function to determine which particle data needs to be exchanged in a parallel distributed setup.