### PR TITLE
Constrain the types a function can deal with.

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -2203,6 +2203,10 @@ namespace Utilities
               const unsigned int root,
               const MPI_Comm     comm)
     {
+      static_assert(is_mpi_type<T>,
+                    "This function is currently only implemented for "
+                    "MPI-supported data types.");
+
 #  ifndef DEAL_II_WITH_MPI
       (void)buffer;
       (void)count;
@@ -2252,8 +2256,8 @@ namespace Utilities
 
       if constexpr (is_mpi_type<T>)
         {
-          T   object = object_to_send;
-          int ierr =
+          T         object = object_to_send;
+          const int ierr =
             MPI_Bcast(&object, 1, mpi_type_id_for_type<T>, root_process, comm);
           AssertThrowMPI(ierr);
 


### PR DESCRIPTION
The `Utilities::MPI::broadcast()` function that takes an array directly calls `MPI_Bcast`, and so can only deal with MPI's own types. Ensure that via a `static_assert`.

(I thought about also adding a C++20 `requires` clause, but decided against it because this is really not a requirement of the function -- it's just that the general case hasn't been implemented yet.)