### PR TITLE
Use 'writable', not 'writeable'.

### DIFF
--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -168,7 +168,7 @@ namespace Step70
   // members of this class and the corresponding entries in the
   // ParameterHandler. Thanks to the use of the
   // ParameterHandler::add_parameter() method, this connection is trivial, but
-  // requires all members of this class to be writeable.
+  // requires all members of this class to be writable.
   template <int dim, int spacedim = dim>
   class StokesImmersedProblemParameters : public ParameterAcceptor
   {

--- a/include/deal.II/lac/block_sparsity_pattern.h
+++ b/include/deal.II/lac/block_sparsity_pattern.h
@@ -711,7 +711,7 @@ namespace TrilinosWrappers
     BlockSparsityPattern(
       const std::vector<IndexSet> &row_parallel_partitioning,
       const std::vector<IndexSet> &column_parallel_partitioning,
-      const std::vector<IndexSet> &writeable_rows,
+      const std::vector<IndexSet> &writable_rows,
       const MPI_Comm               communicator = MPI_COMM_WORLD);
 
     /**
@@ -756,7 +756,7 @@ namespace TrilinosWrappers
     void
     reinit(const std::vector<IndexSet> &row_parallel_partitioning,
            const std::vector<IndexSet> &column_parallel_partitioning,
-           const std::vector<IndexSet> &writeable_rows,
+           const std::vector<IndexSet> &writable_rows,
            const MPI_Comm               communicator = MPI_COMM_WORLD);
 
     /**

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -609,7 +609,7 @@ public:
   operator()(const size_type i) const;
 
   /**
-   * Access components, returns U(i) as a writeable reference.
+   * Access components, returns U(i) as a writable reference.
    */
   reference
   operator()(const size_type i);
@@ -623,7 +623,7 @@ public:
   operator[](const size_type i) const;
 
   /**
-   * Access components, returns U(i) as a writeable reference.
+   * Access components, returns U(i) as a writable reference.
    *
    * Exactly the same as operator().
    */

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1103,7 +1103,7 @@ public:
   diag_element(const size_type i) const;
 
   /**
-   * Same as above, but return a writeable reference. You're sure you know
+   * Same as above, but return a writable reference. You're sure you know
    * what you do?
    */
   number &

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -530,7 +530,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * TrilinosWrappers::SparsityPattern object that in turn has been
    * initialized with the reinit function specifying three index sets, one for
    * the rows, one for the columns and for the larger set of @p
-   * writeable_rows, and the operation is an addition. At some point in the
+   * writable_rows, and the operation is an addition. At some point in the
    * future, Trilinos support might be complete enough such that initializing
    * from a TrilinosWrappers::SparsityPattern that has been filled by a
    * function similar to DoFTools::make_sparsity_pattern always results in a
@@ -683,7 +683,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
      *
      * If you want to write to the matrix from several threads and use MPI,
      * you need to use this reinit method with a sparsity pattern that has
-     * been created with explicitly stating writeable rows. In all other
+     * been created with explicitly stating writable rows. In all other
      * cases, you cannot mix MPI with multithreaded writing into the matrix.
      */
     void

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -605,7 +605,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &row_parallel_partitioning,
            const IndexSet &col_parallel_partitioning,
-           const IndexSet &writeable_rows,
+           const IndexSet &writable_rows,
            const MPI_Comm  communicator      = MPI_COMM_WORLD,
            const size_type n_entries_per_row = 0);
 

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -616,7 +616,7 @@ namespace LinearAlgebra
       void
       reinit(const IndexSet &row_parallel_partitioning,
              const IndexSet &col_parallel_partitioning,
-             const IndexSet &writeable_rows,
+             const IndexSet &writable_rows,
              const MPI_Comm  communicator      = MPI_COMM_WORLD,
              const size_type n_entries_per_row = 0);
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -679,7 +679,7 @@ public:
   operator()(const size_type i) const;
 
   /**
-   * Access the @p ith component as a writeable reference.
+   * Access the @p ith component as a writable reference.
    */
   Number &
   operator()(const size_type i);
@@ -693,7 +693,7 @@ public:
   operator[](const size_type i) const;
 
   /**
-   * Access the @p ith component as a writeable reference.
+   * Access the @p ith component as a writable reference.
    *
    * Exactly the same as operator().
    */

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -161,7 +161,7 @@ namespace Particles
     get_location(const Handle handle) const;
 
     /**
-     * Return a writeable reference to the location of a particle
+     * Return a writable reference to the location of a particle
      * identified by the given `handle`.
      */
     Point<spacedim> &

--- a/tests/non_matching/step-70.cc
+++ b/tests/non_matching/step-70.cc
@@ -169,7 +169,7 @@ namespace Step70
   // members of this class and the corresponding entries in the
   // ParameterHandler. Thanks to the use of the
   // ParameterHandler::add_parameter() method, this connection is trivial, but
-  // requires all members of this class to be writeable.
+  // requires all members of this class to be writable.
   template <int dim, int spacedim = dim>
   class StokesImmersedProblemParameters : public ParameterAcceptor
   {


### PR DESCRIPTION
Both are correct, but 'writable' is more common (in practice as in our code base). Google Gemini tells me:

> Both writable and writeable are used and often considered acceptable, but writable is generally preferred and more common, especially in computing, while dictionaries like Merriam-Webster list only "writable," often redirecting "writeable" to it. The standard rule of dropping the 'e' before '-able' applies, making "writable" the more conventional choice, though "writeable" appears in product names and technical contexts, causing confusion.  