### PR TITLE
Modules: Fix compiling without NOX

### DIFF
--- a/module/interface_module_partitions/trilinos.ccm
+++ b/module/interface_module_partitions/trilinos.ccm
@@ -61,14 +61,16 @@ module;
 #  include <Epetra_SerialComm.h>
 #  include <Epetra_Vector.h>
 #  include <Ifpack_Chebyshev.h>
-#  include <NOX_Abstract_Group.H>
-#  include <NOX_Abstract_Vector.H>
-#  include <NOX_Solver_Factory.H>
-#  include <NOX_Solver_Generic.H>
-#  include <NOX_StatusTest_Combo.H>
-#  include <NOX_StatusTest_MaxIters.H>
-#  include <NOX_StatusTest_NormF.H>
-#  include <NOX_StatusTest_RelativeNormF.H>
+#  ifdef DEAL_II_TRILINOS_WITH_NOX
+#    include <NOX_Abstract_Group.H>
+#    include <NOX_Abstract_Vector.H>
+#    include <NOX_Solver_Factory.H>
+#    include <NOX_Solver_Generic.H>
+#    include <NOX_StatusTest_Combo.H>
+#    include <NOX_StatusTest_MaxIters.H>
+#    include <NOX_StatusTest_NormF.H>
+#    include <NOX_StatusTest_RelativeNormF.H>
+#  endif
 #  include <Teuchos_BLAS_types.hpp>
 #  include <Teuchos_Comm.hpp>
 #  include <Teuchos_ConfigDefs.hpp>
@@ -197,6 +199,7 @@ export
     using ::EpetraExt::MatrixMatrix;
   }
 
+#  ifdef DEAL_II_TRILINOS_WITH_NOX
   namespace NOX
   {
     namespace Abstract
@@ -226,6 +229,7 @@ export
     using ::NOX::CopyType;
     using ::NOX::size_type;
   } // namespace NOX
+#  endif
 
 #  ifdef DEAL_II_TRILINOS_WITH_ROL
   namespace ROL


### PR DESCRIPTION
NOX is not a required component in `Trilinos` for us.