### PR TITLE
Remove an unused variable.

### DIFF
--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -313,8 +313,7 @@ namespace VectorTools
 
     Number                                            mean = Number();
     typename numbers::NumberTraits<Number>::real_type area = 0.;
-    unsigned int last_n_quadrature_points = numbers::invalid_unsigned_int;
-    const Vector<Number> exemplar(n_components);
+    const Vector<Number>                              exemplar(n_components);
     // Compute mean value
     for (const auto &cell :
          dof.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
@@ -323,8 +322,7 @@ namespace VectorTools
         const FEValues<dim, spacedim> &fe_values =
           fe_values_collection.get_present_fe_values();
 
-        if (last_n_quadrature_points != fe_values.n_quadrature_points)
-          values.resize(fe_values.n_quadrature_points, exemplar);
+        values.resize(fe_values.n_quadrature_points, exemplar);
         fe_values.get_function_values(v, values);
         for (unsigned int k = 0; k < fe_values.n_quadrature_points; ++k)
           {


### PR DESCRIPTION
I didn't notice that it was never used in the last PR (#19214): if the new vector size equals the old size then resize() doesn't modify it.