### PR TITLE
Reduce run time of two tests by using FE_RaviartThomasNodal

### DIFF
--- a/tests/fe/interpolate_system_2.cc
+++ b/tests/fe/interpolate_system_2.cc
@@ -23,7 +23,7 @@
 
 
 //
-// Check convert_generalized_support_opint_values_to_dof_values for systems
+// Check convert_generalized_support_point_values_to_dof_values for systems
 // of non-Lagrangian elements.
 //
 
@@ -31,9 +31,9 @@ template <int dim, typename T>
 void
 check(T function, const unsigned int degree)
 {
-  FESystem<dim> fe(FE_RaviartThomas<dim>(degree),
+  FESystem<dim> fe(FE_RaviartThomasNodal<dim>(degree),
                    2,
-                   FESystem<dim>(FE_RaviartThomas<dim>(degree), 2),
+                   FESystem<dim>(FE_RaviartThomasNodal<dim>(degree), 2),
                    1);
   deallog << fe.get_name() << std::endl;
 

--- a/tests/fe/interpolate_system_2.output
+++ b/tests/fe/interpolate_system_2.output
@@ -1,13 +1,13 @@
 
-DEAL::FESystem<2>[FE_RaviartThomas<2>(1)^2-FESystem<2>[FE_RaviartThomas<2>(1)^2]]
+DEAL::FESystem<2>[FE_RaviartThomasNodal<2>(1)^2-FESystem<2>[FE_RaviartThomasNodal<2>(1)^2]]
+DEAL:: vector 5.55112e-17
+DEAL::FESystem<2>[FE_RaviartThomasNodal<2>(2)^2-FESystem<2>[FE_RaviartThomasNodal<2>(2)^2]]
 DEAL:: vector 1.66533e-16
-DEAL::FESystem<2>[FE_RaviartThomas<2>(2)^2-FESystem<2>[FE_RaviartThomas<2>(2)^2]]
-DEAL:: vector 2.39392e-16
-DEAL::FESystem<2>[FE_RaviartThomas<2>(3)^2-FESystem<2>[FE_RaviartThomas<2>(3)^2]]
-DEAL:: vector 1.87784e-16
-DEAL::FESystem<3>[FE_RaviartThomas<3>(1)^2-FESystem<3>[FE_RaviartThomas<3>(1)^2]]
-DEAL:: vector 1.59595e-16
-DEAL::FESystem<3>[FE_RaviartThomas<3>(2)^2-FESystem<3>[FE_RaviartThomas<3>(2)^2]]
-DEAL:: vector 5.22585e-16
-DEAL::FESystem<3>[FE_RaviartThomas<3>(3)^2-FESystem<3>[FE_RaviartThomas<3>(3)^2]]
-DEAL:: vector 3.52637e-16
+DEAL::FESystem<2>[FE_RaviartThomasNodal<2>(3)^2-FESystem<2>[FE_RaviartThomasNodal<2>(3)^2]]
+DEAL:: vector 1.38778e-16
+DEAL::FESystem<3>[FE_RaviartThomasNodal<3>(1)^2-FESystem<3>[FE_RaviartThomasNodal<3>(1)^2]]
+DEAL:: vector 8.32667e-17
+DEAL::FESystem<3>[FE_RaviartThomasNodal<3>(2)^2-FESystem<3>[FE_RaviartThomasNodal<3>(2)^2]]
+DEAL:: vector 1.66533e-16
+DEAL::FESystem<3>[FE_RaviartThomasNodal<3>(3)^2-FESystem<3>[FE_RaviartThomasNodal<3>(3)^2]]
+DEAL:: vector 1.66533e-16

--- a/tests/fe/interpolate_system_3.cc
+++ b/tests/fe/interpolate_system_3.cc
@@ -31,8 +31,8 @@ template <int dim, typename T>
 void
 check(T function, const unsigned int degree)
 {
-  FESystem<dim> fe = {FE_RaviartThomas<dim>(degree) ^ 2,
-                      FESystem<dim>(FE_RaviartThomas<dim>(degree), 2) ^ 1};
+  FESystem<dim> fe = {FE_RaviartThomasNodal<dim>(degree) ^ 2,
+                      FESystem<dim>(FE_RaviartThomasNodal<dim>(degree), 2) ^ 1};
   deallog << fe.get_name() << std::endl;
 
   std::vector<double> dofs(fe.dofs_per_cell);

--- a/tests/fe/interpolate_system_3.output
+++ b/tests/fe/interpolate_system_3.output
@@ -1,13 +1,13 @@
 
-DEAL::FESystem<2>[FE_RaviartThomas<2>(1)^2-FESystem<2>[FE_RaviartThomas<2>(1)^2]]
+DEAL::FESystem<2>[FE_RaviartThomasNodal<2>(1)^2-FESystem<2>[FE_RaviartThomasNodal<2>(1)^2]]
+DEAL:: vector 5.55112e-17
+DEAL::FESystem<2>[FE_RaviartThomasNodal<2>(2)^2-FESystem<2>[FE_RaviartThomasNodal<2>(2)^2]]
 DEAL:: vector 1.66533e-16
-DEAL::FESystem<2>[FE_RaviartThomas<2>(2)^2-FESystem<2>[FE_RaviartThomas<2>(2)^2]]
-DEAL:: vector 2.39392e-16
-DEAL::FESystem<2>[FE_RaviartThomas<2>(3)^2-FESystem<2>[FE_RaviartThomas<2>(3)^2]]
-DEAL:: vector 1.87784e-16
-DEAL::FESystem<3>[FE_RaviartThomas<3>(1)^2-FESystem<3>[FE_RaviartThomas<3>(1)^2]]
-DEAL:: vector 1.59595e-16
-DEAL::FESystem<3>[FE_RaviartThomas<3>(2)^2-FESystem<3>[FE_RaviartThomas<3>(2)^2]]
-DEAL:: vector 5.22585e-16
-DEAL::FESystem<3>[FE_RaviartThomas<3>(3)^2-FESystem<3>[FE_RaviartThomas<3>(3)^2]]
-DEAL:: vector 3.52637e-16
+DEAL::FESystem<2>[FE_RaviartThomasNodal<2>(3)^2-FESystem<2>[FE_RaviartThomasNodal<2>(3)^2]]
+DEAL:: vector 1.38778e-16
+DEAL::FESystem<3>[FE_RaviartThomasNodal<3>(1)^2-FESystem<3>[FE_RaviartThomasNodal<3>(1)^2]]
+DEAL:: vector 8.32667e-17
+DEAL::FESystem<3>[FE_RaviartThomasNodal<3>(2)^2-FESystem<3>[FE_RaviartThomasNodal<3>(2)^2]]
+DEAL:: vector 1.66533e-16
+DEAL::FESystem<3>[FE_RaviartThomasNodal<3>(3)^2-FESystem<3>[FE_RaviartThomasNodal<3>(3)^2]]
+DEAL:: vector 1.66533e-16


### PR DESCRIPTION
The constructor of `FE_RaviarThomas` is expensive, let's simply use `FE_RaviartThomasNodal`, which is also a non-primitive element to assess those in the code.