### PR TITLE
Add documentation about which children are stored.

### DIFF
--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -175,7 +175,8 @@ namespace internal
 
       /**
        * One integer for every consecutive pair of cells to store which index
-       * their parent has.
+       * their parent has. Information is only stored for the even (index 0, 2
+       * 4, ...) child.
        *
        * (We store this information once for each pair of cells since every
        * refinement, isotropic or anisotropic, and in any space dimension,

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -87,11 +87,11 @@ namespace internal
       get_bounding_object_indices(const unsigned int index);
 
       /**
-       * Index of the even children of an object. Since when objects are
-       * refined, all children are created at the same time, they are appended
-       * to the list at least in pairs after each other. We therefore only
-       * store the index of the even children, the uneven follow immediately
-       * afterwards.
+       * Index of the even children (index 0, 2, 4, ...) of an object. Since
+       * when objects are refined, all children are created at the same time,
+       * they are appended to the list at least in pairs after each other. We
+       * therefore only store the index of the even children, the uneven follow
+       * immediately afterwards.
        *
        * If an object has no children, -1 is stored in this list. An object is
        * called active if it has no children. The function


### PR DESCRIPTION
Add documentation to [`parents`](https://github.com/dealii/dealii/blob/6e37b15d485bf87f8951567b485b34449599716e/include/deal.II/grid/tria_levels.h#L176-L185) pointing out which children this concerns (similar to [`children`](
https://github.com/dealii/dealii/blob/6e37b15d485bf87f8951567b485b34449599716e/include/deal.II/grid/tria_objects.h#L89-L100) vector in `tria_objects.h`).

*Part of https://github.com/dealii/dealii/issues/19170*