### PR TITLE
Fix a compile warning

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
@@ -120,7 +120,9 @@ namespace internal
           const unsigned int my_offset =
             offset + (structdim > 1 ? g * outer_stride : 0);
 
-          // extract values to interpolate
+          // extract values to interpolate, setting the first variable to zero
+          // to avoid compile warnings about possibly uninitialized variables
+          temp[0] = 0;
           for (unsigned int k = 0; k < points; ++k)
             temp[k] = values[my_offset + k * stride];
 


### PR DESCRIPTION
I get some annoying warning about an initialized variable with gcc-14. While the warning is not relevant, because whenever `n_points % 2` evaluates to true, the place where the compiler warns, the loop `for (unsigned int k = 0; k < points; ++k)` must perform at least one iteration. But it does not hurt either if we do it for one element.