### PR TITLE
gh-actions: Fix merge commit detection for CI.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -85,5 +85,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
     - run:  python -m pip install networkx
     - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,6 @@ repos:
     language: system
   - id: detect-merges-in-feature-branch
     name: Detect merge commits in current feature branch
-    entry: bash contrib/utilities/detect_merges_from_master_in_feature_branch.sh
+    entry: bash contrib/utilities/detect_merges_from_master_in_feature_branch.sh remotes/origin/master
     pass_filenames: false
     language: system


### PR DESCRIPTION
Fixes #18145.

We have to specify the `remotes/origin/master` branch as the parent of the feature branch to make the script work in github actions.