### PR TITLE
`MappingFEField`: `fix get_vertices()`.

### DIFF
--- a/doc/news/changes/minor/20260125DavidWells
+++ b/doc/news/changes/minor/20260125DavidWells
@@ -1,0 +1,3 @@
+Fixed: MappingFEField::get_vertices() correctly works with threads again.
+<br>
+(David Wells, 2026/01/25)

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -711,7 +711,15 @@ private:
   mutable FEValues<dim, spacedim> fe_values;
 
   /**
-   * A variable to guard access to the fe_values variable.
+   * DoF indices of the current cell.
+   */
+  mutable std::vector<types::global_dof_index> dof_indices;
+
+  /**
+   * A variable to guard access to fe_values and dof_indices.
+   *
+   * @note These three variables are only used in get_vertices(): all other
+   * functions use InternalData to store temporary values.
    */
   mutable Threads::Mutex fe_values_mutex;
 

--- a/include/deal.II/fe/mapping_fe_field.templates.h
+++ b/include/deal.II/fe/mapping_fe_field.templates.h
@@ -351,6 +351,7 @@ MappingFEField<dim, spacedim, VectorType>::MappingFEField(
   , fe_values(this->euler_dof_handler->get_fe(),
               reference_cell.template get_nodal_type_quadrature<dim>(),
               update_values)
+  , dof_indices(fe_values.dofs_per_cell)
 {
   AssertDimension(euler_dof_handler.n_dofs(), euler_vector.size());
 }
@@ -374,6 +375,7 @@ MappingFEField<dim, spacedim, VectorType>::MappingFEField(
   , fe_values(this->euler_dof_handler->get_fe(),
               reference_cell.template get_nodal_type_quadrature<dim>(),
               update_values)
+  , dof_indices(fe_values.dofs_per_cell)
 {
   Assert(euler_dof_handler.has_level_dofs(),
          ExcMessage("The underlying DoFHandler object did not call "
@@ -409,6 +411,7 @@ MappingFEField<dim, spacedim, VectorType>::MappingFEField(
   , fe_values(this->euler_dof_handler->get_fe(),
               reference_cell.template get_nodal_type_quadrature<dim>(),
               update_values)
+  , dof_indices(fe_values.dofs_per_cell)
 {
   Assert(euler_dof_handler.has_level_dofs(),
          ExcMessage("The underlying DoFHandler object did not call "
@@ -441,6 +444,7 @@ MappingFEField<dim, spacedim, VectorType>::MappingFEField(
   , fe_values(mapping.euler_dof_handler->get_fe(),
               reference_cell.template get_nodal_type_quadrature<dim>(),
               update_values)
+  , dof_indices(fe_values.dofs_per_cell)
 {}
 
 
@@ -510,13 +514,8 @@ MappingFEField<dim, spacedim, VectorType>::get_vertices(
   else
     AssertDimension(euler_vector[0]->size(), euler_dof_handler->n_dofs());
 
-  {
-    std::lock_guard<std::mutex> lock(fe_values_mutex);
-    fe_values.reinit(dof_cell);
-  }
-  const unsigned int dofs_per_cell =
-    euler_dof_handler->get_fe().n_dofs_per_cell();
-  std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
+  std::lock_guard<std::mutex> lock(fe_values_mutex);
+  fe_values.reinit(dof_cell);
   if (uses_level_dofs)
     dof_cell->get_mg_dof_indices(dof_indices);
   else


### PR DESCRIPTION
Another heaptrack-inspired PR.

Since we modify FEValues and read from it, we need to acquire the mutex for the remainder of the function. While we're at it, move up the scratch vector of DoF indices so that we do not need to reallocate it every time we use it.