### PR TITLE
Add missing boost include

### DIFF
--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -38,6 +38,7 @@
 #include <boost/math/special_functions/relative_difference.hpp>
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/math/tools/roots.hpp>
+#include <boost/math/tools/toms748_solve.hpp>
 
 #include <algorithm>
 #include <vector>


### PR DESCRIPTION
We use `boost::math::tools::toms748_solve` but we forgot the include. I get an error with Boost 1.90.0