### PR TITLE
Workaround bug in nvcc with C++20

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -68,8 +68,8 @@
  *
  * @ingroup Exceptions
  */
-// We explicit assign msg to arg to workaround a bug in nvcc 13.1 and earlier
-// when using C++20.
+// We explicitly assign msg to arg (instead of using the member initializer list
+// syntax) to work around a bug in nvcc 13.1 and earlier when using C++20.
 #  define DeclExceptionMsg(Exception, defaulttext)    \
     class Exception : public dealii::ExceptionBase    \
     {                                                 \


### PR DESCRIPTION
Without this patch I am getting these strange errors
```
/usr/include/c++/13/bits/stl_iterator.h(1062): error: incomplete type "std::iterator_traits<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::pointer>" (aka "std::iterator_traits<ch
ar *>") is not allowed                                                                                                                                                                                             
        typedef typename __traits_type::iterator_category iterator_category;                                                                                                                                       
                         ^                                                                                                                                                                                         
          detected during:                                                                                                                                                                                         
            instantiation of class "__gnu_cxx::__normal_iterator<_Iterator, _Container> [with _Iterator=char *, _Container=std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>]" at line
 247 of /usr/include/c++/13/bits/basic_string.tcc                                                                                                                                                                  
            instantiation of "void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_construct(_FwdIterator, _FwdIterator, std::forward_iterator_tag) [with _CharT=char, _Traits=std::char_traits<char>, _All
oc=std::allocator<char>, _FwdIterator=const char *]" at line 3206 of /usr/include/c++/13/type_traits                                                                                                               
            instantiation of "const bool std::is_object_v [with _Tp=char]" at line 225 of /usr/include/c++/13/bits/basic_string.tcc                                                                                
            instantiation of "void std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::_M_construct(_FwdIterator, _FwdIterator, std::forward_iterator_tag) [with _CharT=char, _Traits=std::char_traits<char>, _All
oc=std::allocator<char>, _FwdIterator=char *]" at line 552 of /usr/include/c++/13/bits/basic_string.h                                                                                                              
            instantiation of "std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::basic_string(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc> &) [with _CharT=char, _Traits=std::char_traits<char>, _Al
loc=std::allocator<char>]" at line 203 of /scratch/source/dealii/include/deal.II/base/exceptions.h
```
I tried CUDA 12.9 and 13.1, same results