### PR TITLE
Provide `max_children_per_cell` equivalent in `ReferenceCell`.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1522,6 +1522,19 @@ namespace ReferenceCells
   template <int structdim>
   constexpr unsigned int
   max_n_faces();
+
+  /**
+   * Return the maximum number of children an object of dimension `structdim`
+   * can have.
+   *
+   * @note If a cell is refined anisotropically, the actual number of children
+   * may be less than the value given here.
+   *
+   * @see ReferenceCells::max_n_faces()
+   */
+  template <int structdim>
+  constexpr unsigned int
+  max_n_children();
 } // namespace ReferenceCells
 
 
@@ -3375,6 +3388,13 @@ namespace ReferenceCells
   max_n_faces()
   {
     return GeometryInfo<structdim>::faces_per_cell;
+  }
+
+  template <int structdim>
+  inline constexpr unsigned int
+  max_n_children()
+  {
+    return GeometryInfo<structdim>::max_children_per_cell;
   }
 } // namespace ReferenceCells
 


### PR DESCRIPTION
Provide [`max_children_per_cell`](https://dealii.org/developer/doxygen/deal.II/structGeometryInfo.html#afd3320089fb8cbd675963e56fb37d01f) equivalent in `ReferenceCell` that has a similar interface to the already existing [`max_n_faces`](https://github.com/dealii/dealii/blob/6e37b15d485bf87f8951567b485b34449599716e/include/deal.II/grid/reference_cell.h#L1522-L1524).

*Part of https://github.com/dealii/dealii/issues/19254*