### PR TITLE
Fix TpetraWrappers::locally_owned_elements

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1044,9 +1044,9 @@ namespace LinearAlgebra
       dealii::IndexSet source_stored_elements;
 
       /**
-       * IndexSet of the nonlocal_entries that are relevant for this vector.
+       * IndexSet of the local owned elements.
        */
-      dealii::IndexSet nonlocal_entries;
+      dealii::IndexSet local_entries;
 
       /**
        * CommunicationPattern for the communication between the


### PR DESCRIPTION
Fixes https://cdash.dealii.org/test/33423837.
We should always define `nonlocal_entries` which can be empty if we only have locally onwed elements but it should still always have the correct size.