### PR TITLE
Test robustness of SolverMPGMRES

### DIFF
--- a/tests/lac/solver_mpgmres_01.cc
+++ b/tests/lac/solver_mpgmres_01.cc
@@ -137,5 +137,5 @@ main()
     solver_mpgmres.solve(matrix, sol, rhs, wrapper_a, wrapper_b, wrapper_c),
     control.last_step(),
     20 - 12,
-    20 + 12);
+    20 + 20);
 }

--- a/tests/lac/solver_mpgmres_01.output
+++ b/tests/lac/solver_mpgmres_01.output
@@ -31,4 +31,4 @@ Applying preconditioner C
 Applying preconditioner A
 Applying preconditioner B
 Applying preconditioner C
-DEAL::Solver stopped within 8 - 32 iterations
+DEAL::Solver stopped within 8 - 40 iterations


### PR DESCRIPTION
On my machine, the full variant of `SolverMPGMRES` takes more iterations on a build with clang-20 and AVX-512, see https://cdash.dealii.org/test/34421791 - I suggest we simply increase the window of valid iteration counts.