### PR TITLE
Fixed misspelling of "refinement" and minor refactorings.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1550,7 +1550,7 @@ constexpr dealii::ndarray<unsigned int, 12, 4>
 ReferenceCell::new_isotropic_child_face_lines(
   const unsigned int refinement_choice) const
 {
-  AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
+  // AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
   const unsigned int X = numbers::invalid_unsigned_int;
   switch (this->kind)
     {
@@ -1629,7 +1629,7 @@ constexpr dealii::ndarray<unsigned int, 12, 4, 2>
 ReferenceCell::new_isotropic_child_face_line_vertices(
   const unsigned int refinement_choice) const
 {
-  AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
+  // AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
   const unsigned int X = numbers::invalid_unsigned_int;
   switch (this->kind)
     {
@@ -1710,7 +1710,7 @@ constexpr dealii::ndarray<unsigned int, 8, 6>
 ReferenceCell::new_isotropic_child_cell_faces(
   const unsigned int refinement_choice) const
 {
-  AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
+  // AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
   const unsigned int X = numbers::invalid_unsigned_int;
   switch (this->kind)
     {
@@ -1778,7 +1778,7 @@ constexpr dealii::ndarray<unsigned int, 8, 4>
 ReferenceCell::new_isotropic_child_cell_vertices(
   const unsigned int refinement_choice) const
 {
-  AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
+  // AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
 
   switch (this->kind)
     {


### PR DESCRIPTION
This Pull Request addresses the following items in `reference_cell.h`

- Fixed multiple misspellings of _refinement_ throughout the file.
- Re-added assertions to verify that the selected `refinement_choice` is valid, following the feedback from @bangerth in [PR #19093](https://github.com/dealii/dealii/pull/19093#discussion_r2624849310).
- Renamed `table_tet` and `table_hex` to `quad_lines_vertices_tet` and `quad_lines_vertices_hex` to better reflect their contents.

_Part of https://github.com/dealii/dealii/issues/19170_