### PR TITLE
Reduce run time of fe/fe*_divergence_theorem tests

### DIFF
--- a/tests/fe/fe_abf_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_abf_gradient_divergence_theorem.cc
@@ -56,6 +56,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -64,16 +65,21 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(4);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_gradients | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(4);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_values | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
+
+  Table<2, Tensor<1, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
 
   for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
        cell != dof.end();
@@ -88,6 +94,23 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<1, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  boundary_integrals(c, i) +=
+                    fe_face_values[single_component].value(i, q) *
+                    fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
+            }
         }
 
       bool cell_ok = true;
@@ -107,17 +130,7 @@ test(const Triangulation<dim> &tr,
                                    fe_values.JxW(q);
                 }
 
-              Tensor<1, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      boundary_integral +=
-                        fe_face_values[single_component].value(i, q) *
-                        fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<1, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))

--- a/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
@@ -54,6 +54,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -62,20 +63,23 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(6);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_3rd_derivatives | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(6);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_hessians | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
 
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
-       cell != dof.end();
-       ++cell)
+  Table<2, Tensor<3, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
+
+  for (const auto &cell : dof.active_cell_iterators())
     {
       fe_values.reinit(cell);
 
@@ -86,6 +90,28 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<3, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  {
+                    Tensor<2, dim> hessian =
+                      fe_face_values[single_component].hessian(i, q);
+                    Tensor<3, dim> hessian_normal_outer_prod =
+                      outer_product(hessian, fe_face_values.normal_vector(q));
+                    boundary_integrals(c, i) +=
+                      hessian_normal_outer_prod * fe_face_values.JxW(q);
+                  }
+            }
         }
 
       bool cell_ok = true;
@@ -109,20 +135,7 @@ test(const Triangulation<dim> &tr,
                     fe_values[single_component].third_derivative(i, q);
                 }
 
-              Tensor<3, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      Tensor<2, dim> hessian =
-                        fe_face_values[single_component].hessian(i, q);
-                      Tensor<3, dim> hessian_normal_outer_prod =
-                        outer_product(hessian, fe_face_values.normal_vector(q));
-                      boundary_integral +=
-                        hessian_normal_outer_prod * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<3, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))

--- a/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
@@ -53,6 +53,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -61,20 +62,23 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(6);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_3rd_derivatives | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(6);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_hessians | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
 
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
-       cell != dof.end();
-       ++cell)
+  Table<2, Tensor<3, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
+
+  for (const auto &cell : dof.active_cell_iterators())
     {
       fe_values.reinit(cell);
 
@@ -85,6 +89,28 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<3, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  {
+                    Tensor<2, dim> hessian =
+                      fe_face_values[single_component].hessian(i, q);
+                    Tensor<3, dim> hessian_normal_outer_prod =
+                      outer_product(hessian, fe_face_values.normal_vector(q));
+                    boundary_integrals(c, i) +=
+                      hessian_normal_outer_prod * fe_face_values.JxW(q);
+                  }
+            }
         }
 
       bool cell_ok = true;
@@ -108,20 +134,7 @@ test(const Triangulation<dim> &tr,
                     fe_values[single_component].third_derivative(i, q);
                 }
 
-              Tensor<3, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      Tensor<2, dim> hessian =
-                        fe_face_values[single_component].hessian(i, q);
-                      Tensor<3, dim> hessian_normal_outer_prod =
-                        outer_product(hessian, fe_face_values.normal_vector(q));
-                      boundary_integral +=
-                        hessian_normal_outer_prod * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<3, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))
@@ -160,10 +173,6 @@ test_hyper_ball(const double tolerance)
 {
   Triangulation<dim> tr;
   GridGenerator::hyper_ball(tr);
-
-  static const SphericalManifold<dim> boundary;
-  tr.set_manifold(0, boundary);
-
   tr.refine_global(1);
 
   FE_DGQ<dim> fe(2);

--- a/tests/fe/fe_dgq_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_gradient_divergence_theorem.cc
@@ -55,6 +55,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -63,20 +64,23 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(3);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_gradients | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(3);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_values | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
 
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
-       cell != dof.end();
-       ++cell)
+  Table<2, Tensor<1, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
+
+  for (const auto &cell : dof.active_cell_iterators())
     {
       fe_values.reinit(cell);
 
@@ -87,6 +91,23 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<1, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  boundary_integrals(c, i) +=
+                    fe_face_values[single_component].value(i, q) *
+                    fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
+            }
         }
 
       bool cell_ok = true;
@@ -106,17 +127,7 @@ test(const Triangulation<dim> &tr,
                                    fe_values.JxW(q);
                 }
 
-              Tensor<1, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      boundary_integral +=
-                        fe_face_values[single_component].value(i, q) *
-                        fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<1, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))
@@ -151,10 +162,6 @@ test_hyper_ball(const double tolerance)
 {
   Triangulation<dim> tr;
   GridGenerator::hyper_ball(tr);
-
-  static const SphericalManifold<dim> boundary;
-  tr.set_manifold(0, boundary);
-
   tr.refine_global(1);
 
   FE_DGQ<dim> fe(2);

--- a/tests/fe/fe_nedelec_sz_divergence_theorem_hanging_nodes.cc
+++ b/tests/fe/fe_nedelec_sz_divergence_theorem_hanging_nodes.cc
@@ -27,7 +27,7 @@
 #include <deal.II/fe/fe_raviart_thomas.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
-#include <deal.II/fe/mapping_q1.h>
+#include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/manifold_lib.h>
@@ -54,6 +54,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -61,17 +62,22 @@ test(const Triangulation<dim> &tr,
 
   deallog << "FE=" << fe.get_name() << std::endl;
 
-  const QGauss<dim> quadrature(4);
-  FEValues<dim>     fe_values(fe,
+  const QGauss<dim> quadrature(5);
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_gradients | update_quadrature_points |
                             update_JxW_values);
 
-  const QGauss<dim - 1> face_quadrature(4);
-  FEFaceValues<dim>     fe_face_values(fe,
+  const QGauss<dim - 1> face_quadrature(5);
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_values | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
+
+  Table<2, Tensor<1, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
 
   for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
        cell != dof.end();
@@ -86,6 +92,23 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<1, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  boundary_integrals(c, i) +=
+                    fe_face_values[single_component].value(i, q) *
+                    fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
+            }
         }
 
       bool cell_ok = true;
@@ -105,17 +128,7 @@ test(const Triangulation<dim> &tr,
                                    fe_values.JxW(q);
                 }
 
-              Tensor<1, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      boundary_integral +=
-                        fe_face_values[single_component].value(i, q) *
-                        fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<1, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))
@@ -150,9 +163,6 @@ test_hyper_ball(const double tolerance)
 {
   Triangulation<dim> tr;
   GridGenerator::hyper_ball(tr);
-
-  static const SphericalManifold<dim> boundary;
-  tr.set_manifold(0, boundary);
 
   // Refine one cell at the boundary,
   // such that the resulting grid contains

--- a/tests/fe/fe_q_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_q_gradient_divergence_theorem.cc
@@ -55,6 +55,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -63,16 +64,21 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(3);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_gradients | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(3);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_values | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
+
+  Table<2, Tensor<1, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
 
   for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
        cell != dof.end();
@@ -87,6 +93,23 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<1, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  boundary_integrals(c, i) +=
+                    fe_face_values[single_component].value(i, q) *
+                    fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
+            }
         }
 
       bool cell_ok = true;
@@ -106,17 +129,7 @@ test(const Triangulation<dim> &tr,
                                    fe_values.JxW(q);
                 }
 
-              Tensor<1, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      boundary_integral +=
-                        fe_face_values[single_component].value(i, q) *
-                        fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<1, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))
@@ -151,10 +164,6 @@ test_hyper_ball(const double tolerance)
 {
   Triangulation<dim> tr;
   GridGenerator::hyper_ball(tr);
-
-  static const SphericalManifold<dim> boundary;
-  tr.set_manifold(0, boundary);
-
   tr.refine_global(1);
 
   FE_Q<dim> fe(2);

--- a/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
@@ -54,6 +54,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -62,20 +63,23 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(6);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_3rd_derivatives | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(6);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_hessians | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
 
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
-       cell != dof.end();
-       ++cell)
+  Table<2, Tensor<3, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
+
+  for (const auto &cell : dof.active_cell_iterators())
     {
       fe_values.reinit(cell);
 
@@ -86,6 +90,28 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<3, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  {
+                    Tensor<2, dim> hessian =
+                      fe_face_values[single_component].hessian(i, q);
+                    Tensor<3, dim> hessian_normal_outer_prod =
+                      outer_product(hessian, fe_face_values.normal_vector(q));
+                    boundary_integrals(c, i) +=
+                      hessian_normal_outer_prod * fe_face_values.JxW(q);
+                  }
+            }
         }
 
       bool cell_ok = true;
@@ -109,20 +135,7 @@ test(const Triangulation<dim> &tr,
                     fe_values[single_component].third_derivative(i, q);
                 }
 
-              Tensor<3, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      Tensor<2, dim> hessian =
-                        fe_face_values[single_component].hessian(i, q);
-                      Tensor<3, dim> hessian_normal_outer_prod =
-                        outer_product(hessian, fe_face_values.normal_vector(q));
-                      boundary_integral +=
-                        hessian_normal_outer_prod * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<3, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))
@@ -161,10 +174,6 @@ test_hyper_ball(const double tolerance)
 {
   Triangulation<dim> tr;
   GridGenerator::hyper_ball(tr);
-
-  static const SphericalManifold<dim> boundary;
-  tr.set_manifold(0, boundary);
-
   tr.refine_global(1);
 
   FE_Q_Hierarchical<dim> fe(2);

--- a/tests/fe/fe_rt_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_rt_gradient_divergence_theorem.cc
@@ -55,6 +55,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -63,16 +64,21 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(4);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_gradients | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(4);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_values | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
+
+  Table<2, Tensor<1, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
 
   for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
        cell != dof.end();
@@ -87,6 +93,23 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<1, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  boundary_integrals(c, i) +=
+                    fe_face_values[single_component].value(i, q) *
+                    fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
+            }
         }
 
       bool cell_ok = true;
@@ -106,17 +129,7 @@ test(const Triangulation<dim> &tr,
                                    fe_values.JxW(q);
                 }
 
-              Tensor<1, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      boundary_integral +=
-                        fe_face_values[single_component].value(i, q) *
-                        fe_face_values.normal_vector(q) * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<1, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))

--- a/tests/fe/fe_rt_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_rt_hessian_divergence_theorem.cc
@@ -54,6 +54,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -62,20 +63,23 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(4);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_hessians | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(4);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_gradients | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
 
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
-       cell != dof.end();
-       ++cell)
+  Table<2, Tensor<2, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
+
+  for (const auto &cell : dof.active_cell_iterators())
     {
       fe_values.reinit(cell);
 
@@ -83,6 +87,27 @@ test(const Triangulation<dim> &tr,
       for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << i << ": (" << cell->vertex(i) << ')' << std::endl;
 
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<2, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  {
+                    Tensor<1, dim> gradient =
+                      fe_face_values[single_component].gradient(i, q);
+                    Tensor<2, dim> gradient_normal_outer_prod =
+                      outer_product(gradient, fe_face_values.normal_vector(q));
+                    boundary_integrals(c, i) +=
+                      gradient_normal_outer_prod * fe_face_values.JxW(q);
+                  }
+            }
+        }
       bool cell_ok = true;
 
       for (unsigned int c = 0; c < fe.n_components(); ++c)
@@ -100,21 +125,7 @@ test(const Triangulation<dim> &tr,
                                    fe_values.JxW(q);
                 }
 
-              Tensor<2, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      Tensor<1, dim> gradient =
-                        fe_face_values[single_component].gradient(i, q);
-                      Tensor<2, dim> gradient_normal_outer_prod =
-                        outer_product(gradient,
-                                      fe_face_values.normal_vector(q));
-                      boundary_integral +=
-                        gradient_normal_outer_prod * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<2, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))

--- a/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
@@ -53,6 +53,7 @@ test(const Triangulation<dim> &tr,
      const FiniteElement<dim> &fe,
      const double              tolerance)
 {
+  MappingQ<dim>   mapping(2);
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
@@ -61,20 +62,23 @@ test(const Triangulation<dim> &tr,
   deallog << "FE=" << fe.get_name() << std::endl;
 
   const QGauss<dim> quadrature(6);
-  FEValues<dim>     fe_values(fe,
+  FEValues<dim>     fe_values(mapping,
+                          fe,
                           quadrature,
                           update_3rd_derivatives | update_quadrature_points |
                             update_JxW_values);
 
   const QGauss<dim - 1> face_quadrature(6);
-  FEFaceValues<dim>     fe_face_values(fe,
+  FEFaceValues<dim>     fe_face_values(mapping,
+                                   fe,
                                    face_quadrature,
                                    update_hessians | update_quadrature_points |
                                      update_normal_vectors | update_JxW_values);
 
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active();
-       cell != dof.end();
-       ++cell)
+  Table<2, Tensor<3, dim>> boundary_integrals(fe.n_components(),
+                                              fe.dofs_per_cell);
+
+  for (const auto &cell : dof.active_cell_iterators())
     {
       fe_values.reinit(cell);
 
@@ -85,6 +89,28 @@ test(const Triangulation<dim> &tr,
           for (unsigned int d = 0; d < dim; ++d)
             deallog << cell->vertex(i)[d] << ' ';
           deallog << ')' << std::endl;
+        }
+
+      // Precompute boundary integrals to avoid frequent
+      // fe_face_values.reinit() calls
+      boundary_integrals.fill(Tensor<3, dim>());
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        {
+          fe_face_values.reinit(cell, face);
+          for (unsigned int c = 0; c < fe.n_components(); ++c)
+            {
+              const FEValuesExtractors::Scalar single_component(c);
+              for (unsigned int i = 0; i < fe_values.dofs_per_cell; ++i)
+                for (const auto q : fe_face_values.quadrature_point_indices())
+                  {
+                    Tensor<2, dim> hessian =
+                      fe_face_values[single_component].hessian(i, q);
+                    Tensor<3, dim> hessian_normal_outer_prod =
+                      outer_product(hessian, fe_face_values.normal_vector(q));
+                    boundary_integrals(c, i) +=
+                      hessian_normal_outer_prod * fe_face_values.JxW(q);
+                  }
+            }
         }
 
       bool cell_ok = true;
@@ -108,20 +134,7 @@ test(const Triangulation<dim> &tr,
                     fe_values[single_component].third_derivative(i, q);
                 }
 
-              Tensor<3, dim> boundary_integral;
-              for (const unsigned int face : GeometryInfo<dim>::face_indices())
-                {
-                  fe_face_values.reinit(cell, face);
-                  for (const auto q : fe_face_values.quadrature_point_indices())
-                    {
-                      Tensor<2, dim> hessian =
-                        fe_face_values[single_component].hessian(i, q);
-                      Tensor<3, dim> hessian_normal_outer_prod =
-                        outer_product(hessian, fe_face_values.normal_vector(q));
-                      boundary_integral +=
-                        hessian_normal_outer_prod * fe_face_values.JxW(q);
-                    }
-                }
+              const Tensor<3, dim> boundary_integral = boundary_integrals(c, i);
 
               if ((bulk_integral - boundary_integral).norm_square() >
                   tolerance * (bulk_integral.norm() + boundary_integral.norm()))
@@ -160,10 +173,6 @@ test_hyper_ball(const double tolerance)
 {
   Triangulation<dim> tr;
   GridGenerator::hyper_ball(tr);
-
-  static const SphericalManifold<dim> boundary;
-  tr.set_manifold(0, boundary);
-
   tr.refine_global(1);
 
   FESystem<dim> fe(FE_Q<dim>(2), 1);


### PR DESCRIPTION
I noticed that many of the tests like `fe_q_hessian_divergence_theorem` have very long run times in debug mode. Looking into them, one sees that they call `FEFaceValues::reinit()` inside a loop over all cell degrees of freedom. The reason is that we want to verify each DoF with integrals over all boundaries. Clearly this should be done by first computing all face integrals for all dofs and put those in a table, and then retrieve that data. I tried to adapt all tests. I increased the mapping order to two to most of the tests, because if we use spherical domains, we should try to have some deformation at least.

This is now much better in terms of run time, all tests run in less than 30 seconds (incl compile time) on my machine.