### PR TITLE
TriaAccessor: refactor how we represent the level.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -2293,7 +2293,7 @@ inline TriaIterator<DoFAccessor<structdim, dim, spacedim, level_dof_access>>
 DoFAccessor<structdim, dim, spacedim, level_dof_access>::child(
   const unsigned int i) const
 {
-  Assert(static_cast<unsigned int>(this->present_level) <
+  Assert(static_cast<unsigned int>(this->level()) <
            this->dof_handler->object_dof_indices.size(),
          ExcMessage("DoFHandler not initialized"));
 

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -104,7 +104,7 @@ void
 DoFCellAccessor<dim, spacedim, lda>::set_dof_indices(
   const std::vector<types::global_dof_index> &local_dof_indices)
 {
-  Assert(static_cast<unsigned int>(this->present_level) <
+  Assert(static_cast<unsigned int>(this->level()) <
            this->dof_handler->object_dof_indices.size(),
          ExcMessage("DoFHandler not initialized"));
 


### PR DESCRIPTION
Since lower-dimensional objects (faces and lines in 3d) don't belong to levels we don't store a `present_level` for those accessors. The current version stores a proxy object which prevents assignment, incrementing, etc.: this patch replaces the proxy object with a base class (which may be empty) with simpler getters and setters.