### PR TITLE
CMake: Bugfix: add missing test dependency on ${_source_file}

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -562,6 +562,7 @@ function(deal_ii_add_test _category _test_name _comparison_file)
           ${_test_directory}
         DEPENDS
           ${_target}
+          ${_source_file}
           ${DEAL_II_PATH}/${DEAL_II_SHARE_RELDIR}/scripts/normalize.pl
         COMMENT
           "Normalizing test output file ${_test_directory}/output"


### PR DESCRIPTION
The custom command that runs a test depends on ${_target}, which in case
of a "test.cc" variant is simply the test executable target. But for
"test.prm" variants the ${_target} is a specified executable and we
simply forgot to also depend on "test.prm" itself, aka the
${_source_file} in this case. Add this dependency so that tests are
rerun properly when the prm file changes.
