### PR TITLE
Add functions `standard_to_real_quad_vertex/line`.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -720,6 +720,38 @@ public:
     const RefinementCase<dim - 1> face_refinement_case) const;
 
   /**
+   * Get the index of vertex @p vertex belonging to a quad of the reference cell
+   * @p quad_ref_cell, while accounting for the orientation @p quad_orientation.
+   * The vertex itself can be retrieved by calling `face.vertex(returned val)`.
+   *
+   * This is very similar to @see ReferenceCell::standard_to_real_face_vertex.
+   * However, this function is static and therefore independent of the context
+   * in which the quad is used (i.e., it doesn't care about which 3D cell the
+   * quad belongs to).
+   */
+  static constexpr unsigned int
+  standard_to_real_quad_vertex(
+    const unsigned int                 vertex,
+    const types::geometric_orientation quad_orientation,
+    const ReferenceCell                quad_ref_cell);
+
+  /**
+   * Get the index of line @p line belonging to a quad of the reference cell
+   * @p quad_ref_cell, while accounting for the orientation @p quad_orientation.
+   * The line itself can be retrieved by calling `face.line(returned val)`.
+   *
+   * This is very similar to @see ReferenceCell::standard_to_real_face_line.
+   * However, this function is static and therefore independent of the context
+   * in which the quad is used (i.e., it doesn't care about which 3D cell the
+   * quad belongs to).
+   */
+  static constexpr unsigned int
+  standard_to_real_quad_line(
+    const unsigned int                 line,
+    const types::geometric_orientation quad_orientation,
+    const ReferenceCell                quad_ref_cell);
+
+  /**
    * Get vertex index of vertex @p vertex belonging to face @p face of the
    * current cell while accounting for orientation @p face_orientation .
    */
@@ -3115,6 +3147,54 @@ ReferenceCell::face_vertex_location(const unsigned int face,
                     std::to_string(get_dimension()) + " dimensional."));
   return this->template vertex<dim>(face_to_cell_vertices(
     face, vertex, numbers::default_geometric_orientation));
+}
+
+
+
+inline constexpr unsigned int
+ReferenceCell::standard_to_real_quad_vertex(
+  const unsigned int                 vertex,
+  const types::geometric_orientation quad_orientation,
+  const ReferenceCell                quad_ref_cell)
+{
+  AssertIndexRange(vertex, quad_ref_cell.n_vertices());
+
+  switch (quad_ref_cell)
+    {
+      case ReferenceCells::Triangle:
+        return triangle_vertex_permutations[quad_orientation][vertex];
+      case ReferenceCells::Quadrilateral:
+        return quadrilateral_vertex_permutations[quad_orientation][vertex];
+      default:
+        // no other 2D cells are known to deal.II
+        DEAL_II_ASSERT_UNREACHABLE();
+    }
+
+  return 0;
+}
+
+
+
+inline constexpr unsigned int
+ReferenceCell::standard_to_real_quad_line(
+  const unsigned int                 line,
+  const types::geometric_orientation quad_orientation,
+  const ReferenceCell                quad_ref_cell)
+{
+  AssertIndexRange(line, quad_ref_cell.n_lines());
+
+  switch (quad_ref_cell)
+    {
+      case ReferenceCells::Triangle:
+        return triangle_line_permutations[quad_orientation][line];
+      case ReferenceCells::Quadrilateral:
+        return quadrilateral_line_permutations[quad_orientation][line];
+      default:
+        // no other 2D cells are known to deal.II
+        DEAL_II_ASSERT_UNREACHABLE();
+    }
+
+  return 0;
 }
 
 

--- a/tests/simplex/orientation_07.cc
+++ b/tests/simplex/orientation_07.cc
@@ -1,0 +1,238 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2021 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// Test a mesh with two tetrahedra for all possible orientations.
+
+#include <deal.II/base/array_view.h>
+
+#include <deal.II/grid/cell_data.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+void
+test_tri(const types::geometric_orientation orientation)
+{
+  const unsigned int face_no = 0;
+
+  Triangulation<3> dummy, tria;
+  GridGenerator::reference_cell(dummy, ReferenceCells::Tetrahedron);
+
+  auto vertices = dummy.get_vertices();
+
+  std::vector<CellData<3>> cells;
+
+  {
+    CellData<3> cell;
+    cell.vertices    = {0, 1, 2, 3};
+    cell.material_id = 0;
+    cells.push_back(cell);
+  }
+
+  {
+    const auto &face = dummy.begin()->face(face_no);
+    const auto  permuted =
+      ReferenceCells::Triangle.permute_by_combined_orientation(
+        make_array_view(std::array<unsigned int, 3>{{0, 1, 2}}), orientation);
+
+    // add new vertex we need for our new triangle
+    vertices.push_back(face->center() + Point<3>(0, 0, 1));
+
+    CellData<3> cell;
+    cell.vertices    = {face->vertex_index(permuted[0]),
+                        face->vertex_index(permuted[1]),
+                        face->vertex_index(permuted[2]),
+                        4};
+    cell.material_id = 1;
+    cells.push_back(cell);
+  }
+
+  tria.create_triangulation(vertices, cells, {});
+
+  auto cell = tria.begin();
+  cell++;
+
+  // check orientation
+  deallog << "face orientation: "
+          << int(cell->combined_face_orientation(face_no)) << std::endl;
+
+  // check vertices
+  {
+    // we do know which vertices should be part of triangle 0 of our cell
+    // (0, 1, 2). Lets' compare their indices.
+    deallog << "expected indices:   ";
+    for (unsigned int v = 0; v < 3; ++v)
+      deallog << cell->vertex_index(v) << ' ';
+
+    deallog << std::endl << "calculated indices: ";
+
+    for (unsigned int v = 0; v < 3; ++v)
+      {
+        const auto orientation = cell->combined_face_orientation(face_no);
+
+        unsigned int corrected_vertex_index =
+          ReferenceCell::standard_to_real_quad_vertex(v,
+                                                      orientation,
+                                                      ReferenceCells::Triangle);
+
+        deallog << cell->face(face_no)->vertex_index(corrected_vertex_index)
+                << ' ';
+      }
+  }
+
+  deallog << std::endl;
+
+  // check lines
+  {
+    // we do know which lines should be part of triangle 0 of our cell
+    // (0, 1, 2). Lets' compare their indices.
+    deallog << "expected lines:   ";
+    for (unsigned int l = 0; l < 3; ++l)
+      deallog << cell->line_index(l) << ' ';
+
+    deallog << std::endl << "calculated lines: ";
+
+    for (unsigned int v = 0; v < 3; ++v)
+      {
+        const auto orientation = cell->combined_face_orientation(face_no);
+
+        unsigned int corrected_line_index =
+          ReferenceCell::standard_to_real_quad_line(v,
+                                                    orientation,
+                                                    ReferenceCells::Triangle);
+
+        deallog << cell->face(face_no)->line_index(corrected_line_index) << ' ';
+      }
+  }
+
+  deallog << std::endl << std::endl;
+}
+
+void
+test_quad(const types::geometric_orientation orientation)
+{
+  const unsigned int face_no = 0;
+
+  Triangulation<3> dummy, tria;
+  GridGenerator::reference_cell(dummy, ReferenceCells::Pyramid);
+
+  // for (auto f : dummy.begin()->face_indices()) {
+  //   deallog << f << ": ";
+  //   for (auto v : dummy.begin()->face(f)->vertex_indices())
+  //     deallog << dummy.begin()->face(f)->vertex_index(v) << " ";
+  //   deallog << std::endl;
+  // }
+
+  auto vertices = dummy.get_vertices();
+
+  std::vector<CellData<3>> cells;
+
+  {
+    CellData<3> cell;
+    cell.vertices    = {0, 1, 2, 3, 4};
+    cell.material_id = 0;
+    cells.push_back(cell);
+  }
+
+  {
+    const auto &face = dummy.begin()->face(face_no);
+    const auto  permuted =
+      ReferenceCells::Quadrilateral.permute_by_combined_orientation(
+        make_array_view(std::array<unsigned int, 4>{{0, 1, 2, 3}}),
+        orientation);
+
+    CellData<3> cell;
+    cell.vertices    = {face->vertex_index(permuted[0]),
+                        face->vertex_index(permuted[1]),
+                        face->vertex_index(permuted[2]),
+                        face->vertex_index(permuted[3]),
+                        4};
+    cell.material_id = 1;
+    cells.push_back(cell);
+  }
+
+  tria.create_triangulation(vertices, cells, {});
+
+  auto cell = tria.begin();
+  cell++;
+
+  // check orientation
+  deallog << "face orientation: "
+          << int(cell->combined_face_orientation(face_no)) << std::endl;
+
+  // check vertices
+  {
+    // we do know which vertices should be part of triangle 0 of our cell
+    // (0, 1, 2). Lets' compare their indices.
+    deallog << "expected indices:   ";
+    for (unsigned int v = 0; v < 4; ++v)
+      deallog << cell->vertex_index(v) << ' ';
+
+    deallog << std::endl << "calculated indices: ";
+
+    for (unsigned int v = 0; v < 4; ++v)
+      {
+        const auto orientation = cell->combined_face_orientation(face_no);
+
+        unsigned int corrected_vertex_index =
+          ReferenceCell::standard_to_real_quad_vertex(
+            v, orientation, ReferenceCells::Quadrilateral);
+
+        deallog << cell->face(face_no)->vertex_index(corrected_vertex_index)
+                << ' ';
+      }
+  }
+
+  deallog << std::endl;
+
+  // check lines
+  {
+    // we do know which lines should be part of triangle 0 of our cell
+    // (0, 1, 2). Lets' compare their indices.
+    deallog << "expected lines:   ";
+    for (unsigned int l = 0; l < 4; ++l)
+      deallog << cell->line_index(l) << ' ';
+
+    deallog << std::endl << "calculated lines: ";
+
+    for (unsigned int v = 0; v < 4; ++v)
+      {
+        const auto orientation = cell->combined_face_orientation(face_no);
+
+        unsigned int corrected_line_index =
+          ReferenceCell::standard_to_real_quad_line(
+            v, orientation, ReferenceCells::Quadrilateral);
+
+        deallog << cell->face(face_no)->line_index(corrected_line_index) << ' ';
+      }
+  }
+
+  deallog << std::endl << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  deallog << "--- Triangle ---" << std::endl;
+  for (unsigned int o = 0; o < 6; ++o)
+    test_tri(o);
+
+  deallog << "--- Quad ---" << std::endl;
+  for (unsigned int o = 0; o < 8; ++o)
+    test_quad(o);
+}

--- a/tests/simplex/orientation_07.output
+++ b/tests/simplex/orientation_07.output
@@ -1,0 +1,87 @@
+
+DEAL::--- Triangle ---
+DEAL::face orientation: 0
+DEAL::expected indices:   0 1 2 
+DEAL::calculated indices: 0 1 2 
+DEAL::expected lines:   0 3 6 
+DEAL::calculated lines: 0 3 6 
+DEAL::
+DEAL::face orientation: 1
+DEAL::expected indices:   0 2 1 
+DEAL::calculated indices: 0 2 1 
+DEAL::expected lines:   6 3 0 
+DEAL::calculated lines: 6 3 0 
+DEAL::
+DEAL::face orientation: 2
+DEAL::expected indices:   2 0 1 
+DEAL::calculated indices: 2 0 1 
+DEAL::expected lines:   6 0 3 
+DEAL::calculated lines: 6 0 3 
+DEAL::
+DEAL::face orientation: 3
+DEAL::expected indices:   2 1 0 
+DEAL::calculated indices: 2 1 0 
+DEAL::expected lines:   3 0 6 
+DEAL::calculated lines: 3 0 6 
+DEAL::
+DEAL::face orientation: 4
+DEAL::expected indices:   1 2 0 
+DEAL::calculated indices: 1 2 0 
+DEAL::expected lines:   3 6 0 
+DEAL::calculated lines: 3 6 0 
+DEAL::
+DEAL::face orientation: 5
+DEAL::expected indices:   1 0 2 
+DEAL::calculated indices: 1 0 2 
+DEAL::expected lines:   0 6 3 
+DEAL::calculated lines: 0 6 3 
+DEAL::
+DEAL::--- Quad ---
+DEAL::face orientation: 0
+DEAL::expected indices:   0 1 2 3 
+DEAL::calculated indices: 0 1 2 3 
+DEAL::expected lines:   1 2 0 4 
+DEAL::calculated lines: 1 2 0 4 
+DEAL::
+DEAL::face orientation: 1
+DEAL::expected indices:   0 2 1 3 
+DEAL::calculated indices: 0 2 1 3 
+DEAL::expected lines:   0 4 1 2 
+DEAL::calculated lines: 0 4 1 2 
+DEAL::
+DEAL::face orientation: 2
+DEAL::expected indices:   2 0 3 1 
+DEAL::calculated indices: 2 0 3 1 
+DEAL::expected lines:   4 0 1 2 
+DEAL::calculated lines: 4 0 1 2 
+DEAL::
+DEAL::face orientation: 3
+DEAL::expected indices:   2 3 0 1 
+DEAL::calculated indices: 2 3 0 1 
+DEAL::expected lines:   1 2 4 0 
+DEAL::calculated lines: 1 2 4 0 
+DEAL::
+DEAL::face orientation: 4
+DEAL::expected indices:   3 2 1 0 
+DEAL::calculated indices: 3 2 1 0 
+DEAL::expected lines:   2 1 4 0 
+DEAL::calculated lines: 2 1 4 0 
+DEAL::
+DEAL::face orientation: 5
+DEAL::expected indices:   3 1 2 0 
+DEAL::calculated indices: 3 1 2 0 
+DEAL::expected lines:   4 0 2 1 
+DEAL::calculated lines: 4 0 2 1 
+DEAL::
+DEAL::face orientation: 6
+DEAL::expected indices:   1 3 0 2 
+DEAL::calculated indices: 1 3 0 2 
+DEAL::expected lines:   0 4 2 1 
+DEAL::calculated lines: 0 4 2 1 
+DEAL::
+DEAL::face orientation: 7
+DEAL::expected indices:   1 0 3 2 
+DEAL::calculated indices: 1 0 3 2 
+DEAL::expected lines:   2 1 0 4 
+DEAL::calculated lines: 2 1 0 4 
+DEAL::


### PR DESCRIPTION
This is part of https://github.com/dealii/dealii/issues/19166.

Currently, there are no "true" replacements for `GeometryInfo<3>::standard_to_real_face_line` and `GeometryInfo<3>::standard_to_real_face_vertex` within `ReferenceCell`. While `ReferenceCell` currently contains functions with similar names, they are not viable replacements in their current state. Primarily because they are instance-based rather than static. This necessitates workarounds in some cases that are difficult to read and maintain.

This PR bridges that gap by providing implementations that are:
* Static.
* Compatible with the modern combined face orientation rather than a tuple of three booleans.
* Supportive of all known 2D face types (unlike the existing `GeometryInfo` versions only supporting quads).

> [!NOTE]  
> To prevent code duplication, it may be beneficial to refactor `GeometryInfo<3>` to utilize the `ReferenceCell` functions introduced in this PR. I would appreciate feedback on whether this is desired. If so, I will create a follow-up PR to address the refactoring.

---

**Before:**
```cpp
// get corrected index for quad
auto l_q = ReferenceCells::Hexahedron.standard_to_real_face_line(l, 0, orientation);
auto v_q = ReferenceCells::Hexahedron.standard_to_real_face_vertex(v, 0, orientation);
// get corrected index for tri
auto l_t = ReferenceCells::Tetrahedron.standard_to_real_face_line(l, 0, orientation);
auto v_q = ReferenceCells::Tetrahedron.standard_to_real_face_vertex(v, 0, orientation);
```

This syntax is counter-intuitive and raises several questions:

- Why is a 3D cell (Hexahedron/Tetrahedron) referenced when asking questions about a 2D face?
- What is the meaning of the "magic" constant `0`?

While these points can obviously be answered upon closer inspection, the current implementation remains unnecessarily opaque.


**After:**
```cpp
// get corrected index for quad
auto l_q = ReferenceCells::standard_to_real_quad_line(l, orientation, ReferenceCells::Quadrilateral);
auto v_q = ReferenceCells::standard_to_real_quad_vertex(v, orientation, ReferenceCells::Quadrilateral);
// get corrected index for tri
auto l_t = ReferenceCells::standard_to_real_quad_line(l, orientation, ReferenceCells::Triangle);
auto v_q = ReferenceCells::standard_to_real_quad_vertex(v, orientation, ReferenceCells::Triangle);
```