### PR TITLE
Make a test robust against roundoff errors

### DIFF
--- a/tests/grid/closest_point.cc
+++ b/tests/grid/closest_point.cc
@@ -29,7 +29,7 @@ test(const ReferenceCell &reference_cell,
                 ExcInternalError());
 
   // Also generate a lot of points in the unit cell - we should be closer than
-  // any generated point
+  // any generated point up to a roundoff error
   const unsigned int n_points_1d = 100;
   if (dim == 2)
     {
@@ -39,7 +39,8 @@ test(const ReferenceCell &reference_cell,
             const Point<dim> grid_point(i / double(n_points_1d),
                                         j / double(n_points_1d));
             if (reference_cell.contains_point(grid_point))
-              AssertThrow(distance_square <= grid_point.distance_square(p),
+              AssertThrow(distance_square <=
+                            (1 + 1e-15) * grid_point.distance_square(p),
                           ExcInternalError());
           }
     }
@@ -55,7 +56,8 @@ test(const ReferenceCell &reference_cell,
                                           -1.0 + 2.0 * j / double(n_points_1d),
                                           k / double(n_points_1d));
               if (reference_cell.contains_point(grid_point))
-                AssertThrow(distance_square <= grid_point.distance_square(p),
+                AssertThrow(distance_square <=
+                              (1 + 1e-15) * grid_point.distance_square(p),
                             ExcInternalError());
             }
     }


### PR DESCRIPTION
The test `grid/closest_point` takes some points outside the unit cell, compute the closest point on a cell and then check that the distance to the closest point is closer than any sampled points within the reference cell. However, roundoff errors can make an exact comparison `distance_closest_point_on_cell <= distance_some_sampled_point_in_cell` fail, in case one of the sampled points is the closest point but differs by the roundoff. We should compare with a tolerance.