### PR TITLE
Arkode - prepend namespaces inside the assertion macros

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -1008,7 +1008,8 @@
  *
  * @ingroup Exceptions
  */
-#  define AssertARKode(code) Assert(code >= 0, ExcARKodeError(code))
+#  define AssertARKode(code) \
+    Assert(code >= 0, ::dealii::SUNDIALS::ExcARKodeError(code))
 
 /**
  * Assertion that checks that the error code produced by calling one
@@ -1027,7 +1028,8 @@
  *
  * @ingroup Exceptions
  */
-#  define AssertKINSOL(code) Assert(code >= 0, ExcKINSOLError(code))
+#  define AssertKINSOL(code) \
+    Assert(code >= 0, ::dealii::SUNDIALS::ExcKINSOLError(code))
 
 /**
  * Assertion that checks that the error code produced by calling one
@@ -1046,7 +1048,8 @@
  *
  * @ingroup Exceptions
  */
-#  define AssertIDA(code) Assert(code >= 0, ExcIDAError(code))
+#  define AssertIDA(code) \
+    Assert(code >= 0, ::dealii::SUNDIALS::ExcIDAError(code))
 #endif
 
 #endif

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -1062,16 +1062,6 @@ namespace SUNDIALS
      */
     std::function<VectorType &()> get_local_tolerances;
 
-    /**
-     * Handle IDA exceptions.
-     */
-    DeclException1(ExcIDAError,
-                   int,
-                   << "One of SUNDIALS IDA's internal functions "
-                   << "returned an error code: " << arg1
-                   << ". Please consult SUNDIALS manual.");
-
-
   private:
     /**
      * Throw an exception when a function with the given name is not
@@ -1137,6 +1127,16 @@ namespace SUNDIALS
 #    endif // PETSC_USE_COMPLEX
 #  endif   // DEAL_II_WITH_PETSC
   };
+
+  /**
+   * Handle IDA exceptions.
+   */
+  DeclException1(ExcIDAError,
+                 int,
+                 << "One of SUNDIALS IDA's internal functions "
+                 << "returned an error code: " << arg1
+                 << ". Please consult SUNDIALS manual.");
+
 } // namespace SUNDIALS
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -702,15 +702,6 @@ namespace SUNDIALS
      */
     std::function<void(void *kinsol_mem)> custom_setup;
 
-    /**
-     * Handle KINSOL exceptions.
-     */
-    DeclException1(ExcKINSOLError,
-                   int,
-                   << "One of the SUNDIALS KINSOL internal functions "
-                   << "returned a negative error code: " << arg1
-                   << ". Please consult SUNDIALS manual.");
-
   private:
     /**
      * Throw an exception when a function with the given name is not
@@ -764,6 +755,15 @@ namespace SUNDIALS
      */
     mutable std::exception_ptr pending_exception;
   };
+
+  /**
+   * Handle KINSOL exceptions.
+   */
+  DeclException1(ExcKINSOLError,
+                 int,
+                 << "One of the SUNDIALS KINSOL internal functions "
+                 << "returned a negative error code: " << arg1
+                 << ". Please consult SUNDIALS manual.");
 
 } // namespace SUNDIALS
 


### PR DESCRIPTION
I have added the namespace `dealii::SUNDIALS` to the assertion macros related to `SUNDIALS` wrappers. Otherwise, the marcos don't work in the user code unless `using namespace dealii::SUNDIALS;` is added.

I also moved exceptions `ExcIDAError` and `ExcKINSOLError` out of the corresponding classes to be consistent with `ExcARKodeError`.