### PR TITLE
Move VTK version macros to source

### DIFF
--- a/include/deal.II/vtk/utilities.h
+++ b/include/deal.II/vtk/utilities.h
@@ -24,26 +24,6 @@
 
 #ifdef DEAL_II_WITH_VTK
 
-// Make sure that the VTK version macros are available.
-#  include <vtkVersion.h>
-
-// VTK_VERSION_CHECK is defined by the header above for 9.3.0 and above, but
-// we provide a fallback older versions.
-#  ifndef VTK_VERSION_CHECK
-#    define VTK_VERSION_CHECK(major, minor, build) \
-      (10000000000ULL * (major) + 100000000ULL * (minor) + (build))
-#  endif
-
-// Normalize the version macro name to cover both the quick (>=9.3) and
-// legacy (<9.3) headers.
-#  if defined(VTK_VERSION_NUMBER_QUICK)
-#    define DEAL_II_VTK_VERSION_NUMBER VTK_VERSION_NUMBER_QUICK
-#  elif defined(VTK_VERSION_NUMBER)
-#    define DEAL_II_VTK_VERSION_NUMBER VTK_VERSION_NUMBER
-#  else
-#    define DEAL_II_VTK_VERSION_NUMBER 0
-#  endif
-
 #  include <vtkDoubleArray.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/vtk/utilities.cc
+++ b/source/vtk/utilities.cc
@@ -36,6 +36,26 @@
 
 #  include <deal.II/lac/vector.h>
 
+// Make sure that the VTK version macros are available.
+#  include <vtkVersion.h>
+
+// VTK_VERSION_CHECK is defined by the header above for 9.3.0 and above, but
+// we provide a fallback older versions.
+#  ifndef VTK_VERSION_CHECK
+#    define VTK_VERSION_CHECK(major, minor, build) \
+      (10000000000ULL * (major) + 100000000ULL * (minor) + (build))
+#  endif
+
+// Normalize the version macro name to cover both the quick (>=9.3) and
+// legacy (<9.3) headers.
+#  if defined(VTK_VERSION_NUMBER_QUICK)
+#    define DEAL_II_VTK_VERSION_NUMBER VTK_VERSION_NUMBER_QUICK
+#  elif defined(VTK_VERSION_NUMBER)
+#    define DEAL_II_VTK_VERSION_NUMBER VTK_VERSION_NUMBER
+#  else
+#    define DEAL_II_VTK_VERSION_NUMBER 0
+#  endif
+
 // Other VTK headers
 #  include <vtkCellData.h>
 #  if DEAL_II_VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 0)


### PR DESCRIPTION
Fixes https://cdash.dealii.org/viewBuildError.php?buildid=4758:
```
[module/implementation_module_partitions/vtk/utilities.cc:26](https://github.com/dealii/dealii/blob/11d8280c36374deb335c701aadf69f4776d45742/module/implementation_module_partitions/vtk/utilities.cc#L26):37: error: function-like macro 'VTK_VERSION_CHECK' is not defined
```
The version macros are only used in the source file so the easiest solution is to just move the macros there.