### PR TITLE
VTKWrappers utilities -- part VII -- data_to_dealii_vector

### DIFF
--- a/source/vtk/utilities.cc
+++ b/source/vtk/utilities.cc
@@ -175,6 +175,7 @@ namespace VTKWrappers
                 CellData<2> cell_data(4);
                 for (unsigned int j = 0; j < 4; ++j)
                   cell_data.vertices[j] = cell->GetPointId(j);
+                std::swap(cell_data.vertices[2], cell_data.vertices[3]);
                 cell_data.material_id = 0;
                 cells.push_back(cell_data);
               }

--- a/tests/vtk/data_to_dealii_vector_01.cc
+++ b/tests/vtk/data_to_dealii_vector_01.cc
@@ -1,0 +1,99 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Test reading of data contained in a vtk file into a serial deal.II
+// Vector<double> using the VTKWrappers::data_to_dealii_vector function.
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/data_out.h>
+
+#include <deal.II/vtk/utilities.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test(const std::string &filename)
+{
+  deallog << "Reading Triangulation<" << dim << ", " << spacedim
+          << "> from file: " << filename << std::endl;
+
+  Triangulation<dim, spacedim> triangulation;
+  DoFHandler<dim, spacedim>    dh(triangulation);
+  Vector<double>               vtk_data;
+  Vector<double>               dealii_data;
+
+  VTKWrappers::read_tria(std::string(SOURCE_DIR) + "/" + filename,
+                         triangulation);
+
+  VTKWrappers::read_all_data(std::string(SOURCE_DIR) + "/" + filename,
+                             vtk_data);
+
+  const auto [fe, data_names] =
+    VTKWrappers::vtk_to_finite_element<dim, spacedim>(std::string(SOURCE_DIR) +
+                                                      "/" + filename);
+
+  dh.distribute_dofs(*fe);
+  dealii_data.reinit(dh.n_dofs());
+
+  VTKWrappers::data_to_dealii_vector(triangulation, vtk_data, dh, dealii_data);
+
+  deallog << "All data size: " << vtk_data.size() << std::endl;
+  deallog << "Dealii vector size: " << dealii_data.size() << std::endl;
+
+  Assert(vtk_data.size() == dealii_data.size(), ExcInternalError());
+
+  // Output using data out
+  if (std::getenv("OUTPUT_VTK"))
+    {
+      DataOut<dim, spacedim> data_out;
+      data_out.attach_dof_handler(dh);
+      data_out.add_data_vector(dealii_data, "data");
+      data_out.build_patches();
+
+      std::ofstream out("output_" + std::to_string(dim) + "_" +
+                        std::to_string(spacedim) + ".vtk");
+      data_out.write_vtk(out);
+    }
+}
+
+int
+main()
+{
+  initlog();
+  test<1, 1>("data/data_1_1.vtk");
+  test<1, 2>("data/data_1_1.vtk");
+  test<1, 3>("data/data_1_1.vtk");
+
+  test<2, 2>("data/data_2_2_simplex.vtk");
+  test<2, 3>("data/data_2_2_simplex.vtk");
+
+  test<2, 2>("data/data_2_2_quad.vtk");
+  test<2, 3>("data/data_2_2_quad.vtk");
+
+  test<3, 3>("data/data_3_3_tets.vtk");
+  test<3, 3>("data/data_3_3_hexes.vtk");
+  return 0;
+}

--- a/tests/vtk/data_to_dealii_vector_01.output
+++ b/tests/vtk/data_to_dealii_vector_01.output
@@ -1,0 +1,28 @@
+
+DEAL::Reading Triangulation<1, 1> from file: data/data_1_1.vtk
+DEAL::All data size: 76
+DEAL::Dealii vector size: 76
+DEAL::Reading Triangulation<1, 2> from file: data/data_1_1.vtk
+DEAL::All data size: 76
+DEAL::Dealii vector size: 76
+DEAL::Reading Triangulation<1, 3> from file: data/data_1_1.vtk
+DEAL::All data size: 76
+DEAL::Dealii vector size: 76
+DEAL::Reading Triangulation<2, 2> from file: data/data_2_2_simplex.vtk
+DEAL::All data size: 72
+DEAL::Dealii vector size: 72
+DEAL::Reading Triangulation<2, 3> from file: data/data_2_2_simplex.vtk
+DEAL::All data size: 72
+DEAL::Dealii vector size: 72
+DEAL::Reading Triangulation<2, 2> from file: data/data_2_2_quad.vtk
+DEAL::All data size: 52
+DEAL::Dealii vector size: 52
+DEAL::Reading Triangulation<2, 3> from file: data/data_2_2_quad.vtk
+DEAL::All data size: 52
+DEAL::Dealii vector size: 52
+DEAL::Reading Triangulation<3, 3> from file: data/data_3_3_tets.vtk
+DEAL::All data size: 268
+DEAL::Dealii vector size: 268
+DEAL::Reading Triangulation<3, 3> from file: data/data_3_3_hexes.vtk
+DEAL::All data size: 140
+DEAL::Dealii vector size: 140


### PR DESCRIPTION
Utility to map data read from a VTK file into a deal.II vector associated with a given DoFHandler.

The new functionality takes data obtained via VTKWrappers::read_all_data() on a serial triangulation and transfers it into a deal.II vector (serial or distributed) that is consistent with a user-provided DoFHandler.

```
// Read serial triangulation from VTK file
Triangulation<dim, spacedim> serial_tria;
VTKWrappers::read_tria(vtk_filename, serial_tria);

// Read all data from VTK file
Vector<double> serial_data;
VTKWrappers::read_all_data(vtk_filename, serial_data);

// Read finite element from VTK file
auto [fe, data_names] =
  VTKWrappers::vtk_to_finite_element<dim, spacedim>(vtk_filename);

// Split serial triangulation into a parallel one
parallel::fullydistributed::Triangulation<dim, spacedim> parallel_tria;
parallel_tria.copy_triangulation(serial_tria);

// Setup DoFHandler on parallel triangulation
DoFHandler<dim, spacedim> dof_handler(parallel_tria);
dof_handler.distribute_dofs(*fe);

// Optionally renumber DoFs here

// Map serial data to distributed vector
LinearAlgebra::distributed::Vector<double> distributed_data;
VTKWrappers::data_to_dealii_vector(serial_tria,
                                  serial_data,
                                  dof_handler,
                                  distributed_data);
```

Part of #19056 