### PR TITLE
`ReferenceCell`: use `MappingP1` in another place.

### DIFF
--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -453,8 +453,11 @@ ReferenceCell::get_default_mapping(const unsigned int degree) const
   if (is_hyper_cube())
     return std::make_unique<MappingQ<dim, spacedim>>(degree);
   else if (is_simplex())
-    return std::make_unique<MappingFE<dim, spacedim>>(
-      FE_SimplexP<dim, spacedim>(degree));
+    if (degree == 1)
+      return std::make_unique<MappingP1<dim, spacedim>>();
+    else
+      return std::make_unique<MappingFE<dim, spacedim>>(
+        FE_SimplexP<dim, spacedim>(degree));
   else if (*this == ReferenceCells::Pyramid)
     return std::make_unique<MappingFE<dim, spacedim>>(
       FE_PyramidP<dim, spacedim>(degree));


### PR DESCRIPTION
Another heaptrack-inspired PR.