### PR TITLE
Project BC div-conf in 3D: Avoid temp vector of global problem size

### DIFF
--- a/doc/news/changes/minor/20260126Kronbichler
+++ b/doc/news/changes/minor/20260126Kronbichler
@@ -1,0 +1,6 @@
+Fixed: The function VectorTools::project_boundary_values_div_conforming()
+would previously allocate an array of length equal to the global number of
+degrees of freedom. This is now fixed, making sure that also large-scale
+parallel programs can fit into memory.
+<br>
+(Martin Kronbichler, 2026/01/26)


### PR DESCRIPTION
In `VectorTools::project_boundary_values_div_conforming`, we would create a temporary vector of size `dof_handler.n_dofs()` to keep temporary data,
https://github.com/dealii/dealii/blob/1c1cbbd3b5a1b8d3182e9e3e9d1ee0d306ead0b7/include/deal.II/numerics/vector_tools_boundary.templates.h#L2450-L2460 and then fill the data. This is problematic when run in a massively parallel setting - I tried this on 1k MPI ranks with some 500m DoFs and always went out-of-memory, before I realized what was happening.

As can be seen from the comments I linked to here, the motivation was some DoFs located at edges in 3D. However, the RT element does not carry any DoFs on the edges, as the dofs are unique to the faces by construction. Therefore, we can avoid the specialized functions we had previously, and directly work with the `AffineConstraints` object. We can also unify the hp and non-hp versions easily. So this saves a substantial number of lines, despite being the general case. I tried the tests I could find locally and they're passing.