### PR TITLE
Build on macos-26.

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        os: [macos-15, macos-26]
 
     steps:
     - uses: actions/checkout@v6
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        os: [macos-15, macos-26]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
`macos-14` will be deprecated in July [1]. As a successor, the `macos-26` image is now generally available [2]. This PR removes the former and adds the latter.

PS: Github again offers macos images with Intel hardware [3]. Do you see a reason to add them to the workflow as well?

[1] -- https://github.com/actions/runner-images/issues/13518
[2] -- https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/
[3] -- https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories