### PR TITLE
Do not call `update_ghost_values` in ROLVector operations.

### DIFF
--- a/include/deal.II/trilinos/rol_vector.h
+++ b/include/deal.II/trilinos/rol_vector.h
@@ -387,14 +387,7 @@ namespace TrilinosWrappers
     if (vector_ptr->locally_owned_elements().is_element(i))
       vec_ptr->operator[](i) = 1.;
 
-    if (vec_ptr->has_ghost_elements())
-      {
-        vec_ptr->update_ghost_values();
-      }
-    else
-      {
-        vec_ptr->compress(VectorOperation::insert);
-      }
+    vec_ptr->compress(VectorOperation::insert);
 
     return ROL::makePtr<ROLVector>(vec_ptr);
   }
@@ -413,14 +406,7 @@ namespace TrilinosWrappers
          iterator++)
       *iterator = f.apply(*iterator);
 
-    if (vector_ptr->has_ghost_elements())
-      {
-        vector_ptr->update_ghost_values();
-      }
-    else
-      {
-        vector_ptr->compress(VectorOperation::insert);
-      }
+    vector_ptr->compress(VectorOperation::insert);
   }
 
 
@@ -448,14 +434,7 @@ namespace TrilinosWrappers
          l_iterator++, r_iterator++)
       *l_iterator = f.apply(*l_iterator, *r_iterator);
 
-    if (vector_ptr->has_ghost_elements())
-      {
-        vector_ptr->update_ghost_values();
-      }
-    else
-      {
-        vector_ptr->compress(VectorOperation::insert);
-      }
+    vector_ptr->compress(VectorOperation::insert);
   }
 
 

--- a/tests/rol/rolvector_no_ghost_01.cc
+++ b/tests/rol/rolvector_no_ghost_01.cc
@@ -78,9 +78,9 @@ test()
   b.compress(VectorOperation::insert);
   c.compress(VectorOperation::insert);
 
-  ROL::Ptr<VectorType> a_ptr = ROL::makePtr<VectorType>(a);
-  ROL::Ptr<VectorType> b_ptr = ROL::makePtr<VectorType>(b);
-  ROL::Ptr<VectorType> c_ptr = ROL::makePtr<VectorType>(c);
+  ROL::Ptr<VectorType> a_ptr = ROL::makePtrFromRef<VectorType>(a);
+  ROL::Ptr<VectorType> b_ptr = ROL::makePtrFromRef<VectorType>(b);
+  ROL::Ptr<VectorType> c_ptr = ROL::makePtrFromRef<VectorType>(c);
 
   // --- Testing the constructor
   TrilinosWrappers::ROLVector<VectorType> a_rol(a_ptr);

--- a/tests/rol/rolvector_with_ghost_01.cc
+++ b/tests/rol/rolvector_with_ghost_01.cc
@@ -90,17 +90,9 @@ test()
   b.compress(VectorOperation::insert);
   c.compress(VectorOperation::insert);
 
-  a.update_ghost_values();
-  b.update_ghost_values();
-  c.update_ghost_values();
-
-  ROL::Ptr<VectorType> a_ptr = ROL::makePtr<VectorType>(a);
-  ROL::Ptr<VectorType> b_ptr = ROL::makePtr<VectorType>(b);
-  ROL::Ptr<VectorType> c_ptr = ROL::makePtr<VectorType>(c);
-
-  a_ptr->update_ghost_values();
-  b_ptr->update_ghost_values();
-  c_ptr->update_ghost_values();
+  ROL::Ptr<VectorType> a_ptr = ROL::makePtrFromRef<VectorType>(a);
+  ROL::Ptr<VectorType> b_ptr = ROL::makePtrFromRef<VectorType>(b);
+  ROL::Ptr<VectorType> c_ptr = ROL::makePtrFromRef<VectorType>(c);
 
   // --- Testing the constructor
   TrilinosWrappers::ROLVector<VectorType> a_rol(a_ptr);


### PR DESCRIPTION
Follows the discussion in https://github.com/dealii/dealii/pull/19015#discussion_r2640454266.

Manipulations on Trilinos and Petsc vectors are only permitted in the non-ghost state. Since the `ROLVector` wrapper class is supposed to work on all distributed vector classes, we should find the common denominator and exchange ghost data only through the `compress` interface.

If the user needs ghost elements on a `LinearAlgebra::distributed::Vector`, they should control their presence/absence manually with the  `update_ghost_values()`/`zero_out_ghost_values()` functionality.

---

This patch reverts #9792. FYI -- @dougshidong
