### PR TITLE
TriaObjects: add an allocate() method.

### DIFF
--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -62,11 +62,32 @@ namespace internal
        */
       TriaObjects(const unsigned int structdim);
 
+      /**
+       * Resize all internal arrays and populate with default values.
+       *
+       * @param[in] n_objects Total number of objects this object
+       *            should store.
+       *
+       * @param[in] children_per_object Number of children to store for each
+       *            object.
+       *
+       * @param[in] faces_per_object Number of faces (i.e., neighbors) to store
+       *            for each object.
+       */
+      void
+      allocate(const std::size_t  n_objects,
+               const unsigned int children_per_object,
+               const unsigned int faces_per_object);
+
       unsigned int structdim;
 
       /**
        * Vector of the objects belonging to this level. The index of the
        * object equals the index in this container.
+       *
+       * @note In this context, "cells" means "geometric entities bounded by
+       * other geometric entities": for example, TriaFaces::quads stores quads
+       * (structdim 2 objects) which are bounded by lines.
        */
       std::vector<int> cells;
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3282,8 +3282,9 @@ namespace internal
               connectivity.entity_to_entities(1, 0);
             const unsigned int n_lines = lines_to_vertices.size();
 
-            // allocate memory
-            reserve_space_(lines_0, n_lines);
+            lines_0.allocate(n_lines,
+                             ReferenceCells::max_n_children<1>(),
+                             ReferenceCells::max_n_faces<1>());
 
             // loop over lines
             for (unsigned int line = 0; line < n_lines; ++line)
@@ -3305,8 +3306,9 @@ namespace internal
             const auto &quads_to_lines = connectivity.entity_to_entities(2, 1);
             const unsigned int n_quads = quads_to_lines.size();
 
-            // allocate memory
-            reserve_space_(quads_0, n_quads);
+            quads_0.allocate(n_quads,
+                             ReferenceCells::max_n_children<2>(),
+                             ReferenceCells::max_n_faces<2>());
             reserve_space_(faces, 2 /*structdim*/, n_quads);
 
             // loop over all quads -> entity type, line indices/orientations
@@ -3375,8 +3377,9 @@ namespace internal
                   }
             }
 
-          // allocate memory
-          reserve_space_(cells_0, n_cell);
+          cells_0.allocate(n_cell,
+                           ReferenceCells::max_n_children<dim>(),
+                           ReferenceCells::max_n_faces<dim>());
           reserve_space_(level, spacedim, n_cell, orientation_needed);
 
           // loop over all cells
@@ -3669,44 +3672,6 @@ namespace internal
         level.global_level_cell_indices.assign(size,
                                                numbers::invalid_dof_index);
       }
-
-
-
-      static void
-      reserve_space_(TriaObjects &obj, const unsigned int size)
-      {
-        const unsigned int structdim = obj.structdim;
-
-        const unsigned int max_children_per_cell = 1 << structdim;
-
-        obj.used.assign(size, true);
-        obj.boundary_or_material_id.assign(
-          size,
-          internal::TriangulationImplementation::TriaObjects::
-            BoundaryOrMaterialId());
-        obj.manifold_id.assign(size, -1);
-        obj.user_flags.assign(size, false);
-        obj.user_data.resize(size);
-
-        if (structdim > 1) // TODO: why?
-          obj.refinement_cases.assign(size, 0);
-
-        obj.children.assign(max_children_per_cell / 2 * size, -1);
-
-        obj.cells.assign(size * max_n_faces(structdim), -1);
-
-        if (structdim <= 2)
-          {
-            obj.next_free_single               = size - 1;
-            obj.next_free_pair                 = 0;
-            obj.reverse_order_next_free_single = true;
-          }
-        else
-          {
-            obj.next_free_single = obj.next_free_pair = 0;
-          }
-      }
-
 
       /**
        * Actually delete a cell, or rather all

--- a/source/grid/tria_objects.cc
+++ b/source/grid/tria_objects.cc
@@ -61,6 +61,42 @@ namespace internal
     }
 
 
+
+    void
+    TriaObjects::allocate(const std::size_t  n_objects,
+                          const unsigned int children_per_object,
+                          const unsigned int faces_per_object)
+    {
+      used.assign(n_objects, true);
+      boundary_or_material_id.assign(n_objects, BoundaryOrMaterialId());
+      manifold_id.assign(n_objects, -1);
+      user_flags.assign(n_objects, false);
+      user_data.resize(n_objects);
+
+      // Lines can only be refined in one way so, in that case, we don't need to
+      // store a field indicating which type of refinement to use per object
+      if (structdim > 1)
+        refinement_cases.assign(n_objects, 0);
+
+      Assert(children_per_object % 2 == 0, ExcNotImplemented());
+      children.assign(children_per_object / 2 * n_objects, -1);
+
+      cells.assign(n_objects * faces_per_object, -1);
+
+      if (structdim <= 2)
+        {
+          next_free_single               = n_objects - 1;
+          next_free_pair                 = 0;
+          reverse_order_next_free_single = true;
+        }
+      else
+        {
+          next_free_single = next_free_pair = 0;
+        }
+    }
+
+
+
     std::size_t
     TriaObjects::memory_consumption() const
     {


### PR DESCRIPTION
This clarifies what the strides are and gets rid of a hardcoded max children per cell calculation.

We discussed potential fallout from increasing `max_children_per_cell` to 10 - I was curious about it and, if we use the maximum number of faces etc. over all present `ReferenceCell`s (instead of the maximum over all `ReferenceCell`s) then we can lower the memory usage of a simplex `Triangulation` by at least 10% (that will go in a future PR). That changeset requires computing strides for arrays stored in `TriaLevel`, `TriaObjects`, etc. To clarify this conversion, I moved one resizing function over to `TriaObjects`.

@AndSte01 FYI