### PR TITLE
github-actions: Added check for merge commits in feature branch.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -24,13 +24,38 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        fetch-depth: 100
+        # Fetches full history, but only for the ref being checked out.
+        fetch-depth: 0
     - name: setup
       run: |
         ./contrib/utilities/download_clang_format
     - name: indent
       run: |
         ./contrib/utilities/check_indentation.sh
+    - name: detect merges
+      if: github.event_name == 'pull_request'
+      run: |
+        # Enable exit on error.
+        set -euo pipefail
+        # We already fetched the full head branch with actions/checkout.
+        # Now we also need to fetch the base branch.
+        git fetch --quiet origin $GITHUB_BASE_REF
+        # For pull_request events, HEAD contains a tentative merge from the
+        # feature into the base branch. Count the number of commits in this pull
+        # request for sanity checks. It should be 1 higher than in the feature
+        # branch (because of the merge commit).
+        echo "Number of commits: $(git rev-list origin/$GITHUB_BASE_REF..HEAD --count)"
+        # Commits with more than two parents are merge commits.
+        MERGES=$(git rev-list origin/$GITHUB_BASE_REF..HEAD --parents | awk 'NF > 2 { print $1 }')
+        # Check whether there are more merge commits than the tentative one.
+        if (( $(wc -w <<< "$MERGES") != 1 )); then
+          echo "Merge commits detected in this PR!"
+          for c in $MERGES; do
+            echo "  - $c"
+          done
+          exit 1
+        fi
+        echo "No merge commits found!"
 
   doxygen:
     # build the documentation


### PR DESCRIPTION
This is a simple script that checks for the presence of _any_ merge commit on a feature branch that wants to be merged to the base branch via pull request. I have added the step to the mandatory `indent` workflow of our github-actions CI.

This step blocks any sort of merge commit. It does not check whether the merges stem from third branches, thus it follows a different approach than #18434. We might consider in the future if we want to bring the two approaches together.

Supersedes #19125. Related to #18145. This was difficult to figure out.

FYI -- @tamiko @jpthiele 