### PR TITLE
Implement vector copy operation on MemorySpace::Default

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1471,11 +1471,14 @@ namespace internal
                                                                        &v_data,
            ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace> &data)
       {
+        typename MemorySpace::kokkos_space::execution_space exec;
         Kokkos::deep_copy(
+          exec,
           Kokkos::subview(data.values,
                           Kokkos::pair<size_type, size_type>(0, size)),
           Kokkos::subview(v_data.values,
                           Kokkos::pair<size_type, size_type>(0, size)));
+        exec.fence();
       }
 
       static void
@@ -2137,11 +2140,15 @@ namespace internal
                                                ::dealii::MemorySpace::Default>
           &data)
       {
+        typename ::dealii::MemorySpace::Default::kokkos_space::execution_space
+          exec;
         Kokkos::deep_copy(
+          exec,
           Kokkos::subview(data.values,
                           Kokkos::pair<size_type, size_type>(0, size)),
           Kokkos::subview(v_data.values,
                           Kokkos::pair<size_type, size_type>(0, size)));
+        exec.fence();
       }
 
       static void
@@ -2152,10 +2159,14 @@ namespace internal
                                                  ::dealii::MemorySpace::Default>
             &data)
       {
+        typename ::dealii::MemorySpace::Default::kokkos_space::execution_space
+          exec;
         Kokkos::deep_copy(
+          exec,
           Kokkos::subview(data.values,
                           Kokkos::pair<size_type, size_type>(0, size)),
           s);
+        exec.fence();
       }
 
       static void

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1464,18 +1464,18 @@ namespace internal
     struct functions
     {
       static void
-      copy(
-        const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner> &
-        /*thread_loop_partitioner*/,
-        const size_type /*size*/,
-        const ::dealii::MemorySpace::MemorySpaceData<Number2, MemorySpace>
-          & /*v_data*/,
-        ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace> & /*data*/)
+      copy(const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner> &
+           /*thread_loop_partitioner*/,
+           const size_type size,
+           const ::dealii::MemorySpace::MemorySpaceData<Number2, MemorySpace>
+                                                                       &v_data,
+           ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace> &data)
       {
-        static_assert(
-          std::is_same_v<MemorySpace, ::dealii::MemorySpace::Default> &&
-            std::is_same_v<Number, Number2>,
-          "For the Default MemorySpace Number and Number2 should be the same type");
+        Kokkos::deep_copy(
+          Kokkos::subview(data.values,
+                          Kokkos::pair<size_type, size_type>(0, size)),
+          Kokkos::subview(v_data.values,
+                          Kokkos::pair<size_type, size_type>(0, size)));
       }
 
       static void

--- a/source/lac/la_parallel_vector.cc
+++ b/source/lac/la_parallel_vector.cc
@@ -101,6 +101,14 @@ namespace LinearAlgebra
     Vector<double, ::dealii::MemorySpace::Default>::
       copy_locally_owned_data_from<double>(
         const Vector<double, ::dealii::MemorySpace::Default> &);
+
+    template void
+    Vector<double, ::dealii::MemorySpace::Default>::
+      copy_locally_owned_data_from<float>(
+        const Vector<float, ::dealii::MemorySpace::Default> &);
+    template void
+    Vector<float, ::dealii::MemorySpace::Default>::copy_locally_owned_data_from<
+      double>(const Vector<double, ::dealii::MemorySpace::Default> &);
 #endif
   } // namespace distributed
 } // namespace LinearAlgebra


### PR DESCRIPTION
I want to run mixed-precision algorithms on a GPU. For this, it is useful to provide functions to copy vectors of different types (`float` and `double`).