### PR TITLE
Fix condition for line identity

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -474,8 +474,7 @@ namespace internal
                               {
                                 unsigned int i = 0;
                                 for (; i < dofs_per_line; ++i)
-                                  if ((identities[i].first != i) &&
-                                      (identities[i].second != i))
+                                  if (identities[i] != std::pair{i, i})
                                     // not an identity
                                     break;
 


### PR DESCRIPTION
Working on #19264 I wondered why a test interpolating a polynomial (like @bangerth suggested [here](https://github.com/dealii/dealii/pull/19264#pullrequestreview-3743190036)) with two `SimplexP<3>(3)` elements still worked if `FE_SimplexP::hp_line_dof_identities()` returned something wrong like `0, 1` `1, 0` instead of `0, 0` `1, 1`. 

The condition now checks if the first and sceond entry of `identities[i]` equals to `i`, which is assumed in https://github.com/dealii/dealii/blob/b4b6e81c60da7ffdc789a4a80cbce89d9d870cce/source/dofs/dof_handler_policy.cc#L522-L530