### PR TITLE
Deprecate EpetraWrappers classes

### DIFF
--- a/doc/news/changes/incompatibilities/20260127Arndt
+++ b/doc/news/changes/incompatibilities/20260127Arndt
@@ -1,0 +1,3 @@
+Deprecated: All classes in the EpetraWrappers namespace have been deprecated.
+<br>
+(Daniel Arndt, 2026/01/27)

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -39,7 +39,9 @@ namespace LinearAlgebra
      * for use in places where a Utilities::MPI::CommunicationPatternBase object
      * is required.
      */
-    class CommunicationPattern : public Utilities::MPI::CommunicationPatternBase
+    class DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+      "Transition to functionality provided in TrilinosWrappers or TpetraWrappers!")
+      CommunicationPattern : public Utilities::MPI::CommunicationPatternBase
     {
     public:
       /**

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -55,7 +55,9 @@ namespace LinearAlgebra
      * This class defines type aliases that are used in vector classes
      * within the EpetraWrappers namespace.
      */
-    class VectorTraits
+    class DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+      "Transition to functionality provided in TrilinosWrappers or TpetraWrappers!")
+      VectorTraits
     {
     public:
       using value_type = double;
@@ -223,7 +225,9 @@ namespace LinearAlgebra
      * @ingroup TrilinosWrappers
      * @ingroup Vectors
      */
-    class Vector : public ReadVector<VectorTraits::value_type>
+    class DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+      "Transition to functionality provided in TrilinosWrappers or TpetraWrappers!")
+      Vector : public ReadVector<VectorTraits::value_type>
     {
     public:
       using value_type      = VectorTraits::value_type;


### PR DESCRIPTION
Related to https://github.com/dealii/dealii/issues/18461.
Since `Epetra` is already removed from the latest Trilinos releases, we should transition to using Tpetra and deprecate `EpetraWrappers`.