### PR TITLE
`IndexSet::n_elements()`: move the check to `compress()`.

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1949,14 +1949,6 @@ IndexSet::n_elements() const
       v              = r.nth_index_in_set + r.end - r.begin;
     }
 
-  if constexpr (running_in_debug_mode())
-    {
-      size_type s = 0;
-      for (const auto &range : ranges)
-        s += (range.end - range.begin);
-      Assert(s == v, ExcInternalError());
-    }
-
   return v;
 }
 


### PR DESCRIPTION
We don't need to check this value if the `IndexSet` hasn't changed. `ReadWriteVector::local_element()` calls this function which leads to poor performance in debug mode for `IndexSet`s with thousands of ranges (like those created by `DataOut`).

I don't have the full stack trace any more, but in my app `DataOut` creates vectors whose `IndexSet`s had about 30k ranges: that causes catastrophic performance problems in debug mode since I was looping over all 30k sets for each vector entry.