### PR TITLE
Add origin to detect merges utility

### DIFF
--- a/contrib/utilities/detect_merges_from_master_in_feature_branch.sh
+++ b/contrib/utilities/detect_merges_from_master_in_feature_branch.sh
@@ -21,7 +21,7 @@
 #       
 
 get_merge_commits_since_master () {
-  echo "$(git log --merges --pretty=format:"%h" master..)"
+  echo "$(git log --merges --pretty=format:"%h" origin/master..)"
 }
 
 get_commit_parents () {


### PR DESCRIPTION
@marcfehling seems like the origin part was missing for Github Actions as master is not checked out as a local copy. 
Maybe we also have to add the `fetch-depth=0` option to the checkout action but let's see if this already does it.