### PR TITLE
Fix a doxygen rendering issue.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1647,9 +1647,9 @@ namespace GridTools
    *  bounding boxes max_boxes can't be reached by merging neighbors
    *  an exception is thrown.
    *
-   * The following image describes an example of the algorithm with @p
-   * refinement_level = 2, @p allow_merge = true and @p max_boxes =
-   * 1. The cells with the property predicate are in red, the area of
+   * The following image describes an example of the algorithm with
+   * @p refinement_level = 2, @p allow_merge = true and @p max_boxes = 1.
+   * The cells with the property predicate are in red, the area of
    * a bounding box is slightly orange.
    * @image html bounding_box_predicate.png
    *


### PR DESCRIPTION
An enumeration is falsely triggered [here](https://dealii.org/developer/doxygen/deal.II/namespaceGridTools.html#a08438d4ad901817b7b638ce733fd664d).

<img width="1700" height="119" alt="image" src="https://github.com/user-attachments/assets/ec316809-70eb-4141-ab07-0d30ad68527a" />
