### PR TITLE
Export std::void_t from dealii.external.std

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -218,6 +218,7 @@ export
     using std::type_identity_t;
     using std::underlying_type_t;
     using std::unsigned_integral;
+    using std::void_t;
 
     // Numeric functions
     using std::abs;


### PR DESCRIPTION
As discussed [here](https://github.com/dealii/dealii/pull/19149#discussion_r2679150546), this small PR makes std::void_t visible when importing dealii.external.std by explicitly exporting it from the std module partition. This avoids compilation failures in C++20 module builds that rely on std::void_t, despite <type_traits> being included.