### PR TITLE
Workaround bug in hipcc 6.4

### DIFF
--- a/include/deal.II/base/polynomials_barycentric.h
+++ b/include/deal.II/base/polynomials_barycentric.h
@@ -263,6 +263,7 @@ public:
    */
   // We need to define the destructor to work around a compiler bug with hipcc
   // 6.4. Using default also triggers the error.
+  // NOLINTNEXTLINE(modernize-use-equals-default)
   virtual ~BarycentricPolynomials(){};
 
   /**


### PR DESCRIPTION
I don't understand why but without this patch I am getting:
```
lld: error: undefined hidden symbol: dealii::EnableObserverPointer::~EnableObserverPointer() 
>>> referenced by table.h:492 (/home/bruno/Documents/dealii/dealii/include/deal.II/base/table.h:492)
>>>               /tmp/polynomials_barycentric-gfx1030-0882a2.o:(dealii::BarycentricPolynomials<1>::~BarycentricPolynomials())    
>>> referenced by table.h:492 (/home/bruno/Documents/dealii/dealii/include/deal.II/base/table.h:492)
>>>               /tmp/polynomials_barycentric-gfx1030-0882a2.o:(dealii::BarycentricPolynomials<1>::~BarycentricPolynomials())
>>> referenced by table.h:492 (/home/bruno/Documents/dealii/dealii/include/deal.II/base/table.h:492) 
>>>               /tmp/polynomials_barycentric-gfx1030-0882a2.o:(dealii::BarycentricPolynomials<1>::~BarycentricPolynomials())
>>> referenced 57 more times  
```