### PR TITLE
Do not allow writing into ghosted Trilinos vectors via VectorReference objects.

### DIFF
--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -721,6 +721,8 @@ namespace LinearAlgebra
       inline const VectorReference &
       VectorReference::operator=(const value_type &value) const
       {
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
         (*vector.vector)[0][index] = value;
 
         return *this;
@@ -731,7 +733,9 @@ namespace LinearAlgebra
       inline const VectorReference &
       VectorReference::operator+=(const value_type &value) const
       {
-        value_type new_value       = static_cast<value_type>(*this) + value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const value_type new_value = static_cast<value_type>(*this) + value;
         (*vector.vector)[0][index] = new_value;
 
         return *this;
@@ -742,7 +746,9 @@ namespace LinearAlgebra
       inline const VectorReference &
       VectorReference::operator-=(const value_type &value) const
       {
-        value_type new_value       = static_cast<value_type>(*this) - value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const value_type new_value = static_cast<value_type>(*this) - value;
         (*vector.vector)[0][index] = new_value;
 
         return *this;
@@ -753,7 +759,9 @@ namespace LinearAlgebra
       inline const VectorReference &
       VectorReference::operator*=(const value_type &value) const
       {
-        value_type new_value       = static_cast<value_type>(*this) * value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const value_type new_value = static_cast<value_type>(*this) * value;
         (*vector.vector)[0][index] = new_value;
 
         return *this;
@@ -764,7 +772,9 @@ namespace LinearAlgebra
       inline const VectorReference &
       VectorReference::operator/=(const value_type &value) const
       {
-        value_type new_value       = static_cast<value_type>(*this) / value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const value_type new_value = static_cast<value_type>(*this) / value;
         (*vector.vector)[0][index] = new_value;
 
         return *this;

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1411,7 +1411,10 @@ namespace LinearAlgebra
       inline const VectorReference<Number, MemorySpace> &
       VectorReference<Number, MemorySpace>::operator=(const Number &value) const
       {
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
         vector.set(1, &index, &value);
+
         return *this;
       }
 
@@ -1422,7 +1425,10 @@ namespace LinearAlgebra
       VectorReference<Number, MemorySpace>::operator+=(
         const Number &value) const
       {
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
         vector.add(1, &index, &value);
+
         return *this;
       }
 
@@ -1433,8 +1439,11 @@ namespace LinearAlgebra
       VectorReference<Number, MemorySpace>::operator-=(
         const Number &value) const
       {
-        Number new_value = -value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const Number new_value = -value;
         vector.add(1, &index, &new_value);
+
         return *this;
       }
 
@@ -1445,8 +1454,11 @@ namespace LinearAlgebra
       VectorReference<Number, MemorySpace>::operator*=(
         const Number &value) const
       {
-        Number new_value = static_cast<Number>(*this) * value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const Number new_value = static_cast<Number>(*this) * value;
         vector.set(1, &index, &new_value);
+
         return *this;
       }
 
@@ -1457,8 +1469,11 @@ namespace LinearAlgebra
       VectorReference<Number, MemorySpace>::operator/=(
         const Number &value) const
       {
-        Number new_value = static_cast<Number>(*this) / value;
+        Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+        const Number new_value = static_cast<Number>(*this) / value;
         vector.set(1, &index, &new_value);
+
         return *this;
       }
     } // namespace internal
@@ -1470,6 +1485,7 @@ namespace LinearAlgebra
   /** @} */
 
 } // namespace LinearAlgebra
+
 
 
 namespace internal

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1452,7 +1452,10 @@ namespace TrilinosWrappers
     inline const VectorReference &
     VectorReference::operator=(const TrilinosScalar &value) const
     {
+      Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
       vector.set(1, &index, &value);
+
       return *this;
     }
 
@@ -1461,7 +1464,10 @@ namespace TrilinosWrappers
     inline const VectorReference &
     VectorReference::operator+=(const TrilinosScalar &value) const
     {
+      Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
       vector.add(1, &index, &value);
+
       return *this;
     }
 
@@ -1470,8 +1476,11 @@ namespace TrilinosWrappers
     inline const VectorReference &
     VectorReference::operator-=(const TrilinosScalar &value) const
     {
-      TrilinosScalar new_value = -value;
+      Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+      const TrilinosScalar new_value = -value;
       vector.add(1, &index, &new_value);
+
       return *this;
     }
 
@@ -1480,8 +1489,12 @@ namespace TrilinosWrappers
     inline const VectorReference &
     VectorReference::operator*=(const TrilinosScalar &value) const
     {
-      TrilinosScalar new_value = static_cast<TrilinosScalar>(*this) * value;
+      Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+      const TrilinosScalar new_value =
+        static_cast<TrilinosScalar>(*this) * value;
       vector.set(1, &index, &new_value);
+
       return *this;
     }
 
@@ -1490,11 +1503,17 @@ namespace TrilinosWrappers
     inline const VectorReference &
     VectorReference::operator/=(const TrilinosScalar &value) const
     {
-      TrilinosScalar new_value = static_cast<TrilinosScalar>(*this) / value;
+      Assert(!vector.has_ghost_elements(), ExcGhostsPresent());
+
+      const TrilinosScalar new_value =
+        static_cast<TrilinosScalar>(*this) / value;
       vector.set(1, &index, &new_value);
+
       return *this;
     }
   } // namespace internal
+
+
 
   namespace MPI
   {


### PR DESCRIPTION
This patch continues what I did in #19089, as part of #19063. When you do
```
  v[42] = 1234.5678;
```
the left hand side evaluates to a `VectorReference` object, and in the assignment operator, we need to check that `v.has_ghosts() == false` to prevent writing into ghosted vectors.

This patch does that for the three Trilinos vector classes. I have checked that the PETSc vector classes are already safe.