### PR TITLE
Fix the target of a compress operation in step-42.

### DIFF
--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1983,7 +1983,7 @@ namespace Step42
     distributed_active_set_vector = 0.;
     for (const auto index : active_set)
       distributed_active_set_vector[index] = 1.;
-    distributed_lambda.compress(VectorOperation::insert);
+    distributed_active_set_vector.compress(VectorOperation::insert);
 
     TrilinosWrappers::MPI::Vector active_set_vector(locally_relevant_dofs,
                                                     mpi_communicator);


### PR DESCRIPTION
I'm pretty sure this is a copy-paste error: We compress the `distributed_lambda` vector a few lines above after filling it. Here, we fill the `distributed_active_set_vector`, and presumably that's what we should be compressing as well.