### PR TITLE
TpetraWrappers::SparsityPattern: Don't check for global properties before compress

### DIFF
--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -416,6 +416,9 @@ namespace LinearAlgebra
                                                  col_map,
                                                  n_entries_per_row);
 
+        // We can't check for equality of sp.n_cols() and
+        // graph->getGlobalNumCols() here since we don't necessarily have a
+        // column map at this point.
         AssertDimension(sp.n_rows(), graph->getGlobalNumRows());
 
         std::vector<TrilinosWrappers::types::int_type> row_indices;


### PR DESCRIPTION
Extracted from #18791. Fixes
```
Throw number = 2
Throw test that evaluated to true: (!this->haveGlobalConstants_) 
Tpetra::CrsGraph<int, long long, Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::Serial, Kokkos::HostSpace> >::getGlobalNumEntries: The graph does not have global constants computed, but the user has requested them.
```
We can't request these constants (or the number of global columns) before they are computed when calling `compress`/`fillComplete`.

Note that we have
```
[...]
graph->fillComplete(column_space_map, graph->getRowMap());

// Check consistency between the sizes set at the beginning and what Trilinos stores:
AssertDimension(n_rows(), graph->getGlobalNumRows());
AssertDimension(n_cols(), graph->getGlobalNumCols());
```
in the `compress()` call that essentially does the same consistency check (at a different point).