### PR TITLE
clarify assert message for FERaviartThomasNodal matrix-free evaluation

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2232,9 +2232,16 @@ namespace internal
             }
           else
             {
-              Assert(false,
-                     ExcNotImplemented("Raviart-Thomas currently only possible "
-                                       "in 2d/3d and with templated degree"));
+              AssertThrow(false,
+                          ExcNotImplemented(
+                            "Raviart-Thomas currently only possible "
+                            "in 2d/3d and with templated degree for "
+                            "requested fe_degree and n_q_points_1d. "
+                            "Ensure that the highest used degree for "
+                            "Raviart-Thomas, fe_degree+1=" +
+                            std::to_string(
+                              fe_eval.get_shape_info().data[0].fe_degree) +
+                            ", does not exceed FE_EVAL_FACTORY_DEGREE_MAX."));
             }
         }
       else


### PR DESCRIPTION
If one uses `FERaviartThomasNodal` (probably also other RT element variants) together with `FEEvaluation` with template `fe_degree=-1` to enable runtime selection of precompiled evaluators for the respective degree, one might use a polynomial degree that is higher than what is precompiled depending on `FE_EVAL_FACTORY_DEGREE_MAX`
[(see here)](https://github.com/dealii/dealii/blob/95ef165b021e21ef4de176e8ac57350be12c68ae/include/deal.II/matrix_free/evaluation_template_factory_internal.h#L22-L24). 

In such a case, we reach this `Assert()`.

The message was not clear enough for a user like me, so I would suggest making it a bit clearer and hinting at `FE_EVAL_FACTORY_DEGREE_MAX`. This came up because my local build uses
`FE_EVAL_FACTORY_DEGREE_MAX = 15`
while the default on the docker image of master is at
`FE_EVAL_FACTORY_DEGREE_MAX = 6`.

I also changed the `Assert()` to `AssertThrow()` as we reach a dead end here. For `FE_Q` or `FE_DGQ` a similar setting (choosing a polynomial degree not precompiled) switches to a "slow path", which is not existent for Raviart-Thomas elements.