### PR TITLE
Fix VTK module

### DIFF
--- a/module/interface_module_partitions/vtk.ccm
+++ b/module/interface_module_partitions/vtk.ccm
@@ -31,8 +31,34 @@ module;
 #include <deal.II/base/config.h>
 
 #ifdef DEAL_II_WITH_VTK
-#  include <vtkDoubleArray.h>
-#  include <vtkSmartPointer.h>
+#include <vtkVersion.h>
+
+// VTK_VERSION_CHECK is defined by the header above for 9.3.0 and above, but
+// we provide a fallback older versions.
+#ifndef VTK_VERSION_CHECK
+#  define VTK_VERSION_CHECK(major, minor, build) \
+    (10000000000ULL * (major) + 100000000ULL * (minor) + (build))
+#endif
+// Normalize the version macro name to cover both the quick (>=9.3) and
+// legacy (<9.3) headers.
+#if defined(VTK_VERSION_NUMBER_QUICK)
+#  define DEAL_II_VTK_VERSION_NUMBER VTK_VERSION_NUMBER_QUICK
+#elif defined(VTK_VERSION_NUMBER)
+#  define DEAL_II_VTK_VERSION_NUMBER VTK_VERSION_NUMBER
+#else
+#  define DEAL_II_VTK_VERSION_NUMBER 0
+#endif
+#if DEAL_II_VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 0)
+#  include <vtkCleanUnstructuredGrid.h>
+#endif
+#include <vtkCellData.h>
+#include <vtkCellType.h>
+#include <vtkDataArray.h>
+#include <vtkDoubleArray.h>
+#include <vtkPointData.h>
+#include <vtkSmartPointer.h>
+#include <vtkUnstructuredGrid.h>
+#include <vtkUnstructuredGridReader.h>
 #endif
 
 
@@ -42,8 +68,17 @@ export module dealii.external.vtk;
 
 export
 {
+  using ::vtkCell;
+  using ::VTKCellType;
+#if DEAL_II_VTK_VERSION_NUMBER >= VTK_VERSION_CHECK(9, 3, 0)
+  using ::vtkCleanUnstructuredGrid;
+#endif
+  using ::vtkDataArray;
   using ::vtkDoubleArray;
+  using ::vtkPoints;
   using ::vtkSmartPointer;
+  using ::vtkUnstructuredGrid;
+  using ::vtkUnstructuredGridReader;
 }
 
 #endif

--- a/source/vtk/utilities.cc
+++ b/source/vtk/utilities.cc
@@ -37,7 +37,7 @@
 #  include <deal.II/lac/vector.h>
 
 // Make sure that the VTK version macros are available.
-#  include <vtkVersion.h>
+#  include <vtkVersion.h> // Do not convert for module purposes
 
 // VTK_VERSION_CHECK is defined by the header above for 9.3.0 and above, but
 // we provide a fallback older versions.


### PR DESCRIPTION
To fix https://cdash.dealii.org/viewBuildError.php?buildid=4830 properly, we had to duplicate the version macro and mkae sure not to replace `vtkVersion.h`.