### PR TITLE
[ARKode] Introduce ARKode steppers

### DIFF
--- a/doc/news/changes/major/20260421Ivannikov
+++ b/doc/news/changes/major/20260421Ivannikov
@@ -1,0 +1,18 @@
+New/Changed: The SUNDIALS ARKODE wrapper has been substantially
+extended and refactored. The time-stepper functionality previously
+embedded in SUNDIALS::ARKode has been extracted into the new
+SUNDIALS::ARKodeStepper interface. A concrete implementation is
+currently provided for the SUNDIALS implicit/explicit ARKStep
+integration module (SUNDIALS::ARKStepper), but the design is open to
+further ARKODE time-steppers. A stepper object is constructed
+independently and passed to the SUNDIALS::ARKode driver, which handles
+the time-marching loop. Method-specific parameters are configured
+through per-class AdditionalData structures.
+<br>
+The previous interface of SUNDIALS::ARKode that exposed the
+right-hand side functions directly on the ARKode object is still
+available but is now deprecated and will be removed in a future
+version. Users are encouraged to migrate to the new stepper-based
+interface.
+<br>
+(Vladimir Ivannikov, 2026/04/21)

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -40,6 +40,7 @@
 #  endif
 #  include <deal.II/base/discrete_time.h>
 
+#  include <deal.II/sundials/arkode_stepper.h>
 #  include <deal.II/sundials/n_vector.h>
 #  include <deal.II/sundials/sundials_types.h>
 #  include <deal.II/sundials/sunlinsol_wrapper.h>
@@ -64,266 +65,73 @@ namespace SUNDIALS
   /**
    * Interface to SUNDIALS additive Runge-Kutta methods (ARKode).
    *
-   * The class ARKode is a wrapper to SUNDIALS variable-step, embedded,
-   * additive Runge-Kutta solver which is a general purpose solver for systems
-   * of ordinary differential equations characterized by the presence of both
-   * fast and slow dynamics.
+   * The class ARKode is a wrapper to SUNDIALS adaptive-step time integration
+   * modules for stiff, nonstiff and mixed stiff/nonstiff systems of ordinary
+   * differential equations (ODEs). This class provides access to general
+   * underlying infrastructure of ARKODE, controls the main time marching loop,
+   * output, reinitializaiton, exception handling. The class ARKode does not
+   * implement any time integration strategies itself. Instead, it employs one
+   * of the available stepper classes, which are basically wrappers around the
+   * corresponding ARKODE steppers. Currently, only ARKStepper is available,
+   * which provides interfaces to ARKode's additive Runge-Kutta steppers.
+   * The documentation of the ARKStepper class also shows examples of how
+   * this class in conjunction with ARKStepper can be used.
+   * Users can also provide their own steppers or implement wrappers around,
+   * e.g., ERKStepper, SPRKStep, LSRKStepper, or MRIStep modules of ARKode.
    *
-   * Fast dynamics are treated implicitly, and slow dynamics are treated
-   * explicitly, using nested families of implicit and explicit Runge-Kutta
-   * solvers.
-   *
-   * Citing directly from ARKode documentation:
-   *
-   * ARKode solves ODE initial value problems (IVPs) in $R^N$. These problems
-   * should be posed in explicit form as
-   *
-   * \f[
-   *   M\dot y = f_E(t, y) + f_I (t, y), \qquad y(t_0) = y_0.
-   * \f]
-   *
-   * Here, $t$ is the independent variable (e.g. time), and the dependent
-   * variables are given by $y \in R^N$, and we use notation $\dot y$ to denote
-   * $dy/dt$. $M$ is a user-supplied nonsingular operator from $R^N \to R^N$.
-   * This operator may depend on $t$ but not on $y$.
-   *
-   * For standard systems of ordinary differential equations and for problems
-   * arising from the spatial semi-discretization of partial differential
-   * equations using finite difference or finite volume methods, $M$ is
-   * typically the identity matrix, $I$. For PDEs using a finite-element
-   * spatial semi-discretization $M$ is typically a well-conditioned mass
-   * matrix.
-   *
-   * The two right-hand side functions may be described as:
-   *
-   * - $f_E(t, y)$: contains the "slow" time scale components of the system.
-   *                This will be integrated using explicit methods.
-   * - $f_I(t, y)$: contains the "fast" time scale components of the system.
-   *                This will be integrated using implicit methods.
-   *
-   * ARKode may be used to solve stiff, nonstiff and multi-rate problems.
-   * Roughly speaking, stiffness is characterized by the presence of at least
-   * one rapidly damped mode, whose time constant is small compared to the time
-   * scale of the solution itself. In the implicit/explicit (ImEx) splitting
-   * above, these stiff components should be included in the right-hand side
-   * function $f_I (t, y)$.
-   *
-   * For multi-rate problems, a user should provide both of the functions $f_E$
-   * and $f_I$ that define the IVP system.
-   *
-   * For nonstiff problems, only $f_E$ should be provided, and $f_I$ is assumed
-   * to be zero, i.e. the system reduces to the non-split IVP:
-   *
-   * \f[
-   *   M\dot y = f_E(t, y), \qquad y(t_0) = y_0.
-   * \f]
-   *
-   * In this scenario, the ARK methods reduce to classical explicit Runge-Kutta
-   * methods (ERK). For these classes of methods, ARKode allows orders of
-   * accuracy $q = \{2, 3, 4, 5, 6, 8\}$, with embeddings of orders $p = \{1,
-   * 2, 3, 4, 5, 7\}$. These default to the Heun-Euler-2-1-2,
-   * Bogacki-Shampine-4-2-3, Zonneveld-5-3-4, Cash-Karp-6-4-5, Verner-8-5-6 and
-   * Fehlberg-13-7-8 methods, respectively.
-   *
-   * Finally, for stiff (linear or nonlinear) problems the user may provide only
-   * $f_I$, implying that $f_E = 0$, so that the system reduces to the non-split
-   * IVP
-   *
-   * \f[
-   *   M\dot y = f_I(t, y), \qquad y(t_0) = y_0.
-   * \f]
-   *
-   * Similarly to ERK methods, in this scenario the ARK methods reduce to
-   * classical diagonally-implicit Runge-Kutta methods (DIRK). For these
-   * classes of methods, ARKode allows orders of accuracy $q = \{2, 3, 4, 5\}$,
-   * with embeddings of orders $p = \{1, 2, 3, 4\}$. These default to the
-   * SDIRK-2-1-2, ARK-4-2-3 (implicit), SDIRK-5-3-4 and ARK-8-4-5 (implicit)
-   * methods, respectively.
-   *
-   * For both DIRK and ARK methods, an implicit system of the form
-   * \f[
-   *  G(z_i) \dealcoloneq M z_i - h_n A^I_{i,i} f_I (t^I_{n,i}, z_i) - a_i = 0
-   * \f]
-   * must be solved for each stage $z_i , i = 1, \ldots, s$, where
-   * we have the data
-   * \f[
-   *  a_i \dealcoloneq
-   *  M y_{n-1} + h_n \sum_{j=1}^{i-1} [ A^E_{i,j} f_E(t^E_{n,j}, z_j)
-   *  + A^I_{i,j} f_I (t^I_{n,j}, z_j)]
-   * \f]
-   * for the ARK methods, or
-   * \f[
-   *  a_i \dealcoloneq
-   *  M y_{n-1} + h_n \sum_{j=1}^{i-1} A^I_{i,j} f_I (t^I_{n,j}, z_j)
-   * \f]
-   * for the DIRK methods. Here $A^I_{i,j}$ and $A^E_{i,j}$ are the Butcher's
-   * tables for the chosen solver.
-   *
-   * If $f_I(t,y)$ depends nonlinearly on $y$ then the systems above correspond
-   * to a nonlinear system of equations; if $f_I (t, y)$ depends linearly on
-   * $y$ then this is a linear system of equations. By specifying the flag
-   * `implicit_function_is_linear`, ARKode takes some shortcuts that allow a
-   * faster solution process.
-   *
-   * For systems of either type, ARKode allows a choice of solution strategy.
-   * The default solver choice is a variant of Newton's method,
-   * \f[
-   *  z_i^{m+1} = z_i^m +\delta^{m+1},
-   * \f]
-   * where $m$ is the Newton step index, and the Newton update $\delta^{m+1}$
-   * requires the solution of the linear Newton system
-   * \f[
-   *  N(z_i^m) \delta^{m+1} = -G(z_i^m),
-   * \f]
-   * where
-   * \f[
-   * N \dealcoloneq M - \gamma J, \quad J
-   * \dealcoloneq \frac{\partial f_I}{\partial y},
-   * \qquad \gamma\dealcoloneq h_n A^I_{i,i}.
-   * \f]
-   *
-   * As an alternate to Newton's method, ARKode may solve for each stage $z_i ,i
-   * = 1, \ldots , s$ using an Anderson-accelerated fixed point iteration
-   * \f[
-   * z_i^{m+1} = g(z_i^{m}), m=0,1,\ldots.
-   * \f]
-   *
-   * Unlike with Newton's method, this option does not require the solution of
-   * a linear system at each iteration, instead opting for solution of a
-   * low-dimensional least-squares solution to construct the nonlinear update.
-   *
-   * Finally, if the user specifies `implicit_function_is_linear`, i.e.,
-   * $f_I(t, y)$ depends linearly on $y$, and if the Newton-based nonlinear
-   * solver is chosen, then the system will be solved using only a single
-   * Newton iteration. Notice that in order for the Newton solver to be used,
-   * then jacobian_times_vector() should be supplied. If it is not supplied then
-   * only the fixed-point iteration will be supported, and the
-   * `implicit_function_is_linear` setting is ignored.
-   *
-   * The optimal solver (Newton vs fixed-point) is highly problem-dependent.
-   * Since fixed-point solvers do not require the solution of any linear
-   * systems, each iteration may be significantly less costly than their Newton
-   * counterparts. However, this can come at the cost of slower convergence (or
-   * even divergence) in comparison with Newton-like methods. These fixed-point
-   * solvers do allow for user specification of the Anderson-accelerated
-   * subspace size, $m_k$. While the required amount of solver memory grows
-   * proportionately to $m_k N$, larger values of $m_k$ may result in faster
-   * convergence.
-   *
-   * This improvement may be significant even for "small" values, e.g. $1 \leq
-   * m_k \leq 5$, and convergence may not improve (or even deteriorate) for
-   * larger values of $m_k$. While ARKode uses a Newton-based iteration as its
-   * default solver due to its increased robustness on very stiff problems, it
-   * is highly recommended that users also consider the fixed-point solver for
-   * their cases when attempting a new problem.
-   *
-   * For either the Newton or fixed-point solvers, it is well-known that both
-   * the efficiency and robustness of the algorithm intimately depends on the
-   * choice of a good initial guess. In ARKode, the initial guess for either
-   * nonlinear solution method is a predicted value $z_i(0)$ that is computed
-   * explicitly from the previously-computed data (e.g. $y_{n-2}, y_{n-1}$, and
-   * $z_j$ where $j < i$). Additional information on the specific predictor
-   * algorithms implemented in ARKode is provided in ARKode documentation.
-   *
-   * The user has to provide the implementation of at least one (or both) of the
-   * following `std::function`s:
-   *  - implicit_function()
-   *  - explicit_function()
-   *
-   * If the @ref GlossMassMatrix "mass matrix" is different from the identity, the user should supply
-   *  - mass_times_vector() and, optionally,
-   *  - mass_times_setup()
-   *
-   * If the use of a Newton method is desired, then the user should also supply
-   * jacobian_times_vector(). jacobian_times_setup() is optional.
-   *
-   * @note Although SUNDIALS can provide a difference quotient approximation
-   *   of the Jacobian, this is currently not supported through this wrapper.
-   *
-   * A SUNDIALS default solver (SPGMR) is used to solve the linear systems. To
-   * use a custom linear solver for the mass matrix and/or Jacobian, set:
-   *  - solve_mass() and/or
-   *  - solve_linearized_system()
-   *
-   * To use a custom preconditioner with either a default or custom linear
-   * solver, set:
-   * - jacobian_preconditioner_solve() and/or mass_preconditioner_solve()
-   * and, optionally,
-   * - jacobian_preconditioner_setup() and/or mass_preconditioner_setup()
-   *
-   * Also the following functions could be rewritten. By default
-   * they do nothing, or are not required.
-   *  - solver_should_restart()
-   *  - get_local_tolerances()
-   *
-   * To produce output at fixed steps, set the function
-   *  - output_step()
-   *
-   * Any other custom settings of the ARKODE object can be specified in
-   *  - custom_setup()
-   *
-   * To provide a simple example, consider the harmonic oscillator problem:
-   * \f[
-   * \begin{split}
-   *   u'' & = -k^2 u \\
-   *   u (0) & = 0 \\
-   *   u'(0) & = k
-   * \end{split}
-   * \f]
-   *
-   * We write it in terms of a first order ode:
-   *\f[
-   * \begin{matrix}
-   *   y_0' & =  y_1 \\
-   *   y_1' & = - k^2 y_0
-   * \end{matrix}
-   * \f]
-   *
-   * That is $y' = A y$
-   * where
-   * \f[
-   * A \dealcoloneq
-   * \begin{pmatrix}
-   * 0 & 1 \\
-   * -k^2 &0
-   * \end{pmatrix}
-   * \f]
-   * and $y(0)=(0, k)^T$.
-   *
-   * The exact solution is $y_0(t) = \sin(k t)$, $y_1(t) = y_0'(t) = k \cos(k
-   *t)$, $y_1'(t) = -k^2 \sin(k t)$.
-   *
-   * A minimal implementation, using only explicit RK methods, is given by the
-   * following code snippet:
-   *
-   * @code
-   * using VectorType = Vector<double>;
-   *
-   * SUNDIALS::ARKode<VectorType> ode;
-   *
-   * const double k = 1.0;
-   *
-   * ode.explicit_function = [k] (const double / * time * /,
-   *                              const VectorType &y,
-   *                              VectorType &ydot)
-   * {
-   *   ydot[0] = y[1];
-   *   ydot[1] = -k*k*y[0];
-   * };
-   *
-   * Vector<double> y(2);
-   * y[1] = k;
-   *
-   * ode.solve_ode(y);
-   * @endcode
-   *
-   * In practice, you would of course at least want to set the end time up
-   * to which the time integrator should run. In the example code shown here,
-   * it is taken from the default value defined by ARKode::AdditionalData.
+   * The integrator settings are primarily customized by setting up fields of
+   * ARKode::AdditionalData passed to the constructors. For most of the cases,
+   * it is advised to set at least the end time up to which the time integrator
+   * should run and the initial time step size. The ARKode behavior can be
+   * further tuned via function object custom_setup().
    */
   template <typename VectorType = Vector<double>>
   class ARKode
   {
+  private:
+    /**
+     * This class is introduced in order to provide backward compatibility with
+     * the previous interface of ARKode class. As the steppers have been
+     * introduced, the function objects required for the ARKStep callbacks have
+     * been moved to the ARKStepper class. In order not to break the existing
+     * codes, the underlying type of the function objects relevant for the time
+     * stepping mechanism was changed from std::function to FunctionProxy. These
+     * proxy objects then provide indirect access from the ARKode interface to
+     * the underlying stepper function objects for the case the stepper is
+     * actually of type ARKStepper and one of the old constructors without a
+     * stepper parameter was used for instantiation of the ARKode object.
+     */
+    template <class Fn>
+    struct FunctionProxy
+    {
+      std::function<Fn> *target;
+
+      FunctionProxy(std::function<Fn> *t = nullptr)
+        : target(t)
+      {}
+
+      FunctionProxy &
+      operator=(std::function<Fn> *t)
+      {
+        target = t;
+        return *this;
+      }
+
+      FunctionProxy &
+      operator=(std::function<Fn> f)
+      {
+        Assert(
+          target,
+          ExcMessage(
+            "Unable to assign the function since the target is not set in the "
+            "proxy. Most probably, you tried to use it with a stepper that does "
+            "not support this type of callback."));
+
+        *target = std::move(f);
+        return *this;
+      }
+    };
+
   public:
     /**
      * Additional parameters that can be passed to the ARKode class.
@@ -332,7 +140,9 @@ namespace SUNDIALS
     {
     public:
       /**
-       * Initialization parameters for ARKode.
+       * Initialization parameters for ARKode. Some parameters are provided for
+       * interface backward compatibility and have been effectively moved to the
+       * AKRStepper additional parameters.
        *
        * Global parameters:
        *
@@ -341,7 +151,7 @@ namespace SUNDIALS
        * @param initial_step_size Initial step size
        * @param output_period Desired time interval between each output
        *
-       * Running parameters:
+       * Run-control parameters:
        *
        * @param minimum_step_size Minimum step size
        * @param maximum_order Maximum ARK order
@@ -361,6 +171,9 @@ namespace SUNDIALS
        * @param absolute_tolerance Absolute error tolerance
        * @param relative_tolerance Relative error tolerance
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Use another constructor and ARKStepper::AdditionalData to initialize "
+        "with the ARKStepper relevant parameters instead.")
       AdditionalData(
         // Initial parameters
         const double initial_time      = 0.0,
@@ -378,6 +191,37 @@ namespace SUNDIALS
         // Error parameters
         const double absolute_tolerance = 1e-6,
         const double relative_tolerance = 1e-5);
+
+      /**
+       * Initialization parameters for ARKode.
+       *
+       * Global parameters:
+       *
+       * @param initial_time Initial time
+       * @param final_time Final time
+       * @param initial_step_size Initial step size
+       * @param output_period Desired time interval between each output
+       *
+       * Running parameters:
+       *
+       * @param minimum_step_size Minimum step size
+       *
+       * Error parameters:
+       *
+       * @param absolute_tolerance Absolute error tolerance
+       * @param relative_tolerance Relative error tolerance
+       */
+      AdditionalData(
+        // Initial parameters
+        const double initial_time,
+        const double final_time,
+        const double initial_step_size,
+        const double output_period,
+        // Running parameters
+        const double minimum_step_size,
+        // Error parameters
+        const double absolute_tolerance,
+        const double relative_tolerance);
 
       /**
        * Add all AdditionalData() parameters to the given ParameterHandler
@@ -428,7 +272,11 @@ namespace SUNDIALS
 
       /**
        * Maximum order of ARK.
+       *
+       * @deprecated Provide ARKStepper::AdditionalData::order instead.
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Provide ARKStepper::AdditionalData::order instead.")
       unsigned int maximum_order;
 
       /**
@@ -440,30 +288,55 @@ namespace SUNDIALS
       /**
        * Maximum number of iterations for Newton or fixed point method during
        * time advancement.
+       *
+       * @deprecated Provide ARKStepper::AdditionalData::maximum_non_linear_iterations instead.
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Provide ARKStepper::AdditionalData::maximum_non_linear_iterations "
+        "instead.")
       unsigned int maximum_non_linear_iterations;
 
       /**
-       * Specify whether the implicit portion of the problem is linear.
+       * Provide whether the implicit portion of the problem is linear.
+       *
+       * @deprecated Provide ARKStepper::AdditionalData::implicit_function_is_linear instead.
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Provide ARKStepper::AdditionalData::implicit_function_is_linear "
+        "instead.")
       bool implicit_function_is_linear;
 
       /**
-       * Specify whether the implicit portion of the problem is linear and time
+       * Provide whether the implicit portion of the problem is linear and time
        * independent.
+       *
+       * @deprecated Provide ARKStepper::AdditionalData::implicit_function_is_time_independent instead.
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Provide ARKStepper::AdditionalData::implicit_function_is_time_independent "
+        "instead.")
       bool implicit_function_is_time_independent;
 
       /**
-       * Specify whether the mass pre-factor is time independent. Has no effect
+       * Provide whether the mass pre-factor is time independent. Has no effect
        * if no mass is specified.
+       *
+       * @deprecated Provide ARKStepper::AdditionalData::mass_is_time_independent instead.
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Provide ARKStepper::AdditionalData::mass_is_time_independent "
+        "instead.")
       bool mass_is_time_independent;
 
       /**
        * Number of subspace vectors to use for Anderson acceleration. Only
        * meaningful if the packaged SUNDIALS fixed-point solver is used.
+       *
+       * @deprecated Provide ARKStepper::AdditionalData::anderson_acceleration_subspace instead.
        */
+      DEAL_II_DEPRECATED_WITH_COMMENT(
+        "Provide ARKStepper::AdditionalData::anderson_acceleration_subspace "
+        "instead.")
       int anderson_acceleration_subspace;
     };
 
@@ -479,13 +352,38 @@ namespace SUNDIALS
     ARKode(const AdditionalData &data = AdditionalData());
 
     /**
-     * Constructor.
+     * Constructor receiving the additional data and MPI communicator.
      *
      * @param data ARKode configuration data
      * @param mpi_comm MPI Communicator over which logging operations are
      * computed. Only used in SUNDIALS 6 and newer.
      */
     ARKode(const AdditionalData &data, const MPI_Comm mpi_comm);
+
+    /**
+     * Constructor receiving the stepper and optionally the additional data.
+     *
+     * @param stepper ARKodeStepper object
+     * @param data ARKode configuration data
+     *
+     * @note With SUNDIALS 6 and later this constructor sets up logging
+     * objects to only work on the present processor (i.e., results are only
+     * communicated over MPI_COMM_SELF).
+     */
+    ARKode(ARKodeStepper<VectorType> &stepper,
+           const AdditionalData      &data = AdditionalData());
+
+    /**
+     * Constructor receiving the stepper, additional data, and MPI communicator.
+     *
+     * @param stepper ARKodeStepper object
+     * @param data ARKode configuration data
+     * @param mpi_comm MPI Communicator over which logging operations are
+     * computed. Only used in SUNDIALS 6 and newer.
+     */
+    ARKode(ARKodeStepper<VectorType> &stepper,
+           const AdditionalData      &data,
+           const MPI_Comm             mpi_comm);
 
     /**
      * Destructor.
@@ -574,18 +472,14 @@ namespace SUNDIALS
      * the explicit part of the IVP right hand side. Sets $explicit_f = f_E(t,
      * y)$.
      *
-     * At least one of explicit_function() or implicit_function() must be
-     * provided. According to which one is provided, explicit, implicit, or
-     * mixed RK methods are used.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::explicit_function instead.
      */
-    std::function<
+    FunctionProxy<
       void(const double t, const VectorType &y, VectorType &explicit_f)>
       explicit_function;
 
@@ -594,18 +488,14 @@ namespace SUNDIALS
      * the implicit part of the IVP right hand side. Sets $implicit_f = f_I(t,
      * y)$.
      *
-     * At least one of explicit_function() or implicit_function() must be
-     * provided. According to which one is provided, explicit, implicit, or
-     * mixed RK methods are used.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::implicit_function instead.
      */
-    std::function<void(const double t, const VectorType &y, VectorType &res)>
+    FunctionProxy<void(const double t, const VectorType &y, VectorType &res)>
       implicit_function;
 
     /**
@@ -615,17 +505,14 @@ namespace SUNDIALS
      * mass_times_setup() has been called at least once. ARKode tries to do its
      * best to call mass_times_setup() the minimum amount of times.
      *
-     * A call to this function should store in `Mv` the result of $M$
-     * applied to `v`.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::mass_times_vector instead.
      */
-    std::function<void(const double t, const VectorType &v, VectorType &Mv)>
+    FunctionProxy<void(const double t, const VectorType &v, VectorType &Mv)>
       mass_times_vector;
 
     /**
@@ -636,33 +523,14 @@ namespace SUNDIALS
      * This function is guaranteed to be called by ARKode at least once, before
      * any call to mass_times_vector().
      *
-     * ARKode supports the case where the mass matrix may depend on time, but
-     * not the case where the mass matrix depends on the solution itself.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * If the user does not provide a mass_times_vector() function, then the
-     * identity is used. If the mass_times_setup() function is not provided,
-     * then mass_times_vector() should do all the work by itself.
-     *
-     * If the user uses a matrix-based computation of the mass matrix, then
-     * this is the right place where an assembly routine should be called to
-     * assemble the matrix. Subsequent calls (possibly  more than one) to
-     * mass_times_vector() can assume that this function has been called at
-     * least once.
-     *
-     * @note No assumption is made by this interface on what the user
-     *   should do in this function. ARKode only assumes that after a call to
-     *   mass_times_setup() it is possible to call mass_times_vector().
-     *
-     * @param t The current evaluation time
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::mass_times_setup instead.
      */
-    std::function<void(const double t)> mass_times_setup;
+    FunctionProxy<void(const double t)> mass_times_setup;
 
     /**
      * A function object that users may supply and that is intended to compute
@@ -670,27 +538,14 @@ namespace SUNDIALS
      * here refers to $J=\frac{\partial f_I}{\partial y}$, i.e., the Jacobian of
      * the user-specified implicit_function.
      *
-     * A call to this function should store in `Jv` the result of $J$
-     * applied to `v`.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * Arguments to the function are
-     *
-     * @param[in] v  The vector to be multiplied by the Jacobian
-     * @param[out] Jv The vector to be filled with the product J*v
-     * @param[in] t  The current time
-     * @param[in] y  The current $y$ vector for the current ARKode internal
-     *   step
-     * @param[in] fy  The current value of the implicit right-hand side at y,
-     *   $f_I (t_n, y)$.
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::jacobian_times_vector instead.
      */
-    std::function<void(const VectorType &v,
+    FunctionProxy<void(const VectorType &v,
                        VectorType       &Jv,
                        const double      t,
                        const VectorType &y,
@@ -699,126 +554,69 @@ namespace SUNDIALS
 
     /**
      * A function object that users may supply and that is intended to set up
-     * all data necessary for the application of jacobian_times_vector(). This
-     * function is called by ARKode any time a Jacobian update is required.
-     * The user should compute the Jacobian (or update all the variables that
-     * allow the application of Jacobian). This function is guaranteed to
-     * be called by ARKode at least once, before any call to
-     * jacobian_times_vector().
+     * all data necessary for the application of jacobian_times_vector().
      *
-     * If the jacobian_times_setup() function is not provided, then
-     * jacobian_times_vector() should do all the work by itself.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * If the user uses a matrix based computation of the Jacobian, then this is
-     * the right place where an assembly routine should be called to assemble
-     * the matrix. Subsequent calls (possibly  more than one) to
-     * jacobian_times_vector() can assume that this function has been called at
-     * least once.
-     *
-     * @note No assumption is made by this interface on what the user
-     *   should do in this function. ARKode only assumes that after a call to
-     *   jacobian_times_setup() it is possible to call jacobian_times_vector().
-     *
-     * @param t  The current time
-     * @param y  The current ARKode internal solution vector $y$
-     * @param fy  The implicit right-hand side function evaluated at the
-     *   current time $t$ and state $y$, i.e., $f_I(y,t)$
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::jacobian_times_vector_setup instead.
      */
-    std::function<
+    FunctionProxy<
       void(const double t, const VectorType &y, const VectorType &fy)>
       jacobian_times_setup;
 
     /**
      * A LinearSolveFunction object that users may supply and that is intended
      * to solve the linearized system $Ax=b$, where $A = M-\gamma J$ is the
-     * Jacobian of the nonlinear residual. The application of the @ref GlossMassMatrix "mass matrix"
-     * $M$ and Jacobian $J$ are known through the functions mass_times_vector()
-     * and jacobian_times_vector() and $\gamma$ is a factor provided by
-     * SUNDIALS. The matrix-vector product $Ax$ is encoded in the supplied
-     * SundialsOperator. If a preconditioner was set through
-     * jacobian_preconditioner_solve(), it is encoded in the
-     * SundialsPreconditioner. If no preconditioner was supplied this way, the
-     * preconditioner is the identity matrix, i.e., no preconditioner. The user
-     * is free to use a custom preconditioner in this function object that is
-     * not supplied through SUNDIALS.
+     * Jacobian of the nonlinear residual.
      *
-     * If you do not specify a solve_linearized_system() function, then a
-     * SUNDIALS packaged SPGMR solver with default settings is used.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * For more details on the function type refer to LinearSolveFunction.
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::solve_linearized_system instead.
      */
-    LinearSolveFunction<VectorType> solve_linearized_system;
+    FunctionProxy<void(SundialsOperator<VectorType>       &op,
+                       SundialsPreconditioner<VectorType> &prec,
+                       VectorType                         &x,
+                       const VectorType                   &b,
+                       double                              tol)>
+      solve_linearized_system;
 
     /**
      * A LinearSolveFunction object that users may supply and that is intended
-     * to solve the mass system $Mx=b$. The matrix-vector product $Mx$ is
-     * encoded in the supplied SundialsOperator. If a preconditioner was set
-     * through mass_preconditioner_solve(), it is encoded in the
-     * SundialsPreconditioner. If no preconditioner was supplied this way, the
-     * preconditioner is the identity matrix, i.e., no preconditioner. The user
-     * is free to use a custom preconditioner in this function object that is
-     * not supplied through SUNDIALS.
+     * to solve the mass system $Mx=b$.
      *
-     * The user must specify this function if a non-identity mass matrix is used
-     * and applied in mass_times_vector().
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * For more details on the function type refer to LinearSolveFunction.
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::solve_mass instead.
      */
-    LinearSolveFunction<VectorType> solve_mass;
+    FunctionProxy<void(SundialsOperator<VectorType>       &op,
+                       SundialsPreconditioner<VectorType> &prec,
+                       VectorType                         &x,
+                       const VectorType                   &b,
+                       double                              tol)>
+      solve_mass;
 
     /**
      * A function object that users may supply to either pass a preconditioner
      * to a SUNDIALS built-in solver or to apply a custom preconditioner within
      * the user's own linear solve specified in solve_linearized_system().
      *
-     * This function should compute the solution to the preconditioner equation
-     * $Pz=r$ and store it in @p z. In this equation $P$ should approximate the
-     * Jacobian $M-\gamma J$ of the nonlinear system.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * @param[in] t  The current time
-     * @param[in] y  The current $y$ vector for the current ARKode internal
-     *   step
-     * @param[in] fy  The current value of the implicit right-hand side at y,
-     *   $f_I (t_n, y)$.
-     * @param[in] r  The right-hand side of the preconditioner equation
-     * @param[out] z The solution of applying the preconditioner, i.e., solving
-     *   $Pz=r$
-     * @param[in] gamma The value $\gamma$ in the preconditioner equation
-     * @param[in] tol The tolerance up to which the system should be solved
-     * @param[in] lr An input flag indicating whether the preconditioner solve
-     *   is to use the left preconditioner (lr = 1) or the right preconditioner
-     *   (lr = 2). Only relevant if used with a SUNDIALS packaged solver. If
-     *   used with a custom solve_mass() function this will be set to zero.
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::jacobian_preconditioner_solve instead.
      */
-    std::function<void(const double      t,
+    FunctionProxy<void(const double      t,
                        const VectorType &y,
                        const VectorType &fy,
                        const VectorType &r,
@@ -832,45 +630,14 @@ namespace SUNDIALS
      * A function object that users may supply to set up a preconditioner
      * specified in jacobian_preconditioner_solve().
      *
-     * This function should prepare the solution of the preconditioner equation
-     * $Pz=r$. In this equation $P$ should approximate the Jacobian $M-\gamma J$
-     * of the nonlinear system.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * If the jacobian_preconditioner_setup() function is not provided, then
-     * jacobian_preconditioner_solve() should do all the work by itself.
-     *
-     * @note No assumption is made by this interface on what the user
-     *   should do in this function. ARKode only assumes that after a call to
-     *   jacobian_preconditioner_setup() it is possible to call
-     *   jacobian_preconditioner_solve().
-     *
-     * @param[in] t  The current time
-     * @param[in] y  The current $y$ vector for the current ARKode internal
-     *   step
-     * @param[in] fy  The current value of the implicit right-hand side at y,
-     *   $f_I (t_n, y)$.
-     * @param[in] jok  An input flag indicating whether the Jacobian-related
-     *   data needs to be updated. The jok argument provides for the reuse of
-     *   Jacobian data in the preconditioner solve function. When jok =
-     *   SUNFALSE, the Jacobian-related data should be recomputed from scratch.
-     *   When jok = SUNTRUE the Jacobian data, if saved from the previous call
-     *   to this function, can be reused (with the current value of gamma). A
-     *   call with jok = SUNTRUE can only occur after a call with jok =
-     *   SUNFALSE.
-     * @param[out] jcur On output this should be set to SUNTRUE if Jacobian data
-     *   was recomputed, or set to SUNFALSE if Jacobian data was not recomputed,
-     *   but saved data was still reused.
-     * @param[in] gamma The value $\gamma$ in $M-\gamma J$. The preconditioner
-     *   should approximate the inverse of this matrix.
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::jacobian_preconditioner_setup instead.
      */
-    std::function<void(const double      t,
+    FunctionProxy<void(const double      t,
                        const VectorType &y,
                        const VectorType &fy,
                        const int         jok,
@@ -883,29 +650,14 @@ namespace SUNDIALS
      * to a SUNDIALS built-in solver or to apply a custom preconditioner within
      * the user's own linear solve specified in solve_mass().
      *
-     * This function should compute the solution to the preconditioner equation
-     * $Pz=r$ and store it in @p z. In this equation $P$ should approximate the
-     * @ref GlossMassMatrix "mass matrix" $M$.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * @param[in] t  The current time
-     * @param[in] r  The right-hand side of the preconditioner equation
-     * @param[out] z The solution of applying the preconditioner, i.e., solving
-     *   $Pz=r$
-     * @param[in] gamma The value $\gamma$ in the preconditioner equation
-     * @param[in] tol The tolerance up to which the system should be solved
-     * @param[in] lr An input flag indicating whether the preconditioner solve
-     *   is to use the left preconditioner (lr = 1) or the right preconditioner
-     *   (lr = 2). Only relevant if used with a SUNDIALS packaged solver. If
-     *   used with a custom solve_mass() function this will be set to zero.
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::mass_preconditioner_solve instead.
      */
-    std::function<void(const double      t,
+    FunctionProxy<void(const double      t,
                        const VectorType &r,
                        VectorType       &z,
                        const double      tol,
@@ -914,29 +666,16 @@ namespace SUNDIALS
 
     /**
      * A function object that users may supply to set up a preconditioner
-     * specified in mass_preconditioner_solve().
+     * specified in mass_preconditioner_setup().
      *
-     * This function should prepare the solution of the preconditioner equation
-     * $Pz=r$. In this equation $P$ should approximate the @ref GlossMassMatrix "mass matrix" $M$.
+     * @note This member represents a local proxy wrapper around the corresponding
+     * property of ARKStepper and should be used only if ARKStepper is provided
+     * to ARKode as a stepper. If this requirement is violated, an exception is
+     * triggered upon access to this field.
      *
-     * If the mass_preconditioner_setup() function is not provided, then
-     * mass_preconditioner_solve() should do all the work by itself.
-     *
-     * @note No assumption is made by this interface on what the user
-     *   should do in this function. ARKode only assumes that after a call to
-     *   mass_preconditioner_setup() it is possible to call
-     *   mass_preconditioner_solve().
-     *
-     * @param[in] t  The current time
-     *
-     * @note This variable represents a
-     * @ref GlossUserProvidedCallBack "user provided callback".
-     * See there for a description of how to deal with errors and other
-     * requirements and conventions. In particular, ARKode can deal
-     * with "recoverable" errors in some circumstances, so callbacks
-     * can throw exceptions of type RecoverableUserCallbackError.
+     * @deprecated Specify @p ARKStepper::mass_preconditioner_solve instead.
      */
-    std::function<void(const double t)> mass_preconditioner_setup;
+    FunctionProxy<void(const double t)> mass_preconditioner_setup;
 
     /**
      * A function object that users may supply and that is intended to
@@ -989,13 +728,13 @@ namespace SUNDIALS
      * custom settings on the supplied @p arkode_mem object. Refer to the
      * SUNDIALS documentation for valid options.
      *
-     * For instance, the following code attaches two files for diagnostic and
-     * error output of the internal ARKODE implementation:
+     * For instance, the following code sets Lagrange interpolants to be used
+     * for dense output (interpolation of solution output values) and implicit
+     * method predictors:
      *
      * @code
      *      ode.custom_setup = [&](void *arkode_mem) {
-     *        ARKStepSetErrFile(arkode_mem, errfile);
-     *        ARKStepSetDiagnostics(arkode_mem, diagnostics_file);
+     *        ARKodeSetInterpolantType(arkode_mem, ARK_INTERP_LAGRANGE);
      *      };
      * @endcode
      *
@@ -1006,7 +745,7 @@ namespace SUNDIALS
      *   options are still available at this point.
      *
      * @param arkode_mem pointer to the ARKODE memory block which can be used
-     *   for custom calls to `ARKStepSet...` methods.
+     *   for custom calls to `ARKodeSet...` methods.
      */
     std::function<void(void *arkode_mem)> custom_setup;
 
@@ -1029,24 +768,6 @@ namespace SUNDIALS
                    const bool            do_reset);
 
     /**
-     * Set up the (non)linear solver and preconditioners in the ARKODE memory
-     * object based on the user-specified functions.
-     * @param solution The solution vector which is used as a template to create
-     *   new vectors.
-     */
-    void
-    setup_system_solver(const VectorType &solution);
-
-    /**
-     * Set up the solver and preconditioner for a non-identity @ref GlossMassMatrix "mass matrix" in
-     * the ARKODE memory object based on the user-specified functions.
-     * @param solution The solution vector which is used as a template to create
-     *   new vectors.
-     */
-    void
-    setup_mass_solver(const VectorType &solution);
-
-    /**
      * This function is executed at construction time to set the
      * std::function above to trigger an assert if they are not
      * implemented.
@@ -1055,14 +776,28 @@ namespace SUNDIALS
     set_functions_to_trigger_an_assert();
 
     /**
+     * This function is executed at construction time to initialize the
+     * SUNContext object.
+     */
+    void
+    initialize_context();
+
+    /**
      * ARKode configuration data.
      */
     AdditionalData data;
 
     /**
-     * ARKode memory object.
+     * Internal stepper object if a constructor without a stepper was invoked.
+     * The need for this object arises due to interface backward compatibility
+     * requirement.
      */
-    void *arkode_mem;
+    std::unique_ptr<ARKStepper<VectorType>> ark_stepper_storage{nullptr};
+
+    /**
+     * Stepper object.
+     */
+    ARKodeStepper<VectorType> &stepper;
 
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     /**
@@ -1081,9 +816,6 @@ namespace SUNDIALS
      * The final time in the last call to solve_ode().
      */
     double last_end_time;
-
-    std::unique_ptr<internal::LinearSolverWrapper<VectorType>> linear_solver;
-    std::unique_ptr<internal::LinearSolverWrapper<VectorType>> mass_solver;
 
     /**
      * A pointer to any exception that may have been thrown in user-defined
@@ -1104,16 +836,6 @@ namespace SUNDIALS
 #    endif // PETSC_USE_COMPLEX
 #  endif   // DEAL_II_WITH_PETSC
   };
-
-
-  /**
-   * Handle ARKode exceptions.
-   */
-  DeclException1(ExcARKodeError,
-                 int,
-                 << "One of the SUNDIALS ARKode internal functions "
-                 << " returned a negative error code: " << arg1
-                 << ". Please consult SUNDIALS manual.");
 
 
   template <typename VectorType>
@@ -1150,7 +872,32 @@ namespace SUNDIALS
     , anderson_acceleration_subspace(anderson_acceleration_subspace)
   {}
 
-
+  template <typename VectorType>
+  ARKode<VectorType>::AdditionalData::AdditionalData(
+    // Initial parameters
+    const double initial_time,
+    const double final_time,
+    const double initial_step_size,
+    const double output_period,
+    // Running parameters
+    const double minimum_step_size,
+    // Error parameters
+    const double absolute_tolerance,
+    const double relative_tolerance)
+    : initial_time(initial_time)
+    , final_time(final_time)
+    , initial_step_size(initial_step_size)
+    , minimum_step_size(minimum_step_size)
+    , absolute_tolerance(absolute_tolerance)
+    , relative_tolerance(relative_tolerance)
+    , maximum_order(5)
+    , output_period(output_period)
+    , maximum_non_linear_iterations(10)
+    , implicit_function_is_linear(false)
+    , implicit_function_is_time_independent(false)
+    , mass_is_time_independent(false)
+    , anderson_acceleration_subspace(3)
+  {}
 
   template <typename VectorType>
   void

--- a/include/deal.II/sundials/arkode.templates.h
+++ b/include/deal.II/sundials/arkode.templates.h
@@ -23,15 +23,11 @@
 #ifdef DEAL_II_WITH_SUNDIALS
 
 #  include <deal.II/base/discrete_time.h>
-#  include <deal.II/base/utilities.h>
 
-#  include <deal.II/sundials/n_vector.h>
-#  include <deal.II/sundials/sunlinsol_wrapper.h>
-#  include <deal.II/sundials/utilities.h>
+#  include <deal.II/sundials/arkode_exception.h>
+#  include <deal.II/sundials/arkode_stepper.h>
 
 #  include <arkode/arkode_arkstep.h>
-#  include <sunlinsol/sunlinsol_spgmr.h>
-#  include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
 
 #  include <iostream>
 
@@ -49,7 +45,15 @@ namespace SUNDIALS
   ARKode<VectorType>::ARKode(const AdditionalData &data,
                              const MPI_Comm        mpi_comm)
     : data(data)
-    , arkode_mem(nullptr)
+    , ark_stepper_storage(std::make_unique<ARKStepper<VectorType>>(
+        typename ARKStepper<VectorType>::AdditionalData(
+          data.maximum_order,
+          data.maximum_non_linear_iterations,
+          data.implicit_function_is_linear,
+          data.implicit_function_is_time_independent,
+          data.mass_is_time_independent,
+          data.anderson_acceleration_subspace)))
+    , stepper(*ark_stepper_storage)
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
     , arkode_ctx(nullptr)
 #  endif
@@ -58,7 +62,70 @@ namespace SUNDIALS
     , pending_exception(nullptr)
   {
     set_functions_to_trigger_an_assert();
+    initialize_context();
 
+    // Set up the proxy objects to provide backwards compatibility with the old
+    // interface
+    explicit_function     = &ark_stepper_storage->explicit_function;
+    implicit_function     = &ark_stepper_storage->implicit_function;
+    mass_times_vector     = &ark_stepper_storage->mass_times_vector;
+    mass_times_setup      = &ark_stepper_storage->mass_times_setup;
+    jacobian_times_vector = &ark_stepper_storage->jacobian_times_vector;
+    jacobian_times_setup  = &ark_stepper_storage->jacobian_times_vector_setup;
+
+    solve_linearized_system = &ark_stepper_storage->solve_linearized_system;
+    solve_mass              = &ark_stepper_storage->solve_mass;
+    jacobian_preconditioner_solve =
+      &ark_stepper_storage->jacobian_preconditioner_solve;
+    jacobian_preconditioner_setup =
+      &ark_stepper_storage->jacobian_preconditioner_setup;
+    mass_preconditioner_solve = &ark_stepper_storage->mass_preconditioner_solve;
+    mass_preconditioner_setup = &ark_stepper_storage->mass_preconditioner_setup;
+  }
+
+
+  template <typename VectorType>
+  ARKode<VectorType>::ARKode(ARKodeStepper<VectorType> &stepper,
+                             const AdditionalData      &data)
+    : ARKode(stepper, data, MPI_COMM_SELF)
+  {}
+
+
+  template <typename VectorType>
+  ARKode<VectorType>::ARKode(ARKodeStepper<VectorType> &stepper,
+                             const AdditionalData      &data,
+                             const MPI_Comm             mpi_comm)
+    : data(data)
+    , stepper(stepper)
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    , arkode_ctx(nullptr)
+#  endif
+    , mpi_communicator(mpi_comm)
+    , last_end_time(data.initial_time)
+    , pending_exception(nullptr)
+  {
+    set_functions_to_trigger_an_assert();
+    initialize_context();
+  }
+
+
+  template <typename VectorType>
+  ARKode<VectorType>::~ARKode()
+  {
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+    const int status = SUNContext_Free(&arkode_ctx);
+    (void)status;
+    AssertARKode(status);
+#  endif
+
+    Assert(pending_exception == nullptr, ExcInternalError());
+  }
+
+
+  template <typename VectorType>
+  void
+  ARKode<VectorType>::initialize_context()
+  {
     // SUNDIALS will always duplicate communicators if we provide them. This
     // can cause problems if SUNDIALS is configured with MPI and we pass along
     // MPI_COMM_SELF in a serial application as MPI won't be
@@ -80,23 +147,6 @@ namespace SUNDIALS
     AssertARKode(status);
 #  endif
   }
-
-
-
-  template <typename VectorType>
-  ARKode<VectorType>::~ARKode()
-  {
-    ARKStepFree(&arkode_mem);
-
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-    const int status = SUNContext_Free(&arkode_ctx);
-    (void)status;
-    AssertARKode(status);
-#  endif
-
-    Assert(pending_exception == nullptr, ExcInternalError());
-  }
-
 
 
   template <typename VectorType>
@@ -124,7 +174,8 @@ namespace SUNDIALS
         "The requested intermediate time is smaller than the last requested "
         "intermediate time."));
 
-    const bool   do_reset = reset_solver || arkode_mem == nullptr;
+    const bool do_reset =
+      reset_solver || stepper.get_arkode_memory() == nullptr;
     DiscreteTime time(last_end_time, intermediate_time, data.initial_step_size);
     return do_evolve_time(solution, time, do_reset);
   }
@@ -151,7 +202,8 @@ namespace SUNDIALS
         // In SUNDIALS 6 and later, SUNDIALS will not do timesteps if the
         // current time is past the set end point (i.e., ARKStepEvolve will
         // return ARK_TSTOP_RETURN).
-        const int status = ARKStepSetStopTime(arkode_mem, time.get_end_time());
+        const int status =
+          ARKStepSetStopTime(stepper.get_arkode_memory(), time.get_end_time());
         (void)status;
         AssertARKode(status);
       }
@@ -176,7 +228,7 @@ namespace SUNDIALS
         // - If no exception, test that SUNDIALS really did successfully return
         Assert(pending_exception == nullptr, ExcInternalError());
         double     actual_next_time;
-        const auto status = ARKStepEvolve(arkode_mem,
+        const auto status = ARKStepEvolve(stepper.get_arkode_memory(),
                                           time.get_next_time(),
                                           solution_nvector,
                                           &actual_next_time,
@@ -223,7 +275,8 @@ namespace SUNDIALS
     last_end_time = time.get_current_time();
 
     long int   n_steps;
-    const auto status = ARKStepGetNumSteps(arkode_mem, &n_steps);
+    const auto status =
+      ARKStepGetNumSteps(stepper.get_arkode_memory(), &n_steps);
     (void)status;
     AssertARKode(status);
 
@@ -264,75 +317,16 @@ namespace SUNDIALS
     AssertARKode(status);
 #  endif
 
-    if (arkode_mem)
-      {
-        ARKStepFree(&arkode_mem);
-        // Initialization is version-dependent: do that in a moment
-      }
-
-    // just a view on the memory in solution, all write operations on yy by
-    // ARKODE will automatically be mirrored to solution
-    auto initial_condition_nvector = internal::make_nvector_view(solution
+    stepper.reinit(
+      current_time, solution, internal::InvocationContext {
+        pending_exception
 #  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                                                 ,
-                                                                 arkode_ctx
+          ,
+          arkode_ctx
 #  endif
-    );
+      });
 
-    Assert(explicit_function || implicit_function,
-           ExcFunctionNotProvided("explicit_function || implicit_function"));
-
-    auto explicit_function_callback = [](SUNDIALS::realtype tt,
-                                         N_Vector           yy,
-                                         N_Vector           yp,
-                                         void              *user_data) -> int {
-      Assert(user_data != nullptr, ExcInternalError());
-      ARKode<VectorType> &solver =
-        *static_cast<ARKode<VectorType> *>(user_data);
-
-      auto *src_yy = internal::unwrap_nvector_const<VectorType>(yy);
-      auto *dst_yp = internal::unwrap_nvector<VectorType>(yp);
-
-      return Utilities::call_and_possibly_capture_exception(
-        solver.explicit_function,
-        solver.pending_exception,
-        tt,
-        *src_yy,
-        *dst_yp);
-    };
-
-
-    auto implicit_function_callback = [](SUNDIALS::realtype tt,
-                                         N_Vector           yy,
-                                         N_Vector           yp,
-                                         void              *user_data) -> int {
-      Assert(user_data != nullptr, ExcInternalError());
-      ARKode<VectorType> &solver =
-        *static_cast<ARKode<VectorType> *>(user_data);
-
-      auto *src_yy = internal::unwrap_nvector_const<VectorType>(yy);
-      auto *dst_yp = internal::unwrap_nvector<VectorType>(yp);
-
-      return Utilities::call_and_possibly_capture_exception(
-        solver.implicit_function,
-        solver.pending_exception,
-        tt,
-        *src_yy,
-        *dst_yp);
-    };
-
-    arkode_mem = ARKStepCreate(explicit_function ? explicit_function_callback :
-                                                   ARKRhsFn(nullptr),
-                               implicit_function ? implicit_function_callback :
-                                                   ARKRhsFn(nullptr),
-                               current_time,
-                               initial_condition_nvector
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                               ,
-                               arkode_ctx
-#  endif
-    );
-    Assert(arkode_mem != nullptr, ExcInternalError());
+    auto *arkode_mem = stepper.get_arkode_memory();
 
     if (get_local_tolerances)
       {
@@ -354,377 +348,15 @@ namespace SUNDIALS
         AssertARKode(status);
       }
 
-    // for version 4.0.0 this call must be made before solver settings
-    status = ARKStepSetUserData(arkode_mem, this);
-    AssertARKode(status);
-
-    setup_system_solver(solution);
-
-    setup_mass_solver(solution);
-
     status = ARKStepSetInitStep(arkode_mem, current_time_step);
     AssertARKode(status);
 
     status = ARKStepSetStopTime(arkode_mem, data.final_time);
     AssertARKode(status);
 
-    status = ARKStepSetOrder(arkode_mem, data.maximum_order);
-    AssertARKode(status);
-
     if (custom_setup)
       custom_setup(arkode_mem);
   }
-
-
-
-  template <typename VectorType>
-  void
-  ARKode<VectorType>::setup_system_solver(const VectorType &solution)
-  {
-    // no point in setting up a solver when there is no linear system
-    if (!implicit_function)
-      return;
-
-    int status;
-    (void)status;
-    // Initialize solver
-    // currently only iterative linear solvers are supported
-    if (jacobian_times_vector)
-      {
-        SUNLinearSolver sun_linear_solver;
-        if (solve_linearized_system)
-          {
-            linear_solver =
-              std::make_unique<internal::LinearSolverWrapper<VectorType>>(
-                solve_linearized_system,
-                pending_exception
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                ,
-                arkode_ctx
-#  endif
-              );
-            sun_linear_solver = *linear_solver;
-          }
-        else
-          {
-            // use default solver from SUNDIALS
-            // TODO give user options
-            auto y_template = internal::make_nvector_view(solution
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                                          ,
-                                                          arkode_ctx
-#  endif
-            );
-#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
-            sun_linear_solver =
-              SUNLinSol_SPGMR(y_template,
-                              PREC_NONE,
-                              0 /*krylov subvectors, 0 uses default*/);
-#  else
-            sun_linear_solver =
-              SUNLinSol_SPGMR(y_template,
-                              SUN_PREC_NONE,
-                              0 /*krylov subvectors, 0 uses default*/,
-                              arkode_ctx);
-#  endif
-          }
-        status = ARKStepSetLinearSolver(arkode_mem, sun_linear_solver, nullptr);
-        AssertARKode(status);
-
-        auto jacobian_times_vector_callback = [](N_Vector           v,
-                                                 N_Vector           Jv,
-                                                 SUNDIALS::realtype t,
-                                                 N_Vector           y,
-                                                 N_Vector           fy,
-                                                 void              *user_data,
-                                                 N_Vector) -> int {
-          Assert(user_data != nullptr, ExcInternalError());
-          ARKode<VectorType> &solver =
-            *static_cast<ARKode<VectorType> *>(user_data);
-
-          auto *src_v  = internal::unwrap_nvector_const<VectorType>(v);
-          auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
-          auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
-
-          auto *dst_Jv = internal::unwrap_nvector<VectorType>(Jv);
-
-          return Utilities::call_and_possibly_capture_exception(
-            solver.jacobian_times_vector,
-            solver.pending_exception,
-            *src_v,
-            *dst_Jv,
-            t,
-            *src_y,
-            *src_fy);
-        };
-
-        auto jacobian_times_vector_setup_callback = [](SUNDIALS::realtype t,
-                                                       N_Vector           y,
-                                                       N_Vector           fy,
-                                                       void *user_data) -> int {
-          Assert(user_data != nullptr, ExcInternalError());
-          ARKode<VectorType> &solver =
-            *static_cast<ARKode<VectorType> *>(user_data);
-
-          auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
-          auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
-
-          return Utilities::call_and_possibly_capture_exception(
-            solver.jacobian_times_setup,
-            solver.pending_exception,
-            t,
-            *src_y,
-            *src_fy);
-        };
-        status = ARKStepSetJacTimes(arkode_mem,
-                                    jacobian_times_setup ?
-                                      jacobian_times_vector_setup_callback :
-                                      ARKLsJacTimesSetupFn(nullptr),
-                                    jacobian_times_vector_callback);
-        AssertARKode(status);
-        if (jacobian_preconditioner_solve)
-          {
-            auto solve_with_jacobian_callback = [](SUNDIALS::realtype t,
-                                                   N_Vector           y,
-                                                   N_Vector           fy,
-                                                   N_Vector           r,
-                                                   N_Vector           z,
-                                                   SUNDIALS::realtype gamma,
-                                                   SUNDIALS::realtype delta,
-                                                   int                lr,
-                                                   void *user_data) -> int {
-              Assert(user_data != nullptr, ExcInternalError());
-              ARKode<VectorType> &solver =
-                *static_cast<ARKode<VectorType> *>(user_data);
-
-              auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
-              auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
-              auto *src_r  = internal::unwrap_nvector_const<VectorType>(r);
-
-              auto *dst_z = internal::unwrap_nvector<VectorType>(z);
-
-              return Utilities::call_and_possibly_capture_exception(
-                solver.jacobian_preconditioner_solve,
-                solver.pending_exception,
-                t,
-                *src_y,
-                *src_fy,
-                *src_r,
-                *dst_z,
-                gamma,
-                delta,
-                lr);
-            };
-
-            auto jacobian_solver_setup_callback =
-              [](SUNDIALS::realtype  t,
-                 N_Vector            y,
-                 N_Vector            fy,
-                 SUNDIALS::booltype  jok,
-                 SUNDIALS::booltype *jcurPtr,
-                 SUNDIALS::realtype  gamma,
-                 void               *user_data) -> int {
-              Assert(user_data != nullptr, ExcInternalError());
-              ARKode<VectorType> &solver =
-                *static_cast<ARKode<VectorType> *>(user_data);
-
-              auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
-              auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
-
-              return Utilities::call_and_possibly_capture_exception(
-                solver.jacobian_preconditioner_setup,
-                solver.pending_exception,
-                t,
-                *src_y,
-                *src_fy,
-                jok,
-                *jcurPtr,
-                gamma);
-            };
-
-            status = ARKStepSetPreconditioner(arkode_mem,
-                                              jacobian_preconditioner_setup ?
-                                                jacobian_solver_setup_callback :
-                                                ARKLsPrecSetupFn(nullptr),
-                                              solve_with_jacobian_callback);
-            AssertARKode(status);
-          }
-        if (data.implicit_function_is_linear)
-          {
-            status = ARKStepSetLinear(
-              arkode_mem, data.implicit_function_is_time_independent ? 0 : 1);
-            AssertARKode(status);
-          }
-      }
-    else
-      {
-        auto y_template = internal::make_nvector_view(solution
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                                      ,
-                                                      arkode_ctx
-#  endif
-        );
-
-#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
-        SUNNonlinearSolver fixed_point_solver =
-          SUNNonlinSol_FixedPoint(y_template,
-                                  data.anderson_acceleration_subspace);
-#  else
-        SUNNonlinearSolver fixed_point_solver =
-          SUNNonlinSol_FixedPoint(y_template,
-                                  data.anderson_acceleration_subspace,
-                                  arkode_ctx);
-#  endif
-
-        status = ARKStepSetNonlinearSolver(arkode_mem, fixed_point_solver);
-        AssertARKode(status);
-      }
-
-    status =
-      ARKStepSetMaxNonlinIters(arkode_mem, data.maximum_non_linear_iterations);
-    AssertARKode(status);
-  }
-
-
-
-  template <typename VectorType>
-  void
-  ARKode<VectorType>::setup_mass_solver(const VectorType &solution)
-  {
-    int status;
-    (void)status;
-
-    if (mass_times_vector)
-      {
-        SUNLinearSolver sun_mass_linear_solver;
-        if (solve_mass)
-          {
-            mass_solver =
-              std::make_unique<internal::LinearSolverWrapper<VectorType>>(
-                solve_mass,
-
-                pending_exception
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                ,
-                arkode_ctx
-#  endif
-              );
-            sun_mass_linear_solver = *mass_solver;
-          }
-        else
-          {
-            auto y_template = internal::make_nvector_view(solution
-#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
-                                                          ,
-                                                          arkode_ctx
-#  endif
-            );
-#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
-            sun_mass_linear_solver =
-              SUNLinSol_SPGMR(y_template,
-                              PREC_NONE,
-                              0 /*krylov subvectors, 0 uses default*/);
-#  else
-            sun_mass_linear_solver =
-              SUNLinSol_SPGMR(y_template,
-                              SUN_PREC_NONE,
-                              0 /*krylov subvectors, 0 uses default*/,
-                              arkode_ctx);
-#  endif
-          }
-
-        SUNDIALS::booltype mass_time_dependent =
-          data.mass_is_time_independent ? SUNFALSE : SUNTRUE;
-
-        status = ARKStepSetMassLinearSolver(arkode_mem,
-                                            sun_mass_linear_solver,
-                                            nullptr,
-                                            mass_time_dependent);
-        AssertARKode(status);
-
-        auto mass_matrix_times_vector_setup_callback =
-          [](SUNDIALS::realtype t, void *mtimes_data) -> int {
-          Assert(mtimes_data != nullptr, ExcInternalError());
-          ARKode<VectorType> &solver =
-            *static_cast<ARKode<VectorType> *>(mtimes_data);
-
-          return Utilities::call_and_possibly_capture_exception(
-            solver.mass_times_setup, solver.pending_exception, t);
-        };
-
-        auto mass_matrix_times_vector_callback = [](N_Vector           v,
-                                                    N_Vector           Mv,
-                                                    SUNDIALS::realtype t,
-                                                    void *mtimes_data) -> int {
-          Assert(mtimes_data != nullptr, ExcInternalError());
-          ARKode<VectorType> &solver =
-            *static_cast<ARKode<VectorType> *>(mtimes_data);
-
-          auto *src_v  = internal::unwrap_nvector_const<VectorType>(v);
-          auto *dst_Mv = internal::unwrap_nvector<VectorType>(Mv);
-
-          return Utilities::call_and_possibly_capture_exception(
-            solver.mass_times_vector,
-            solver.pending_exception,
-            t,
-            *src_v,
-            *dst_Mv);
-        };
-
-        status = ARKStepSetMassTimes(arkode_mem,
-                                     mass_times_setup ?
-                                       mass_matrix_times_vector_setup_callback :
-                                       ARKLsMassTimesSetupFn(nullptr),
-                                     mass_matrix_times_vector_callback,
-                                     this);
-        AssertARKode(status);
-
-        if (mass_preconditioner_solve)
-          {
-            auto mass_matrix_solver_setup_callback =
-              [](SUNDIALS::realtype t, void *user_data) -> int {
-              Assert(user_data != nullptr, ExcInternalError());
-              ARKode<VectorType> &solver =
-                *static_cast<ARKode<VectorType> *>(user_data);
-
-              return Utilities::call_and_possibly_capture_exception(
-                solver.mass_preconditioner_setup, solver.pending_exception, t);
-            };
-
-            auto solve_with_mass_matrix_callback = [](SUNDIALS::realtype t,
-                                                      N_Vector           r,
-                                                      N_Vector           z,
-                                                      SUNDIALS::realtype delta,
-                                                      int                lr,
-                                                      void *user_data) -> int {
-              Assert(user_data != nullptr, ExcInternalError());
-              ARKode<VectorType> &solver =
-                *static_cast<ARKode<VectorType> *>(user_data);
-
-              auto *src_r = internal::unwrap_nvector_const<VectorType>(r);
-              auto *dst_z = internal::unwrap_nvector<VectorType>(z);
-
-              return Utilities::call_and_possibly_capture_exception(
-                solver.mass_preconditioner_solve,
-                solver.pending_exception,
-                t,
-                *src_r,
-                *dst_z,
-                delta,
-                lr);
-            };
-
-            status =
-              ARKStepSetMassPreconditioner(arkode_mem,
-                                           mass_preconditioner_setup ?
-                                             mass_matrix_solver_setup_callback :
-                                             ARKLsMassPrecSetupFn(nullptr),
-                                           solve_with_mass_matrix_callback);
-            AssertARKode(status);
-          }
-      }
-  }
-
 
 
   template <typename VectorType>
@@ -742,7 +374,7 @@ namespace SUNDIALS
   void *
   ARKode<VectorType>::get_arkode_memory() const
   {
-    return arkode_mem;
+    return stepper.get_arkode_memory();
   }
 
 } // namespace SUNDIALS

--- a/include/deal.II/sundials/arkode_exception.h
+++ b/include/deal.II/sundials/arkode_exception.h
@@ -1,0 +1,42 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#ifndef dealii_sundials_arkode_exception_h
+#define dealii_sundials_arkode_exception_h
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+namespace SUNDIALS
+{
+  /**
+   * Handle ARKode exceptions.
+   */
+  DeclException1(ExcARKodeError,
+                 int,
+                 << "One of the SUNDIALS ARKode internal functions "
+                 << " returned a negative error code: " << arg1
+                 << ". Please consult SUNDIALS manual.");
+} // namespace SUNDIALS
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -894,8 +894,8 @@ namespace SUNDIALS
     std::function<void(void *arkode_mem)> custom_setup;
 
   private:
-    using CallbackContext = typename ARKodeStepper<VectorType>::CallbackContext<
-      ARKStepper<VectorType>>;
+    using CallbackContext = typename ARKodeStepper<
+      VectorType>::template CallbackContext<ARKStepper<VectorType>>;
 
     /**
      * Rebuild the stepper at a given time instance and for a given state

--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -1,0 +1,1003 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#ifndef dealii_sundials_arkode_stepper_h
+#define dealii_sundials_arkode_stepper_h
+
+#include <deal.II/base/config.h>
+
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+#  include <deal.II/base/conditional_ostream.h>
+#  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/mpi_stub.h>
+#  include <deal.II/base/parameter_handler.h>
+
+#  ifdef DEAL_II_WITH_PETSC
+#    include <deal.II/lac/petsc_block_vector.h>
+#    include <deal.II/lac/petsc_vector.h>
+#  endif
+#  include <deal.II/lac/vector.h>
+#  include <deal.II/lac/vector_memory.h>
+
+#  include <arkode/arkode.h>
+#  include <nvector/nvector_serial.h>
+#  ifdef DEAL_II_WITH_MPI
+#    include <nvector/nvector_parallel.h>
+#  endif
+#  include <deal.II/base/discrete_time.h>
+
+#  include <deal.II/sundials/invocation_context.h>
+#  include <deal.II/sundials/n_vector.h>
+#  include <deal.II/sundials/sundials_types.h>
+#  include <deal.II/sundials/sunlinsol_wrapper.h>
+
+#  include <boost/signals2.hpp>
+
+#  include <sundials/sundials_linearsolver.h>
+#  include <sundials/sundials_math.h>
+
+#  include <exception>
+#  include <memory>
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+namespace SUNDIALS
+{
+  /**
+   * Forward declare ARKode class.
+   */
+  template <typename VectorType>
+  class ARKode;
+
+  /**
+   * A base class for the implementation of ARKode stepper classes.
+   *
+   * This class does not perform any actions during the time marching itself.
+   * It is responsible for setting up the internal data structures of the ARKODE
+   * via the ARKODE memory block. This setup is very much stepper specific,
+   * whereas the time advance itself is generalized in ARKODE. This separation
+   * of responsibilities is reflected in the current design that distributes the
+   * functionality between ARKode and ARKodeStepper accordingly.
+   */
+  template <typename VectorType>
+  class ARKodeStepper
+  {
+  public:
+    /**
+     * Make ARKode class a friend such that the latter could access reinit()
+     * method.
+     */
+    friend class ARKode<VectorType>;
+
+    /**
+     * Destructor. Made `virtual` to allow this class to be used as an abstract
+     * base class.
+     */
+    virtual ~ARKodeStepper() = default;
+
+    /**
+     * Provides user access to the internally used ARKODE memory.
+     *
+     * This functionality is intended for users who wish to query additional
+     * information directly from the ARKODE integrator, refer to the ARKODE
+     * manual for the various `ARKStepGet...` functions. The `ARKStepSet...`
+     * functions should not be called since this might lead to conflicts with
+     * various settings that are performed by this ARKodeStepper object.
+     *
+     * @note If custom settings of ARKODE functionality (that are not achievable
+     *   via the interface of this class) are required, the function
+     *   custom_setup() should be used.
+     *
+     * @return pointer to the ARKODE memory block that can be passed to SUNDIALS
+     *   functions
+     */
+    virtual void *
+    get_arkode_memory() const = 0;
+
+  private:
+    /**
+     * Rebuild the stepper at a given time instance and for a given state
+     * vector.
+     *
+     * To transport exceptions and maintain context across C boundaries, the
+     * code uses `internal::InvocationContext` (see `invocation_context.h`)
+     * which carries an `std::exception_ptr` that is inspected after a callback
+     * returns.
+     *
+     * @param t0 Time instance that serves as starting time
+     * @param y0 Initial state vector whose layout is used for initialization of
+     *   the internal ARKODE vectors
+     * @param inv_ctx Invocation context that provides access to the SUNContext
+     *   object and the exception pointer managed by the caller
+     */
+    virtual void
+    reinit(double                      t0,
+           const VectorType           &y0,
+           internal::InvocationContext inv_ctx) = 0;
+
+  protected:
+    /**
+     * This struct stores the pointers to the stepper and the exception pointer
+     * object. This object is basically supplied to the native ARKODE callbacks
+     * as user data.
+     */
+    template <typename Stepper>
+    struct CallbackContext
+    {
+      Stepper            *stepper           = nullptr;
+      std::exception_ptr *pending_exception = nullptr;
+    };
+  };
+
+  /**
+   * This class provides a wrapper to ARKStep time-stepping module. It is one of
+   * the possible steppers one can use together with the ARKode class.
+   *
+   * ARKStep solves ODE initial value problems (IVPs) in $R^N$. These problems
+   * should be posed in split, linearly-implicit form as
+   *
+   * \f[
+   *   M\dot y = f_E(t, y) + f_I (t, y), \qquad y(t_0) = y_0.
+   * \f]
+   *
+   * Here, $t$ is the independent variable (e.g. time), and the dependent
+   * variables are given by $y \in R^N$, and we use notation $\dot y$ to denote
+   * $dy/dt$. $M$ is a user-supplied nonsingular operator from $R^N \to R^N$.
+   * This operator may depend on $t$ but not on $y$.
+   *
+   * For standard systems of ordinary differential equations and for problems
+   * arising from the spatial semi-discretization of partial differential
+   * equations using finite difference or finite volume methods, $M$ is
+   * typically the identity matrix, $I$. For PDEs using a finite-element
+   * spatial semi-discretization $M$ is typically a well-conditioned mass
+   * matrix.
+   *
+   * The two right-hand side functions may be described as:
+   *
+   * - $f_E(t, y)$: contains the "slow" time scale components of the system.
+   *                This will be integrated using explicit methods.
+   * - $f_I(t, y)$: contains the "fast" time scale components of the system.
+   *                This will be integrated using implicit methods.
+   *
+   * ARKStep may be used to solve stiff, nonstiff and multi-rate problems.
+   * Roughly speaking, stiffness is characterized by the presence of at least
+   * one rapidly damped mode, whose time constant is small compared to the time
+   * scale of the solution itself. In the implicit/explicit (ImEx) splitting
+   * above, these stiff components should be included in the right-hand side
+   * function $f_I (t, y)$.
+   *
+   * For multi-rate problems, a user should provide both of the functions $f_E$
+   * and $f_I$ that define the IVP system.
+   *
+   * For nonstiff problems, only $f_E$ should be provided, and $f_I$ is assumed
+   * to be zero, i.e. the system reduces to the non-split IVP:
+   *
+   * \f[
+   *   M\dot y = f_E(t, y), \qquad y(t_0) = y_0.
+   * \f]
+   *
+   * In this scenario, the ARK methods reduce to classical explicit Runge-Kutta
+   * methods (ERK). For these classes of methods, ARKStep allows orders of
+   * accuracy $q = \{2, 3, 4, 5, 6, 8\}$, with embeddings of orders $p = \{1,
+   * 2, 3, 4, 5, 7\}$. These default to the Heun-Euler-2-1-2,
+   * Bogacki-Shampine-4-2-3, Zonneveld-5-3-4, Cash-Karp-6-4-5, Verner-8-5-6 and
+   * Fehlberg-13-7-8 methods, respectively.
+   *
+   * Finally, for stiff (linear or nonlinear) problems the user may provide only
+   * $f_I$, implying that $f_E = 0$, so that the system reduces to the non-split
+   * IVP
+   *
+   * \f[
+   *   M\dot y = f_I(t, y), \qquad y(t_0) = y_0.
+   * \f]
+   *
+   * Similarly to ERK methods, in this scenario the ARK methods reduce to
+   * classical diagonally-implicit Runge-Kutta methods (DIRK). For these
+   * classes of methods, ARKStep allows orders of accuracy $q = \{2, 3, 4, 5\}$,
+   * with embeddings of orders $p = \{1, 2, 3, 4\}$. These default to the
+   * SDIRK-2-1-2, ARK-4-2-3 (implicit), SDIRK-5-3-4 and ARK-8-4-5 (implicit)
+   * methods, respectively.
+   *
+   * For both DIRK and ARK methods, an implicit system of the form
+   * \f[
+   *  G(z_i) \dealcoloneq M z_i - h_n A^I_{i,i} f_I (t^I_{n,i}, z_i) - a_i = 0
+   * \f]
+   * must be solved for each stage $z_i , i = 1, \ldots, s$, where
+   * we have the data
+   * \f[
+   *  a_i \dealcoloneq
+   *  M y_{n-1} + h_n \sum_{j=1}^{i-1} [ A^E_{i,j} f_E(t^E_{n,j}, z_j)
+   *  + A^I_{i,j} f_I (t^I_{n,j}, z_j)]
+   * \f]
+   * for the ARK methods, or
+   * \f[
+   *  a_i \dealcoloneq
+   *  M y_{n-1} + h_n \sum_{j=1}^{i-1} A^I_{i,j} f_I (t^I_{n,j}, z_j)
+   * \f]
+   * for the DIRK methods. Here $A^I_{i,j}$ and $A^E_{i,j}$ are the Butcher's
+   * tables for the chosen solver.
+   *
+   * If $f_I(t,y)$ depends nonlinearly on $y$ then the systems above correspond
+   * to a nonlinear system of equations; if $f_I (t, y)$ depends linearly on
+   * $y$ then this is a linear system of equations. By specifying the flag
+   * `implicit_function_is_linear`, ARKStep takes some shortcuts that allow a
+   * faster solution process.
+   *
+   * For systems of either type, ARKStep allows a choice of solution strategy.
+   * The default solver choice is a variant of Newton's method,
+   * \f[
+   *  z_i^{m+1} = z_i^m +\delta^{m+1},
+   * \f]
+   * where $m$ is the Newton step index, and the Newton update $\delta^{m+1}$
+   * requires the solution of the linear Newton system
+   * \f[
+   *  N(z_i^m) \delta^{m+1} = -G(z_i^m),
+   * \f]
+   * where
+   * \f[
+   * N \dealcoloneq M - \gamma J, \quad J
+   * \dealcoloneq \frac{\partial f_I}{\partial y},
+   * \qquad \gamma\dealcoloneq h_n A^I_{i,i}.
+   * \f]
+   *
+   * As an alternate to Newton's method, ARKStep may solve for each stage $z_i
+   *,i = 1, \ldots , s$ using an Anderson-accelerated fixed point iteration \f[
+   * z_i^{m+1} = g(z_i^{m}), m=0,1,\ldots.
+   * \f]
+   *
+   * Unlike with Newton's method, this option does not require the solution of
+   * a linear system at each iteration, instead opting for solution of a
+   * low-dimensional least-squares solution to construct the nonlinear update.
+   *
+   * Finally, if the user specifies `implicit_function_is_linear`, i.e.,
+   * $f_I(t, y)$ depends linearly on $y$, and if the Newton-based nonlinear
+   * solver is chosen, then the system will be solved using only a single
+   * Newton iteration. Notice that in order for the Newton solver to be used,
+   * then jacobian_times_vector() should be supplied. If it is not supplied then
+   * only the fixed-point iteration will be supported, and the
+   * `implicit_function_is_linear` setting is ignored.
+   *
+   * The optimal solver (Newton vs fixed-point) is highly problem-dependent.
+   * Since fixed-point solvers do not require the solution of any linear
+   * systems, each iteration may be significantly less costly than their Newton
+   * counterparts. However, this can come at the cost of slower convergence (or
+   * even divergence) in comparison with Newton-like methods. These fixed-point
+   * solvers do allow for user specification of the Anderson-accelerated
+   * subspace size, $m_k$. While the required amount of solver memory grows
+   * proportionately to $m_k N$, larger values of $m_k$ may result in faster
+   * convergence.
+   *
+   * This improvement may be significant even for "small" values, e.g. $1 \leq
+   * m_k \leq 5$, and convergence may not improve (or even deteriorate) for
+   * larger values of $m_k$. While ARKStep uses a Newton-based iteration as its
+   * default solver due to its increased robustness on very stiff problems, it
+   * is highly recommended that users also consider the fixed-point solver for
+   * their cases when attempting a new problem.
+   *
+   * For either the Newton or fixed-point solvers, it is well-known that both
+   * the efficiency and robustness of the algorithm intimately depends on the
+   * choice of a good initial guess. In ARKStep, the initial guess for either
+   * nonlinear solution method is a predicted value $z_i(0)$ that is computed
+   * explicitly from the previously-computed data (e.g. $y_{n-2}, y_{n-1}$, and
+   * $z_j$ where $j < i$). Additional information on the specific predictor
+   * algorithms implemented in ARKStep is provided in ARKStep documentation of
+   * ARKode.
+   *
+   * The user has to provide the implementation of at least one (or both) of the
+   * following `std::function`s:
+   *  - implicit_function()
+   *  - explicit_function()
+   *
+   * If the @ref GlossMassMatrix "mass matrix" is different from the identity, the user should supply
+   *  - mass_times_vector() and, optionally,
+   *  - mass_times_setup()
+   *
+   * If the use of a Newton method is desired, then the user should also supply
+   * jacobian_times_vector(). jacobian_times_vector_setup() is optional.
+   *
+   * @note Although SUNDIALS can provide a difference quotient approximation
+   *   of the Jacobian, this is currently not supported through this wrapper.
+   *
+   * A SUNDIALS default solver (SPGMR) is used to solve the linear systems. To
+   * use a custom linear solver for the mass matrix and/or Jacobian, set:
+   *  - solve_mass() and/or
+   *  - solve_linearized_system()
+   *
+   * To use a custom preconditioner with either a default or custom linear
+   * solver, set:
+   * - jacobian_preconditioner_solve() and/or mass_preconditioner_solve()
+   * and, optionally,
+   * - jacobian_preconditioner_setup() and/or mass_preconditioner_setup()
+   *
+   * Also the following functions could be rewritten. By default
+   * they do nothing, or are not required.
+   *  - solver_should_restart()
+   *  - get_local_tolerances()
+   *
+   * To produce output at fixed steps, set the function
+   *  - output_step()
+   *
+   * Any other custom settings of the ARKStep object can be specified in
+   *  - custom_setup()
+   *
+   * To provide a simple example, consider the harmonic oscillator problem:
+   * \f[
+   * \begin{split}
+   *   u'' & = -k^2 u \\
+   *   u (0) & = 0 \\
+   *   u'(0) & = k
+   * \end{split}
+   * \f]
+   *
+   * We write it in terms of a first order ode:
+   *\f[
+   * \begin{matrix}
+   *   y_0' & =  y_1 \\
+   *   y_1' & = - k^2 y_0
+   * \end{matrix}
+   * \f]
+   *
+   * That is $y' = A y$
+   * where
+   * \f[
+   * A \dealcoloneq
+   * \begin{pmatrix}
+   * 0 & 1 \\
+   * -k^2 &0
+   * \end{pmatrix}
+   * \f]
+   * and $y(0)=(0, k)^T$.
+   *
+   * The exact solution is $y_0(t) = \sin(k t)$, $y_1(t) = y_0'(t) = k \cos(k
+   *t)$, $y_1'(t) = -k^2 \sin(k t)$.
+   *
+   * A minimal implementation, using only explicit RK methods, is given by the
+   * following code snippet:
+   *
+   * @code
+   * using VectorType = Vector<double>;
+   *
+   * SUNDIALS::ARKStepper<VectorType> steppper;
+   * SUNDIALS::ARKode<VectorType> ode(stepper);
+   *
+   * const double k = 1.0;
+   *
+   * stepper.explicit_function = [k] (const double / * time * /,
+   *                                  const VectorType &y,
+   *                                  VectorType &ydot)
+   * {
+   *   ydot[0] = y[1];
+   *   ydot[1] = -k*k*y[0];
+   * };
+   *
+   * Vector<double> y(2);
+   * y[1] = k;
+   *
+   * ode.solve_ode(y);
+   * @endcode
+   */
+  template <typename VectorType = Vector<double>>
+  class ARKStepper : public ARKodeStepper<VectorType>
+  {
+  public:
+    /**
+     * Additional parameters that can be passed to the ARKStepper class.
+     */
+    class AdditionalData
+    {
+    public:
+      /**
+       * Initialization parameters for ARKStepper.
+       *
+       * @param order Desired order of accuracy for the time integration.
+       *   If set to 0 the default order for the chosen method is used.
+       * @param maximum_non_linear_iterations Maximum number of nonlinear
+       *   iterations
+       * @param implicit_function_is_linear Specifies that the implicit portion
+       *   of the problem is linear
+       * @param implicit_function_is_time_independent Specifies that the
+       *   implicit portion of the problem is linear and time independent
+       * @param mass_is_time_independent Specifies that the mass pre-factor is
+       *   independent of time
+       * @param anderson_acceleration_subspace The number of vectors to use for
+       *   Anderson acceleration within the packaged SUNDIALS solver.
+       */
+      AdditionalData(const unsigned int order                         = 0,
+                     const unsigned int maximum_non_linear_iterations = 10,
+                     const bool         implicit_function_is_linear   = false,
+                     const bool implicit_function_is_time_independent = false,
+                     const bool mass_is_time_independent              = false,
+                     const int  anderson_acceleration_subspace        = 3);
+
+      /**
+       * Add all AdditionalData() parameters to the given ParameterHandler
+       * object. When the parameters are parsed from a file, the internal
+       * parameters are automatically updated.
+       *
+       * The options you pass at construction time are set as default values in
+       * the ParameterHandler object `prm`. You can later modify them by parsing
+       * a parameter file using `prm`. The values of the parameter will be
+       * updated whenever the content of `prm` is updated.
+       *
+       * Make sure that this class lives longer than `prm`. Undefined behavior
+       * will occur if you destroy this class, and then parse a parameter file
+       * using `prm`.
+       */
+      void
+      add_parameters(ParameterHandler &prm);
+
+      /**
+       * Desired order of accuracy for the time integration. If set to 0
+       * the default order for the chosen method is used.
+       */
+      unsigned int order;
+
+      /**
+       * Maximum number of iterations for Newton or fixed point method during
+       * time advancement.
+       */
+      unsigned int maximum_non_linear_iterations;
+
+      /**
+       * Specify whether the implicit portion of the problem is linear.
+       */
+      bool implicit_function_is_linear;
+
+      /**
+       * Specify whether the implicit portion of the problem is linear and time
+       * independent.
+       */
+      bool implicit_function_is_time_independent;
+
+      /**
+       * Specify whether the mass pre-factor is time independent. Has no effect
+       * if no mass is specified.
+       */
+      bool mass_is_time_independent;
+
+      /**
+       * Number of subspace vectors to use for Anderson acceleration. Only
+       * meaningful if the packaged SUNDIALS fixed-point solver is used.
+       */
+      int anderson_acceleration_subspace;
+    };
+
+    /**
+     * Constructor, with class parameters set by the AdditionalData object.
+     *
+     * @param data ARKStep configuration data
+     */
+    ARKStepper(const AdditionalData &data = AdditionalData());
+
+    /**
+     * Destructor. Cleans up the internal ARKODE memory block.
+     */
+    ~ARKStepper();
+
+    void *
+    get_arkode_memory() const override;
+
+    /**
+     * A function object that users may supply and that is intended to compute
+     * the explicit part of the IVP right hand side. Sets $explicit_f = f_E(t,
+     * y)$.
+     *
+     * At least one of explicit_function() or implicit_function() must be
+     * provided. According to which one is provided, explicit, implicit, or
+     * mixed RK methods are used.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<
+      void(const double t, const VectorType &y, VectorType &explicit_f)>
+      explicit_function;
+
+    /**
+     * A function object that users may supply and that is intended to compute
+     * the implicit part of the IVP right hand side. Sets $implicit_f = f_I(t,
+     * y)$.
+     *
+     * At least one of explicit_function() or implicit_function() must be
+     * provided. According to which one is provided, explicit, implicit, or
+     * mixed RK methods are used.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double t, const VectorType &y, VectorType &res)>
+      implicit_function;
+
+    /**
+     * A function object that users may supply and that is intended to compute
+     * the product of the @ref GlossMassMatrix "mass matrix" with a given vector `v`.
+     * This function will be called by ARKode (possibly several times) after
+     * mass_times_setup() has been called at least once. ARKode tries to do its
+     * best to call mass_times_setup() the minimum amount of times.
+     *
+     * A call to this function should store in `Mv` the result of $M$
+     * applied to `v`.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double t, const VectorType &v, VectorType &Mv)>
+      mass_times_vector;
+
+    /**
+     * A function object that users may supply and that is intended to set up
+     * the @ref GlossMassMatrix "mass matrix". This function is called by ARKode
+     * any time a mass matrix update is required. The user should compute the
+     * mass matrix (or update all the variables that allow the application of
+     * the mass matrix). This function is guaranteed to be called by ARKode at
+     * least once, before any call to mass_times_vector().
+     *
+     * ARKode supports the case where the mass matrix may depend on time, but
+     * not the case where the mass matrix depends on the solution itself.
+     *
+     * If the user does not provide a mass_times_vector() function, then the
+     * identity is used. If the mass_times_setup() function is not provided,
+     * then mass_times_vector() should do all the work by itself.
+     *
+     * If the user uses a matrix-based computation of the mass matrix, then
+     * this is the right place where an assembly routine should be called to
+     * assemble the matrix. Subsequent calls (possibly  more than one) to
+     * mass_times_vector() can assume that this function has been called at
+     * least once.
+     *
+     * @note No assumption is made by this interface on what the user
+     *   should do in this function. ARKode only assumes that after a call to
+     *   mass_times_setup() it is possible to call mass_times_vector().
+     *
+     * @param t The current evaluation time
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double t)> mass_times_setup;
+
+    /**
+     * A function object that users may supply and that is intended to compute
+     * the product of the Jacobian matrix with a given vector `v`. The Jacobian
+     * here refers to $J=\frac{\partial f_I}{\partial y}$, i.e., the Jacobian of
+     * the user-specified implicit_function.
+     *
+     * A call to this function should store in `Jv` the result of $J$
+     * applied to `v`.
+     *
+     * Arguments to the function are
+     *
+     * @param[in] v  The vector to be multiplied by the Jacobian
+     * @param[out] Jv The vector to be filled with the product J*v
+     * @param[in] t  The current time
+     * @param[in] y  The current $y$ vector for the current ARKode internal
+     *   step
+     * @param[in] fy  The current value of the implicit right-hand side at y,
+     *   $f_I (t_n, y)$.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const VectorType &v,
+                       VectorType       &Jv,
+                       const double      t,
+                       const VectorType &y,
+                       const VectorType &fy)>
+      jacobian_times_vector;
+
+    /**
+     * A function object that users may supply and that is intended to set up
+     * all data necessary for the application of jacobian_times_vector(). This
+     * function is called by ARKode any time a Jacobian update is required.
+     * The user should compute the Jacobian (or update all the variables that
+     * allow the application of Jacobian). This function is guaranteed to
+     * be called by ARKode at least once, before any call to
+     * jacobian_times_vector().
+     *
+     * If the jacobian_times_vector_setup() function is not provided, then
+     * jacobian_times_vector() should do all the work by itself.
+     *
+     * If the user uses a matrix based computation of the Jacobian, then this is
+     * the right place where an assembly routine should be called to assemble
+     * the matrix. Subsequent calls (possibly  more than one) to
+     * jacobian_times_vector() can assume that this function has been called at
+     * least once.
+     *
+     * @note No assumption is made by this interface on what the user
+     *   should do in this function. ARKode only assumes that after a call to
+     *   jacobian_times_vector_setup() it is possible to call
+     *   jacobian_times_vector().
+     *
+     * @param t  The current time
+     * @param y  The current ARKode internal solution vector $y$
+     * @param fy  The implicit right-hand side function evaluated at the
+     *   current time $t$ and state $y$, i.e., $f_I(y,t)$
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<
+      void(const double t, const VectorType &y, const VectorType &fy)>
+      jacobian_times_vector_setup;
+
+    /**
+     * A LinearSolveFunction object that users may supply and that is intended
+     * to solve the linearized system $Ax=b$, where $A = M-\gamma J$ is the
+     * Jacobian of the nonlinear residual. The application of the @ref GlossMassMatrix "mass matrix"
+     * $M$ and Jacobian $J$ are known through the functions mass_times_vector()
+     * and jacobian_times_vector() and $\gamma$ is a factor provided by
+     * SUNDIALS. The matrix-vector product $Ax$ is encoded in the supplied
+     * SundialsOperator. If a preconditioner was set through
+     * jacobian_preconditioner_solve(), it is encoded in the
+     * SundialsPreconditioner. If no preconditioner was supplied this way, the
+     * preconditioner is the identity matrix, i.e., no preconditioner. The user
+     * is free to use a custom preconditioner in this function object that is
+     * not supplied through SUNDIALS.
+     *
+     * If you do not specify a solve_linearized_system() function, then a
+     * SUNDIALS packaged SPGMR solver with default settings is used.
+     *
+     * For more details on the function type refer to LinearSolveFunction.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    LinearSolveFunction<VectorType> solve_linearized_system;
+
+    /**
+     * A LinearSolveFunction object that users may supply and that is intended
+     * to solve the mass system $Mx=b$. The matrix-vector product $Mx$ is
+     * encoded in the supplied SundialsOperator. If a preconditioner was set
+     * through mass_preconditioner_solve(), it is encoded in the
+     * SundialsPreconditioner. If no preconditioner was supplied this way, the
+     * preconditioner is the identity matrix, i.e., no preconditioner. The user
+     * is free to use a custom preconditioner in this function object that is
+     * not supplied through SUNDIALS.
+     *
+     * The user must specify this function if a non-identity mass matrix is used
+     * and applied in mass_times_vector().
+     *
+     * For more details on the function type refer to LinearSolveFunction.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    LinearSolveFunction<VectorType> solve_mass;
+
+    /**
+     * A function object that users may supply to either pass a preconditioner
+     * to a SUNDIALS built-in solver or to apply a custom preconditioner within
+     * the user's own linear solve specified in solve_linearized_system().
+     *
+     * This function should compute the solution to the preconditioner equation
+     * $Pz=r$ and store it in @p z. In this equation $P$ should approximate the
+     * Jacobian $M-\gamma J$ of the nonlinear system.
+     *
+     * @param[in] t  The current time
+     * @param[in] y  The current $y$ vector for the current ARKode internal
+     *   step
+     * @param[in] fy  The current value of the implicit right-hand side at y,
+     *   $f_I (t_n, y)$.
+     * @param[in] r  The right-hand side of the preconditioner equation
+     * @param[out] z The solution of applying the preconditioner, i.e., solving
+     *   $Pz=r$
+     * @param[in] gamma The value $\gamma$ in the preconditioner equation
+     * @param[in] tol The tolerance up to which the system should be solved
+     * @param[in] lr An input flag indicating whether the preconditioner solve
+     *   is to use the left preconditioner (lr = 1) or the right preconditioner
+     *   (lr = 2). Only relevant if used with a SUNDIALS packaged solver. If
+     *   used with a custom solve_mass() function this will be set to zero.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double      t,
+                       const VectorType &y,
+                       const VectorType &fy,
+                       const VectorType &r,
+                       VectorType       &z,
+                       const double      gamma,
+                       const double      tol,
+                       const int         lr)>
+      jacobian_preconditioner_solve;
+
+    /**
+     * A function object that users may supply to set up a preconditioner
+     * specified in jacobian_preconditioner_solve().
+     *
+     * This function should prepare the solution of the preconditioner equation
+     * $Pz=r$. In this equation $P$ should approximate the Jacobian $M-\gamma J$
+     * of the nonlinear system.
+     *
+     * If the jacobian_preconditioner_setup() function is not provided, then
+     * jacobian_preconditioner_solve() should do all the work by itself.
+     *
+     * @note No assumption is made by this interface on what the user
+     *   should do in this function. ARKode only assumes that after a call to
+     *   jacobian_preconditioner_setup() it is possible to call
+     *   jacobian_preconditioner_solve().
+     *
+     * @param[in] t  The current time
+     * @param[in] y  The current $y$ vector for the current ARKode internal
+     *   step
+     * @param[in] fy  The current value of the implicit right-hand side at y,
+     *   $f_I (t_n, y)$.
+     * @param[in] jok  An input flag indicating whether the Jacobian-related
+     *   data needs to be updated. The jok argument provides for the reuse of
+     *   Jacobian data in the preconditioner solve function. When jok =
+     *   SUNFALSE, the Jacobian-related data should be recomputed from scratch.
+     *   When jok = SUNTRUE the Jacobian data, if saved from the previous call
+     *   to this function, can be reused (with the current value of gamma). A
+     *   call with jok = SUNTRUE can only occur after a call with jok =
+     *   SUNFALSE.
+     * @param[out] jcur On output this should be set to SUNTRUE if Jacobian data
+     *   was recomputed, or set to SUNFALSE if Jacobian data was not recomputed,
+     *   but saved data was still reused.
+     * @param[in] gamma The value $\gamma$ in $M-\gamma J$. The preconditioner
+     *   should approximate the inverse of this matrix.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double      t,
+                       const VectorType &y,
+                       const VectorType &fy,
+                       const int         jok,
+                       int              &jcur,
+                       const double      gamma)>
+      jacobian_preconditioner_setup;
+
+    /**
+     * A function object that users may supply to either pass a preconditioner
+     * to a SUNDIALS built-in solver or to apply a custom preconditioner within
+     * the user's own linear solve specified in solve_mass().
+     *
+     * This function should compute the solution to the preconditioner equation
+     * $Pz=r$ and store it in @p z. In this equation $P$ should approximate the
+     * @ref GlossMassMatrix "mass matrix" $M$.
+     *
+     * @param[in] t  The current time
+     * @param[in] r  The right-hand side of the preconditioner equation
+     * @param[out] z The solution of applying the preconditioner, i.e., solving
+     *   $Pz=r$
+     * @param[in] gamma The value $\gamma$ in the preconditioner equation
+     * @param[in] tol The tolerance up to which the system should be solved
+     * @param[in] lr An input flag indicating whether the preconditioner solve
+     *   is to use the left preconditioner (lr = 1) or the right preconditioner
+     *   (lr = 2). Only relevant if used with a SUNDIALS packaged solver. If
+     *   used with a custom solve_mass() function this will be set to zero.
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double      t,
+                       const VectorType &r,
+                       VectorType       &z,
+                       const double      tol,
+                       const int         lr)>
+      mass_preconditioner_solve;
+
+    /**
+     * A function object that users may supply to set up a preconditioner
+     * specified in mass_preconditioner_solve().
+     *
+     * This function should prepare the solution of the preconditioner equation
+     * $Pz=r$. In this equation $P$ should approximate the @ref GlossMassMatrix "mass matrix" $M$.
+     *
+     * If the mass_preconditioner_setup() function is not provided, then
+     * mass_preconditioner_solve() should do all the work by itself.
+     *
+     * @note No assumption is made by this interface on what the user
+     *   should do in this function. ARKode only assumes that after a call to
+     *   mass_preconditioner_setup() it is possible to call
+     *   mass_preconditioner_solve().
+     *
+     * @param[in] t  The current time
+     *
+     * @note This variable represents a
+     * @ref GlossUserProvidedCallBack "user provided callback".
+     * See there for a description of how to deal with errors and other
+     * requirements and conventions. In particular, ARKode can deal
+     * with "recoverable" errors in some circumstances, so callbacks
+     * can throw exceptions of type RecoverableUserCallbackError.
+     */
+    std::function<void(const double t)> mass_preconditioner_setup;
+
+    /**
+     * A function object that users may supply and which is intended to perform
+     * custom settings on the supplied @p arkode_mem object. Refer to the
+     * SUNDIALS documentation for valid options.
+     *
+     * For instance, the following code indicates to use specific built-in
+     * Butcher tables for the ERK, DIRK or ARK method of the ARKStep module:
+     *
+     * @code
+     *      stepper.custom_setup = [&](void *arkode_mem) {
+     *        const int status = ARKStepSetTableName(
+     *          arkode_mem, implicit_method_name, explicit_method_name);
+     *
+     *        AssertARKode(status);
+     *      };
+     * @endcode
+     *
+     * @note This function will be called at the end of all other set up right
+     *   before the actual time evolution is started or continued with
+     *   solve_ode(). This function is also called when the solver is restarted,
+     *   see solver_should_restart(). Consult the SUNDIALS manual to see which
+     *   options are still available at this point.
+     *
+     * @param arkode_mem pointer to the ARKODE memory block which can be used
+     *   for custom calls to `ARKStepSet...` methods.
+     */
+    std::function<void(void *arkode_mem)> custom_setup;
+
+  private:
+    using CallbackContext = typename ARKodeStepper<VectorType>::CallbackContext<
+      ARKStepper<VectorType>>;
+
+    /**
+     * Rebuild the stepper at a given time instance and for a given state
+     * vector. Required by the ARKodeStepper interface.
+     *
+     * @param t0 Time instance that serves as starting time
+     * @param y0 Initial state vector whose layout is used for initialization of
+     *   the internal ARKODE vectors
+     * @param inv_ctx Invocation context that provides access to the SUNContext
+     *   object and the exception pointer managed by the caller
+     */
+    void
+    reinit(double                      t0,
+           const VectorType           &y0,
+           internal::InvocationContext inv_ctx) override;
+
+    /**
+     * Set up the (non)linear solver and preconditioners in the ARKODE memory
+     * object based on the user-specified functions.
+     *
+     * @param solution The solution vector which is used as a template to create
+     *   new vectors.
+     * @param inv_ctx Invocation context that provides access to the SUNContext
+     *   object and the exception pointer managed by the caller
+     */
+    void
+    setup_system_solver(const VectorType           &solution,
+                        internal::InvocationContext inv_ctx);
+
+    /**
+     * Set up the solver and preconditioner for a non-identity @ref GlossMassMatrix
+     * "mass matrix" in the ARKODE memory object based on the user-specified
+     * functions.
+     *
+     * @param solution The solution vector which is used as a template to create
+     *   new vectors.
+     * @param inv_ctx Invocation context that provides access to the SUNContext
+     *   object and the exception pointer managed by the caller
+     */
+    void
+    setup_mass_solver(const VectorType           &solution,
+                      internal::InvocationContext inv_ctx);
+
+    /**
+     * ARKode memory object.
+     */
+    void *arkode_mem;
+
+    /**
+     * ARKStepper configuration data.
+     */
+    AdditionalData data;
+
+    std::unique_ptr<internal::LinearSolverWrapper<VectorType>> linear_solver;
+    std::unique_ptr<internal::LinearSolverWrapper<VectorType>> mass_solver;
+
+    /**
+     * ARKStepper callback context.
+     */
+    CallbackContext callback_ctx;
+  };
+
+
+  template <typename VectorType>
+  ARKStepper<VectorType>::AdditionalData::AdditionalData(
+    const unsigned int order,
+    const unsigned int maximum_non_linear_iterations,
+    const bool         implicit_function_is_linear,
+    const bool         implicit_function_is_time_independent,
+    const bool         mass_is_time_independent,
+    const int          anderson_acceleration_subspace)
+    : order(order)
+    , maximum_non_linear_iterations(maximum_non_linear_iterations)
+    , implicit_function_is_linear(implicit_function_is_linear)
+    , implicit_function_is_time_independent(
+        implicit_function_is_time_independent)
+    , mass_is_time_independent(mass_is_time_independent)
+    , anderson_acceleration_subspace(anderson_acceleration_subspace)
+  {}
+
+
+
+  template <typename VectorType>
+  void
+  ARKStepper<VectorType>::AdditionalData::add_parameters(ParameterHandler &prm)
+  {
+    prm.add_parameter("Integration accuracy order", order);
+    prm.add_parameter("Maximum number of nonlinear iterations",
+                      maximum_non_linear_iterations);
+    prm.add_parameter("Implicit function is linear",
+                      implicit_function_is_linear);
+    prm.add_parameter("Implicit function is time independent",
+                      implicit_function_is_time_independent);
+    prm.add_parameter("Mass is time independent", mass_is_time_independent);
+    prm.add_parameter("Anderson-acceleration subspace",
+                      anderson_acceleration_subspace);
+  }
+
+} // namespace SUNDIALS
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -1,0 +1,527 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#ifndef dealii_sundials_arkode_stepper_templates_h
+#define dealii_sundials_arkode_stepper_templates_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/sundials/arkode_stepper.h>
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+#  include <deal.II/base/utilities.h>
+
+#  include <deal.II/sundials/arkode_exception.h>
+#  include <deal.II/sundials/invocation_context.h>
+#  include <deal.II/sundials/n_vector.h>
+#  include <deal.II/sundials/sunlinsol_wrapper.h>
+#  include <deal.II/sundials/utilities.h>
+
+#  include <arkode/arkode_arkstep.h>
+#  include <sunlinsol/sunlinsol_spgmr.h>
+#  include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
+
+#  include <iostream>
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+namespace SUNDIALS
+{
+  template <typename VectorType>
+  ARKStepper<VectorType>::ARKStepper(const AdditionalData &data)
+    : arkode_mem(nullptr)
+    , data(data)
+  {}
+
+
+
+  template <typename VectorType>
+  ARKStepper<VectorType>::~ARKStepper()
+  {
+    if (arkode_mem)
+      {
+        ARKStepFree(&arkode_mem);
+        arkode_mem = nullptr;
+      }
+  }
+
+
+
+  template <typename VectorType>
+  void
+  ARKStepper<VectorType>::reinit(double                      t0,
+                                 const VectorType           &y0,
+                                 internal::InvocationContext inv_ctx)
+  {
+    if (arkode_mem)
+      {
+        ARKStepFree(&arkode_mem);
+        arkode_mem = nullptr;
+      }
+
+    Assert(explicit_function || implicit_function,
+           ExcFunctionNotProvided("explicit_function || implicit_function"));
+
+    const auto explicit_function_callback = [](SUNDIALS::realtype tt,
+                                               N_Vector           yy,
+                                               N_Vector           yp,
+                                               void *user_data) -> int {
+      Assert(user_data != nullptr, ExcInternalError());
+      auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+      auto *src_yy = internal::unwrap_nvector_const<VectorType>(yy);
+      auto *dst_yp = internal::unwrap_nvector<VectorType>(yp);
+
+      return Utilities::call_and_possibly_capture_exception(
+        callback_ctx.stepper->explicit_function,
+        *callback_ctx.pending_exception,
+        tt,
+        *src_yy,
+        *dst_yp);
+    };
+
+    const auto implicit_function_callback = [](SUNDIALS::realtype tt,
+                                               N_Vector           yy,
+                                               N_Vector           yp,
+                                               void *user_data) -> int {
+      Assert(user_data != nullptr, ExcInternalError());
+      auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+      auto *src_yy = internal::unwrap_nvector_const<VectorType>(yy);
+      auto *dst_yp = internal::unwrap_nvector<VectorType>(yp);
+
+      return Utilities::call_and_possibly_capture_exception(
+        callback_ctx.stepper->implicit_function,
+        *callback_ctx.pending_exception,
+        tt,
+        *src_yy,
+        *dst_yp);
+    };
+
+    // just a view on the memory in solution, all write operations on yy by
+    // ARKODE will automatically be mirrored to solution
+    const auto initial_condition_nvector =
+      internal::make_nvector_view(y0
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                  ,
+                                  inv_ctx.arkode_ctx
+#  endif
+      );
+
+    arkode_mem = ARKStepCreate(explicit_function ? explicit_function_callback :
+                                                   ARKRhsFn(nullptr),
+                               implicit_function ? implicit_function_callback :
+                                                   ARKRhsFn(nullptr),
+                               t0,
+                               initial_condition_nvector
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                               ,
+                               inv_ctx.arkode_ctx
+#  endif
+    );
+    Assert(arkode_mem != nullptr, ExcInternalError());
+
+    callback_ctx = {this, &inv_ctx.pending_exception};
+    int status   = ARKStepSetUserData(arkode_mem, &callback_ctx);
+    AssertARKode(status);
+
+    setup_system_solver(y0, inv_ctx);
+
+    setup_mass_solver(y0, inv_ctx);
+
+    if (data.order != 0)
+      {
+#  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
+        status = ARKodeSetOrder(arkode_mem, data.order);
+#  else
+        status = ARKStepSetOrder(arkode_mem, data.order);
+#  endif
+        AssertARKode(status);
+      }
+
+    if (custom_setup)
+      custom_setup(arkode_mem);
+  }
+
+
+
+  template <typename VectorType>
+  void
+  ARKStepper<VectorType>::setup_system_solver(
+    const VectorType           &solution,
+    internal::InvocationContext inv_ctx)
+  {
+    // no point in setting up a solver when there is no linear system
+    if (!implicit_function)
+      return;
+
+    int status;
+    (void)status;
+    // Initialize solver
+    // currently only iterative linear solvers are supported
+    if (jacobian_times_vector)
+      {
+        SUNLinearSolver sun_linear_solver;
+        if (solve_linearized_system)
+          {
+            linear_solver =
+              std::make_unique<internal::LinearSolverWrapper<VectorType>>(
+                solve_linearized_system,
+                inv_ctx.pending_exception
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                ,
+                inv_ctx.arkode_ctx
+#  endif
+              );
+            sun_linear_solver = *linear_solver;
+          }
+        else
+          {
+            // use default solver from SUNDIALS
+            // TODO give user options
+            auto y_template = internal::make_nvector_view(solution
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                                          ,
+                                                          inv_ctx.arkode_ctx
+#  endif
+            );
+#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+            sun_linear_solver =
+              SUNLinSol_SPGMR(y_template,
+                              PREC_NONE,
+                              0 /*krylov subvectors, 0 uses default*/);
+#  else
+            sun_linear_solver =
+              SUNLinSol_SPGMR(y_template,
+                              SUN_PREC_NONE,
+                              0 /*krylov subvectors, 0 uses default*/,
+                              inv_ctx.arkode_ctx);
+#  endif
+          }
+        status = ARKStepSetLinearSolver(arkode_mem, sun_linear_solver, nullptr);
+        AssertARKode(status);
+
+        auto jacobian_times_vector_callback = [](N_Vector           v,
+                                                 N_Vector           Jv,
+                                                 SUNDIALS::realtype t,
+                                                 N_Vector           y,
+                                                 N_Vector           fy,
+                                                 void              *user_data,
+                                                 N_Vector) -> int {
+          Assert(user_data != nullptr, ExcInternalError());
+          auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+          auto *src_v  = internal::unwrap_nvector_const<VectorType>(v);
+          auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
+          auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
+
+          auto *dst_Jv = internal::unwrap_nvector<VectorType>(Jv);
+
+          return Utilities::call_and_possibly_capture_exception(
+            callback_ctx.stepper->jacobian_times_vector,
+            *callback_ctx.pending_exception,
+            *src_v,
+            *dst_Jv,
+            t,
+            *src_y,
+            *src_fy);
+        };
+
+        auto jacobian_times_vector_setup_callback = [](SUNDIALS::realtype t,
+                                                       N_Vector           y,
+                                                       N_Vector           fy,
+                                                       void *user_data) -> int {
+          Assert(user_data != nullptr, ExcInternalError());
+          auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+          auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
+          auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
+
+          return Utilities::call_and_possibly_capture_exception(
+            callback_ctx.stepper->jacobian_times_vector_setup,
+            *callback_ctx.pending_exception,
+            t,
+            *src_y,
+            *src_fy);
+        };
+        status = ARKStepSetJacTimes(arkode_mem,
+                                    jacobian_times_vector_setup ?
+                                      jacobian_times_vector_setup_callback :
+                                      ARKLsJacTimesSetupFn(nullptr),
+                                    jacobian_times_vector_callback);
+        AssertARKode(status);
+        if (jacobian_preconditioner_solve)
+          {
+            auto solve_with_jacobian_callback = [](SUNDIALS::realtype t,
+                                                   N_Vector           y,
+                                                   N_Vector           fy,
+                                                   N_Vector           r,
+                                                   N_Vector           z,
+                                                   SUNDIALS::realtype gamma,
+                                                   SUNDIALS::realtype delta,
+                                                   int                lr,
+                                                   void *user_data) -> int {
+              Assert(user_data != nullptr, ExcInternalError());
+              auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+              auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
+              auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
+              auto *src_r  = internal::unwrap_nvector_const<VectorType>(r);
+
+              auto *dst_z = internal::unwrap_nvector<VectorType>(z);
+
+              return Utilities::call_and_possibly_capture_exception(
+                callback_ctx.stepper->jacobian_preconditioner_solve,
+                *callback_ctx.pending_exception,
+                t,
+                *src_y,
+                *src_fy,
+                *src_r,
+                *dst_z,
+                gamma,
+                delta,
+                lr);
+            };
+
+            auto jacobian_solver_setup_callback =
+              [](SUNDIALS::realtype  t,
+                 N_Vector            y,
+                 N_Vector            fy,
+                 SUNDIALS::booltype  jok,
+                 SUNDIALS::booltype *jcurPtr,
+                 SUNDIALS::realtype  gamma,
+                 void               *user_data) -> int {
+              Assert(user_data != nullptr, ExcInternalError());
+              auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+              auto *src_y  = internal::unwrap_nvector_const<VectorType>(y);
+              auto *src_fy = internal::unwrap_nvector_const<VectorType>(fy);
+
+              return Utilities::call_and_possibly_capture_exception(
+                callback_ctx.stepper->jacobian_preconditioner_setup,
+                *callback_ctx.pending_exception,
+                t,
+                *src_y,
+                *src_fy,
+                jok,
+                *jcurPtr,
+                gamma);
+            };
+
+            status = ARKStepSetPreconditioner(arkode_mem,
+                                              jacobian_preconditioner_setup ?
+                                                jacobian_solver_setup_callback :
+                                                ARKLsPrecSetupFn(nullptr),
+                                              solve_with_jacobian_callback);
+            AssertARKode(status);
+          }
+        if (data.implicit_function_is_linear)
+          {
+            status = ARKStepSetLinear(
+              arkode_mem, data.implicit_function_is_time_independent ? 0 : 1);
+            AssertARKode(status);
+          }
+      }
+    else
+      {
+        auto y_template = internal::make_nvector_view(solution
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                                      ,
+                                                      inv_ctx.arkode_ctx
+#  endif
+        );
+
+#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+        SUNNonlinearSolver fixed_point_solver =
+          SUNNonlinSol_FixedPoint(y_template,
+                                  data.anderson_acceleration_subspace);
+#  else
+        SUNNonlinearSolver fixed_point_solver =
+          SUNNonlinSol_FixedPoint(y_template,
+                                  data.anderson_acceleration_subspace,
+                                  inv_ctx.arkode_ctx);
+#  endif
+
+        status = ARKStepSetNonlinearSolver(arkode_mem, fixed_point_solver);
+        AssertARKode(status);
+      }
+
+    status =
+      ARKStepSetMaxNonlinIters(arkode_mem, data.maximum_non_linear_iterations);
+    AssertARKode(status);
+  }
+
+
+
+  template <typename VectorType>
+  void
+  ARKStepper<VectorType>::setup_mass_solver(const VectorType &solution,
+                                            internal::InvocationContext inv_ctx)
+  {
+    int status;
+    (void)status;
+
+    if (mass_times_vector)
+      {
+        SUNLinearSolver sun_mass_linear_solver;
+        if (solve_mass)
+          {
+            mass_solver =
+              std::make_unique<internal::LinearSolverWrapper<VectorType>>(
+                solve_mass,
+
+                inv_ctx.pending_exception
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                ,
+                inv_ctx.arkode_ctx
+#  endif
+              );
+            sun_mass_linear_solver = *mass_solver;
+          }
+        else
+          {
+            auto y_template = internal::make_nvector_view(solution
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+                                                          ,
+                                                          inv_ctx.arkode_ctx
+#  endif
+            );
+#  if DEAL_II_SUNDIALS_VERSION_LT(6, 0, 0)
+            sun_mass_linear_solver =
+              SUNLinSol_SPGMR(y_template,
+                              PREC_NONE,
+                              0 /*krylov subvectors, 0 uses default*/);
+#  else
+            sun_mass_linear_solver =
+              SUNLinSol_SPGMR(y_template,
+                              SUN_PREC_NONE,
+                              0 /*krylov subvectors, 0 uses default*/,
+                              inv_ctx.arkode_ctx);
+#  endif
+          }
+
+        SUNDIALS::booltype mass_time_dependent =
+          data.mass_is_time_independent ? SUNFALSE : SUNTRUE;
+
+        status = ARKStepSetMassLinearSolver(arkode_mem,
+                                            sun_mass_linear_solver,
+                                            nullptr,
+                                            mass_time_dependent);
+        AssertARKode(status);
+
+        auto mass_matrix_times_vector_setup_callback =
+          [](SUNDIALS::realtype t, void *mtimes_data) -> int {
+          Assert(mtimes_data != nullptr, ExcInternalError());
+          auto &callback_ctx = *static_cast<CallbackContext *>(mtimes_data);
+
+          return Utilities::call_and_possibly_capture_exception(
+            callback_ctx.stepper->mass_times_setup,
+            *callback_ctx.pending_exception,
+            t);
+        };
+
+        auto mass_matrix_times_vector_callback = [](N_Vector           v,
+                                                    N_Vector           Mv,
+                                                    SUNDIALS::realtype t,
+                                                    void *mtimes_data) -> int {
+          Assert(mtimes_data != nullptr, ExcInternalError());
+          auto &callback_ctx = *static_cast<CallbackContext *>(mtimes_data);
+
+          auto *src_v  = internal::unwrap_nvector_const<VectorType>(v);
+          auto *dst_Mv = internal::unwrap_nvector<VectorType>(Mv);
+
+          return Utilities::call_and_possibly_capture_exception(
+            callback_ctx.stepper->mass_times_vector,
+            *callback_ctx.pending_exception,
+            t,
+            *src_v,
+            *dst_Mv);
+        };
+
+        status = ARKStepSetMassTimes(arkode_mem,
+                                     mass_times_setup ?
+                                       mass_matrix_times_vector_setup_callback :
+                                       ARKLsMassTimesSetupFn(nullptr),
+                                     mass_matrix_times_vector_callback,
+                                     this);
+        AssertARKode(status);
+
+        if (mass_preconditioner_solve)
+          {
+            auto mass_matrix_solver_setup_callback =
+              [](SUNDIALS::realtype t, void *user_data) -> int {
+              Assert(user_data != nullptr, ExcInternalError());
+              auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+              return Utilities::call_and_possibly_capture_exception(
+                callback_ctx.stepper->mass_preconditioner_setup,
+                *callback_ctx.pending_exception,
+                t);
+            };
+
+            auto solve_with_mass_matrix_callback = [](SUNDIALS::realtype t,
+                                                      N_Vector           r,
+                                                      N_Vector           z,
+                                                      SUNDIALS::realtype delta,
+                                                      int                lr,
+                                                      void *user_data) -> int {
+              Assert(user_data != nullptr, ExcInternalError());
+              auto &callback_ctx = *static_cast<CallbackContext *>(user_data);
+
+              auto *src_r = internal::unwrap_nvector_const<VectorType>(r);
+              auto *dst_z = internal::unwrap_nvector<VectorType>(z);
+
+              return Utilities::call_and_possibly_capture_exception(
+                callback_ctx.stepper->mass_preconditioner_solve,
+                *callback_ctx.pending_exception,
+                t,
+                *src_r,
+                *dst_z,
+                delta,
+                lr);
+            };
+
+            status =
+              ARKStepSetMassPreconditioner(arkode_mem,
+                                           mass_preconditioner_setup ?
+                                             mass_matrix_solver_setup_callback :
+                                             ARKLsMassPrecSetupFn(nullptr),
+                                           solve_with_mass_matrix_callback);
+            AssertARKode(status);
+          }
+      }
+  }
+
+
+
+  template <typename VectorType>
+  void *
+  ARKStepper<VectorType>::get_arkode_memory() const
+  {
+    return arkode_mem;
+  }
+
+} // namespace SUNDIALS
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/sundials/invocation_context.h
+++ b/include/deal.II/sundials/invocation_context.h
@@ -1,0 +1,58 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#ifndef dealii_sundials_invocation_context_h
+#define dealii_sundials_invocation_context_h
+
+#include <deal.II/base/config.h>
+
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+#  include <sundials/sundials_types.h>
+
+#  include <exception>
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+
+DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
+namespace SUNDIALS
+{
+  namespace internal
+  {
+    /**
+     * This struct contains references to the std::exception_ptr @p
+     * pending_exception and SUNContext @p arkode_ctx for SUNDIALS 6.0 and
+     * newer. This is required for situations when an object needs to pass
+     * the context to the objects it uses.
+     */
+    struct InvocationContext
+    {
+      std::exception_ptr &pending_exception;
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+      SUNContext &arkode_ctx;
+#  endif
+    };
+  } // namespace internal
+} // namespace SUNDIALS
+
+#endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/sundials/CMakeLists.txt
+++ b/source/sundials/CMakeLists.txt
@@ -19,6 +19,7 @@ set(_inst)
 if (DEAL_II_WITH_SUNDIALS)
   set(_src
     ${_src}
+    arkode_stepper.cc
     arkode.cc
     ida.cc
     kinsol.cc
@@ -28,6 +29,7 @@ if (DEAL_II_WITH_SUNDIALS)
 
   set(_inst
     ${_inst}
+    arkode_stepper.inst.in
     arkode.inst.in
     n_vector.inst.in
     sunlinsol_wrapper.inst.in

--- a/source/sundials/arkode_stepper.cc
+++ b/source/sundials/arkode_stepper.cc
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/sundials/arkode_stepper.h>
+#include <deal.II/sundials/arkode_stepper.templates.h>
+
+#ifdef DEAL_II_WITH_SUNDIALS
+
+#  include <deal.II/lac/block_vector.h>
+#  include <deal.II/lac/la_parallel_block_vector.h>
+#  include <deal.II/lac/la_parallel_vector.h>
+#  include <deal.II/lac/vector.h>
+#  ifdef DEAL_II_WITH_TRILINOS
+#    include <deal.II/lac/trilinos_parallel_block_vector.h>
+#    include <deal.II/lac/trilinos_vector.h>
+#  endif
+#  ifdef DEAL_II_WITH_PETSC
+#    include <deal.II/lac/petsc_block_vector.h>
+#    include <deal.II/lac/petsc_vector.h>
+#  endif
+
+DEAL_II_NAMESPACE_OPEN
+
+// We don't build the .inst file if deal.II isn't configured
+// with SUNDIALS, but doxygen doesn't know that and tries to find that
+// file anyway for parsing -- which then of course it fails on. So
+// exclude the following from doxygen consideration.
+#  ifndef DOXYGEN
+#    include "sundials/arkode_stepper.inst"
+#  endif
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/sundials/arkode_stepper.inst.in
+++ b/source/sundials/arkode_stepper.inst.in
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+// serial Vector and BlockVector
+for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
+  {
+    template class SUNDIALS::ARKStepper<V<S>>;
+  }
+
+// parallel Vector and BlockVector
+for (S : REAL_SCALARS; V : DEAL_II_VEC_TEMPLATES)
+  {
+    template class SUNDIALS::ARKStepper<LinearAlgebra::distributed::V<S>>;
+  }
+
+#if defined(DEAL_II_WITH_MPI) && defined(DEAL_II_WITH_TRILINOS)
+// TrilinosWrappers Vector and BlockVector
+for (V : DEAL_II_VEC_TEMPLATES)
+  {
+    template class SUNDIALS::ARKStepper<TrilinosWrappers::MPI::V>;
+  }
+#endif
+
+#if defined(DEAL_II_WITH_MPI) && defined(DEAL_II_WITH_PETSC)
+#  ifndef DEAL_II_PETSC_WITH_COMPLEX
+// PETScWrappers Vector and BlockVector
+for (V : DEAL_II_VEC_TEMPLATES)
+  {
+    template class SUNDIALS::ARKStepper<PETScWrappers::MPI::V>;
+  }
+#  endif
+#endif


### PR DESCRIPTION
This PR introduces `ARKodeStepper` interface whose goal is to split general ARKODE callbacks from the time stepper specific ones. This approach basically mimics the structure or ARKODE itself and makes it possible to use different steppers: e.g.,

- `ARKStep` (its wrapper is implemented in this PR)
- `ERKStep`
- `LSRKStep`, etc

With the old implementation, `ARKStep` was the only available option (hardcoded).

To provide the backwards compatibility for the `ARKode` interface, this PR uses a lightweight function proxy object. But I would discourage the use of old interfaces, that is already reflected in the documentation and by marking them as deprecated.