### PR TITLE
Hp dof identities for simplices, wedges and pyramids

### DIFF
--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -179,6 +179,13 @@ public:
   std::vector<std::pair<unsigned int, unsigned int>>
   hp_line_dof_identities(
     const FiniteElement<dim, spacedim> &fe_other) const override;
+
+  /**
+   * @copydoc dealii::FiniteElement::hp_quad_dof_identities()
+   */
+  std::vector<std::pair<unsigned int, unsigned int>>
+  hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int face_no = 0) const override;
 };
 
 

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -520,6 +520,16 @@ FE_PyramidP<dim, spacedim>::compare_for_domination(
       else
         return FiniteElementDomination::other_element_dominates;
     }
+  else if (const FE_WedgeP<dim, spacedim> *fe_pp_other =
+             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_pp_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_pp_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
   else if (const FE_Nothing<dim, spacedim> *fe_nothing =
              dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other))
     {
@@ -546,7 +556,9 @@ FE_PyramidP<dim, spacedim>::hp_vertex_dof_identities(
   (void)fe_other;
 
   Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
-           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)),
+           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
          ExcNotImplemented());
 
   return {{0, 0}};
@@ -559,19 +571,43 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_PyramidP<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
-  (void)fe_other;
-
   Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
-           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)),
+           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
          ExcNotImplemented());
 
-  std::vector<std::pair<unsigned int, unsigned int>> result;
+  std::vector<std::pair<unsigned int, unsigned int>> identities;
+  // check if the support points are the same location on the line
+  // the pyramid base is defined by the vertices [-1,-1,0], [1,-1,0],
+  // [-1,1,0], [1,1,0], to avoid rescaling use the support points on the faces
+  const auto face_support_points = this->get_unit_face_support_points(0);
+  const auto face_support_points_other =
+    fe_other.get_unit_face_support_points(0);
 
-  result.reserve(this->degree - 1);
-  for (unsigned int i = 0; i < this->degree - 1; ++i)
-    result.emplace_back(i, i);
+  // now just compare the DoFs on the line going from [0,0] to [1,0]
+  // for a triangular face that is the first line
+  // for a quad face that is the third line
+  // adjust the offsets accordingly
+  // face number 0 of the pyramid is a quad
+  const unsigned int offset =
+    this->reference_cell().face_reference_cell(0).n_vertices() +
+    2 * this->n_dofs_per_line();
 
-  return result;
+  const unsigned int offset_other =
+    fe_other.reference_cell().face_reference_cell(0).is_hyper_cube() ?
+      fe_other.reference_cell().face_reference_cell(0).n_vertices() +
+        2 * fe_other.n_dofs_per_line() :
+      fe_other.reference_cell().face_reference_cell(0).n_vertices();
+
+  // now get the identities
+  for (unsigned int i = 0; i < this->n_dofs_per_line(); ++i)
+    for (unsigned int j = 0; j < fe_other.n_dofs_per_line(); ++j)
+      if (face_support_points[i + offset].distance(
+            face_support_points_other[j + offset_other]) < 1e-14)
+        identities.emplace_back(i, j);
+
+  return identities;
 }
 
 
@@ -582,29 +618,68 @@ FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
   const unsigned int                  face_no) const
 {
-  (void)fe_other;
-
-
   AssertIndexRange(face_no, 5);
+  std::vector<std::pair<unsigned int, unsigned int>> identities;
+
+  unsigned int face_no_neighbor;
 
   if (face_no == 0)
     {
-      Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)),
+      // on a quad, neighbor can be a hex, a pyramid or a wedge
+      Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
              ExcNotImplemented());
+      // for the wedge the first quad face is face no. 2
+      if (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+        face_no_neighbor = 2;
+      else
+        face_no_neighbor = 0;
     }
   else
     {
-      Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)),
+      Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
              ExcNotImplemented());
+      // on tri, neighbor can be a tet, a pyramid or a wedge
+      if (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+        face_no_neighbor = 1;
+      else
+        face_no_neighbor = 0;
     }
 
-  std::vector<std::pair<unsigned int, unsigned int>> result;
+  // compare the face support points
+  const auto face_support_points = this->get_unit_face_support_points(face_no);
+  const auto face_support_points_other =
+    fe_other.get_unit_face_support_points(face_no_neighbor);
 
-  result.reserve(this->n_dofs_per_quad(face_no));
+  // get the offsets to only compare the DoFs within the face as the vertices
+  // and lines were done before
+  const auto face_reference_cell =
+    this->reference_cell().face_reference_cell(face_no);
+
+  Assert(face_reference_cell ==
+           fe_other.reference_cell().face_reference_cell(face_no_neighbor),
+         ExcInternalError());
+
+  const unsigned int offset =
+    face_reference_cell.n_vertices() +
+    face_reference_cell.n_lines() * this->n_dofs_per_line();
+
+  const unsigned int offset_other =
+    face_reference_cell.n_vertices() +
+    face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
+
+  // do the comparison
   for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
-    result.emplace_back(i, i);
+    for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
+         ++j)
+      if (face_support_points[i + offset].distance(
+            face_support_points_other[j + offset_other]) < 1e-14)
+        identities.emplace_back(i, j);
 
-  return result;
+  return identities;
 }
 
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -741,8 +741,12 @@ FE_Q_Base<dim, spacedim>::hp_vertex_dof_identities(
       // should have identical value
       return {{0U, 0U}};
     }
-  else if (dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other) !=
-           nullptr)
+  else if ((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other) !=
+            nullptr) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other) !=
+            nullptr) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other) !=
+            nullptr))
     {
       // there should be exactly one single DoF of each FE at a vertex, and they
       // should have identical value
@@ -821,33 +825,39 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
 
       return identities;
     }
-  else if (const FE_SimplexP<dim, spacedim> *fe_p_other =
-             dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other))
+  else if ((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)))
     {
-      // DoFs are located along lines, so two dofs are identical if they are
-      // located at identical positions. If we had only equidistant points, we
-      // could simply check for similarity like (i+1)*q == (j+1)*p, but we
-      // might have other support points (e.g. Gauss-Lobatto
-      // points). Therefore, read the points in unit_support_points for the
-      // first coordinate direction. For FE_Q, we take the lexicographic
-      // ordering of the line support points in the first direction (i.e.,
-      // x-direction), which we access between index 1 and p-1 (index 0 and p
-      // are vertex dofs). For FE_SimplexP, they are currently hard-coded and we
-      // iterate over points on the first line which begin after the 3 vertex
-      // points in the complete list of unit support points
-
-      Assert(fe_p_other->degree <= 2, ExcNotImplemented());
-
-      const std::vector<unsigned int> &index_map_inverse_q =
-        this->get_poly_space_numbering_inverse();
-
       std::vector<std::pair<unsigned int, unsigned int>> identities;
+      // check if the support points are the same location on the line
+      // to avoid rescaling for pyramids use the support points on the faces
+      const auto face_support_points = this->get_unit_face_support_points(0);
+      const auto face_support_points_other =
+        fe_other.get_unit_face_support_points(0);
 
+      // now just compare the DoFs on the line going from [0,0] to [1,0]
+      // for a triangular face that is the first line
+      // for a quad face that is the third line
+      // adjust the offsets accordingly
+      // face number 0 of the hex is a quad
+      // in 2d we need just to account for the vertices
+      const unsigned int offset =
+        dim == 2 ? this->reference_cell().face_reference_cell(0).n_vertices() :
+                   this->reference_cell().face_reference_cell(0).n_vertices() +
+                     2 * this->n_dofs_per_line();
+
+      const unsigned int offset_other =
+        fe_other.reference_cell().face_reference_cell(0).is_simplex() ?
+          fe_other.reference_cell().face_reference_cell(0).n_vertices() :
+          fe_other.reference_cell().face_reference_cell(0).n_vertices() +
+            2 * fe_other.n_dofs_per_line();
+
+      // now get the identities
       for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
-          if (std::fabs(
-                this->unit_support_points[index_map_inverse_q[i + 1]][0] -
-                fe_p_other->get_unit_support_points()[j + 3][0]) < 1e-14)
+        for (unsigned int j = 0; j < fe_other.degree - 1; ++j)
+          if (face_support_points[i + offset].distance(
+                face_support_points_other[j + offset_other]) < 1e-14)
             identities.emplace_back(i, j);
 
       return identities;
@@ -920,6 +930,43 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
                                             [0]) < 1e-14))
                 identities.emplace_back(i1 * (p - 1) + i2, j1 * (q - 1) + j2);
 
+      return identities;
+    }
+  else if ((dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ||
+           (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr))
+    {
+      const unsigned int face_no_neighbor =
+        (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ? 0 : 2;
+
+      std::vector<std::pair<unsigned int, unsigned int>> identities;
+
+      // compare the face support points
+      const auto face_support_points = this->get_unit_face_support_points(0);
+      const auto face_support_points_other =
+        fe_other.get_unit_face_support_points(face_no_neighbor);
+
+      // get the offsets to skip vertices and lines
+      const auto face_reference_cell =
+        this->reference_cell().face_reference_cell(0);
+      Assert(face_reference_cell ==
+               fe_other.reference_cell().face_reference_cell(face_no_neighbor),
+             ExcInternalError());
+
+      const auto offset =
+        face_reference_cell.n_vertices() +
+        face_reference_cell.n_lines() * this->n_dofs_per_line();
+
+      const auto offset_other =
+        face_reference_cell.n_vertices() +
+        face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
+
+      // now compare the points
+      for (unsigned int i = 0; i < this->n_dofs_per_quad(0); ++i)
+        for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
+             ++j)
+          if (face_support_points[i + offset].distance(
+                face_support_points_other[j + offset_other]) < 1e-14)
+            identities.emplace_back(i, j);
       return identities;
     }
   else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -19,9 +19,11 @@
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_pyramid_p.h>
 #include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_tools.h>
+#include <deal.II/fe/fe_wedge_p.h>
 #include <deal.II/fe/mapping.h>
 
 #include <deal.II/grid/grid_generator.h>
@@ -846,6 +848,26 @@ FE_SimplexP<dim, spacedim>::compare_for_domination(
       else
         return FiniteElementDomination::other_element_dominates;
     }
+  else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_p_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_p_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
+  else if (const FE_WedgeP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_p_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_p_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
   else if (const FE_Nothing<dim, spacedim> *fe_nothing =
              dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other))
     {
@@ -869,15 +891,12 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_SimplexP<dim, spacedim>::hp_vertex_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
-  AssertDimension(dim, 2);
-
-  if (dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other) != nullptr)
-    {
-      // there should be exactly one single DoF of each FE at a vertex, and
-      // they should have identical value
-      return {{0U, 0U}};
-    }
-  else if (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other) != nullptr)
+  if ((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other) !=
+       nullptr) ||
+      (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other) != nullptr) ||
+      (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other) !=
+       nullptr) ||
+      (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other) != nullptr))
     {
       // there should be exactly one single DoF of each FE at a vertex, and
       // they should have identical value
@@ -914,74 +933,38 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
-  AssertDimension(dim, 2);
-
-  if (const FE_SimplexP<dim, spacedim> *fe_p_other =
-        dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other))
+  if ((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
+      (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+      (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+      (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)))
     {
-      // dofs are located along lines, so two dofs are identical if they are
-      // located at identical positions.
-      // Therefore, read the points in unit_support_points for the
-      // first coordinate direction. For FE_SimplexP, they are currently
-      // hard-coded and we iterate over points on the first line which begin
-      // after the 3 vertex points in the complete list of unit support points
-
       std::vector<std::pair<unsigned int, unsigned int>> identities;
+      // check if the support points are the same location on the line
+      // to avoid rescaling for pyramids use the support points on the faces
+      const auto face_support_points = this->get_unit_face_support_points(0);
+      const auto face_support_points_other =
+        fe_other.get_unit_face_support_points(0);
 
+      // now just compare the DoFs on the line going from [0,0] to [1,0]
+      // for a triangular face that is the first line
+      // for a quad face that is the third line
+      // adjust the offsets accordingly
+      // face number 0 of the tet is a triangle
+      const unsigned int offset =
+        this->reference_cell().face_reference_cell(0).n_vertices();
+
+      const unsigned int offset_other =
+        fe_other.reference_cell().face_reference_cell(0).is_simplex() ?
+          fe_other.reference_cell().face_reference_cell(0).n_vertices() :
+          fe_other.reference_cell().face_reference_cell(0).n_vertices() +
+            2 * fe_other.n_dofs_per_line();
+
+      // now get the identities
       for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_p_other->degree - 1; ++j)
-          if (std::fabs(this->unit_support_points[i + 3][0] -
-                        fe_p_other->unit_support_points[i + 3][0]) < 1e-14)
+        for (unsigned int j = 0; j < fe_other.degree - 1; ++j)
+          if (face_support_points[i + offset].distance(
+                face_support_points_other[j + offset_other]) < 1e-14)
             identities.emplace_back(i, j);
-          else
-            {
-              // If nodes are not located in the same place, we have to
-              // interpolate. This is then not handled through the
-              // current function, but via interpolation matrices that
-              // result in constraints, rather than identities. Since
-              // that happens in a different function, there is nothing
-              // for us to do here.
-            }
-
-      return identities;
-    }
-  else if (const FE_Q<dim, spacedim> *fe_q_other =
-             dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other))
-    {
-      // dofs are located along lines, so two dofs are identical if they are
-      // located at identical positions. if we had only equidistant points, we
-      // could simply check for similarity like (i+1)*q == (j+1)*p, but we
-      // might have other support points (e.g. Gauss-Lobatto
-      // points). Therefore, read the points in unit_support_points for the
-      // first coordinate direction. For FE_Q, we take the lexicographic
-      // ordering of the line support points in the first direction (i.e.,
-      // x-direction), which we access between index 1 and p-1 (index 0 and p
-      // are vertex dofs). For FE_SimplexP, they are currently hard-coded and we
-      // iterate over points on the first line which begin after the 3 vertex
-      // points in the complete list of unit support points
-
-      const std::vector<unsigned int> &index_map_inverse_q_other =
-        fe_q_other->get_poly_space_numbering_inverse();
-
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
-
-      for (unsigned int i = 0; i < this->degree - 1; ++i)
-        for (unsigned int j = 0; j < fe_q_other->degree - 1; ++j)
-          if (std::fabs(this->unit_support_points[i + 3][0] -
-                        fe_q_other->get_unit_support_points()
-                          [index_map_inverse_q_other[j + 1]][0]) < 1e-14)
-            identities.emplace_back(i, j);
-          else
-            {
-              // If nodes are not located in the same place, we have to
-              // interpolate. This will then also
-              // capture the case where the FE_Q has a different polynomial
-              // degree than the current element. In either case, the resulting
-              // constraints are computed elsewhere, rather than via the
-              // identities this function returns: Since
-              // that happens in a different function, there is nothing
-              // for us to do here.
-            }
 
       return identities;
     }
@@ -1008,6 +991,80 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
     {
       DEAL_II_NOT_IMPLEMENTED();
       return {};
+    }
+}
+
+
+
+template <int dim, int spacedim>
+std::vector<std::pair<unsigned int, unsigned int>>
+FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int) const
+{
+  AssertDimension(dim, 3);
+
+  if ((dynamic_cast<const FE_SimplexP<dim> *>(&fe_other) != nullptr) ||
+      (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr) ||
+      (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr))
+    {
+      std::vector<std::pair<unsigned int, unsigned int>> result;
+      const unsigned int                                 face_no_neighbor =
+        (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ? 1 : 0;
+
+      // compare the face support points
+      const auto face_support_points = this->get_unit_face_support_points(0);
+      const auto face_support_points_other =
+        fe_other.get_unit_face_support_points(face_no_neighbor);
+
+      // get the offsets to only compare the DoFs within the face as the
+      // vertices and lines were done before
+      const auto face_reference_cell =
+        this->reference_cell().face_reference_cell(0);
+
+      Assert(face_reference_cell ==
+               fe_other.reference_cell().face_reference_cell(face_no_neighbor),
+             ExcInternalError());
+
+      const unsigned int offset =
+        face_reference_cell.n_vertices() +
+        face_reference_cell.n_lines() * this->n_dofs_per_line();
+
+      const unsigned int offset_other =
+        face_reference_cell.n_vertices() +
+        face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
+
+      // do the comparison
+      for (unsigned int i = 0; i < this->n_dofs_per_quad(0); ++i)
+        for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
+             ++j)
+          if (face_support_points[i + offset].distance(
+                face_support_points_other[j + offset_other]) < 1e-14)
+            result.emplace_back(i, j);
+
+      return result;
+    }
+  else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
+    {
+      // the FE_Nothing has no degrees of freedom, so there are no
+      // equivalencies to be recorded
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+  else if (fe_other.n_unique_faces() == 1 && fe_other.n_dofs_per_face(0) == 0)
+    {
+      // if the other element has no elements on faces at all,
+      // then it would be impossible to enforce any kind of
+      // continuity even if we knew exactly what kind of element
+      // we have -- simply because the other element declares
+      // that it is discontinuous because it has no DoFs on
+      // its faces. in that case, just state that we have no
+      // constraints to declare
+      return std::vector<std::pair<unsigned int, unsigned int>>();
+    }
+  else
+    {
+      DEAL_II_NOT_IMPLEMENTED();
+      return std::vector<std::pair<unsigned int, unsigned int>>();
     }
 }
 

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -244,6 +244,16 @@ FE_WedgeP<dim, spacedim>::compare_for_domination(
       else
         return FiniteElementDomination::other_element_dominates;
     }
+  else if (const FE_PyramidP<dim, spacedim> *fe_p_other =
+             dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
+    {
+      if (this->degree < fe_p_other->degree)
+        return FiniteElementDomination::this_element_dominates;
+      else if (this->degree == fe_p_other->degree)
+        return FiniteElementDomination::either_element_can_dominate;
+      else
+        return FiniteElementDomination::other_element_dominates;
+    }
   else if (const FE_Nothing<dim> *fe_nothing =
              dynamic_cast<const FE_Nothing<dim> *>(&fe_other))
     {
@@ -270,7 +280,9 @@ FE_WedgeP<dim, spacedim>::hp_vertex_dof_identities(
   (void)fe_other;
 
   Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
-           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)),
+           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
          ExcNotImplemented());
 
   return {{0, 0}};
@@ -283,19 +295,41 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_WedgeP<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other) const
 {
-  (void)fe_other;
-
   Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
-           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)),
+           (dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
          ExcNotImplemented());
 
-  std::vector<std::pair<unsigned int, unsigned int>> result;
+  std::vector<std::pair<unsigned int, unsigned int>> identities;
+  // check if the support points are the same location on the line
+  // to avoid rescaling for pyramids use the support points on the faces
+  const auto face_support_points = this->get_unit_face_support_points(0);
+  const auto face_support_points_other =
+    fe_other.get_unit_face_support_points(0);
 
-  result.reserve(this->degree - 1);
-  for (unsigned int i = 0; i < this->degree - 1; ++i)
-    result.emplace_back(i, i);
+  // now just compare the DoFs on the line going from [0,0] to [1,0]
+  // for a triangular face that is the first line
+  // for a quad face that is the third line
+  // adjust the offsets accordingly
+  // face number 0 of the wedge is a triangle
+  const unsigned int offset =
+    this->reference_cell().face_reference_cell(0).n_vertices();
 
-  return result;
+  const unsigned int offset_other =
+    fe_other.reference_cell().face_reference_cell(0).is_hyper_cube() ?
+      fe_other.reference_cell().face_reference_cell(0).n_vertices() +
+        2 * fe_other.n_dofs_per_line() :
+      fe_other.reference_cell().face_reference_cell(0).n_vertices();
+
+  // now get the identities
+  for (unsigned int i = 0; i < this->n_dofs_per_line(); ++i)
+    for (unsigned int j = 0; j < fe_other.n_dofs_per_line(); ++j)
+      if (face_support_points[i + offset].distance(
+            face_support_points_other[j + offset_other]) < 1e-14)
+        identities.emplace_back(i, j);
+
+  return identities;
 }
 
 
@@ -306,27 +340,62 @@ FE_WedgeP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
   const unsigned int                  face_no) const
 {
-  (void)fe_other;
-
   AssertIndexRange(face_no, 5);
+
+  std::vector<std::pair<unsigned int, unsigned int>> result;
+  unsigned int                                       face_no_neighbor;
 
   if (face_no < 2)
     {
-      Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)),
+      // triangular face
+      Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
              ExcNotImplemented());
+      if ((dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)))
+        face_no_neighbor = 1;
+      else
+        face_no_neighbor = 0;
     }
   else
     {
-      Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)),
+      // quad face
+      Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
              ExcNotImplemented());
+      if ((dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)))
+        face_no_neighbor = 2;
+      else
+        face_no_neighbor = 0;
     }
 
-  std::vector<std::pair<unsigned int, unsigned int>> result;
+  // compare the face support points
+  const auto face_support_points = this->get_unit_face_support_points(face_no);
+  const auto face_support_points_other =
+    fe_other.get_unit_face_support_points(face_no_neighbor);
 
-  result.reserve(this->n_dofs_per_quad(face_no));
+  // get the offsets to skip vertices and lines
+  const auto face_reference_cell =
+    this->reference_cell().face_reference_cell(face_no);
+  Assert(face_reference_cell ==
+           fe_other.reference_cell().face_reference_cell(face_no_neighbor),
+         ExcInternalError());
+
+  const auto offset = face_reference_cell.n_vertices() +
+                      face_reference_cell.n_lines() * this->n_dofs_per_line();
+
+  const auto offset_other =
+    face_reference_cell.n_vertices() +
+    face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
+
+  // now compare the points
   for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
-    result.emplace_back(i, i);
-
+    for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
+         ++j)
+      if (face_support_points[i + offset].distance(
+            face_support_points_other[j + offset_other]) < 1e-14)
+        result.emplace_back(i, j);
   return result;
 }
 

--- a/tests/simplex/hp_constraints_01.cc
+++ b/tests/simplex/hp_constraints_01.cc
@@ -1,0 +1,279 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2009 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// check that right number of DoFs is created with hp-constraints for
+// FE_SimplexP, FE_WedgeP and FE_PyramidP elements on pure meshes
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test_n_dofs(const hp::FECollection<dim> &fe,
+            const Triangulation<dim>    &triangulation,
+            const unsigned int           face_no)
+{
+  DoFHandler<dim> dof_handler(triangulation);
+  Assert(fe.size() == 2, ExcInternalError());
+  Assert(triangulation.get_reference_cells().size() == 1, ExcInternalError());
+
+  deallog << "Testing number of dofs " << fe[0].get_name() << " vs. "
+          << fe[1].get_name() << std::endl;
+
+  const unsigned int n_cells = triangulation.n_active_cells();
+  unsigned int       i       = 0;
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (i < n_cells / 2)
+        {
+          cell->set_active_fe_index(0);
+        }
+      else
+        {
+          cell->set_active_fe_index(1);
+        }
+      ++i;
+    }
+
+  dof_handler.distribute_dofs(fe);
+
+  unsigned int n_dofs_expected = 0;
+  n_dofs_expected += fe[0].get_unit_support_points().size();
+  n_dofs_expected += fe[1].get_unit_support_points().size();
+
+  // subtract the interface
+  if (fe[0].degree == fe[1].degree)
+    {
+      // subtract vertices, edges and face
+      n_dofs_expected -= fe[0].n_dofs_per_face(face_no);
+    }
+  else
+    {
+      // only vertices
+      n_dofs_expected -=
+        fe[0].reference_cell().face_reference_cell(face_no).n_vertices();
+    }
+
+  if (dof_handler.n_dofs() != n_dofs_expected)
+    DEAL_II_ASSERT_UNREACHABLE();
+
+  deallog << dof_handler.n_dofs() << " compared to " << n_dofs_expected
+          << " dofs" << std::endl;
+}
+
+template <int dim>
+void
+test_mesh(const Triangulation<dim> &tria,
+          const unsigned int        face_no,
+          const unsigned int        degree1,
+          const unsigned int        degree2)
+{
+  hp::FECollection<dim> fe;
+
+  const auto reference_cells = tria.get_reference_cells();
+
+  if (reference_cells[0].is_simplex())
+    {
+      fe.push_back(FE_SimplexP<dim>(degree1));
+      fe.push_back(FE_SimplexP<dim>(degree2));
+    }
+  else if (reference_cells[0] == ReferenceCells::Pyramid)
+    {
+      fe.push_back(FE_PyramidP<dim>(degree1));
+      fe.push_back(FE_PyramidP<dim>(degree2));
+    }
+  else if (reference_cells[0] == ReferenceCells::Wedge)
+    {
+      fe.push_back(FE_WedgeP<dim>(degree1));
+      fe.push_back(FE_WedgeP<dim>(degree2));
+    }
+
+  test_n_dofs(fe, tria, face_no);
+  deallog << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  Triangulation<3>         tria;
+  std::vector<Point<3>>    vertices;
+  std::vector<CellData<3>> cells;
+
+  {
+    // tet mesh with 2 elements
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    {
+      CellData<3> tet;
+      tet.vertices = {0, 1, 2, 3};
+      cells.push_back(tet);
+    }
+    {
+      CellData<3> tet;
+      tet.vertices = {1, 2, 3, 4};
+      cells.push_back(tet);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        test_mesh<3>(tria, 0, i, j);
+  }
+
+  {
+    // pyramid mesh with 2 elements
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(0., 0., -1.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 4};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 5};
+      cells.push_back(pyramid);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        test_mesh<3>(tria, 0, i, j);
+  }
+
+  {
+    // pyramid mesh with 2 elements attached at the triangular sides
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(-1., 0., 0.));
+    vertices.push_back(Point<3>(-1., -1., 0.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 4};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 2, 5, 6, 4};
+      cells.push_back(pyramid);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        test_mesh<3>(tria, 1, i, j);
+  }
+
+  {
+    // wedge mesh with 2 elements
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(1., 1., 1.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 3, 2, 4, 7, 6};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 3, 4, 5, 7};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int j = 1; j < 3; ++j)
+      for (unsigned int i = 1; i < 3; ++i)
+        test_mesh<3>(tria, 2, i, j);
+  }
+
+
+  {
+    // wedge mesh with 2 elements attached at the triangle sides
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(0., 0., -1.));
+    vertices.push_back(Point<3>(1., 0., -1.));
+    vertices.push_back(Point<3>(0., 1., -1.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 3, 4, 5};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 6, 7, 8};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 3; ++i)
+      for (unsigned int j = 1; j < 3; ++j)
+        test_mesh<3>(tria, 0, i, j);
+  }
+
+  return 0;
+}

--- a/tests/simplex/hp_constraints_01.output
+++ b/tests/simplex/hp_constraints_01.output
@@ -1,0 +1,106 @@
+
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::5 compared to 5 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::11 compared to 11 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::21 compared to 21 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::11 compared to 11 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::14 compared to 14 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::27 compared to 27 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_SimplexP<3>(1)
+DEAL::21 compared to 21 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_SimplexP<3>(2)
+DEAL::27 compared to 27 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_SimplexP<3>(3)
+DEAL::30 compared to 30 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::6 compared to 6 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::15 compared to 15 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::31 compared to 31 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::15 compared to 15 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::19 compared to 19 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::40 compared to 40 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::31 compared to 31 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::40 compared to 40 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::44 compared to 44 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::7 compared to 7 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::32 compared to 32 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::41 compared to 41 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::32 compared to 32 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::41 compared to 41 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::50 compared to 50 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::8 compared to 8 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::20 compared to 20 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::20 compared to 20 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::27 compared to 27 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::9 compared to 9 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::21 compared to 21 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::21 compared to 21 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::30 compared to 30 dofs
+DEAL::

--- a/tests/simplex/hp_constraints_02.cc
+++ b/tests/simplex/hp_constraints_02.cc
@@ -1,0 +1,332 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2009 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// like hp_constraints_01 but on mixed meshes
+// check that right number of DoFs is created with hp-constraints for
+// FE_SimplexP, FE_WedgeP and FE_PyramidP elements on mixed meshes
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test_n_dofs(const hp::FECollection<dim> &fe,
+            const Triangulation<dim>    &triangulation,
+            const unsigned int           face_no)
+{
+  DoFHandler<dim> dof_handler(triangulation);
+  Assert(fe.size() == 2, ExcInternalError());
+  Assert(triangulation.get_reference_cells().size() == 2, ExcInternalError());
+
+  deallog << "Testing number of dofs " << fe[0].get_name() << " vs. "
+          << fe[1].get_name() << std::endl;
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->reference_cell() == fe[0].reference_cell())
+        cell->set_active_fe_index(0);
+      else if (cell->reference_cell() == fe[1].reference_cell())
+        cell->set_active_fe_index(1);
+      else
+        DEAL_II_ASSERT_UNREACHABLE();
+    }
+  dof_handler.distribute_dofs(fe);
+
+  unsigned int n_dofs_expected = 0;
+  n_dofs_expected += fe[0].get_unit_support_points().size();
+  n_dofs_expected += fe[1].get_unit_support_points().size();
+
+  // subtract the interface
+  if (fe[0].degree == fe[1].degree)
+    {
+      if ((fe[0].degree == 3 && fe[0].reference_cell().is_hyper_cube()) ||
+          (fe[1].degree == 3 && fe[1].reference_cell().is_hyper_cube()))
+        // only vertices as FE_Q has non equidistant support points
+        n_dofs_expected -=
+          fe[0].reference_cell().face_reference_cell(face_no).n_vertices();
+      else
+        // subtract vertices, edges and face
+        n_dofs_expected -= fe[0].n_dofs_per_face(face_no);
+    }
+  else
+    {
+      // only vertices
+      n_dofs_expected -=
+        fe[0].reference_cell().face_reference_cell(face_no).n_vertices();
+    }
+
+  if (dof_handler.n_dofs() != n_dofs_expected)
+    DEAL_II_ASSERT_UNREACHABLE();
+
+  deallog << dof_handler.n_dofs() << " compared to " << n_dofs_expected
+          << " dofs" << std::endl;
+}
+
+
+template <int dim>
+void
+test_mixed_mesh(const Triangulation<dim> &tria,
+                const unsigned int        face_no,
+                const unsigned int        degree,
+                const unsigned int        degree_neighbor,
+                const bool                swap_fe_indices)
+{
+  hp::FECollection<dim> fe;
+  const auto            reference_cells = tria.get_reference_cells();
+
+  for (unsigned int i = 0; i < reference_cells.size(); ++i)
+    {
+      const unsigned int current_degree = (i == 0) ? degree : degree_neighbor;
+      const unsigned int index =
+        swap_fe_indices ? reference_cells.size() - 1 - i : i;
+      const auto reference_cell = reference_cells[index];
+
+      if (reference_cell.is_hyper_cube())
+        fe.push_back(FE_Q<dim>(current_degree));
+      else if (reference_cell.is_simplex())
+        fe.push_back(FE_SimplexP<dim>(current_degree));
+      else if (reference_cell == ReferenceCells::Pyramid)
+        fe.push_back(FE_PyramidP<dim>(current_degree));
+      else if (reference_cell == ReferenceCells::Wedge)
+        fe.push_back(FE_WedgeP<dim>(current_degree));
+    }
+
+  test_n_dofs(fe, tria, face_no);
+  deallog << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  Triangulation<3>         tria;
+  std::vector<Point<3>>    vertices;
+  std::vector<CellData<3>> cells;
+
+  {
+    // tet + pyramid mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(-1., 0., 0.));
+
+    CellData<3> pyramid;
+    pyramid.vertices = {0, 1, 2, 3, 4};
+    cells.push_back(pyramid);
+
+
+    CellData<3> tet;
+    tet.vertices = {0, 1, 4, 5};
+    cells.push_back(tet);
+
+    tria.create_triangulation(vertices, cells, SubCellData());
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, 1, i, j, false);
+          test_mixed_mesh<3>(tria, 1, j, i, true);
+        }
+  }
+
+  {
+    // tet + wedge mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(0., 0., -1.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 3, 4, 5};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> tet;
+      tet.vertices = {0, 1, 2, 6};
+      cells.push_back(tet);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 3; ++j)
+        {
+          test_mixed_mesh<3>(tria, 1, i, j, false);
+          test_mixed_mesh<3>(tria, 1, j, i, true);
+        }
+  }
+
+  {
+    // hex + pyramid mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(0., 0., -1.));
+    vertices.push_back(Point<3>(1., 0., -1.));
+    vertices.push_back(Point<3>(0., 1., -1.));
+    vertices.push_back(Point<3>(1., 1., -1.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 4};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> hex;
+      hex.vertices = {0, 1, 2, 3, 5, 6, 7, 8};
+      cells.push_back(hex);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, 0, j, i, false);
+          test_mixed_mesh<3>(tria, 0, i, j, true);
+        }
+  }
+
+  {
+    // hex + wedge mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0.5, 0.5));
+    vertices.push_back(Point<3>(1., 0.5, 0.5));
+    vertices.push_back(Point<3>(0., 0., -1.));
+    vertices.push_back(Point<3>(1., 0., -1.));
+    vertices.push_back(Point<3>(0., 1., -1.));
+    vertices.push_back(Point<3>(1., 1., -1.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 4, 2, 1, 5, 3};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> hex;
+      hex.vertices = {0, 1, 2, 3, 6, 7, 8, 9};
+      cells.push_back(hex);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 3; ++j)
+        {
+          test_mixed_mesh<3>(tria, 2, j, i, false);
+          test_mixed_mesh<3>(tria, 2, i, j, true);
+        }
+  }
+
+  {
+    // pyramid + wedge mesh at quad face
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0.5, 0.5));
+    vertices.push_back(Point<3>(1., 0.5, 0.5));
+    vertices.push_back(Point<3>(0., 0., -1.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 6};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 4, 2, 1, 5, 3};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 3; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, 0, j, i, false);
+          test_mixed_mesh<3>(tria, 2, i, j, true);
+        }
+  }
+
+  {
+    // pyramid + wedge mesh at triangular face
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(-1., 0., 0.));
+    vertices.push_back(Point<3>(-1., 1., 0.));
+    vertices.push_back(Point<3>(-1., 0., 1.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 4};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 4, 2, 5, 6, 7};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int j = 1; j < 4; ++j)
+      for (unsigned int i = 1; i < 3; ++i)
+        {
+          test_mixed_mesh<3>(tria, 1, j, i, false);
+          test_mixed_mesh<3>(tria, 1, i, j, true);
+        }
+  }
+
+  return 0;
+}

--- a/tests/simplex/hp_constraints_02.output
+++ b/tests/simplex/hp_constraints_02.output
@@ -1,0 +1,253 @@
+
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::6 compared to 6 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::6 compared to 6 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::15 compared to 15 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::15 compared to 15 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::31 compared to 31 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_SimplexP<3>(1)
+DEAL::31 compared to 31 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::12 compared to 12 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::12 compared to 12 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::18 compared to 18 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::18 compared to 18 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::37 compared to 37 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_SimplexP<3>(2)
+DEAL::37 compared to 37 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::31 compared to 31 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::31 compared to 31 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::40 compared to 40 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_SimplexP<3>(3)
+DEAL::40 compared to 40 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::7 compared to 7 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::7 compared to 7 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::19 compared to 19 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::19 compared to 19 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::13 compared to 13 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::13 compared to 13 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::23 compared to 23 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::23 compared to 23 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::35 compared to 35 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::35 compared to 35 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_Q<3>(1)
+DEAL::9 compared to 9 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::9 compared to 9 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_Q<3>(1)
+DEAL::18 compared to 18 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::18 compared to 18 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_Q<3>(1)
+DEAL::34 compared to 34 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::34 compared to 34 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_Q<3>(2)
+DEAL::28 compared to 28 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::28 compared to 28 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_Q<3>(2)
+DEAL::32 compared to 32 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::32 compared to 32 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_Q<3>(2)
+DEAL::53 compared to 53 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::53 compared to 53 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_Q<3>(3)
+DEAL::65 compared to 65 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::65 compared to 65 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_Q<3>(3)
+DEAL::74 compared to 74 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::74 compared to 74 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_Q<3>(3)
+DEAL::90 compared to 90 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::90 compared to 90 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_Q<3>(1)
+DEAL::10 compared to 10 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::10 compared to 10 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_Q<3>(1)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::22 compared to 22 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_Q<3>(2)
+DEAL::29 compared to 29 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::29 compared to 29 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_Q<3>(2)
+DEAL::36 compared to 36 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::36 compared to 36 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_Q<3>(3)
+DEAL::66 compared to 66 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::66 compared to 66 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_Q<3>(3)
+DEAL::78 compared to 78 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::78 compared to 78 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::7 compared to 7 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::7 compared to 7 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::32 compared to 32 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::32 compared to 32 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::19 compared to 19 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::19 compared to 19 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::23 compared to 23 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::23 compared to 23 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::44 compared to 44 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::44 compared to 44 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::8 compared to 8 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::8 compared to 8 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::20 compared to 20 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::20 compared to 20 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::17 compared to 17 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::17 compared to 17 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::26 compared to 26 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::26 compared to 26 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::33 compared to 33 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::33 compared to 33 dofs
+DEAL::
+DEAL::Testing number of dofs FE_PyramidP<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::45 compared to 45 dofs
+DEAL::
+DEAL::Testing number of dofs FE_WedgeP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::45 compared to 45 dofs
+DEAL::

--- a/tests/simplex/hp_constraints_03.cc
+++ b/tests/simplex/hp_constraints_03.cc
@@ -1,0 +1,286 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2009 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// check that computation of hp-constraints works for FE_SimplexP, FE_PyramidP
+// and FE_WedgeP elements by interpolating a function on a pure mesh
+// see also the tests in tests/hp/hp_constraints_common.h
+
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/fe_values.h>
+#include <deal.II/hp/mapping_collection.h>
+#include <deal.II/hp/q_collection.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+#include "simplex_grids.h"
+
+template <int dim>
+void
+test_interpolation(const hp::FECollection<dim> &fe,
+                   const Triangulation<dim>    &triangulation)
+{
+  Assert(fe.size() == 2, ExcInternalError());
+  Assert(triangulation.get_reference_cells().size() == 1, ExcInternalError());
+
+  deallog << "Testing interpolation " << fe[0].get_name() << " vs. "
+          << fe[1].get_name() << std::endl;
+
+
+  DoFHandler<dim>    dof_handler(triangulation);
+  const unsigned int n_cells      = triangulation.n_active_cells();
+  unsigned int       cell_counter = 0;
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell_counter < n_cells / 2)
+        {
+          cell->set_active_fe_index(0);
+        }
+      else
+        {
+          cell->set_active_fe_index(1);
+        }
+      ++cell_counter;
+    }
+
+  dof_handler.distribute_dofs(fe);
+
+  Vector<double> interpolant(dof_handler.n_dofs());
+  Vector<float>  error(triangulation.n_active_cells());
+
+  const unsigned int min_degree = std::min(fe[0].degree, fe[1].degree);
+  // interpolate monomials of the for x1^a*x2^b*x3^c
+  // tets can interpolate a + b + c <= degree exactly
+  // wedges can interpolate a + b <= degree and c <= degree exactly
+  // pyramids can interpolate a + b + c <= degree exactly
+  // so now figure out what to use
+  std::vector<Tensor<1, dim>> exponents;
+  for (unsigned int a = 0; a <= min_degree; ++a)
+    for (unsigned int b = 0; b <= min_degree; ++b)
+      for (unsigned int c = 0; c <= min_degree; ++c)
+        {
+          Tensor<1, dim> exponent;
+
+          bool use_exponent = true;
+          for (unsigned int i = 0; i < fe.size(); ++i)
+            {
+              if (fe[i].reference_cell().is_simplex() ||
+                  fe[i].reference_cell() == ReferenceCells::Pyramid)
+                {
+                  if (a + b + c > fe[i].degree)
+                    use_exponent = false;
+                }
+              else if (fe[i].reference_cell() == ReferenceCells::Wedge)
+                {
+                  if (a + b > fe[i].degree)
+                    use_exponent = false;
+                }
+            }
+
+          if (use_exponent)
+            {
+              exponent[0] = a;
+              if constexpr (dim > 1)
+                exponent[1] = b;
+              if constexpr (dim > 2)
+                exponent[2] = c;
+
+              exponents.emplace_back(exponent);
+            }
+        }
+
+  deallog << "  Relative interpolation errors:";
+  for (const auto &exponent : exponents)
+    {
+      const Functions::Monomial<dim> test_function(exponent, fe.n_components());
+
+      hp::MappingCollection<dim> mapping_collection;
+      mapping_collection.push_back(
+        fe[0].reference_cell().template get_default_linear_mapping<dim>());
+      mapping_collection.push_back(
+        fe[1].reference_cell().template get_default_linear_mapping<dim>());
+
+      // interpolate the function
+      VectorTools::interpolate(mapping_collection,
+                               dof_handler,
+                               test_function,
+                               interpolant);
+
+      // then compute the interpolation error
+      hp::QCollection<dim> quadrature_collection;
+      quadrature_collection.push_back(
+        fe[0].reference_cell().get_gauss_type_quadrature(fe[0].degree + 3));
+      quadrature_collection.push_back(
+        fe[1].reference_cell().get_gauss_type_quadrature(fe[1].degree + 3));
+
+      VectorTools::integrate_difference(mapping_collection,
+                                        dof_handler,
+                                        interpolant,
+                                        test_function,
+                                        error,
+                                        quadrature_collection,
+                                        VectorTools::L2_norm);
+
+      if (error.l2_norm() / interpolant.l2_norm() < 1e-12)
+        deallog << " ok";
+
+      Assert(error.l2_norm() < 1e-12 * interpolant.l2_norm(),
+             ExcInternalError());
+    }
+  deallog << std::endl;
+}
+
+
+template <int dim>
+void
+test_mesh(const Triangulation<dim> &tria,
+          const unsigned int        degree1,
+          const unsigned int        degree2)
+{
+  hp::FECollection<dim> fe;
+
+  const auto reference_cells = tria.get_reference_cells();
+
+  if (reference_cells[0].is_simplex())
+    {
+      fe.push_back(FE_SimplexP<dim>(degree1));
+      fe.push_back(FE_SimplexP<dim>(degree2));
+    }
+  else if (reference_cells[0] == ReferenceCells::Pyramid)
+    {
+      fe.push_back(FE_PyramidP<dim>(degree1));
+      fe.push_back(FE_PyramidP<dim>(degree2));
+    }
+  else if (reference_cells[0] == ReferenceCells::Wedge)
+    {
+      fe.push_back(FE_WedgeP<dim>(degree1));
+      fe.push_back(FE_WedgeP<dim>(degree2));
+    }
+
+  test_interpolation(fe, tria);
+  deallog << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+
+  Triangulation<3>         tria;
+  std::vector<Point<3>>    vertices;
+  std::vector<CellData<3>> cells;
+
+  {
+    // tet mesh
+    tria.clear();
+    GridGenerator::subdivided_hyper_cube_with_simplices(tria, 5);
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        test_mesh<3>(tria, i, j);
+  }
+
+  {
+    // pyramid mesh
+    tria.clear();
+    GridGenerator::subdivided_hyper_cube_with_pyramids(tria, 5);
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        test_mesh<3>(tria, i, j);
+  }
+
+  {
+    // wedge mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 1.));
+    vertices.push_back(Point<3>(0., 0., 2.));
+    vertices.push_back(Point<3>(1., 0., 2.));
+    vertices.push_back(Point<3>(0., 1., 2.));
+    vertices.push_back(Point<3>(1., 1., 2.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 3, 4, 5};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {1, 6, 2, 4, 7, 5};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {3, 4, 5, 8, 9, 10};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {4, 7, 5, 9, 11, 10};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+    tria.refine_global(2);
+
+    for (unsigned int j = 1; j < 3; ++j)
+      for (unsigned int i = 1; i < 3; ++i)
+        test_mesh<3>(tria, i, j);
+  }
+
+  return 0;
+}

--- a/tests/simplex/hp_constraints_03.output
+++ b/tests/simplex/hp_constraints_03.output
@@ -1,0 +1,67 @@
+
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::

--- a/tests/simplex/hp_constraints_04.cc
+++ b/tests/simplex/hp_constraints_04.cc
@@ -1,0 +1,421 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2009 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// like hp_constraints_03 but on mixed meshes
+// check that computation of hp-constraints works for FE_SimplexP, FE_PyramidP
+// and FE_WedgeP elements by interpolating a function on a mixed mesh
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/fe_values.h>
+#include <deal.II/hp/mapping_collection.h>
+#include <deal.II/hp/q_collection.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+#include "simplex_grids.h"
+
+template <int dim>
+void
+test_interpolation(const hp::FECollection<dim> &fe,
+                   const Triangulation<dim>    &triangulation)
+{
+  Assert(fe.size() == 2, ExcInternalError());
+  Assert(triangulation.get_reference_cells().size() == 2, ExcInternalError());
+
+  deallog << "Testing interpolation " << fe[0].get_name() << " vs. "
+          << fe[1].get_name() << std::endl;
+
+
+  DoFHandler<dim> dof_handler(triangulation);
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->reference_cell() == fe[0].reference_cell())
+        cell->set_active_fe_index(0);
+      else if (cell->reference_cell() == fe[1].reference_cell())
+        cell->set_active_fe_index(1);
+      else
+        DEAL_II_ASSERT_UNREACHABLE();
+    }
+
+  dof_handler.distribute_dofs(fe);
+
+  Vector<double> interpolant(dof_handler.n_dofs());
+  Vector<float>  error(triangulation.n_active_cells());
+
+  const unsigned int min_degree = std::min(fe[0].degree, fe[1].degree);
+  // interpolate monomials of the for x1^a*x2^b*x3^c
+  // tets can interpolate a + b + c <= degree exactly
+  // wedges can interpolate a + b <= degree and c <= degree exactly
+  // pyramids can interpolate a + b + c <= degree exactly
+  // hex can interpolate a, b, c <= degree exactly
+  // so now figure out what to use
+  // on a mixed mesh use the most restricting space
+  std::vector<Tensor<1, dim>> exponents;
+  for (unsigned int a = 0; a <= min_degree; ++a)
+    for (unsigned int b = 0; b <= min_degree; ++b)
+      for (unsigned int c = 0; c <= min_degree; ++c)
+        {
+          Tensor<1, dim> exponent;
+
+          bool use_exponent = true;
+          for (unsigned int i = 0; i < fe.size(); ++i)
+            {
+              if (fe[i].reference_cell().is_simplex() ||
+                  fe[i].reference_cell() == ReferenceCells::Pyramid)
+                {
+                  if (a + b + c > fe[i].degree)
+                    use_exponent = false;
+                }
+              else if (fe[i].reference_cell() == ReferenceCells::Wedge)
+                {
+                  if (a + b > fe[i].degree)
+                    use_exponent = false;
+                }
+            }
+
+          if (use_exponent)
+            {
+              exponent[0] = a;
+              if constexpr (dim > 1)
+                exponent[1] = b;
+              if constexpr (dim > 2)
+                exponent[2] = c;
+
+              exponents.emplace_back(exponent);
+            }
+        }
+
+  deallog << "  Relative interpolation errors:";
+  for (const auto &exponent : exponents)
+    {
+      const Functions::Monomial<dim> test_function(exponent, fe.n_components());
+
+      hp::MappingCollection<dim> mapping_collection;
+      mapping_collection.push_back(
+        fe[0].reference_cell().template get_default_linear_mapping<dim>());
+      mapping_collection.push_back(
+        fe[1].reference_cell().template get_default_linear_mapping<dim>());
+
+      // interpolate the function
+      VectorTools::interpolate(mapping_collection,
+                               dof_handler,
+                               test_function,
+                               interpolant);
+
+      // then compute the interpolation error
+      hp::QCollection<dim> quadrature_collection;
+      quadrature_collection.push_back(
+        fe[0].reference_cell().get_gauss_type_quadrature(fe[0].degree + 3));
+      quadrature_collection.push_back(
+        fe[1].reference_cell().get_gauss_type_quadrature(fe[1].degree + 3));
+
+      VectorTools::integrate_difference(mapping_collection,
+                                        dof_handler,
+                                        interpolant,
+                                        test_function,
+                                        error,
+                                        quadrature_collection,
+                                        VectorTools::L2_norm);
+
+      if (error.l2_norm() / interpolant.l2_norm() < 1e-12)
+        deallog << " ok";
+
+      Assert(error.l2_norm() < 1e-12 * interpolant.l2_norm(),
+             ExcInternalError());
+    }
+  deallog << std::endl;
+}
+
+template <int dim>
+void
+test_mixed_mesh(const Triangulation<dim> &tria,
+                const unsigned int        degree,
+                const unsigned int        degree_neighbor,
+                const bool                swap_fe_indices)
+{
+  hp::FECollection<dim> fe;
+  const auto            reference_cells = tria.get_reference_cells();
+
+  for (unsigned int i = 0; i < reference_cells.size(); ++i)
+    {
+      const unsigned int current_degree = (i == 0) ? degree : degree_neighbor;
+      const unsigned int index =
+        swap_fe_indices ? reference_cells.size() - 1 - i : i;
+      const auto reference_cell = reference_cells[index];
+
+      if (reference_cell.is_hyper_cube())
+        fe.push_back(FE_Q<dim>(current_degree));
+      else if (reference_cell.is_simplex())
+        fe.push_back(FE_SimplexP<dim>(current_degree));
+      else if (reference_cell == ReferenceCells::Pyramid)
+        fe.push_back(FE_PyramidP<dim>(current_degree));
+      else if (reference_cell == ReferenceCells::Wedge)
+        fe.push_back(FE_WedgeP<dim>(current_degree));
+    }
+
+  test_interpolation(fe, tria);
+  deallog << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  Triangulation<3>         tria;
+  std::vector<Point<3>>    vertices;
+  std::vector<CellData<3>> cells;
+  {
+    // tet + pyramid mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 1., 1.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 4};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> tet;
+      tet.vertices = {3, 4, 1, 5};
+      cells.push_back(tet);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, i, j, false);
+          test_mixed_mesh<3>(tria, j, i, true);
+        }
+  }
+
+  {
+    // tet + wedge mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(0., 0., 2.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 3, 4, 5};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> tet;
+      tet.vertices = {3, 4, 5, 6};
+      cells.push_back(tet);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+    tria.refine_global(2);
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 3; ++j)
+        {
+          test_mixed_mesh<3>(tria, i, j, false);
+          test_mixed_mesh<3>(tria, j, i, true);
+        }
+  }
+
+  {
+    // hex + pyramid mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(1., 1., 1.));
+    vertices.push_back(Point<3>(0., 0., 2.));
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 1, 2, 3, 4};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> hex;
+      hex.vertices = {5, 6, 7, 8, 0, 1, 2, 3};
+      cells.push_back(hex);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, j, i, false);
+          test_mixed_mesh<3>(tria, i, j, true);
+        }
+  }
+
+  {
+    // hex + wedge mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(1., 1., 1.));
+    vertices.push_back(Point<3>(2., 0.5, 0.));
+    vertices.push_back(Point<3>(2., 0.5, 1.));
+    {
+      CellData<3> wedge;
+      wedge.vertices = {2, 8, 3, 6, 9, 7};
+      cells.push_back(wedge);
+    }
+    {
+      CellData<3> hex;
+      hex.vertices = {0, 1, 2, 3, 4, 5, 6, 7};
+      cells.push_back(hex);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+    tria.refine_global(2);
+
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 3; ++j)
+        {
+          test_mixed_mesh<3>(tria, j, i, false);
+          test_mixed_mesh<3>(tria, i, j, true);
+        }
+  }
+
+  {
+    // pyramid + wedge mesh at quad face
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(-1.0, 0.5, 0.5));
+
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {0, 3, 2, 5, 6};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 3, 4, 5};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 3; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, j, i, false);
+          test_mixed_mesh<3>(tria, i, j, true);
+        }
+  }
+
+  {
+    // pyramid + wedge mesh at triangular face
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(1., 0., 2.));
+    vertices.push_back(Point<3>(0., 1., 2.));
+
+    {
+      CellData<3> pyramid;
+      pyramid.vertices = {4, 6, 5, 7, 3};
+      cells.push_back(pyramid);
+    }
+    {
+      CellData<3> wedge;
+      wedge.vertices = {0, 1, 2, 3, 4, 5};
+      cells.push_back(wedge);
+    }
+    tria.create_triangulation(vertices, cells, SubCellData());
+
+    for (unsigned int i = 1; i < 3; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, j, i, false);
+          test_mixed_mesh<3>(tria, i, j, true);
+        }
+  }
+
+  return 0;
+}

--- a/tests/simplex/hp_constraints_04.output
+++ b/tests/simplex/hp_constraints_04.output
@@ -1,0 +1,253 @@
+
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_SimplexP<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_Q<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_Q<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_Q<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_Q<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_Q<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_Q<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_Q<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(3) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_Q<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(3) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_Q<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(3) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_Q<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_Q<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_Q<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_Q<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_Q<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_Q<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_Q<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_WedgeP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(1) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(1) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_PyramidP<3>(1)
+DEAL::  Relative interpolation errors: ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(2) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_PyramidP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_PyramidP<3>(3) vs. FE_WedgeP<3>(2)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::
+DEAL::Testing interpolation FE_WedgeP<3>(2) vs. FE_PyramidP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::

--- a/tests/simplex/hp_constraints_05.cc
+++ b/tests/simplex/hp_constraints_05.cc
@@ -1,0 +1,165 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2009 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// like hp_constraints_02 but for FE_SimplexP and FE_Q connected by an edge
+// check that right number of DoFs is created with hp-constraints
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test_n_dofs(const hp::FECollection<dim> &fe,
+            const Triangulation<dim>    &triangulation,
+            const bool                   equidistant_support_points)
+{
+  DoFHandler<dim> dof_handler(triangulation);
+  Assert(fe.size() == 2, ExcInternalError());
+  Assert(triangulation.get_reference_cells().size() == 2, ExcInternalError());
+
+  deallog << "Testing number of dofs " << fe[0].get_name() << " vs. "
+          << fe[1].get_name() << std::endl;
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->reference_cell() == fe[0].reference_cell())
+        cell->set_active_fe_index(0);
+      else if (cell->reference_cell() == fe[1].reference_cell())
+        cell->set_active_fe_index(1);
+      else
+        DEAL_II_ASSERT_UNREACHABLE();
+    }
+  dof_handler.distribute_dofs(fe);
+
+  unsigned int n_dofs_expected = 0;
+  n_dofs_expected += fe[0].get_unit_support_points().size();
+  n_dofs_expected += fe[1].get_unit_support_points().size();
+
+  // 2 vertices
+  n_dofs_expected -= 2;
+  // subtract the line
+  if (fe[0].degree == fe[1].degree)
+    {
+      // for degrees larger than 3 check if the support points are equidistant
+      if (fe[0].degree > 2 && !equidistant_support_points)
+        {
+          // nothing to do
+        }
+      else
+        // subtract the edge dofs
+        n_dofs_expected -= fe[0].n_dofs_per_line();
+    }
+
+  if (dof_handler.n_dofs() != n_dofs_expected)
+    DEAL_II_ASSERT_UNREACHABLE();
+
+  deallog << dof_handler.n_dofs() << " compared to " << n_dofs_expected
+          << " dofs" << std::endl;
+}
+
+
+template <int dim>
+void
+test_mixed_mesh(const Triangulation<dim> &tria,
+                const unsigned int        degree,
+                const unsigned int        degree_neighbor,
+                const bool                swap_fe_indices,
+                const bool                equidistant_support_points)
+{
+  hp::FECollection<dim> fe;
+  const auto            reference_cells = tria.get_reference_cells();
+
+  for (unsigned int i = 0; i < reference_cells.size(); ++i)
+    {
+      const unsigned int current_degree = (i == 0) ? degree : degree_neighbor;
+      const unsigned int index =
+        swap_fe_indices ? reference_cells.size() - 1 - i : i;
+      const auto reference_cell = reference_cells[index];
+
+      if (reference_cell.is_hyper_cube())
+        {
+          if (equidistant_support_points)
+            fe.push_back(
+              FE_Q<dim>(QIterated<1>(QTrapezoid<1>(), current_degree)));
+          else
+            fe.push_back(FE_Q<dim>(current_degree));
+        }
+      else
+        fe.push_back(FE_SimplexP<dim>(current_degree));
+    }
+
+  test_n_dofs(fe, tria, equidistant_support_points);
+  deallog << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  Triangulation<3>         tria;
+  std::vector<Point<3>>    vertices;
+  std::vector<CellData<3>> cells;
+
+  {
+    // tet + pyramid mesh
+    tria.clear();
+    vertices.clear();
+    cells.clear();
+
+    vertices.push_back(Point<3>(0., 0., 0.));
+    vertices.push_back(Point<3>(1., 0., 0.));
+    vertices.push_back(Point<3>(0., 1., 0.));
+    vertices.push_back(Point<3>(1., 1., 0.));
+    vertices.push_back(Point<3>(0., 0., 1.));
+    vertices.push_back(Point<3>(1., 0., 1.));
+    vertices.push_back(Point<3>(0., 1., 1.));
+    vertices.push_back(Point<3>(1., 1., 1.));
+    vertices.push_back(Point<3>(-0.5, 0.5, 0.5));
+    vertices.push_back(Point<3>(-0.5, 0.5, 1.5));
+
+
+    CellData<3> hex;
+    hex.vertices = {0, 1, 2, 3, 4, 5, 6, 7};
+    cells.push_back(hex);
+
+
+    CellData<3> tet;
+    tet.vertices = {4, 6, 8, 9};
+    cells.push_back(tet);
+
+    tria.create_triangulation(vertices, cells, SubCellData());
+    for (unsigned int i = 1; i < 4; ++i)
+      for (unsigned int j = 1; j < 4; ++j)
+        {
+          test_mixed_mesh<3>(tria, i, j, false, false);
+          test_mixed_mesh<3>(tria, i, j, false, true);
+          test_mixed_mesh<3>(tria, j, i, true, false);
+          test_mixed_mesh<3>(tria, j, i, true, true);
+        }
+  }
+
+  return 0;
+}

--- a/tests/simplex/hp_constraints_05.output
+++ b/tests/simplex/hp_constraints_05.output
@@ -1,0 +1,109 @@
+
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_Q<3>(1)
+DEAL::10 compared to 10 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_Q<3>(1)
+DEAL::10 compared to 10 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::10 compared to 10 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_SimplexP<3>(1)
+DEAL::10 compared to 10 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_Q<3>(2)
+DEAL::29 compared to 29 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_Q<3>(2)
+DEAL::29 compared to 29 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::29 compared to 29 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_SimplexP<3>(1)
+DEAL::29 compared to 29 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_Q<3>(3)
+DEAL::66 compared to 66 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(1) vs. FE_Q<3>(QIterated(QTrapezoid(),3))
+DEAL::66 compared to 66 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_SimplexP<3>(1)
+DEAL::66 compared to 66 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(QIterated(QTrapezoid(),3)) vs. FE_SimplexP<3>(1)
+DEAL::66 compared to 66 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_Q<3>(1)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_Q<3>(1)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_SimplexP<3>(2)
+DEAL::16 compared to 16 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_Q<3>(2)
+DEAL::34 compared to 34 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_Q<3>(2)
+DEAL::34 compared to 34 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::34 compared to 34 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_SimplexP<3>(2)
+DEAL::34 compared to 34 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_Q<3>(3)
+DEAL::72 compared to 72 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(2) vs. FE_Q<3>(QIterated(QTrapezoid(),3))
+DEAL::72 compared to 72 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_SimplexP<3>(2)
+DEAL::72 compared to 72 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(QIterated(QTrapezoid(),3)) vs. FE_SimplexP<3>(2)
+DEAL::72 compared to 72 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_Q<3>(1)
+DEAL::26 compared to 26 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_Q<3>(1)
+DEAL::26 compared to 26 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::26 compared to 26 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(1) vs. FE_SimplexP<3>(3)
+DEAL::26 compared to 26 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_Q<3>(2)
+DEAL::45 compared to 45 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_Q<3>(2)
+DEAL::45 compared to 45 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::45 compared to 45 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(2) vs. FE_SimplexP<3>(3)
+DEAL::45 compared to 45 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_Q<3>(3)
+DEAL::82 compared to 82 dofs
+DEAL::
+DEAL::Testing number of dofs FE_SimplexP<3>(3) vs. FE_Q<3>(QIterated(QTrapezoid(),3))
+DEAL::80 compared to 80 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(3) vs. FE_SimplexP<3>(3)
+DEAL::82 compared to 82 dofs
+DEAL::
+DEAL::Testing number of dofs FE_Q<3>(QIterated(QTrapezoid(),3)) vs. FE_SimplexP<3>(3)
+DEAL::80 compared to 80 dofs
+DEAL::

--- a/tests/simplex/hp_identities_01.cc
+++ b/tests/simplex/hp_identities_01.cc
@@ -1,0 +1,138 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// check that the hp identity functions for mixed meshes give consistent
+// results by printing the identities
+
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+
+#include <deal.II/hp/fe_collection.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test_hp_vertex_dof_identities(const FiniteElement<dim> &fe,
+                              const FiniteElement<dim> &fe_other)
+{
+  const auto result = fe.hp_vertex_dof_identities(fe_other);
+  deallog << "hp vertex dof identities between " << fe.get_name() << " and "
+          << fe_other.get_name() << ": " << result[0].first << " "
+          << result[0].second << std::endl;
+}
+
+template <int dim>
+void
+test_hp_line_dof_identities(const FiniteElement<dim> &fe,
+                            const FiniteElement<dim> &fe_other)
+{
+  const auto results = fe.hp_line_dof_identities(fe_other);
+
+  deallog << "hp line dof identities between " << fe.get_name() << " and "
+          << fe_other.get_name() << ": ";
+  for (const auto &result : results)
+    deallog << result.first << " " << result.second << ", ";
+  deallog << std::endl;
+}
+
+
+
+template <int dim>
+void
+test_hp_quad_dof_identities(const FiniteElement<dim> &fe,
+                            const FiniteElement<dim> &fe_other)
+{
+  std::vector<std::pair<unsigned int, unsigned int>> results;
+
+  const auto reference_cell       = fe.reference_cell();
+  const auto reference_cell_other = fe_other.reference_cell();
+  // go over all faces and see if they are quads or tris
+  // if they are the same then check if there are identities
+  for (const auto f : reference_cell.face_indices())
+    for (const auto f_other : reference_cell_other.face_indices())
+      if (reference_cell.face_reference_cell(f) ==
+          reference_cell_other.face_reference_cell(f_other))
+        {
+          const auto additional_results =
+            fe.hp_quad_dof_identities(fe_other, f);
+          for (const auto &r : additional_results)
+            results.emplace_back(r);
+        }
+
+  deallog << "hp quad dof identities between " << fe.get_name() << " and "
+          << fe_other.get_name() << ": ";
+  for (const auto &result : results)
+    deallog << result.first << " " << result.second << ", ";
+  deallog << std::endl;
+}
+
+template <int dim>
+void
+test()
+{
+  hp::FECollection<dim> fes;
+  for (unsigned int i = 1; i <= 3; ++i)
+    fes.push_back(FE_SimplexP<dim>(i));
+  for (unsigned int i = 1; i <= 4; ++i)
+    fes.push_back(FE_Q<dim>(i));
+  for (unsigned int i = 1; i <= 4; ++i)
+    fes.push_back(FE_Q<dim>(QIterated<1>(QTrapezoid<1>(), i)));
+  if constexpr (dim == 3)
+    {
+      for (unsigned int i = 1; i <= 2; ++i)
+        fes.push_back(FE_WedgeP<dim>(i));
+      for (unsigned int i = 1; i <= 3; ++i)
+        fes.push_back(FE_PyramidP<dim>(i));
+    }
+
+  for (unsigned int i = 0; i < fes.size(); ++i)
+    for (unsigned int j = 0; j < fes.size(); ++j)
+      test_hp_vertex_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+
+  for (unsigned int i = 0; i < fes.size(); ++i)
+    for (unsigned int j = 0; j < fes.size(); ++j)
+      test_hp_line_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+
+  if constexpr (dim == 3)
+    for (unsigned int i = 0; i < fes.size(); ++i)
+      for (unsigned int j = 0; j < fes.size(); ++j)
+        test_hp_quad_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/simplex/hp_identities_01.output
+++ b/tests/simplex/hp_identities_01.output
@@ -1,0 +1,1017 @@
+
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(3): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(4): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:2d::
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(2): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(4): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(4): 0 1, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(2): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(3): 0 0, 1 1, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(4): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(4): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(4): 0 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_SimplexP<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(3): 0 0, 1 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(4): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_SimplexP<2>(2): 1 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(2): 1 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(4): 0 0, 1 1, 2 2, 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(2): 1 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),4)): 1 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(4): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(4): 0 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2): 0 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(3): 0 0, 1 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(4): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),4)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(2): 1 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2): 1 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(3): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(4): 1 1, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2): 1 0, 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),3)): 
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),4)): 0 0, 1 1, 2 2, 
+DEAL:2d::
+DEAL:2d::
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(3): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(4): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(1): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(2): 0 0
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3): 0 0
+DEAL:3d::
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4): 0 1, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(4): 0 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(3): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_SimplexP<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(4): 0 0, 1 1, 2 2, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)): 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(4): 0 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(3): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(4): 1 1, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0, 1 1, 2 2, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2): 1 0, 
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(4): 0 1, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(4): 0 1, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 1, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2): 0 0, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(3): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(3): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(4): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(1): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(2): 
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3): 0 0, 1 1, 
+DEAL:3d::
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(4): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(3): 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(4): 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)): 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(4): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3): 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(4): 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 4 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2): 4 0, 4 0, 4 0, 4 0, 4 0, 4 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(4): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2): 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(4): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)): 0 4, 0 4, 0 4, 0 4, 0 4, 0 4, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(2): 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2): 0 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(3): 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(3): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(4): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)): 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 0 0, 1 1, 2 2, 3 3, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(1): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(2): 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3): 0 0, 1 1, 2 2, 3 3, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 0 0, 
+DEAL:3d::

--- a/tests/simplex/hp_identities_02.cc
+++ b/tests/simplex/hp_identities_02.cc
@@ -1,0 +1,215 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// verify symmetric consistency of hp identity functions on mixed meshes
+// fe_1.hp_vertex_dof_identities(fe_2) should give the same result as
+// fe_2.hp_vertex_dof_identities(fe_1)
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+
+#include <deal.II/hp/fe_collection.h>
+
+#include "../tests.h"
+
+
+bool
+check_vectors_for_consistency(
+  const std::vector<std::pair<unsigned int, unsigned int>> &result_fe,
+  const std::vector<std::pair<unsigned int, unsigned int>> &result_fe_other)
+{
+  bool is_consistent = true;
+
+  // check if they have the same length
+  if (result_fe.size() != result_fe_other.size())
+    is_consistent = false;
+
+  // check if they have the same entries
+  if (is_consistent)
+    for (unsigned int i = 0; i < result_fe.size(); ++i)
+      {
+        if (result_fe[i].first == result_fe_other[i].second &&
+            result_fe[i].second == result_fe_other[i].first)
+          {
+            // consistent result
+          }
+        else
+          is_consistent = false;
+      }
+  return is_consistent;
+}
+
+template <int dim>
+void
+test_hp_vertex_dof_identities(const FiniteElement<dim> &fe,
+                              const FiniteElement<dim> &fe_other)
+{
+  const auto result_fe       = fe.hp_vertex_dof_identities(fe_other);
+  const auto result_fe_other = fe_other.hp_vertex_dof_identities(fe);
+
+  const bool is_consistent =
+    check_vectors_for_consistency(result_fe, result_fe_other);
+
+  if (is_consistent)
+    deallog << "hp vertex identities between " << fe.get_name() << " and "
+            << fe_other.get_name() << " are consistent" << std::endl;
+  else
+    {
+      deallog << "hp vertex identities between " << fe.get_name() << " and "
+              << fe_other.get_name() << " are not consistent!" << std::endl;
+      for (auto &r : result_fe)
+        deallog << r.first << " " << r.second << "  ";
+      deallog << std::endl;
+      for (auto &r : result_fe_other)
+        deallog << r.first << " " << r.second << "  ";
+      deallog << std::endl;
+
+      DEAL_II_ASSERT_UNREACHABLE();
+    }
+}
+
+template <int dim>
+void
+test_hp_line_dof_identities(const FiniteElement<dim> &fe,
+                            const FiniteElement<dim> &fe_other)
+{
+  const auto results_fe    = fe.hp_line_dof_identities(fe_other);
+  const auto results_other = fe_other.hp_line_dof_identities(fe);
+
+  const bool is_consistent =
+    check_vectors_for_consistency(results_fe, results_other);
+
+  if (is_consistent)
+    deallog << "hp line dof identities between " << fe.get_name() << " and "
+            << fe_other.get_name() << " are consistent" << std::endl;
+  else
+    {
+      deallog << "hp line dof identities between " << fe.get_name() << " and "
+              << fe_other.get_name() << " are not consistent!" << std::endl;
+      for (auto &r : results_fe)
+        deallog << r.first << " " << r.second << "  ";
+      deallog << std::endl;
+      for (auto &r : results_other)
+        deallog << r.first << " " << r.second << "  ";
+      deallog << std::endl;
+
+      DEAL_II_ASSERT_UNREACHABLE();
+    }
+}
+
+template <int dim>
+void
+test_hp_quad_dof_identities(const FiniteElement<dim> &fe,
+                            const FiniteElement<dim> &fe_other)
+{
+  std::vector<std::pair<unsigned int, unsigned int>> results_fe;
+  std::vector<std::pair<unsigned int, unsigned int>> results_fe_other;
+
+  const auto reference_cell       = fe.reference_cell();
+  const auto reference_cell_other = fe_other.reference_cell();
+  // go over all faces and see if they are quads or tris
+  // if they are the same then check if there are identities
+  for (const auto f : reference_cell.face_indices())
+    for (const auto f_other : reference_cell_other.face_indices())
+      if (reference_cell.face_reference_cell(f) ==
+          reference_cell_other.face_reference_cell(f_other))
+        {
+          const auto identities = fe.hp_quad_dof_identities(fe_other, f);
+          const auto identities_other =
+            fe_other.hp_quad_dof_identities(fe, f_other);
+
+          for (const auto &r : identities)
+            results_fe.emplace_back(r);
+
+          for (const auto &r : identities_other)
+            results_fe_other.emplace_back(r);
+        }
+
+  const bool is_consistent =
+    check_vectors_for_consistency(results_fe, results_fe_other);
+
+  if (is_consistent)
+    deallog << "hp quad dof identities between " << fe.get_name() << " and "
+            << fe_other.get_name() << " are consistent" << std::endl;
+  else
+    {
+      deallog << "hp quad dof identities between " << fe.get_name() << " and "
+              << fe_other.get_name() << " are not consistent!" << std::endl;
+      for (auto &r : results_fe)
+        deallog << r.first << " " << r.second << "  ";
+      deallog << std::endl;
+      for (auto &r : results_fe_other)
+        deallog << r.first << " " << r.second << "  ";
+      deallog << std::endl;
+
+      DEAL_II_ASSERT_UNREACHABLE();
+    }
+}
+
+template <int dim>
+void
+test()
+{
+  hp::FECollection<dim> fes;
+  for (unsigned int i = 1; i <= 3; ++i)
+    fes.push_back(FE_SimplexP<dim>(i));
+  for (unsigned int i = 1; i <= 4; ++i)
+    fes.push_back(FE_Q<dim>(i));
+  for (unsigned int i = 1; i <= 4; ++i)
+    fes.push_back(FE_Q<dim>(QIterated<1>(QTrapezoid<1>(), i)));
+  if constexpr (dim == 3)
+    {
+      for (unsigned int i = 1; i <= 2; ++i)
+        fes.push_back(FE_WedgeP<dim>(i));
+      for (unsigned int i = 1; i <= 3; ++i)
+        fes.push_back(FE_PyramidP<dim>(i));
+    }
+
+  for (unsigned int i = 0; i < fes.size(); ++i)
+    for (unsigned int j = i; j < fes.size(); ++j)
+      test_hp_vertex_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+
+  for (unsigned int i = 0; i < fes.size(); ++i)
+    for (unsigned int j = i; j < fes.size(); ++j)
+      test_hp_line_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+
+  if constexpr (dim == 3)
+    for (unsigned int i = 0; i < fes.size(); ++i)
+      for (unsigned int j = i; j < fes.size(); ++j)
+        test_hp_quad_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/simplex/hp_identities_02.output
+++ b/tests/simplex/hp_identities_02.output
@@ -1,0 +1,547 @@
+
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(3) and FE_Q<2>(3) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(3) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(3) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(3) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(4) and FE_Q<2>(4) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(4) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(4) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp vertex identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(3) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(4) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:2d::
+DEAL:2d::
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_Q<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_Q<3>(4) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(4) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp vertex identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp vertex identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp vertex identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(4) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(4) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1) are consistent
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2) are consistent
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3) are consistent
+DEAL:3d::

--- a/tests/simplex/hp_identities_03.cc
+++ b/tests/simplex/hp_identities_03.cc
@@ -1,0 +1,267 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+// check that the hp identity functions for mixed meshes by checking if the
+// expected number of entries are returned
+
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_pyramid_p.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_wedge_p.h>
+
+#include <deal.II/hp/fe_collection.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test_hp_vertex_dof_identities(const FiniteElement<dim> &fe,
+                              const FiniteElement<dim> &fe_other)
+{
+  const auto result = fe.hp_vertex_dof_identities(fe_other);
+  // expect one entry for all cases
+  if (result.size() == 1)
+    deallog << "hp vertex dof identities between " << fe.get_name() << " and "
+            << fe_other.get_name() << " ok " << result.size() << std::endl;
+  else
+    {
+      deallog << "hp vertex dof identities between " << fe.get_name() << " and "
+              << fe_other.get_name() << " expected size 1 but got "
+              << result.size() << std::endl;
+
+      DEAL_II_ASSERT_UNREACHABLE();
+    }
+}
+
+template <int dim>
+void
+test_hp_line_dof_identities(const FiniteElement<dim> &fe,
+                            const FiniteElement<dim> &fe_other)
+{
+  const auto results = fe.hp_line_dof_identities(fe_other);
+
+  unsigned int n_expected = 0;
+  // with the same degree the DoFs could agree but do not have to
+  if (fe.degree == fe_other.degree)
+    {
+      // for degree 1 nothing to do
+      if (fe.degree > 1)
+        {
+          // check if points are equidistant
+          bool fe_is_equidistant, fe_other_is_equidistant;
+
+          const double scale =
+            (fe.unit_support_point(1) - fe.unit_support_point(0))[0];
+          const Point<dim> first_line_point =
+            fe.unit_support_point(fe.get_first_line_index());
+          const double distance =
+            fe.unit_support_point(0).distance(first_line_point);
+          if (std::fabs(distance - (scale / fe.degree)) < 1e-12)
+            fe_is_equidistant = true;
+          else
+            fe_is_equidistant = false;
+
+          const double     scale_other = (fe_other.unit_support_point(1) -
+                                      fe_other.unit_support_point(0))[0];
+          const Point<dim> first_line_point_other =
+            fe_other.unit_support_point(fe_other.get_first_line_index());
+          const double distance_other =
+            fe_other.unit_support_point(0).distance(first_line_point_other);
+          if (std::fabs(distance_other - (scale_other / fe_other.degree)) <
+              1e-12)
+            fe_other_is_equidistant = true;
+          else
+            fe_other_is_equidistant = false;
+
+          // if both are equidistant or both are not equidistant then we have
+          // degree - 1 DoFs on each line
+          if (fe_is_equidistant == fe_other_is_equidistant)
+            n_expected = fe.degree - 1;
+          // if they do not agree the midpoints could coincide if they have one
+          else if (fe.degree % 2 == 0 && fe_other.degree % 2 == 0)
+            {
+              n_expected = 1;
+            }
+        }
+    }
+  // if they have different degrees the midpoints could coincide if they have
+  // one
+  else if (fe.degree % 2 == 0 && fe_other.degree % 2 == 0)
+    {
+      // in this case they have a shared midpoint between them
+      n_expected = 1;
+    }
+
+  if (results.size() == n_expected)
+    deallog << "hp line dof identities between " << fe.get_name() << " and "
+            << fe_other.get_name() << " ok " << results.size() << std::endl;
+  else
+    {
+      deallog << "hp line dof identities between " << fe.get_name() << " and "
+              << fe_other.get_name() << " expected size " << n_expected
+              << " but got " << results.size() << std::endl;
+
+      DEAL_II_ASSERT_UNREACHABLE();
+    }
+}
+
+
+
+template <int dim>
+void
+test_hp_quad_dof_identities(const FiniteElement<dim> &fe,
+                            const FiniteElement<dim> &fe_other)
+{
+  deallog << "hp quad dof identities between " << fe.get_name() << " and "
+          << fe_other.get_name() << " ";
+
+  const auto reference_cell       = fe.reference_cell();
+  const auto reference_cell_other = fe_other.reference_cell();
+
+  // go over all faces and see if they are quads or tris
+  // if they are the same then check if there are identities
+  for (const auto f : reference_cell.face_indices())
+    for (const auto f_other : reference_cell_other.face_indices())
+      if (reference_cell.face_reference_cell(f) ==
+          reference_cell_other.face_reference_cell(f_other))
+        {
+          const auto results = fe.hp_quad_dof_identities(fe_other, f);
+
+          unsigned int n_expected = 0;
+          // they could have the same support points if they have the same
+          // degree
+          if (fe.degree == fe_other.degree)
+            {
+              // nothing to do for degree 1
+              if (fe.degree > 1)
+                {
+                  // check if points are equidistant
+                  bool fe_is_equidistant, fe_other_is_equidistant;
+
+                  const double scale =
+                    (fe.unit_support_point(1) - fe.unit_support_point(0))[0];
+                  const Point<dim> first_line_point =
+                    fe.unit_support_point(fe.get_first_line_index());
+                  const double distance =
+                    fe.unit_support_point(0).distance(first_line_point);
+                  if (std::fabs(distance - (scale / fe.degree)) < 1e-12)
+                    fe_is_equidistant = true;
+                  else
+                    fe_is_equidistant = false;
+
+                  const double scale_other =
+                    (fe_other.unit_support_point(1) -
+                     fe_other.unit_support_point(0))[0];
+                  const Point<dim> first_line_point_other =
+                    fe_other.unit_support_point(
+                      fe_other.get_first_line_index());
+                  const double distance_other =
+                    fe_other.unit_support_point(0).distance(
+                      first_line_point_other);
+                  if (std::fabs(distance_other -
+                                (scale_other / fe_other.degree)) < 1e-12)
+                    fe_other_is_equidistant = true;
+                  else
+                    fe_other_is_equidistant = false;
+
+                  // if both are equidistant or both are not equidistant then
+                  // they should be the same
+                  if (fe_is_equidistant == fe_other_is_equidistant)
+                    n_expected = fe.n_dofs_per_quad(f);
+                  // if they do not agree the midpoints could coincide if they
+                  // have one
+                  else if (fe.degree % 2 == 0 && fe_other.degree % 2 == 0)
+                    {
+                      n_expected = 1;
+                    }
+                }
+            }
+          // both can have the same midpoint
+          else if (reference_cell.face_reference_cell(f).is_hyper_cube())
+            if (fe.degree % 2 == 0 && fe_other.degree % 2 == 0)
+              {
+                // only midpoint is identical
+                n_expected = 1;
+              }
+
+          if (results.size() == n_expected)
+            deallog << "ok " << results.size() << ", ";
+          else
+            {
+              deallog << " on face " << f << " and " << f_other
+                      << " expected size is " << n_expected << " but got "
+                      << results.size() << std::endl;
+
+              DEAL_II_ASSERT_UNREACHABLE();
+            }
+        }
+  deallog << std::endl;
+}
+
+template <int dim>
+void
+test()
+{
+  hp::FECollection<dim> fes;
+  for (unsigned int i = 1; i <= 3; ++i)
+    fes.push_back(FE_SimplexP<dim>(i));
+  for (unsigned int i = 1; i <= 4; ++i)
+    fes.push_back(FE_Q<dim>(i));
+  for (unsigned int i = 1; i <= 4; ++i)
+    fes.push_back(FE_Q<dim>(QIterated<1>(QTrapezoid<1>(), i)));
+  if constexpr (dim == 3)
+    {
+      for (unsigned int i = 1; i <= 2; ++i)
+        fes.push_back(FE_WedgeP<dim>(i));
+      for (unsigned int i = 1; i <= 3; ++i)
+        fes.push_back(FE_PyramidP<dim>(i));
+    }
+
+  for (unsigned int i = 0; i < fes.size(); ++i)
+    for (unsigned int j = 0; j < fes.size(); ++j)
+      test_hp_vertex_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+
+  for (unsigned int i = 0; i < fes.size(); ++i)
+    for (unsigned int j = 0; j < fes.size(); ++j)
+      test_hp_line_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+
+  if constexpr (dim == 3)
+    for (unsigned int i = 0; i < fes.size(); ++i)
+      for (unsigned int j = 0; j < fes.size(); ++j)
+        test_hp_quad_dof_identities(fes[i], fes[j]);
+  deallog << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/simplex/hp_identities_03.output
+++ b/tests/simplex/hp_identities_03.output
@@ -1,0 +1,1017 @@
+
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(3) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(4) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:2d::hp vertex dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(4) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(4) ok 1
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_SimplexP<2>(3) ok 2
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(4) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 2
+DEAL:2d::hp line dof identities between FE_SimplexP<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(4) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(4) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_SimplexP<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(3) ok 2
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(4) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(3) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(4) ok 3
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(4) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(4) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(1) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(4) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(2) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_SimplexP<2>(3) ok 2
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(4) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(2) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 2
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),3)) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_SimplexP<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(3) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(4) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(1) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(2) ok 1
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:2d::hp line dof identities between FE_Q<2>(QIterated(QTrapezoid(),4)) and FE_Q<2>(QIterated(QTrapezoid(),4)) ok 3
+DEAL:2d::
+DEAL:2d::
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(3) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(4) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(1) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp vertex dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3) ok 1
+DEAL:3d::
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3) ok 2
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 2
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3) ok 2
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(3) ok 2
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(4) ok 3
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(3) ok 2
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 2
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3) ok 2
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(4) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 3
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(4) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2) ok 1
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(3) ok 2
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(3) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(4) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 2
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(1) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(2) ok 0
+DEAL:3d::hp line dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3) ok 2
+DEAL:3d::
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_SimplexP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(3) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(4) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(1) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(2) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(1) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_SimplexP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(3) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(4) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(1) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(2) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(2) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_SimplexP<3>(3) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(3) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(4) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(1) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(2) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_SimplexP<3>(3) and FE_PyramidP<3>(3) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(4) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(3) ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(3) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(4) ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_WedgeP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(4) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(1) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(4) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_WedgeP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(2) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),3)) and FE_PyramidP<3>(3) ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(1) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(2) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_SimplexP<3>(3) 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(4) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, ok 9, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_WedgeP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_Q<3>(QIterated(QTrapezoid(),4)) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_SimplexP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(1) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_SimplexP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(4) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_WedgeP<3>(2) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_SimplexP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(1) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_SimplexP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(4) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(2) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_WedgeP<3>(2) ok 1, ok 1, ok 1, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(2) ok 1, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(2) and FE_PyramidP<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_SimplexP<3>(3) ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(3) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(4) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),3)) ok 4, ok 4, ok 4, ok 4, ok 4, ok 4, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_Q<3>(QIterated(QTrapezoid(),4)) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_WedgeP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(1) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(2) ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, ok 0, 
+DEAL:3d::hp quad dof identities between FE_PyramidP<3>(3) and FE_PyramidP<3>(3) ok 4, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, ok 1, 
+DEAL:3d::


### PR DESCRIPTION
Part of #17576. The code does not assume the identities of DoFs if two elements have the same polynomial degree, but checks if two elements have the same support points.