### PR TITLE
Use unpreconditioned norm in petsc ksp

### DIFF
--- a/doc/news/changes/minor/20260305YLW
+++ b/doc/news/changes/minor/20260305YLW
@@ -1,0 +1,6 @@
+Fixed: When using the PETSc solver through PETScWrappers,
+the original code will use the l2 norm of the preconditioned residual.
+This is not consistent with deal.II expectations and example usage.
+This PR fixes the issue by using the unpreconditioned residual norm.
+<br>
+(Yiliang Wang, 2026/03/05)

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -102,6 +102,13 @@ namespace PETScWrappers
          * this can be overridden by command line.
          */
         AssertPETSc(KSPSetReusePreconditioner(ksp, PETSC_TRUE));
+
+        // By default, we use the unpreconditioned norm to check for
+        // convergence. This is consistent with the behavior of deal.II's own
+        // solvers, and is also more efficient to compute. However, users can
+        // override this default behavior with command-line options if they wish
+        // to use a different norm for convergence testing.
+        AssertPETSc(KSPSetNormType(ksp, KSP_NORM_UNPRECONDITIONED));
       }
 
     // setting the preconditioner overwrites the used matrices.

--- a/tests/examples/step-17.with_petsc=true.output
+++ b/tests/examples/step-17.with_petsc=true.output
@@ -1,32 +1,32 @@
 Cycle 0:
    Number of active cells:       64
    Number of degrees of freedom: 162 (by partition: 162)
-   Solver converged in 9 iterations.
+   Solver converged in 10 iterations.
 Cycle 1:
-   Number of active cells:       121
-   Number of degrees of freedom: 298 (by partition: 298)
+   Number of active cells:       124
+   Number of degrees of freedom: 302 (by partition: 302)
    Solver converged in 17 iterations.
 Cycle 2:
-   Number of active cells:       229
-   Number of degrees of freedom: 550 (by partition: 550)
-   Solver converged in 26 iterations.
+   Number of active cells:       238
+   Number of degrees of freedom: 570 (by partition: 570)
+   Solver converged in 27 iterations.
 Cycle 3:
-   Number of active cells:       433
-   Number of degrees of freedom: 1004 (by partition: 1004)
-   Solver converged in 36 iterations.
+   Number of active cells:       454
+   Number of degrees of freedom: 1046 (by partition: 1046)
+   Solver converged in 35 iterations.
 Cycle 4:
-   Number of active cells:       820
-   Number of degrees of freedom: 1826 (by partition: 1826)
-   Solver converged in 51 iterations.
+   Number of active cells:       862
+   Number of degrees of freedom: 1910 (by partition: 1910)
+   Solver converged in 53 iterations.
 Cycle 5:
-   Number of active cells:       1558
-   Number of degrees of freedom: 3348 (by partition: 3348)
+   Number of active cells:       1636
+   Number of degrees of freedom: 3506 (by partition: 3506)
    Solver converged in 67 iterations.
 Cycle 6:
-   Number of active cells:       2953
-   Number of degrees of freedom: 6318 (by partition: 6318)
+   Number of active cells:       3100
+   Number of degrees of freedom: 6626 (by partition: 6626)
    Solver converged in 93 iterations.
 Cycle 7:
-   Number of active cells:       5596
-   Number of degrees of freedom: 11706 (by partition: 11706)
-   Solver converged in 122 iterations.
+   Number of active cells:       5884
+   Number of degrees of freedom: 12286 (by partition: 12286)
+   Solver converged in 124 iterations.

--- a/tests/examples/step-18.diff
+++ b/tests/examples/step-18.diff
@@ -31,8 +31,8 @@
 >                                        system_rhs,
 >                                        preconditioner),
 >                               solver_control.last_step(),
->                               100,
->                               175);
+>                               250,
+>                               360);
 1330c1340
 <     output_results();
 ---

--- a/tests/examples/step-18.mpirun=2.with_petsc=true.output
+++ b/tests/examples/step-18.mpirun=2.with_petsc=true.output
@@ -3,13 +3,13 @@ Timestep 1 at time 1
     Number of active cells:       3712 (by partition: 1856+1856)
     Number of degrees of freedom: 17226 (by partition: 8874+8352)
     Assembling system... norm of rhs is 1.88062e+10
-Solver stopped within 100 - 175 iterations
+Solver stopped within 250 - 360 iterations
     Updating quadrature point data...
   Cycle 1:
-    Number of active cells:       12805 (by partition: 6399+6406)
-    Number of degrees of freedom: 51720 (by partition: 25902+25818)
-    Assembling system... norm of rhs is 1.72532e+10
-Solver stopped within 100 - 175 iterations
+    Number of active cells:       13050 (by partition: 6522+6528)
+    Number of degrees of freedom: 52722 (by partition: 26436+26286)
+    Assembling system... norm of rhs is 3.61177e+10
+Solver stopped within 250 - 360 iterations
     Updating quadrature point data...
     Moving mesh...
 

--- a/tests/examples/step-40.mpirun=2.with_p4est=true.with_petsc_with_hypre=true.output
+++ b/tests/examples/step-40.mpirun=2.with_p4est=true.with_petsc_with_hypre=true.output
@@ -2,15 +2,15 @@ Running with PETSc on 2 MPI rank(s)...
 Cycle 0:
    Number of active cells:       1024
    Number of degrees of freedom: 4225
-Solver stopped after 7 iterations
+Solver stopped after 6 iterations
 
 Cycle 1:
-   Number of active cells:       1966
-   Number of degrees of freedom: 8453
-Solver stopped after 7 iterations
+   Number of active cells:       1963
+   Number of degrees of freedom: 8437
+Solver stopped after 6 iterations
 
 Cycle 2:
-   Number of active cells:       3676
-   Number of degrees of freedom: 16211
+   Number of active cells:       3670
+   Number of degrees of freedom: 16175
 Solver stopped after 7 iterations
 

--- a/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=1.output
+++ b/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=1.output
@@ -18,7 +18,7 @@ DEAL::Cycle 3:
 DEAL::   Number of active cells      : 1365
 DEAL::   Number of degrees of freedom: 12493
 DEAL::   Number of constraints       : 3079
-DEAL::   Solved in 17 iterations.
+DEAL::   Solved in 16 iterations.
 DEAL::Cycle 4:
 DEAL::   Number of active cells      : 1668
 DEAL::   Number of degrees of freedom: 18490

--- a/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=2.output
+++ b/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=2.output
@@ -13,7 +13,7 @@ DEAL::Cycle 2:
 DEAL::   Number of active cells      : 1149
 DEAL::   Number of degrees of freedom: 8556
 DEAL::   Number of constraints       : 1998
-DEAL::   Solved in 11 iterations.
+DEAL::   Solved in 10 iterations.
 DEAL::Cycle 3:
 DEAL::   Number of active cells      : 1365
 DEAL::   Number of degrees of freedom: 12537

--- a/tests/mpi/step-40_cuthill_mckee.with_petsc_with_hypre=true.mpirun=4.with_p4est=true.output
+++ b/tests/mpi/step-40_cuthill_mckee.with_petsc_with_hypre=true.mpirun=4.with_p4est=true.output
@@ -12,6 +12,6 @@ Cycle 1:
       1024+1024+1024+1024+
    Number of degrees of freedom: 16641
       4225+4160+4160+4096+
-DEAL:mpi::Solver stopped within 11 - 11 iterations
-   Solved in 11 iterations.
+DEAL:mpi::Solver stopped after 10 iterations
+   Solved in 10 iterations.
 

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.with_petsc_with_hypre=true.mpirun=7.with_p4est=true.output
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.with_petsc_with_hypre=true.mpirun=7.with_p4est=true.output
@@ -12,6 +12,6 @@ Cycle 1:
       1024+1024+1024+1024+
    Number of degrees of freedom: 16641
       4225+4160+4160+4096+
-DEAL:mpi::Solver stopped within 11 - 11 iterations
-   Solved in 11 iterations.
+DEAL:mpi::Solver stopped after 10 iterations
+   Solved in 10 iterations.
 

--- a/tests/petsc/step-40-multithreading.with_p4est=true.mpirun=2.output
+++ b/tests/petsc/step-40-multithreading.with_p4est=true.mpirun=2.output
@@ -6,8 +6,8 @@ DEAL:0::   Number of degrees of freedom: 4225
 DEAL:0::Solver stopped within 5 - 10 iterations
 DEAL:0::
 DEAL:0::Cycle 1:
-DEAL:0::   Number of active cells:       1966
-DEAL:0::   Number of degrees of freedom: 8453
+DEAL:0::   Number of active cells:       1963
+DEAL:0::   Number of degrees of freedom: 8437
 DEAL:0::Solver stopped within 5 - 10 iterations
 DEAL:0::
 
@@ -18,8 +18,8 @@ DEAL:1::   Number of degrees of freedom: 4225
 DEAL:1::Solver stopped within 5 - 10 iterations
 DEAL:1::
 DEAL:1::Cycle 1:
-DEAL:1::   Number of active cells:       1966
-DEAL:1::   Number of degrees of freedom: 8453
+DEAL:1::   Number of active cells:       1963
+DEAL:1::   Number of degrees of freedom: 8437
 DEAL:1::Solver stopped within 5 - 10 iterations
 DEAL:1::
 


### PR DESCRIPTION
When using the PETSc solver through PETScWrappers, I noticed that the wrapper does not explicitly specify which residual norm is used for the convergence check.

If the norm type is not explicitly set, PETSc defaults to using the l2 norm of the preconditioned residual (see KSPSetNormType:
https://petsc.org/release/manualpages/KSP/KSPSetNormType/).

However, based on the deal.II examples and typical solver usage patterns in the library, it appears that the expected behavior is to monitor convergence using the l2 norm of the true (unpreconditioned) residual.

For this reason, this PR explicitly sets the norm type to ensure that the convergence check uses the l2 norm of the true residual, aligning PETSc solver behavior with deal.II expectations and example usage.