### PR TITLE
Fix a comment in step-42.

### DIFF
--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -2021,13 +2021,12 @@ namespace Step42
 
     // In the remainder of the function, we generate one VTU file on
     // every processor, indexed by the subdomain id of this processor.
-    // On the first processor, we then also create a <code>.pvtu</code>
+    // On the first processor, the call below also creates a <code>.pvtu</code>
     // file that indexes <i>all</i> of the VTU files so that the entire
     // set of output files can be read at once. These <code>.pvtu</code>
     // are used by Paraview to describe an entire parallel computation's
-    // output files. We then do the same again for the competitor of
-    // Paraview, the VisIt visualization program, by creating a matching
-    // <code>.visit</code> file.
+    // output files. The principal competitor of Paraview, the VisIt
+    // visualization program, can also read these files.
     const std::string pvtu_filename = data_out.write_vtu_with_pvtu_record(
       output_dir, "solution", current_refinement_cycle, mpi_communicator, 2);
     pcout << pvtu_filename << std::endl;


### PR DESCRIPTION
The program doesn't actually generate the `.visit` file, unlike what the comment says. But it's also no longer necessary to create these files: Visit can read the `.pvtu` files just fine. (I verified.)