### PR TITLE
implement `n_children` to output meaningful values for unrefined cells.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -2478,8 +2478,66 @@ ReferenceCell<dim>::n_children(const RefinementCase<dim> ref_case) const
   // Use GeometryInfo here to keep it the single source of truth
   if (this->is_hyper_cube())
     return GeometryInfo<dim>::n_children(ref_case);
-  else
-    return this->n_isotropic_children();
+
+  // TODO: Rewrite once refinement cases are cleaned up
+  // For all other cells, we assume that only isotropic refinement is
+  // implemented. This is a strong assumption that should be removed as soon as
+  // the issue regarding the uniqueness of refinement cases is resolved.
+  //
+  // This is a short outline of the issue: Different refinement options are
+  // stored as an enum, primarily focusing on hypercubes. They therefore are (to
+  // some extent) unsuitable for other cell types. For example, there are
+  // multiple ways to isotropically refine a tetrahedron. Distinguishing between
+  // these required the introduction of the additional
+  // `IsotropicRefinementChoice` enum. However, this leads to a conflict where
+  // the same integer value is assigned to multiple different refinement options
+  // across the existing refinement cases. The most critical conflict is likely
+  // `IsotropicRefinementChoice::isotropic_refinement` shadowing
+  // `RefinementPossibilities<~>::no_refinement`.
+  // The following code attempts to circumvent this mess by predicting whether
+  // the given refinement case is isotropic and then returning either the number
+  // of isotropic children or `0` (see below for why `0` is used).
+
+  // Detect isotropic refinement.
+  // Only in 3D and only for Tetrahedrons we have ambiguity. But first assume
+  // that we don't have a tet.
+  bool is_isotropic =
+    (ref_case == RefinementPossibilities<dim>::isotropic_refinement);
+
+  // check if assumption of line above was correct, else apply fix for tet
+  if constexpr (dim == 3) // check for dim first (only 3D relevant for tet)
+    if (*this == ReferenceCells::Tetrahedron) // tets
+      is_isotropic =
+        ((ref_case == //
+          RefinementPossibilities<dim>::isotropic_refinement) ||
+         // We must not check
+         // `IsotropicRefinementChoice::isotropic_refinement`
+         // because it coincides with
+         // `RefinementPossibilities<dim>::no_refinement`
+         // (both are 0).
+         (ref_case ==
+          static_cast<typename RefinementPossibilities<dim>::Possibilities>(
+            IsotropicRefinementChoice::cut_tet_68)) || //
+         (ref_case ==
+          static_cast<typename RefinementPossibilities<dim>::Possibilities>(
+            IsotropicRefinementChoice::cut_tet_57)) || //
+         (ref_case ==
+          static_cast<typename RefinementPossibilities<dim>::Possibilities>(
+            IsotropicRefinementChoice::cut_tet_49)));
+
+
+  // return the according value
+  if (is_isotropic)
+    return n_isotropic_children();
+
+  // Unsupported case
+
+  // DEAL_II_NOT_IMPLEMENTED();
+  // We must return some data. Many parts of the code aren't aware
+  // which refinement cases are actually supported, calling this
+  // function with impossible refinement cases and expecting some
+  // output. One example is the constructor of `FiniteElement`.
+  return 0;
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5814,11 +5814,8 @@ TriaAccessor<structdim, dim, spacedim>::n_children() const
   Assert(this->state() == IteratorState::valid,
          TriaAccessorExceptions::ExcDereferenceInvalidObject<TriaAccessor>(
            *this));
-  if (reference_cell() == ReferenceCells::Tetrahedron)
-    return GeometryInfo<structdim>::n_children(
-      RefinementCase<structdim>::isotropic_refinement);
-  else
-    return GeometryInfo<structdim>::n_children(refinement_case());
+
+  return reference_cell().n_children(refinement_case());
 }
 
 

--- a/tests/grid/reference_cell_n_children.cc
+++ b/tests/grid/reference_cell_n_children.cc
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// Test ReferenceCell::face_indices_by_type()
+
+#include <deal.II/base/geometry_info.h>
+
+#include <deal.II/grid/reference_cell.h>
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+template <unsigned int dim>
+std::vector<ReferenceCell<dim>>
+get_all_ref_cells()
+{
+  // switch won't work because conditions MUST be constexpr for type deduction.
+  if constexpr (dim == 0)
+    return {{ReferenceCells::Vertex}};
+  else if constexpr (dim == 1)
+    return {ReferenceCells::Line};
+  else if constexpr (dim == 2)
+    return {ReferenceCells::Triangle, ReferenceCells::Quadrilateral};
+  else if constexpr (dim == 3)
+    return {ReferenceCells::Tetrahedron,
+            ReferenceCells::Pyramid,
+            ReferenceCells::Wedge,
+            ReferenceCells::Hexahedron};
+  else
+    DEAL_II_NOT_IMPLEMENTED();
+}
+
+template <unsigned int dim>
+void
+test_generic()
+{
+  for (auto cell_type : get_all_ref_cells<dim>())
+    {
+      deallog << std::setw(7) << cell_type.to_string() << " ";
+      for (auto ref_choice : RefinementCase<dim>::all_refinement_cases())
+        deallog << static_cast<int>(ref_choice) << " "
+                << cell_type.n_children(ref_choice) << "   ";
+      deallog << std::endl;
+    }
+}
+
+void
+test_special_tet()
+{
+  deallog << std::setw(7) << "Tet"
+          << " ";
+  auto choices = {
+    // let's not test isotropic_refinement because it really doesn't match the
+    // code structure (see https://github.com/dealii/dealii/pull/19261)
+    // IsotropicRefinementChoice::isotropic_refinement,
+    IsotropicRefinementChoice::cut_tet_68,
+    IsotropicRefinementChoice::cut_tet_57,
+    IsotropicRefinementChoice::cut_tet_49,
+  };
+  for (auto ref_choice : choices)
+    deallog << static_cast<int>(ref_choice) << " "
+            << ReferenceCells::Tetrahedron.n_children(
+                 RefinementCase<3>(static_cast<std::uint8_t>(ref_choice)))
+            << "   ";
+  deallog << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  deallog << std::left;
+
+  // test_generic<0>(); // no refinement for vertex
+  test_generic<1>();
+  test_generic<2>();
+  test_generic<3>();
+
+  deallog << std::endl
+          << std::endl
+          << "Special cases" << std::endl
+          << std::endl;
+  test_special_tet();
+}

--- a/tests/grid/reference_cell_n_children.output
+++ b/tests/grid/reference_cell_n_children.output
@@ -1,0 +1,13 @@
+
+DEAL::Line    0 0   1 2   
+DEAL::Tri     0 0   1 0   2 0   3 4   
+DEAL::Quad    0 0   1 2   2 2   3 4   
+DEAL::Tet     0 0   1 8   2 8   3 8   4 0   5 0   6 0   7 8   
+DEAL::Pyramid 0 0   1 0   2 0   3 0   4 0   5 0   6 0   7 0   
+DEAL::Wedge   0 0   1 0   2 0   3 0   4 0   5 0   6 0   7 8   
+DEAL::Hex     0 0   1 2   2 2   3 4   4 2   5 4   6 4   7 8   
+DEAL::
+DEAL::
+DEAL::Special cases
+DEAL::
+DEAL::Tet     1 8   2 8   3 8   


### PR DESCRIPTION
According to the deal.II documentation, *["[...] The number of children of an unrefined cell is zero."](https://dealii.org/developer/doxygen/deal.II/classTriaAccessor.html#a634bf3e1c46e9ba87dfafa8c869e8972)* However, `n_children` in both `TriaAccessor` and `ReferenceCell` currently returns $8$ for non-hexahedral cells, regardless of their actual refinement state.

This behavior is obviously inconsistent with the specification. This PR addresses the issue by ensuring that [`n_isotropic_children`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/reference_cell.h#L2417-L2445) is returned for refined non-hexahedral cells, and $0$ is returned otherwise.

---

### Additional Observations

While working on this fix, I noticed a few implementation details that seem suboptimal or inconsistent:

- **Deprecated usage of enum values**: Although `RefinementChoices` [explicitly states](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/base/geometry_info.h#L812-L815) that using enum values as array indices is deprecated, the implementation of [`GeometryInfo<dim>::n_children`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/base/geometry_info.h#L3516-L3519) a few lines below in the same file does exactly this.
- **Suitability of `RefinementChoices`**: This enum appears to be designed primarily for hypercubes and doesn't fit other cell types well. This is evidenced by:
  - The introduction of [`IsotropicRefinementChoice`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/reference_cell.h#L75-L93) for tetrahedra, which creates ambiguity. For instance, a value of $1$ in [`refinement_cases`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/tria_objects.h#L107) could represent either an isotropically refined tetrahedron or an anisotropically refined cell using `cut_x`[^1]. The most confusing case is where $0$ might mean `RefinementPossibilities::no_refinement` or `IsotropicRefinementChoice::isotropic_refinement`, which are determined to be [logically opposites](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/base/geometry_info.h#L834-L842).
  - The fact that current anisotropic refinement choices don't really fit non-hypercube cells. Eventually new ones need to be defined (e.g. `cut_xy_plane` for wedges). Addressing this now would likely simplify the future implementation of anisotropic refinement in 2D and 3D for the non hypercube cells.
- **Inconsistent cases for tetrahedron**: Additionally to the above mentioned issues there is also the inconsistency that [`ReferenceCell::refinement_cases()`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/reference_cell.h#L2496-L2574) only returns `RefinementPossibilities<3>::isotropic_refinement` which is equal to $7$ however in `refinement_cases` we only store values of [`IsotropicRefinementChoice`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/reference_cell.h#L75-L93) with values $\in[0,4]$ since [`TriaAccessor::refinement_case()`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/tria_accessor.h#L5765) directly returns the value in [`refinement_cases`](https://github.com/dealii/dealii/blob/41672923aeb14f951475cc9d369a248cc63372bd/include/deal.II/grid/tria_objects.h#L107) we will never receive a value of $7$ which `ReferenceCell` considers to be the only valid option.

_Part of https://github.com/dealii/dealii/issues/19170_

[^1]: To clarify, it isn't impossible to derive the actual refinement case (as this PR demonstrates), but the current system is already reaching its limits, forcing us to also rely on checks for the current cell type. I suggest to make this more consistent, similar to what has been done for orientations (which I think are implemented in a very nice and smart way).