### PR TITLE
Distributed PSBLAS matrices and sparsity patterns

### DIFF
--- a/cmake/config/template-arguments.in
+++ b/cmake/config/template-arguments.in
@@ -275,3 +275,9 @@ OUTPUT_FLAG_TYPES := { DXFlags; UcdFlags; GnuplotFlags; PovrayFlags; EpsFlags;
 // CGAL Kernels
 CGAL_KERNELS := {CGAL::Simple_cartesian<double>; CGAL::Exact_predicates_exact_constructions_kernel; 
                 CGAL::Exact_predicates_inexact_constructions_kernel }
+
+// PSCToolkit matrix
+PSCTOOLKIT_MATRICES := {@DEAL_II_EXPAND_PSBLAS_SPARSE_MATRICES@}
+
+// PSCToolkit vector
+PSCTOOLKIT_VECTORS := {@DEAL_II_EXPAND_PSBLAS_VECTOR@}

--- a/cmake/configure/configure_50_psblas.cmake
+++ b/cmake/configure/configure_50_psblas.cmake
@@ -14,7 +14,7 @@
 # Configuration for the PSBLAS library:
 #
 
-set(FEATURE_PSBLAS_DEPENDS MPI)
+set(FEATURE_PSBLAS_DEPENDS MPI LAPACK)
 
 macro(feature_psblas_find_external var)
     find_package(DEAL_II_PSBLAS)
@@ -36,4 +36,11 @@ macro(feature_psblas_find_external var)
         endif()
     endif()
 endmacro()
+
+macro(feature_psblas_configure_external)
+  set(DEAL_II_EXPAND_PSBLAS_VECTOR "PSCToolkitWrappers::Vector")
+  set(DEAL_II_EXPAND_PSBLAS_SPARSE_MATRICES "PSCToolkitWrappers::SparseMatrix")
+  set(DEAL_II_EXPAND_PSBLAS_SPARSITY_PATTERN "PSCToolkitWrappers::SparsityPattern")
+endmacro()
+
 configure_feature(PSBLAS)

--- a/cmake/modules/FindDEAL_II_PSBLAS.cmake
+++ b/cmake/modules/FindDEAL_II_PSBLAS.cmake
@@ -84,6 +84,7 @@ process_feature(PSBLAS
       ${_psblas_library_variables}
       ${_additional_libraries}
       LAPACK_LIBRARIES
+    OPTIONAL
       MPI_CXX_LIBRARIES
       MPI_Fortran_LIBRARIES
   INCLUDE_DIRS 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -38,6 +38,8 @@
 #include <deal.II/lac/petsc_block_vector.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/psblas_sparse_matrix.h>
+#include <deal.II/lac/psblas_vector.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparse_matrix_ez.h>
 #include <deal.II/lac/sparsity_pattern.h>

--- a/include/deal.II/lac/psblas_common.h
+++ b/include/deal.II/lac/psblas_common.h
@@ -49,7 +49,6 @@ namespace PSCToolkitWrappers
     /**
      * Enum to indicate the state of the vector (building or assembled).
      */
-
     enum State
     {
       /**
@@ -57,13 +56,15 @@ namespace PSCToolkitWrappers
        * In this state, no operations are possible.
        */
       Default,
+
       /**
        * State entered after the first allocation, and before the first
        * assembly; in this state it is possible to add communication
        * requirements among different processes.
        */
       Build,
-      /*
+
+      /**
        * State entered after the assembly; computations such as matrix-vector
        * products, are only possible in this state.
        */
@@ -73,7 +74,8 @@ namespace PSCToolkitWrappers
   } // namespace internal
 
   /**
-   * Exception
+   * An error occurred code during the initialization of a PSBLAS distributed
+   * vector.
    */
   DeclException1(ExcInitializePSBLASVector,
                  int,
@@ -81,7 +83,7 @@ namespace PSCToolkitWrappers
                  << " occurred while initializing a PSBLAS vector.");
 
   /**
-   * Exception
+   * An error occurred while freeing (deallocating) a PSBLAS distributed vector.
    */
   DeclException1(ExcFreePSBLASVector,
                  int,
@@ -89,7 +91,7 @@ namespace PSCToolkitWrappers
                  << " occurred while freeing a PSBLAS vector.");
 
   /**
-   * Exception
+   * An error occurred while initializing a communication descriptor.
    */
   DeclException1(ExcInitializePSBLASDescriptor,
                  int,
@@ -97,7 +99,8 @@ namespace PSCToolkitWrappers
                  << " occurred while initializing a PSBLAS descriptor.");
 
   /**
-   * Exception
+   * An error occurred while assembling (finalizing) a PSBLAS distributed
+   * vector.
    */
   DeclException1(ExcAssemblePSBLASVector,
                  int,
@@ -105,7 +108,8 @@ namespace PSCToolkitWrappers
                  << " occurred while assembling a PSBLAS vector.");
 
   /**
-   * Exception
+   * An error occurred while assembling (finalizing) a PSBLAS communication
+   * descriptor.
    */
   DeclException1(ExcAssemblePSBLASDescriptor,
                  int,
@@ -114,7 +118,7 @@ namespace PSCToolkitWrappers
 
 
   /**
-   * Exception
+   * The object is in a state not suitable for this operation.
    */
   DeclException1(ExcInvalidState,
                  int,
@@ -125,17 +129,10 @@ namespace PSCToolkitWrappers
                  << " state. Did you forget to call reinit() or compress()?");
 
   /**
-   * Exception
-   */
-  DeclException1(ExcInvalidStateBuild,
-                 int,
-                 << "Vector's state is invalid. It should be in "
-                 << "Build state but it is in "
-                 << (arg1 == 0 ? "Default" : "Assembled")
-                 << " state. Did you forget to call reinit()?");
-
-  /**
-   * Exception
+   * This exception is thrown when an operation that requires the object to be
+   * in the Assembled state is called while the object is in a different state
+   * (Default or Build). The argument encodes the actual state: 0 = Default,
+   * 1 = Build.
    */
   DeclException1(ExcInvalidStateAssembled,
                  int,
@@ -145,16 +142,20 @@ namespace PSCToolkitWrappers
                  << " state. Did you forget to call compress()?");
 
   /**
-   * Exception
+   * This exception is thrown when an operation that requires the object to be
+   * in the Build or Assembled state is called while the object is still in
+   * the Default state, i.e., before reinit() has been called.
    */
   DeclExceptionMsg(
     ExcInvalidDefault,
     "Vector's state is invalid. It should be in "
     "Build or Assembled state but it is in Default state. Did you forget"
-    " to reinit it()?");
+    " to call reinit()?");
 
   /**
-   * Exception
+   * This exception is thrown when a generic PSBLAS C interface function
+   * returns a nonzero error code. The first argument is the error code and
+   * the second argument is the name of the PSBLAS function that failed.
    */
   DeclException2(ExcCallingPSBLASFunction,
                  int,
@@ -164,7 +165,8 @@ namespace PSCToolkitWrappers
                  << std::endl);
 
   /**
-   * Exception
+   * An error occurred while performing an AXPBY (scaled vector addition)
+   * operation.
    */
   DeclException1(ExcAXPBY,
                  int,
@@ -172,7 +174,8 @@ namespace PSCToolkitWrappers
                  << " occurred while performing the AXPBY operation.");
 
   /**
-   * Exception
+   * An error occurred while inserting or setting entries in a distributed
+   * vector.
    */
   DeclException1(ExcInsertionInPSBLASVector,
                  int,
@@ -180,7 +183,11 @@ namespace PSCToolkitWrappers
                  << " occurred while inserting values into a PSBLAS vector.");
 
   /**
-   * Exception
+   * This exception is thrown when the caller attempts a 'set' or 'add'
+   * operation on a vector that is currently in the opposite mode. Both
+   * modes cannot be mixed without an intervening call to compress().
+   * The first argument is the requested mode and the second is the current
+   * mode (1 = set, 2 = add).
    */
   DeclException2(ExcWrongMode,
                  int,
@@ -192,7 +199,8 @@ namespace PSCToolkitWrappers
                  << " mode. You first have to call 'compress()'.");
 
   /**
-   * Exception
+   * Error while accessing an element of a distributed vector that is not stored
+   * locally.
    */
   DeclException3(
     ExcAccessToNonlocalElement,
@@ -211,30 +219,48 @@ namespace PSCToolkitWrappers
     << "'locally owned'). You need to pass a vector that has these "
     << "elements as ghost entries.");
 
-  // Matrix-related exceptions
-
+  /**
+   * An error occurred while allocating a distributed sparse matrix.
+   */
   DeclException1(ExcAllocationPSBLASMatrix,
                  int,
                  << "An error with error number " << arg1
                  << " occurred while allocating a PSBLAS sparse matrix.");
 
+  /**
+   * An error occurred while assembling (finalizing) a distributed sparse
+   * matrix, i.e., during the transition from the Build state to the Assembled
+   * state.
+   */
   DeclException1(ExcAssemblePSBLASMatrix,
                  int,
                  << "An error with error number " << arg1
                  << " occurred while assembling a PSBLAS sparse matrix.");
 
+  /**
+   * An error occurred while inserting or setting entries in a distributed
+   * sparse matrix.
+   */
   DeclException1(
     ExcInsertionInPSBLASMatrix,
     int,
     << "An error with error number " << arg1
     << " occurred while inserting values into a PSBLAS sparse matrix.");
 
+  /**
+   * An error occurred while performing a sparse matrix-vector product.
+   */
   DeclException1(
     ExcMatVecPSBLAS,
     int,
     << "An error with error number " << arg1
     << " occurred while performing a matrix-vector operation with a PSBLAS sparse matrix.");
 
+  /**
+   * The source and destination objects of an operation are the same object,
+   * but the operation requires them to be distinct (e.g., a vector copy or a
+   * matrix-vector product into itself).
+   */
   DeclExceptionMsg(ExcSourceEqualsDestination,
                    "You are attempting an operation on two vectors that "
                    "are the same object, but the operation requires that the "

--- a/include/deal.II/lac/psblas_common.h
+++ b/include/deal.II/lac/psblas_common.h
@@ -1,0 +1,257 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2019 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef dealii_psblas_common_h
+#define dealii_psblas_common_h
+
+#include <deal.II/base/config.h>
+
+#include "deal.II/base/exception_macros.h"
+#include <deal.II/base/exceptions.h>
+
+
+#ifdef DEAL_II_WITH_PSBLAS
+
+#  include <psb_base_cbind.h>
+#  include <psb_c_base.h>
+#  include <psb_c_dbase.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace PSCToolkitWrappers
+{
+
+  namespace internal
+  {
+    /*
+     * Custom deleter for PSBLAS descriptor. This will be invoked automatically
+     * by the shared pointer.
+     */
+    struct DescriptorDeleter
+    {
+      void
+      operator()(psb_c_descriptor *p) const
+      {
+        if (p != nullptr)
+          psb_c_cdfree(p);
+      }
+    };
+
+    /**
+     * Enum to indicate the state of the vector (building or assembled).
+     */
+
+    enum State
+    {
+      /**
+       * State entered after the default constructor, before any allocation.
+       * In this state, no operations are possible.
+       */
+      Default,
+      /**
+       * State entered after the first allocation, and before the first
+       * assembly; in this state it is possible to add communication
+       * requirements among different processes.
+       */
+      Build,
+      /*
+       * State entered after the assembly; computations such as matrix-vector
+       * products, are only possible in this state.
+       */
+      Assembled
+    };
+
+  } // namespace internal
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcInitializePSBLASVector,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while initializing a PSBLAS vector.");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcFreePSBLASVector,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while freeing a PSBLAS vector.");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcInitializePSBLASDescriptor,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while initializing a PSBLAS descriptor.");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcAssemblePSBLASVector,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while assembling a PSBLAS vector.");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcAssemblePSBLASDescriptor,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while assembling a PSBLAS descriptor.");
+
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcInvalidState,
+                 int,
+                 << "Vector's state is invalid. It is in "
+                 << (arg1 == 0 ? "Default" :
+                     arg1 == 1 ? "Build" :
+                                 "Assembled")
+                 << " state. Did you forget to call reinit() or compress()?");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcInvalidStateBuild,
+                 int,
+                 << "Vector's state is invalid. It should be in "
+                 << "Build state but it is in "
+                 << (arg1 == 0 ? "Default" : "Assembled")
+                 << " state. Did you forget to call reinit()?");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcInvalidStateAssembled,
+                 int,
+                 << "Vector's state is invalid. It should be in "
+                 << "Assembled state but it is in "
+                 << (arg1 == 0 ? "Default" : "Build")
+                 << " state. Did you forget to call compress()?");
+
+  /**
+   * Exception
+   */
+  DeclExceptionMsg(
+    ExcInvalidDefault,
+    "Vector's state is invalid. It should be in "
+    "Build or Assembled state but it is in Default state. Did you forget"
+    " to reinit it()?");
+
+  /**
+   * Exception
+   */
+  DeclException2(ExcCallingPSBLASFunction,
+                 int,
+                 std::string,
+                 << "An error with error number " << arg1
+                 << " occurred while calling a PSBLAS function: " << arg2
+                 << std::endl);
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcAXPBY,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while performing the AXPBY operation.");
+
+  /**
+   * Exception
+   */
+  DeclException1(ExcInsertionInPSBLASVector,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while inserting values into a PSBLAS vector.");
+
+  /**
+   * Exception
+   */
+  DeclException2(ExcWrongMode,
+                 int,
+                 int,
+                 << "You tried to do a "
+                 << (arg1 == 1 ? "'set'" : (arg1 == 2 ? "'add'" : "???"))
+                 << " operation but the vector is currently in "
+                 << (arg2 == 1 ? "'set'" : (arg2 == 2 ? "'add'" : "???"))
+                 << " mode. You first have to call 'compress()'.");
+
+  /**
+   * Exception
+   */
+  DeclException3(
+    ExcAccessToNonlocalElement,
+    int,
+    int,
+    int,
+    << "You tried to access element " << arg1
+    << " of a distributed vector, but only elements in range [" << arg2 << ','
+    << arg3 << "] are stored locally and can be accessed."
+    << "\n\n"
+    << "A common source for this kind of problem is that you "
+    << "are passing a 'fully distributed' vector into a function "
+    << "that needs read access to vector elements that correspond "
+    << "to degrees of freedom on ghost cells (or at least to "
+    << "'locally active' degrees of freedom that are not also "
+    << "'locally owned'). You need to pass a vector that has these "
+    << "elements as ghost entries.");
+
+  // Matrix-related exceptions
+
+  DeclException1(ExcAllocationPSBLASMatrix,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while allocating a PSBLAS sparse matrix.");
+
+  DeclException1(ExcAssemblePSBLASMatrix,
+                 int,
+                 << "An error with error number " << arg1
+                 << " occurred while assembling a PSBLAS sparse matrix.");
+
+  DeclException1(
+    ExcInsertionInPSBLASMatrix,
+    int,
+    << "An error with error number " << arg1
+    << " occurred while inserting values into a PSBLAS sparse matrix.");
+
+  DeclException1(
+    ExcMatVecPSBLAS,
+    int,
+    << "An error with error number " << arg1
+    << " occurred while performing a matrix-vector operation with a PSBLAS sparse matrix.");
+
+  DeclExceptionMsg(ExcSourceEqualsDestination,
+                   "You are attempting an operation on two vectors that "
+                   "are the same object, but the operation requires that the "
+                   "two objects are in fact different.");
+
+
+} // namespace PSCToolkitWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_PSBLAS
+#endif

--- a/include/deal.II/lac/psblas_sparse_matrix.h
+++ b/include/deal.II/lac/psblas_sparse_matrix.h
@@ -1,0 +1,405 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2019 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_psblas_matrix_h
+#define dealii_psblas_matrix_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/vector.h>
+
+
+#ifdef DEAL_II_WITH_PSBLAS
+
+#  include <deal.II/lac/psblas_sparsity_pattern.h>
+#  include <deal.II/lac/psblas_vector.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace PSCToolkitWrappers
+{
+
+  class SparseMatrix : public EnableObserverPointer
+  {
+  public:
+    /**
+     * Type for container size.
+     */
+    using size_type = dealii::types::global_dof_index;
+
+    /**
+     * Type for container values.
+     */
+    using value_type = double;
+
+    /**
+     *Default constructor. Generates an empty (zero-size) matrix.
+     */
+    SparseMatrix();
+
+    /**
+     * Destructor. Internally, its frees the PSBLAS sparse matrix.
+     */
+    ~SparseMatrix();
+
+    /**
+     * Generate a matrix from a PSBLAS SparsityPattern.
+     */
+    SparseMatrix(const SparsityPattern &psblas_sparsity_pattern,
+                 const MPI_Comm         communicator = MPI_COMM_WORLD);
+
+    /**
+     * Copy-constructor is deleted.
+     *
+     */
+    SparseMatrix(const SparseMatrix &) = delete;
+
+    /**
+     * Copy assignment is deleted.
+     *
+     */
+    SparseMatrix &
+    operator=(const SparseMatrix &) = delete;
+
+    /**
+     * Assignment of a scalar to all elements of the matrix is deleted.
+     */
+    SparseMatrix &
+    operator=(const value_type d) = delete;
+
+    /**
+     * Copy the contents of another SparseMatrix into this one.
+     *
+     * @note Currently not implemented for PSBLAS matrices.
+     */
+    void
+    copy_from(const SparseMatrix &other);
+
+
+    /**
+     * Initialize using an IndexSet and a MPI communicator to describe the
+     * parallel partitioning of the matrix.
+     */
+    void
+    reinit(const IndexSet &parallel_partitioning,
+           const MPI_Comm  communicator = MPI_COMM_WORLD);
+
+    /**
+     * Initialize using an IndexSet and a MPI communicator to describe the
+     * parallel partitioning of the matrix.
+     */
+    void
+    reinit(const SparsityPattern &psblas_sparsity_pattern,
+           const MPI_Comm         communicator = MPI_COMM_WORLD);
+
+    /**
+     * Initialize a square matrix where the size() of the IndexSet determines
+     * the number of rows and columns.
+     */
+    void
+    reinit(const IndexSet               &local_rows,
+           const DynamicSparsityPattern &sparsity_pattern,
+           const MPI_Comm                communicator = MPI_COMM_WORLD);
+
+    /**
+     * Return the number of rows in this matrix.
+     */
+    size_type
+    m() const;
+
+    /**
+     * Return the number of columns in this matrix.
+     */
+    size_type
+    n() const;
+
+    /**
+     * Return the local dimension of the matrix, i.e. the number of rows stored
+     * on the present MPI process. For sequential matrices, this number is the
+     * same as m(), but for parallel matrices it may be smaller.
+     * To figure out which elements exactly are stored locally, use
+     * local_range().
+     */
+    size_type
+    local_size() const;
+
+    /**
+     * Return a pair of indices indicating which rows of this matrix are
+     * stored locally. The first number is the index of the first row stored,
+     * the second the index of the one past the last one that is stored
+     * locally. If this is a sequential matrix, then the result will be the
+     * pair (0,m()), otherwise it will be a pair (i,i+n), where
+     * <tt>n=local_size()</tt>.
+     */
+    std::pair<size_type, size_type>
+    local_range() const;
+
+    /**
+     * Return whether @p index is in the local range or not, see also
+     * local_range().
+     */
+    bool
+    in_local_range(const size_type index) const;
+
+    /**
+     * Return the number of nonzero elements of this matrix.
+     */
+    size_type
+    n_nonzero_elements() const;
+
+    /**
+     * Return the value of the matrix entry (<i>i,j</i>).
+     *
+     */
+    value_type
+    el(const size_type i, const size_type j) const;
+
+    /**
+     * Return the diagonal element of the matrix at row <i>i</i>.
+     *
+     */
+    value_type
+    diag_element(const size_type i) const;
+
+    /**
+     * Return the element (i,j) of the matrix. This function is equivalent to
+     * the el() function.
+     *
+     */
+    value_type
+    operator()(const size_type i, const size_type j) const;
+
+    /**
+     * Set the element (i,j) to 'value'. If <tt>value</tt> is
+     * not a finite number an exception is thrown.
+     */
+    void
+    set(const size_type i, const size_type j, const value_type value);
+
+    /**
+     * Set all elements given in a FullMatrix into the sparse matrix locations
+     * given by <tt>indices</tt>. In other words, this function writes the
+     * elements in <tt>full_matrix</tt> into the calling matrix, using the
+     * local-to-global indexing specified by <tt>indices</tt> for both the rows
+     * and the columns of the matrix. This function assumes a quadratic sparse
+     * matrix and a quadratic full_matrix, the usual situation in FE
+     * calculations.
+     */
+    void
+    set(const std::vector<size_type> &indices,
+        const FullMatrix<double>     &matrix);
+
+    /**
+     * Add value 'value' to the element (i,j). If <tt>value</tt> is
+     * not a finite number an exception is thrown.
+     */
+    void
+    add(const size_type i, const size_type j, const value_type value);
+
+    /**
+     * Set several elements in the specified row of the matrix with column
+     * indices as given by @p col_indices to the respective value.
+     */
+    void
+    add(const size_type                row,
+        const std::vector<size_type>  &col_indices,
+        const std::vector<value_type> &values,
+        const bool = false);
+
+    /**
+     * Add an array of values given by @p values in the given global matrix @p row at
+     * columns specified by @p col_indices in the sparse matrix.
+     */
+    void
+    add(const size_type               row,
+        const size_type               ncols,
+        const std::vector<size_type> &col_indices,
+        const value_type             *values,
+        const bool = false,
+        const bool = false);
+
+    /**
+     * Same as above, but with a vector of values instead of a pointer to an
+     * array. The vector must have the same size as the number of columns
+     given by @p ncols and the size of @p col_indices.
+     */
+    void
+    add(const size_type                row,
+        const size_type                ncols,
+        const std::vector<size_type>  &col_indices,
+        const std::vector<value_type> &values,
+        const bool = false,
+        const bool = false);
+
+    /**
+     * Same as above, but using raw pointers for the column indices and values.
+     * The array of column indices must have the same size as @p ncols, and
+     * the array of values must have the same size as @p ncols as well.
+     */
+    void
+    add(const size_type   row,
+        const size_type   n_cols,
+        const size_type  *col_indices,
+        const value_type *values,
+        const bool        elide_zero_values      = true,
+        const bool        col_indices_are_sorted = false);
+
+    /**
+     * Compress the matrix after all insertions have been done.
+     */
+    void
+    compress();
+
+    /**
+     * Matrix-vector multiplication: let <i>dst = M*src</i> with <i>M</i>
+     * being this matrix.
+     *
+     * Source and destination must not be the same vector.
+     */
+    void
+    vmult(Vector &dst, const Vector &src) const;
+
+    /**
+     * Adding matrix-vector multiplication: Add <i>M*src</i> to <i>dst</i> with
+     * <i>M</i> being this matrix.
+     *
+     * Source and destination must not be the same vector.
+     */
+    void
+    vmult_add(Vector &dst, const Vector &src) const;
+
+
+    /**
+     * Matrix-vector multiplication: let <i>dst = M<sup>T</sup>*src</i> with
+     * <i>M</i> being this matrix. This function does the same as vmult() but
+     * takes the transposed matrix.
+     *
+     * Source and destination must not be the same vector.
+     */
+    void
+    Tvmult(Vector &dst, const Vector &src) const;
+
+    /**
+     * Adding matrix-vector multiplication: Add <i>M^T*src</i> to <i>dst</i>
+     * with <i>M</i> being this matrix.
+     *
+     * Source and destination must not be the same vector.
+     */
+    void
+    Tvmult_add(Vector &dst, const Vector &src) const;
+
+    /**
+     * Return the l1-norm of the matrix.
+     *
+     * @note Currently not implemented.
+     */
+    value_type
+    l1_norm() const;
+
+    /**
+     * Return the linfty-norm of the matrix.
+     *
+     * @note Currently not implemented.
+     */
+    value_type
+    linfty_norm() const;
+
+    /**
+     * Return the Frobenius of the matrix.
+     *
+     * @note Currently not implemented.
+     */
+    value_type
+    frobenius_norm() const;
+
+    /**
+     * Returns the trace of the matrix, i.e., the sum of the diagonal elements.
+     *
+     */
+    value_type
+    trace() const;
+
+    /**
+     * Get the underlying PSBLAS sparse matrix. Do not use this function unless
+     * you know what you are doing.
+     */
+    psb_c_dspmat *
+    get_psblas_matrix() const;
+
+    /**
+     * Get the underlying PSBLAS descriptor. Do not use this function unless you
+     * know what you are doing.
+     */
+    psb_c_descriptor *
+    get_psblas_descriptor() const;
+
+    /**
+     * Return the underlying MPI communicator. Do not use this function unless
+     * you know what you are doing.
+     */
+    MPI_Comm
+    get_mpi_communicator() const;
+
+
+  private:
+    /**
+     * The underlying MPI communicator.
+     *
+     */
+    MPI_Comm communicator;
+
+    /**
+     * Pointer the underlying PSBLAS sparse matrix.
+     *
+     */
+    psb_c_dspmat *psblas_sparse_matrix;
+
+    /**
+     * Shared pointer to the underlying PSBLAS descriptor object.
+     *
+     */
+    std::shared_ptr<psb_c_descriptor> psblas_descriptor;
+
+    /**
+     * Pointer to the underlying PSBLAS context object.
+     *
+     */
+    psb_c_ctxt *psblas_context;
+
+    /**
+     * State of the descriptor associated with the vector. Its state can be
+     * either default, building or assembled).
+     */
+    internal::State state;
+  };
+
+
+} // namespace PSCToolkitWrappers
+
+
+DEAL_II_NAMESPACE_CLOSE
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_PSBLAS
+#endif

--- a/include/deal.II/lac/psblas_sparse_matrix.h
+++ b/include/deal.II/lac/psblas_sparse_matrix.h
@@ -34,6 +34,34 @@ DEAL_II_NAMESPACE_OPEN
 namespace PSCToolkitWrappers
 {
 
+  /**
+   * Implementation of a distributed parallel sparse matrix class based on
+   * PSBLAS (Parallel Sparse BLAS), which is the computational kernel of the
+   * <a href="https://psctoolkit.github.io/">PSCToolkit</a> library.
+   *
+   * Rows of the matrix are distributed across MPI processes according to
+   * an IndexSet partitioning (just as for the Vector class). The matrix
+   * supports element-wise set/add assembly as well as matrix-vector
+   * products (vmult(), Tvmult(), and their <code>_add</code> variants).
+   *
+   * A typical workflow for using this matrix is as follows:
+   * -# Create the matrix by providing a SparsityPattern (recommended) or
+   *    an IndexSet that describes the parallel row partitioning, together
+   *    with the MPI communicator, either through the constructor or a
+   *    call to reinit().  At this point the matrix is in the
+   *    <em>Build</em> state.
+   * -# Fill the matrix by inserting or adding entries through set() or
+   *    add().
+   * -# Call compress() to transition the matrix to the
+   *    <em>Assembled</em> state, in which matrix-vector products and
+   *    other algebraic operations become available.
+   *
+   * A SparsityPattern can optionally be provided at construction time to
+   * pre-allocate the non-zero structure, which is strongly recommended
+   * for performance.
+   *
+   * @ingroup PSCToolkitWrappers
+   */
   class SparseMatrix : public EnableObserverPointer
   {
   public:
@@ -65,13 +93,11 @@ namespace PSCToolkitWrappers
 
     /**
      * Copy-constructor is deleted.
-     *
      */
     SparseMatrix(const SparseMatrix &) = delete;
 
     /**
      * Copy assignment is deleted.
-     *
      */
     SparseMatrix &
     operator=(const SparseMatrix &) = delete;
@@ -164,14 +190,12 @@ namespace PSCToolkitWrappers
 
     /**
      * Return the value of the matrix entry (<i>i,j</i>).
-     *
      */
     value_type
     el(const size_type i, const size_type j) const;
 
     /**
      * Return the diagonal element of the matrix at row <i>i</i>.
-     *
      */
     value_type
     diag_element(const size_type i) const;
@@ -179,7 +203,6 @@ namespace PSCToolkitWrappers
     /**
      * Return the element (i,j) of the matrix. This function is equivalent to
      * the el() function.
-     *
      */
     value_type
     operator()(const size_type i, const size_type j) const;
@@ -235,8 +258,8 @@ namespace PSCToolkitWrappers
 
     /**
      * Same as above, but with a vector of values instead of a pointer to an
-     * array. The vector must have the same size as the number of columns
-     given by @p ncols and the size of @p col_indices.
+     * array. The vector must have the same size as the number of columns given
+     * by @p ncols and the size of @p col_indices.
      */
     void
     add(const size_type                row,
@@ -329,7 +352,6 @@ namespace PSCToolkitWrappers
 
     /**
      * Returns the trace of the matrix, i.e., the sum of the diagonal elements.
-     *
      */
     value_type
     trace() const;
@@ -359,25 +381,21 @@ namespace PSCToolkitWrappers
   private:
     /**
      * The underlying MPI communicator.
-     *
      */
     MPI_Comm communicator;
 
     /**
      * Pointer the underlying PSBLAS sparse matrix.
-     *
      */
     psb_c_dspmat *psblas_sparse_matrix;
 
     /**
      * Shared pointer to the underlying PSBLAS descriptor object.
-     *
      */
     std::shared_ptr<psb_c_descriptor> psblas_descriptor;
 
     /**
      * Pointer to the underlying PSBLAS context object.
-     *
      */
     psb_c_ctxt *psblas_context;
 

--- a/include/deal.II/lac/psblas_sparsity_pattern.h
+++ b/include/deal.II/lac/psblas_sparsity_pattern.h
@@ -27,7 +27,19 @@ namespace PSCToolkitWrappers
 {
 
   /**
-   * This class implements a sparsity pattern based on PSBLAS framework.
+   * Implementation of a distributed sparsity pattern based on PSBLAS
+   * (Parallel Sparse BLAS), which is the
+   * computational kernel of the
+   * <a href="https://psctoolkit.github.io/">PSCToolkit</a> library.
+   *
+   * This class describes the non-zero structure of a distributed sparse
+   * matrix.  Rows are partitioned across MPI processes according to an
+   * IndexSet.  After construction the pattern is in the <em>Build</em>
+   * state; calling compress() transitions it to the <em>Assembled</em>
+   * state so that it can be passed to a SparseMatrix for allocation.
+   *
+   * @ingroup PSCToolkitWrappers
+   * @ingroup Sparsity
    */
   class SparsityPattern : public SparsityPatternBase
   {
@@ -60,11 +72,19 @@ namespace PSCToolkitWrappers
                 ForwardIterator end,
                 const bool      indices_are_sorted = false);
 
+    /**
+     * Add new entries to a given row. It calls the add_entries() function using
+     * columns.begin() and columns.end() as begin and end iterators,
+     * respectively.
+     */
     virtual void
     add_row_entries(const size_type                  &row,
                     const ArrayView<const size_type> &columns,
                     const bool indices_are_sorted = false) override;
 
+    /**
+     * Add a single entry to the sparsity pattern.
+     */
     void
     add(const size_type i, const size_type j);
 
@@ -82,6 +102,9 @@ namespace PSCToolkitWrappers
     compress();
 
   private:
+    /**
+     * Shared pointer to the PSBLAS descriptor object.
+     */
     std::shared_ptr<psb_c_descriptor> psblas_descriptor;
 
     friend class SparseMatrix;

--- a/include/deal.II/lac/psblas_sparsity_pattern.h
+++ b/include/deal.II/lac/psblas_sparsity_pattern.h
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2019 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_psblas_sparsity_h
+#define dealii_psblas_sparsity_h
+
+#include <deal.II/lac/sparsity_pattern_base.h>
+
+#ifdef DEAL_II_WITH_PSBLAS
+
+#  include <deal.II/lac/psblas_common.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace PSCToolkitWrappers
+{
+
+  /**
+   * This class implements a sparsity pattern based on PSBLAS framework.
+   */
+  class SparsityPattern : public SparsityPatternBase
+  {
+  public:
+    using size_type = dealii::types::global_dof_index;
+
+    /**
+     * Default constructor.
+     */
+    SparsityPattern() = default;
+
+    /**
+     * Constructor of a square sparsity pattern from an existing IndexSet.
+     */
+    SparsityPattern(const IndexSet &parallel_partitioning,
+                    const MPI_Comm  communicator = MPI_COMM_WORLD);
+
+    /**
+     * Destructor.
+     */
+    virtual ~SparsityPattern() override = default;
+
+    /**
+     * Add several elements in one row to the sparsity pattern.
+     */
+    template <typename ForwardIterator>
+    void
+    add_entries(const size_type row,
+                ForwardIterator begin,
+                ForwardIterator end,
+                const bool      indices_are_sorted = false);
+
+    virtual void
+    add_row_entries(const size_type                  &row,
+                    const ArrayView<const size_type> &columns,
+                    const bool indices_are_sorted = false) override;
+
+    void
+    add(const size_type i, const size_type j);
+
+    using SparsityPatternBase::add_entries;
+
+    /**
+     * This function compresses the sparsity pattern and allows the resulting
+     * pattern to be used for actually generating a PSBLAS Sparse matrix.
+     * This function must therefore be called once the structure is fixed.
+     * Internally, it finalizes the descriptor object. This is a collective
+     * operation, i.e., it needs to be run on all processors when used in
+     * parallel.
+     */
+    void
+    compress();
+
+  private:
+    std::shared_ptr<psb_c_descriptor> psblas_descriptor;
+
+    friend class SparseMatrix;
+  };
+
+
+} // namespace PSCToolkitWrappers
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#else
+
+// Make sure the scripts that create the C++20 module input files have
+// something to latch on if the preprocessor #ifdef above would
+// otherwise lead to an empty content of the file.
+DEAL_II_NAMESPACE_OPEN
+DEAL_II_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_PSBLAS
+#endif

--- a/include/deal.II/lac/psblas_vector.h
+++ b/include/deal.II/lac/psblas_vector.h
@@ -15,7 +15,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/types.h>
 
@@ -29,57 +28,12 @@
 
 #ifdef DEAL_II_WITH_PSBLAS
 
-#  include <psb_base_cbind.h>
-#  include <psb_c_base.h>
-#  include <psb_c_dbase.h>
+#  include <deal.II/lac/psblas_common.h>
 
 DEAL_II_NAMESPACE_OPEN
 
 namespace PSCToolkitWrappers
 {
-
-  namespace internal
-  {
-    /*
-     * Custom deleter for PSBLAS descriptor.
-     */
-    struct PSBLASDescriptorDeleter
-    {
-      void
-      operator()(psb_c_descriptor *p) const
-      {
-        if (p)
-          psb_c_cdfree(p);
-      }
-    };
-
-    /**
-     * Enum to indicate the state of the vector (building or assembled).
-     * TODO[MF]: use the same also when I'll introduce the matrix class. Move to
-     * a common .h file?
-     */
-
-    enum State
-    {
-      /**
-       * State entered after the default constructor, before any allocation.
-       * In this state, no operations are possible.
-       */
-      Default,
-      /**
-       * State entered after the first allocation, and before the first
-       * assembly; in this state it is possible to add communication
-       * requirements among different processes.
-       */
-      Build,
-      /*
-       * State entered after the assembly; computations such as matrix-vector
-       * products, are only possible in this state.
-       */
-      Assembled
-    };
-
-  } // namespace internal
 
   class Vector : public ReadVector<double>
   {
@@ -259,145 +213,6 @@ namespace PSCToolkitWrappers
     using size_type = dealii::types::global_dof_index;
 
     using value_type = double;
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcInitializePSBLASVector,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while initializing a PSBLAS vector.");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcFreePSBLASVector,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while freeing a PSBLAS vector.");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcInitializePSBLASDescriptor,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while initializing a PSBLAS descriptor.");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcAssemblePSBLASVector,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while assembling a PSBLAS vector.");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcAssemblePSBLASDescriptor,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while assembling a PSBLAS descriptor.");
-
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcInvalidState,
-                   int,
-                   << "Vector's state is invalid. It is in "
-                   << (arg1 == 0 ? "Default" :
-                       arg1 == 1 ? "Build" :
-                                   "Assembled")
-                   << " state. Did you forget to call reinit() or compress()?");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcInvalidStateBuild,
-                   int,
-                   << "Vector's state is invalid. It should be in "
-                   << "Build state but it is in "
-                   << (arg1 == 0 ? "Default" : "Assembled")
-                   << " state. Did you forget to call reinit()?");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcInvalidStateAssembled,
-                   int,
-                   << "Vector's state is invalid. It should be in "
-                   << "Assembled state but it is in "
-                   << (arg1 == 0 ? "Default" : "Build")
-                   << " state. Did you forget to call compress()?");
-
-    /**
-     * Exception
-     */
-    DeclExceptionMsg(
-      ExcInvalidDefault,
-      "Vector's state is invalid. It should be in "
-      "Build or Assembled state but it is in Default state. Did you forget"
-      " to reinit it()?");
-
-    /**
-     * Exception
-     */
-    DeclException2(ExcCallingPSBLASFunction,
-                   int,
-                   std::string,
-                   << "An error with error number " << arg1
-                   << " occurred while calling a PSBLAS function: " << arg2
-                   << std::endl);
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcAXPBY,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while performing the AXPBY operation.");
-
-    /**
-     * Exception
-     */
-    DeclException1(ExcInsertionInPSBLASVector,
-                   int,
-                   << "An error with error number " << arg1
-                   << " occurred while inserting values into a PSBLAS vector.");
-
-    /**
-     * Exception
-     */
-    DeclException2(ExcWrongMode,
-                   int,
-                   int,
-                   << "You tried to do a "
-                   << (arg1 == 1 ? "'set'" : (arg1 == 2 ? "'add'" : "???"))
-                   << " operation but the vector is currently in "
-                   << (arg2 == 1 ? "'set'" : (arg2 == 2 ? "'add'" : "???"))
-                   << " mode. You first have to call 'compress()'.");
-
-    /**
-     * Exception
-     */
-    DeclException3(
-      ExcAccessToNonlocalElement,
-      int,
-      int,
-      int,
-      << "You tried to access element " << arg1
-      << " of a distributed vector, but only elements in range [" << arg2 << ','
-      << arg3 << "] are stored locally and can be accessed."
-      << "\n\n"
-      << "A common source for this kind of problem is that you "
-      << "are passing a 'fully distributed' vector into a function "
-      << "that needs read access to vector elements that correspond "
-      << "to degrees of freedom on ghost cells (or at least to "
-      << "'locally active' degrees of freedom that are not also "
-      << "'locally owned'). You need to pass a vector that has these "
-      << "elements as ghost entries.");
 
     /**
      *Default constructor. Generates an empty (zero-size) vector.
@@ -911,8 +726,7 @@ namespace PSCToolkitWrappers
      */
     VectorOperation::values last_action;
 
-    // TODO[MF]: uncomment when the matrix class will be introduced
-    // friend class SparseMatrix;
+    friend class SparseMatrix;
   };
 
 

--- a/include/deal.II/lac/psblas_vector.h
+++ b/include/deal.II/lac/psblas_vector.h
@@ -35,6 +35,35 @@ DEAL_II_NAMESPACE_OPEN
 namespace PSCToolkitWrappers
 {
 
+  /**
+   * Implementation of a distributed parallel vector class based on PSBLAS
+   * (Parallel Sparse BLAS), which is the computational kernel of the
+   * <a href="https://psctoolkit.github.io/">PSCToolkit</a> library.
+   *
+   * This class stores a contiguous block of vector entries on each MPI
+   * process according to an IndexSet partitioning, and optionally
+   * maintains read-only ghost elements for entries owned by other
+   * processes. It supports the standard algebraic operations (addition,
+   * scaling, inner products, norms) as well as element-wise access. The
+   * interface is designed to be as close as possible to that of
+   * PETScWrappers::MPI::Vector.
+   *
+   * A typical workflow for using this vector is as follows:
+   * -# Create the vector by providing an IndexSet that describes the
+   *    parallel partitioning (i.e., which global degrees of freedom are
+   *    owned by each MPI process) and the MPI communicator, either
+   *    through the constructor or a call to reinit().  At this point the
+   *    vector is in the <em>Build</em> state.
+   * -# Fill the vector by inserting or adding values through set(),
+   *    add(), or the element access operators.
+   * -# Call compress() to transition the vector to the
+   *    <em>Assembled</em> state, in which algebraic operations such as
+   *    norms, inner products, and matrix-vector products become
+   *    available.
+   *
+   * @ingroup PSCToolkitWrappers
+   * @ingroup Vectors
+   */
   class Vector : public ReadVector<double>
   {
   private:
@@ -446,7 +475,6 @@ namespace PSCToolkitWrappers
      * this->add(a, V);
      * return_value = *this * W;
      * @endcode
-     *
      */
     value_type
     add_and_dot(const value_type a, const Vector &v, const Vector &W);
@@ -688,7 +716,7 @@ namespace PSCToolkitWrappers
     psb_c_ctxt *psblas_context;
 
     /*
-     * Pointer to PSBLAS descriptor.
+     * Shared pointer to the PSBLAS descriptor.
      */
     std::shared_ptr<psb_c_descriptor> psblas_descriptor;
 

--- a/module/interface_module_partitions/psblas.ccm
+++ b/module/interface_module_partitions/psblas.ccm
@@ -43,6 +43,7 @@ export
 {
   using ::psb_c_ctxt;
   using ::psb_c_descriptor;
+  using ::psb_c_dspmat;
   using ::psb_c_dvector;
   using ::psb_d_t;
   using ::psb_i_t;

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -187,6 +187,8 @@ if(DEAL_II_WITH_PSBLAS)
   set(_unity_include_src
     ${_unity_include_src}
     psblas_vector.cc
+    psblas_sparsity_pattern.cc
+    psblas_sparse_matrix.cc
   )
 endif()
 

--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -406,6 +406,38 @@ for (V : EXTERNAL_PARALLEL_VECTORS)
     template void AffineConstraints<V::value_type>::distribute<V>(V &) const;
   }
 
+// PSCToolkit
+for (M : PSCTOOLKIT_MATRICES)
+  {
+    template void AffineConstraints<double>::
+      distribute_local_to_global<M, PSCToolkitWrappers::Vector>(
+        const FullMatrix<double> &,
+        const Vector<double> &,
+        const std::vector<AffineConstraints<double>::size_type> &,
+        M &,
+        PSCToolkitWrappers::Vector &,
+        bool,
+        std::bool_constant<false>) const;
+
+    template void AffineConstraints<double>::distribute_local_to_global<M>(
+      const FullMatrix<double> &,
+      const std::vector<AffineConstraints<double>::size_type> &,
+      M &) const;
+
+    template void AffineConstraints<double>::distribute_local_to_global<M>(
+      const FullMatrix<double> &,
+      const std::vector<AffineConstraints<double>::size_type> &,
+      const std::vector<AffineConstraints<double>::size_type> &,
+      M &) const;
+
+    template void AffineConstraints<double>::distribute_local_to_global<M>(
+      const FullMatrix<double> &,
+      const std::vector<AffineConstraints<double>::size_type> &,
+      const AffineConstraints<double> &,
+      const std::vector<AffineConstraints<double>::size_type> &,
+      M &) const;
+  }
+
 
 //
 // FIXME: These mixed variants are needed for multigrid and matrix free.

--- a/source/lac/psblas_sparse_matrix.cc
+++ b/source/lac/psblas_sparse_matrix.cc
@@ -1,0 +1,725 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2019 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include "deal.II/base/exception_macros.h"
+#include "deal.II/base/exceptions.h"
+#include "deal.II/base/index_set.h"
+#include "deal.II/base/mpi.h"
+#include "deal.II/base/tensor.h"
+#include "deal.II/base/types.h"
+
+#include "deal.II/lac/dynamic_sparsity_pattern.h"
+#include "deal.II/lac/exceptions.h"
+#include "deal.II/lac/psblas_common.h"
+#include <deal.II/lac/psblas_sparse_matrix.h>
+
+#include <muParserDef.h>
+#include <psb_types.h>
+
+#include <utility>
+
+#ifdef DEAL_II_WITH_PSBLAS
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace PSCToolkitWrappers
+{
+
+  SparseMatrix::SparseMatrix()
+    : psblas_sparse_matrix(nullptr)
+    , psblas_descriptor(nullptr)
+    , state(internal::State::Default)
+  {}
+
+  SparseMatrix::SparseMatrix(const SparsityPattern &psblas_sparsity_pattern,
+                             const MPI_Comm         communicator)
+  {
+    Assert(psblas_descriptor.get() == nullptr,
+           ExcMessage("PSBLAS matrix descriptor must not be initialized."));
+
+    Assert(psblas_sparsity_pattern.psblas_descriptor.get() != nullptr,
+           ExcMessage("The given SparsityPattern is not valid."));
+
+    this->communicator = communicator;
+    Assert(communicator != MPI_COMM_NULL,
+           ExcMessage("MPI_COMM_NULL passed to SparseMatrix::reinit()."));
+
+    psblas_descriptor = psblas_sparsity_pattern.psblas_descriptor;
+
+    // Create a new PSBLAS sparse matrix
+    psblas_sparse_matrix = psb_c_new_dspmat();
+
+    // Initialize the sparse matrix with the descriptor
+    int err =
+      psb_c_dspall_remote(psblas_sparse_matrix, psblas_descriptor.get());
+    Assert(err == 0, ExcAllocationPSBLASMatrix(err));
+  }
+
+
+
+  SparseMatrix::~SparseMatrix()
+  {
+    if (psblas_sparse_matrix != nullptr && psblas_descriptor.get() != nullptr)
+      {
+        // We clear the underlying PSBLAS sparse matrix
+        int err = psb_c_dspfree(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcCallingPSBLASFunction(err, "psb_c_dspfree"));
+      }
+  }
+
+
+
+  void
+  SparseMatrix::copy_from(const SparseMatrix &other)
+  {
+    if (this == &other)
+      return;
+
+    DEAL_II_NOT_IMPLEMENTED();
+  }
+
+
+  void
+  SparseMatrix::reinit(const IndexSet &index_set, const MPI_Comm comm)
+  {
+    Assert(index_set.n_elements() > 0,
+           ExcMessage("An empty IndexSet has been given."));
+
+    Assert(comm != MPI_COMM_NULL,
+           ExcMessage("MPI_COMM_NULL passed to SparseMatrix::reinit()."));
+    communicator = comm;
+
+    // Free old resources before reinitializing
+    if (psblas_sparse_matrix != nullptr && psblas_descriptor.get() != nullptr)
+      {
+        int err = psb_c_dspfree(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcCallingPSBLASFunction(err, "psb_c_dspfree"));
+        psblas_sparse_matrix = nullptr;
+      }
+
+    // Create a new PSBLAS descriptor
+    psblas_descriptor.reset(psb_c_new_descriptor(),
+                            PSCToolkitWrappers::internal::DescriptorDeleter());
+
+    // Use get_index_vector() from IndexSet to get the indexes
+    const std::vector<types::global_dof_index> &indexes =
+      index_set.get_index_vector();
+
+    psb_i_t number_of_local_indexes = indexes.size(); // Number of local indexes
+
+    // Copy the indexes into an array called vl
+    std::vector<psb_l_t> vl(number_of_local_indexes);
+    for (psb_i_t i = 0; i < number_of_local_indexes; ++i)
+      {
+        const auto psblas_index = static_cast<psb_l_t>(indexes[i]);
+        AssertIntegerConversion(psblas_index, indexes[i]);
+        vl[i] = psblas_index;
+      }
+
+    // Insert the indexes into the descriptor
+    psb_c_cdall_vl(number_of_local_indexes,
+                   vl.data(),
+                   *InitFinalize::get_psblas_context(),
+                   psblas_descriptor.get());
+
+    // Create a new PSBLAS sparse matrix
+    psblas_sparse_matrix = psb_c_new_dspmat();
+
+    // Initialize the sparse matrix with the descriptor
+    int err =
+      psb_c_dspall_remote(psblas_sparse_matrix, psblas_descriptor.get());
+    Assert(err == 0, ExcAllocationPSBLASMatrix(err));
+
+    state = internal::State::Build;
+  }
+
+
+
+  void
+  SparseMatrix::reinit(const SparsityPattern &psblas_sparsity_pattern,
+                       const MPI_Comm         communicator)
+  {
+    Assert(psblas_sparsity_pattern.psblas_descriptor.get() != nullptr,
+           ExcMessage("The given SparsityPattern is not valid."));
+
+    this->communicator = communicator;
+    Assert(communicator != MPI_COMM_NULL,
+           ExcMessage("MPI_COMM_NULL passed to SparseMatrix::reinit()."));
+
+    // Free old resources before reinitializing
+    if (psblas_sparse_matrix != nullptr && psblas_descriptor.get() != nullptr)
+      {
+        int err = psb_c_dspfree(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcCallingPSBLASFunction(err, "psb_c_dspfree"));
+        psblas_sparse_matrix = nullptr;
+      }
+
+    psblas_descriptor = psblas_sparsity_pattern.psblas_descriptor;
+
+    // Create a new PSBLAS sparse matrix
+    psblas_sparse_matrix = psb_c_new_dspmat();
+
+    // Initialize the sparse matrix with the descriptor
+    int err =
+      psb_c_dspall_remote(psblas_sparse_matrix, psblas_descriptor.get());
+    Assert(err == 0, ExcAllocationPSBLASMatrix(err));
+
+    state = internal::State::Build;
+  }
+
+
+
+  void
+  SparseMatrix::reinit(const IndexSet               &local_rows,
+                       const DynamicSparsityPattern &sparsity_pattern,
+                       const MPI_Comm                communicator)
+  {
+    Assert(sparsity_pattern.n_rows() == sparsity_pattern.n_cols(),
+           ExcNotQuadratic());
+
+    // Check dimensions match IndexSet
+    Assert(sparsity_pattern.n_rows() == local_rows.size(),
+           ExcMessage(
+             "SparsityPattern and IndexSet have different number of rows"));
+
+    Assert(local_rows.is_ascending_and_one_to_one(communicator),
+           ExcNotImplemented());
+
+    // Free old resources before reinitializing
+    if (psblas_sparse_matrix != nullptr && psblas_descriptor.get() != nullptr)
+      {
+        int err = psb_c_dspfree(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcCallingPSBLASFunction(err, "psb_c_dspfree"));
+        psblas_sparse_matrix = nullptr;
+      }
+
+
+    if constexpr (running_in_debug_mode())
+      {
+        types::global_dof_index row_owners =
+          Utilities::MPI::sum(local_rows.n_elements(), communicator);
+        Assert(row_owners == sparsity_pattern.n_rows(),
+               ExcMessage(
+                 std::string(
+                   "Each row has to be owned by exactly one owner (n_rows()=") +
+                 std::to_string(sparsity_pattern.n_rows()) +
+                 " but sum(local_rows.n_elements())=" +
+                 std::to_string(row_owners) + ")"));
+      }
+
+    this->communicator = communicator;
+
+    // Set up the PSBLAS descriptor from the local IndexSet
+    psblas_descriptor.reset(psb_c_new_descriptor(),
+                            PSCToolkitWrappers::internal::DescriptorDeleter());
+
+    {
+      const std::vector<types::global_dof_index> indexes =
+        local_rows.get_index_vector();
+      const psb_i_t n_local = static_cast<psb_i_t>(indexes.size());
+
+      std::vector<psb_l_t> vl(n_local);
+      for (psb_i_t i = 0; i < n_local; ++i)
+        {
+          const auto idx = static_cast<psb_l_t>(indexes[i]);
+          AssertIntegerConversion(idx, indexes[i]);
+          vl[i] = idx;
+        }
+
+      psb_c_cdall_vl(n_local,
+                     vl.data(),
+                     *InitFinalize::get_psblas_context(),
+                     psblas_descriptor.get());
+    }
+
+    // Create and initialize the sparse matrix
+    psblas_sparse_matrix = psb_c_new_dspmat();
+
+    int err;
+
+    if (local_rows.n_elements() > 0)
+      {
+        const psb_l_t local_row_start =
+          static_cast<psb_l_t>(local_rows.nth_index_in_set(0));
+        const psb_l_t local_row_end =
+          local_row_start + static_cast<psb_l_t>(local_rows.n_elements());
+
+        // Insert entries from the sparsity pattern row by row
+        for (psb_l_t i = local_row_start; i < local_row_end; ++i)
+          {
+            const auto row_length =
+              static_cast<psb_i_t>(sparsity_pattern.row_length(i));
+            if (row_length == 0)
+              continue;
+
+            std::vector<psb_l_t> irw(row_length, i);
+            std::vector<psb_l_t> icl(row_length);
+
+            psb_i_t k = 0;
+            for (typename DynamicSparsityPattern::iterator p =
+                   sparsity_pattern.begin(i);
+                 p != sparsity_pattern.end(i);
+                 ++p, ++k)
+              {
+                const auto col = static_cast<psb_l_t>(p->column());
+                AssertIntegerConversion(col, p->column());
+                icl[k] = col;
+              }
+
+            err = psb_c_cdins(row_length,
+                              irw.data(),
+                              icl.data(),
+                              psblas_descriptor.get());
+            Assert(err == 0, ExcInsertionInPSBLASMatrix(err));
+          }
+
+        // Initialize the sparse matrix with the descriptor
+        err =
+          psb_c_dspall_remote(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcAllocationPSBLASMatrix(err));
+      }
+    else
+      {
+        // empty local partition: just initialize
+        err =
+          psb_c_dspall_remote(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcAllocationPSBLASMatrix(err));
+      }
+
+    state = internal::State::Build;
+  }
+
+
+
+  SparseMatrix::size_type
+  SparseMatrix::local_size() const
+  {
+    return psb_c_cd_get_local_rows(psblas_descriptor.get());
+  }
+
+
+  std::pair<SparseMatrix::size_type, SparseMatrix::size_type>
+  SparseMatrix::local_range() const
+  {
+    std::vector<psb_l_t> local_indices(local_size());
+    int                  err = psb_c_cd_get_global_indices(local_indices.data(),
+                                          local_size(),
+                                          true /*only owned indices*/,
+                                          psblas_descriptor.get());
+    Assert(err == 0,
+           ExcCallingPSBLASFunction(err, "psb_c_cd_get_global_indices"));
+
+    return {local_indices[0], local_indices.back() + 1};
+  }
+
+
+
+  bool
+  SparseMatrix::in_local_range(const size_type index) const
+  {
+    std::pair<size_type, size_type> local_range = this->local_range();
+    return index >= local_range.first && index < local_range.second;
+  }
+
+
+
+  SparseMatrix::size_type
+  SparseMatrix::m() const
+  {
+    return psb_c_cd_get_global_rows(psblas_descriptor.get());
+  }
+
+
+
+  SparseMatrix::size_type
+  SparseMatrix::n() const
+  {
+    return psb_c_cd_get_global_cols(psblas_descriptor.get());
+  }
+
+
+
+  SparseMatrix::size_type
+  SparseMatrix::n_nonzero_elements() const
+  {
+    return psb_c_dnnz(psblas_sparse_matrix, psblas_descriptor.get());
+  }
+
+
+
+  void
+  SparseMatrix::set(const SparseMatrix::size_type  i,
+                    const SparseMatrix::size_type  j,
+                    const SparseMatrix::value_type value)
+  {
+    // Insert a value into the sparse matrix
+    psb_l_t irw = i;
+    psb_l_t icl = j;
+    psb_d_t val = value;
+
+    int err = psb_c_dspins(
+      1, &irw, &icl, &val, psblas_sparse_matrix, psblas_descriptor.get());
+    Assert(err == 0, ExcInsertionInPSBLASMatrix(err));
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::el(const SparseMatrix::size_type i,
+                   const SparseMatrix::size_type j) const
+  {
+    const auto psblas_index_i = static_cast<psb_l_t>(i);
+    AssertIntegerConversion(psblas_index_i, i);
+    const auto psblas_index_j = static_cast<psb_l_t>(j);
+    AssertIntegerConversion(psblas_index_j, j);
+
+    return psb_c_dmatgetelem(psblas_sparse_matrix,
+                             psblas_index_i,
+                             psblas_index_j,
+                             psblas_descriptor.get());
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::diag_element(const SparseMatrix::size_type i) const
+  {
+    Assert(m() == n(), ExcNotQuadratic());
+    return el(i, i);
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::operator()(const SparseMatrix::size_type i,
+                           const SparseMatrix::size_type j) const
+  {
+    Assert(m() == n(), ExcNotQuadratic());
+    return el(i, j);
+  }
+
+
+
+  psb_c_dspmat *
+  SparseMatrix::get_psblas_matrix() const
+  {
+    return psblas_sparse_matrix;
+  }
+
+
+
+  psb_c_descriptor *
+  SparseMatrix::get_psblas_descriptor() const
+  {
+    return psblas_descriptor.get();
+  }
+
+
+
+  MPI_Comm
+  SparseMatrix::get_mpi_communicator() const
+  {
+    return communicator;
+  }
+
+
+
+  void
+  SparseMatrix::set(const std::vector<SparseMatrix::size_type> &indices,
+                    const FullMatrix<double>                   &matrix)
+  {
+    Assert(psblas_sparse_matrix != nullptr,
+           ExcMessage("PSBLAS matrix has not been initialized."));
+    Assert(matrix.m() == indices.size(),
+           ExcDimensionMismatch(matrix.m(), indices.size()));
+    Assert(matrix.n() == indices.size(),
+           ExcDimensionMismatch(matrix.n(), indices.size()));
+
+    // Get the number of indices.
+    const unsigned int n_indices = indices.size();
+    psb_i_t            nz = n_indices * n_indices; // Number of non-zero entries
+
+    // Fill the arrays with row indices, column indices, and values
+    std::vector<psb_l_t> irw(nz);
+    std::vector<psb_l_t> icl(nz);
+    std::vector<psb_d_t> val(nz);
+    for (unsigned int i = 0; i < n_indices; ++i)
+      {
+        for (unsigned int j = 0; j < n_indices; ++j)
+          {
+            const auto psblas_row_index = static_cast<psb_l_t>(indices[i]);
+            const auto psblas_col_index = static_cast<psb_l_t>(indices[j]);
+            AssertIntegerConversion(psblas_row_index, indices[i]);
+            AssertIntegerConversion(psblas_col_index, indices[j]);
+            irw[i * n_indices + j] = psblas_row_index;
+            icl[i * n_indices + j] = psblas_col_index;
+            val[i * n_indices + j] = matrix(i, j);
+          }
+      }
+
+    // Insert the values into the sparse matrix
+    int err = psb_c_dspins(nz,
+                           irw.data(),
+                           icl.data(),
+                           val.data(),
+                           psblas_sparse_matrix,
+                           psblas_descriptor.get());
+
+    Assert(err == 0, ExcInsertionInPSBLASMatrix(err));
+  }
+
+
+
+  void
+  SparseMatrix::add(const SparseMatrix::size_type  i,
+                    const SparseMatrix::size_type  j,
+                    const SparseMatrix::value_type value)
+  {
+    AssertIsFinite(value);
+
+    psb_l_t irw  = i;
+    psb_l_t icl  = j;
+    int     info = psb_c_dspins(1 /*nz*/,
+                            &irw,
+                            &icl,
+                            &value,
+                            psblas_sparse_matrix,
+                            psblas_descriptor.get());
+    Assert(info == 0, ExcInsertionInPSBLASMatrix(info));
+  }
+
+
+
+  void
+  SparseMatrix::add(const SparseMatrix::size_type               row,
+                    const SparseMatrix::size_type               ncols,
+                    const std::vector<SparseMatrix::size_type> &col_indices,
+                    const SparseMatrix::value_type             *values,
+                    const bool,
+                    const bool)
+  {
+    Assert(col_indices.size() == ncols,
+           ExcDimensionMismatch(col_indices.size(), ncols));
+    // Call the function below taking a raw pointer from the vector
+    add(row, ncols, col_indices.data(), values, false, false);
+  }
+
+
+
+  void
+  SparseMatrix::add(const SparseMatrix::size_type                row,
+                    const SparseMatrix::size_type                ncols,
+                    const std::vector<SparseMatrix::size_type>  &col_indices,
+                    const std::vector<SparseMatrix::value_type> &values,
+                    const bool,
+                    const bool)
+  {
+    Assert(col_indices.size() == ncols,
+           ExcDimensionMismatch(col_indices.size(), ncols));
+    Assert(values.size() == ncols, ExcDimensionMismatch(ncols, values.size()));
+    // Call the function below taking a raw pointer from the vector
+    add(row, ncols, col_indices.data(), values.data(), false, false);
+  }
+
+
+
+  void
+  SparseMatrix::add(const SparseMatrix::size_type   row,
+                    const SparseMatrix::size_type   ncols,
+                    const SparseMatrix::size_type  *col_indices,
+                    const SparseMatrix::value_type *values,
+                    const bool,
+                    const bool)
+  {
+    std::vector<psb_l_t> irw(ncols);
+    std::vector<psb_l_t> icl(ncols);
+    for (SparseMatrix::size_type i = 0; i < ncols; ++i)
+      {
+        irw[i] = static_cast<psb_l_t>(row);
+        icl[i] = static_cast<psb_l_t>(col_indices[i]);
+      }
+
+    int info = psb_c_dspins(ncols /*nz*/,
+                            irw.data(),
+                            icl.data(),
+                            values,
+                            psblas_sparse_matrix,
+                            psblas_descriptor.get());
+    Assert(info == 0, ExcInsertionInPSBLASMatrix(info));
+  }
+
+
+
+  void
+  SparseMatrix::compress()
+  {
+    // We start by checking if the descriptor has already been assembled
+    // elsewhere
+    int err = -1;
+    if (!psb_c_cd_is_asb(psblas_descriptor.get()))
+      {
+        err = psb_c_cdasb(psblas_descriptor.get());
+        Assert(err == 0, ExcAssemblePSBLASDescriptor(err));
+      }
+
+    // Check if the sparse matrix is not already assembled
+    if (!psb_c_dis_matasb(psblas_sparse_matrix, psblas_descriptor.get()))
+      {
+        // ... and the sparse matrix
+        err = psb_c_dspasb(psblas_sparse_matrix, psblas_descriptor.get());
+        Assert(err == 0, ExcAssemblePSBLASMatrix(err));
+        state = internal::State::Assembled;
+      }
+  }
+
+
+
+  void
+  SparseMatrix::vmult(Vector &dst, const Vector &src) const
+  {
+    Assert(psblas_sparse_matrix != nullptr,
+           ExcMessage("PSBLAS matrix has not been initialized."));
+    Assert(src.psblas_vector != nullptr,
+           ExcMessage("Source PSBLAS vector has not been initialized."));
+    Assert(&src != &dst, ExcSourceEqualsDestination());
+    Assert(state == internal::State::Assembled,
+           ExcMessage("PSBLAS matrix has not been assembled."));
+
+    int err = psb_c_dspmm(value_type(1.0), // alpha
+                          psblas_sparse_matrix,
+                          src.psblas_vector,
+                          value_type(0.0), // beta
+                          dst.psblas_vector,
+                          psblas_descriptor.get());
+    Assert(err == 0, ExcMatVecPSBLAS(err));
+  }
+
+
+
+  void
+  SparseMatrix::vmult_add(Vector &dst, const Vector &src) const
+  {
+    Assert(psblas_sparse_matrix != nullptr,
+           ExcMessage("PSBLAS matrix has not been initialized."));
+    Assert(src.psblas_vector != nullptr,
+           ExcMessage("Source PSBLAS vector has not been initialized."));
+    Assert(&src != &dst, ExcSourceEqualsDestination());
+    Assert(state == internal::State::Assembled,
+           ExcMessage("PSBLAS matrix has not been assembled."));
+
+    int err = psb_c_dspmm(value_type(1.0), // alpha
+                          psblas_sparse_matrix,
+                          src.psblas_vector,
+                          value_type(1.0), // beta
+                          dst.psblas_vector,
+                          psblas_descriptor.get());
+    Assert(err == 0, ExcMatVecPSBLAS(err));
+  }
+
+
+
+  void
+  SparseMatrix::Tvmult(Vector &dst, const Vector &src) const
+  {
+    Assert(psblas_sparse_matrix != nullptr,
+           ExcMessage("PSBLAS matrix has not been initialized."));
+    Assert(src.psblas_vector != nullptr,
+           ExcMessage("Source PSBLAS vector has not been initialized."));
+    Assert(&src != &dst, ExcSourceEqualsDestination());
+    Assert(state == internal::State::Assembled,
+           ExcMessage("PSBLAS matrix has not been assembled."));
+
+    char transpose = 'T';
+    int  err       = psb_c_dspmm_opt(value_type(1.0), // alpha
+                              psblas_sparse_matrix,
+                              src.psblas_vector,
+                              value_type(0.0), // beta
+                              dst.psblas_vector,
+                              psblas_descriptor.get(),
+                              &transpose,
+                              true);
+    Assert(err == 0, ExcMatVecPSBLAS(err));
+  }
+
+
+
+  void
+  SparseMatrix::Tvmult_add(Vector &dst, const Vector &src) const
+  {
+    Assert(psblas_sparse_matrix != nullptr,
+           ExcMessage("PSBLAS matrix has not been initialized."));
+    Assert(src.psblas_vector != nullptr,
+           ExcMessage("Source PSBLAS vector has not been initialized."));
+    Assert(&src != &dst, ExcSourceEqualsDestination());
+    Assert(state == internal::State::Assembled,
+           ExcMessage("PSBLAS matrix has not been assembled."));
+
+    char transpose = 'T';
+    int  err       = psb_c_dspmm_opt(value_type(1.0), // alpha
+                              psblas_sparse_matrix,
+                              src.psblas_vector,
+                              value_type(1.0), // beta
+                              dst.psblas_vector,
+                              psblas_descriptor.get(),
+                              &transpose,
+                              true);
+    Assert(err == 0, ExcMatVecPSBLAS(err));
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::l1_norm() const
+  {
+    DEAL_II_NOT_IMPLEMENTED();
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::linfty_norm() const
+  {
+    DEAL_II_NOT_IMPLEMENTED();
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::frobenius_norm() const
+  {
+    DEAL_II_NOT_IMPLEMENTED();
+  }
+
+
+
+  SparseMatrix::value_type
+  SparseMatrix::trace() const
+  {
+    Assert(m() == n(), ExcNotQuadratic());
+    value_type local_diagonal_sum = 0;
+    const auto local_indices      = local_range();
+    for (types::global_dof_index idx = local_indices.first;
+         idx < local_indices.second;
+         ++idx)
+      local_diagonal_sum += diag_element(idx);
+
+    return Utilities::MPI::sum(local_diagonal_sum, communicator);
+  }
+
+
+
+} // namespace PSCToolkitWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+#endif // DEAL_II_WITH_PSBLAS

--- a/source/lac/psblas_sparsity_pattern.cc
+++ b/source/lac/psblas_sparsity_pattern.cc
@@ -1,0 +1,133 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2019 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/init_finalize.h>
+
+#include "deal.II/lac/psblas_common.h"
+
+#include <psb_c_base.h>
+
+
+#ifdef DEAL_II_WITH_PSBLAS
+#  include <deal.II/lac/psblas_sparsity_pattern.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace PSCToolkitWrappers
+{
+  // SparsityPattern
+  SparsityPattern::SparsityPattern(const IndexSet &index_set,
+                                   const MPI_Comm  communicator)
+  {
+    SparsityPatternBase::resize(index_set.size(), index_set.size());
+
+    Assert(communicator != MPI_COMM_NULL,
+           ExcMessage("MPI_COMM_NULL passed to SparseMatrix::reinit()."));
+
+    psblas_descriptor.reset(psb_c_new_descriptor(),
+                            PSCToolkitWrappers::internal::DescriptorDeleter());
+
+    // Use get_index_vector() from IndexSet to get the indexes
+    const std::vector<types::global_dof_index> &indexes =
+      index_set.get_index_vector();
+
+    psb_i_t number_of_local_indexes = indexes.size(); // Number of local indexes
+    // Copy the indexes into a psb_l_t vector
+    std::vector<psb_l_t> vl(number_of_local_indexes);
+    for (psb_i_t i = 0; i < number_of_local_indexes; ++i)
+      {
+        const auto psblas_index = static_cast<psb_l_t>(indexes[i]);
+        AssertIntegerConversion(psblas_index, indexes[i]);
+        vl[i] = psblas_index;
+      }
+
+    // Insert the indexes into the descriptor
+    psb_c_cdall_vl(number_of_local_indexes,
+                   vl.data(),
+                   *InitFinalize::get_psblas_context(),
+                   psblas_descriptor.get());
+  }
+
+
+
+  void
+  SparsityPattern::add(const PSCToolkitWrappers::SparsityPattern::size_type i,
+                       const PSCToolkitWrappers::SparsityPattern::size_type j)
+  {
+    add_entries(i, &j, &j + 1);
+  }
+
+
+
+  template <typename ForwardIterator>
+  inline void
+  SparsityPattern::add_entries(
+    const PSCToolkitWrappers::SparsityPattern::size_type row,
+    ForwardIterator                                      begin,
+    ForwardIterator                                      end,
+    const bool                                           indices_are_sorted)
+  {
+    Assert(psblas_descriptor.get() != nullptr,
+           ExcMessage("PSBLAS descriptor is null."));
+    if (begin == end)
+      return;
+
+    (void)indices_are_sorted;
+    psb_i_t              nz = static_cast<int>(end - begin);
+    std::vector<psb_l_t> ia(nz);
+    std::vector<psb_l_t> ja(nz);
+
+    for (int k = 0; k < nz; ++k)
+      {
+        ia[k] = row;          // row index
+        ja[k] = *(begin + k); // column index
+      }
+    int err = psb_c_cdins(nz, ia.data(), ja.data(), psblas_descriptor.get());
+    Assert(err == 0, ExcInsertionInPSBLASMatrix(err));
+  }
+
+
+
+  void
+  SparsityPattern::add_row_entries(const size_type                  &row,
+                                   const ArrayView<const size_type> &columns,
+                                   const bool indices_are_sorted)
+  {
+    add_entries(row, columns.begin(), columns.end(), indices_are_sorted);
+  }
+
+
+
+  void
+  SparsityPattern::compress()
+  {
+    Assert(psblas_descriptor.get() != nullptr,
+           ExcMessage("PSBLAS descriptor is null."));
+    int err = -1;
+    if (!psb_c_cd_is_asb(psblas_descriptor.get()))
+      {
+        err = psb_c_cdasb(psblas_descriptor.get());
+        Assert(
+          err == 0,
+          ExcCallingPSBLASFunction(
+            err,
+            "Error while finalizing SparsityPattern through psb_c_cdasb."));
+      }
+  }
+} // namespace PSCToolkitWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+#endif

--- a/source/lac/psblas_vector.cc
+++ b/source/lac/psblas_vector.cc
@@ -101,8 +101,8 @@ namespace PSCToolkitWrappers
     // been assembled
     if (psblas_descriptor.get() == nullptr || is_vector_changed == true)
       {
-        psblas_descriptor = std::shared_ptr<psb_c_descriptor>(
-          psb_c_new_descriptor(), internal::PSBLASDescriptorDeleter{});
+        psblas_descriptor.reset(psb_c_new_descriptor(),
+                                internal::DescriptorDeleter());
 
         // Use get_index_vector() from IndexSet to get the indexes
         const std::vector<types::global_dof_index> &indexes =
@@ -169,8 +169,8 @@ namespace PSCToolkitWrappers
     int ierr;
     if (psblas_descriptor.get() == nullptr || is_vector_changed == true)
       {
-        psblas_descriptor = std::shared_ptr<psb_c_descriptor>(
-          psb_c_new_descriptor(), internal::PSBLASDescriptorDeleter{});
+        psblas_descriptor.reset(psb_c_new_descriptor(),
+                                internal::DescriptorDeleter());
 
         // Use get_index_vector() from IndexSet to get the indexes
         const std::vector<types::global_dof_index> &indexes =

--- a/tests/psblas/psblas_matrix_01.cc
+++ b/tests/psblas/psblas_matrix_01.cc
@@ -1,0 +1,109 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// check setting elements in a PSBLAS matrix
+
+#include "deal.II/base/exception_macros.h"
+#include "deal.II/base/exceptions.h"
+#include "deal.II/base/index_set.h"
+
+#include <deal.II/lac/psblas_sparse_matrix.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+
+int
+main(int argc, char **argv)
+{
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+      MPILogInitAll                    log;
+      {
+        const IndexSet                      index_set = complete_index_set(5);
+        PSCToolkitWrappers::SparsityPattern sparsity_pattern(index_set,
+                                                             MPI_COMM_WORLD);
+        // sparsity pattern
+        unsigned int n_expected_elements = 0;
+        for (unsigned int i = 0; i < 5; ++i)
+          for (unsigned int j = 0; j < 5; ++j)
+            if ((i + 2 * j + 1) % 3 == 0)
+              {
+                sparsity_pattern.add(i, j);
+                n_expected_elements++;
+              }
+
+        sparsity_pattern.compress();
+
+        // now set a few entries
+        PSCToolkitWrappers::SparseMatrix matrix(sparsity_pattern,
+                                                MPI_COMM_WORLD);
+        for (unsigned int i = 0; i < matrix.m(); ++i)
+          for (unsigned int j = 0; j < matrix.m(); ++j)
+            if ((i + 2 * j + 1) % 3 == 0)
+              matrix.set(i, j, i * j * .5 + .5);
+
+        matrix.compress();
+
+        deallog << "Matrix dimensions: " << matrix.m() << " x " << matrix.n()
+                << std::endl;
+
+        AssertThrow(
+          matrix.n_nonzero_elements() == n_expected_elements,
+          ExcMessage(
+            "The number of nonzero elements in the matrix does not match the "
+            "expected value."));
+        deallog << "Nonzero elements: " << matrix.n_nonzero_elements()
+                << std::endl;
+
+        // check that the new elements are the right ones.
+        for (unsigned int i = 0; i < matrix.m(); ++i)
+          for (unsigned int j = 0; j < matrix.n(); ++j)
+            if ((i + 2 * j + 1) % 3 == 0)
+              {
+                const double expected_value = i * j * .5 + .5;
+                AssertThrow(matrix.el(i, j) == expected_value,
+                            ExcMessage("Wrong matrix entries. Test failed."));
+              }
+
+        deallog << "OK" << std::endl;
+      }
+    }
+  catch (const std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    };
+}

--- a/tests/psblas/psblas_matrix_01.output
+++ b/tests/psblas/psblas_matrix_01.output
@@ -1,0 +1,4 @@
+
+DEAL:0::Matrix dimensions: 5 x 5
+DEAL:0::Nonzero elements: 8
+DEAL:0::OK

--- a/tests/psblas/psblas_matrix_02.cc
+++ b/tests/psblas/psblas_matrix_02.cc
@@ -36,7 +36,7 @@
 
 #include <iostream>
 
-#include "../../tests/tests.h"
+#include "../tests.h"
 
 using namespace dealii;
 

--- a/tests/psblas/psblas_matrix_02.cc
+++ b/tests/psblas/psblas_matrix_02.cc
@@ -1,0 +1,204 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2017 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/types.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/petsc_sparse_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/psblas_sparse_matrix.h>
+#include <deal.II/lac/psblas_vector.h>
+
+#include <iostream>
+
+#include "../../tests/tests.h"
+
+using namespace dealii;
+
+// Test the consistency of the PSBLAS matrix and vector classes. We check that
+// the mat-vec product with a rhs vector is identical to a PETSc one.
+
+template <int dim>
+void
+test(MPI_Comm mpi_communicator)
+{
+  // Create distributed triangulation of the unit square
+  Triangulation<dim> tria_base;
+
+  deallog << "Testing PSBLAS matrix with dim=" << dim << std::endl;
+
+  // Create a serial triangulation (here by reading an external mesh):
+  GridGenerator::hyper_cube(tria_base, 0, 1);
+  tria_base.refine_global(3);
+
+  // Partition
+  GridTools::partition_triangulation(
+    Utilities::MPI::n_mpi_processes(mpi_communicator), tria_base);
+
+  // Create building blocks:
+  const TriangulationDescription::Description<dim> description =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria_base, mpi_communicator);
+
+  // Create a fully distributed triangulation:
+  parallel::fullydistributed::Triangulation<dim> triangulation(
+    mpi_communicator);
+  triangulation.create_triangulation(description);
+
+  // Finite element and DoFHandler
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe);
+
+  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+
+  AffineConstraints<double> constraints;
+
+  // PSBLAS matrix and vectors
+  PSCToolkitWrappers::SparseMatrix psblas_matrix;
+  psblas_matrix.reinit(locally_owned_dofs, mpi_communicator);
+
+  PSCToolkitWrappers::Vector psblas_rhs_vector(locally_owned_dofs,
+                                               mpi_communicator);
+
+  //  PETSc matrix and vector
+  PETScWrappers::MPI::Vector petsc_test_vector;
+  petsc_test_vector.reinit(locally_owned_dofs, mpi_communicator);
+
+  PETScWrappers::MPI::SparseMatrix petsc_matrix;
+  DynamicSparsityPattern           dsp(locally_relevant_dofs);
+
+  DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             mpi_communicator,
+                                             locally_relevant_dofs);
+
+  petsc_matrix.reinit(locally_owned_dofs,
+                      locally_owned_dofs,
+                      dsp,
+                      mpi_communicator);
+
+  QGauss<dim>   quadrature_formula(fe.degree + 1);
+  FEValues<dim> fe_values(fe,
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int n_q_points    = quadrature_formula.size();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>     cell_rhs(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+
+          cell_matrix = 0.;
+          cell_rhs    = 0.;
+
+          for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+            {
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                {
+                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                    cell_matrix(i, j) += fe_values.shape_grad(i, q_point) *
+                                         fe_values.shape_grad(j, q_point) *
+                                         fe_values.JxW(q_point);
+
+                  cell_rhs(i) += 1. * fe_values.shape_value(i, q_point) *
+                                 fe_values.JxW(q_point);
+                }
+            }
+
+          cell->get_dof_indices(local_dof_indices);
+
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 psblas_matrix,
+                                                 psblas_rhs_vector);
+
+
+
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 petsc_matrix,
+                                                 petsc_test_vector);
+        }
+    }
+  petsc_test_vector.compress(VectorOperation::add);
+  petsc_matrix.compress(VectorOperation::add);
+  psblas_matrix.compress();
+  psblas_rhs_vector.compress(VectorOperation::add);
+
+  AssertThrow(psblas_matrix.n_nonzero_elements() ==
+                petsc_matrix.n_nonzero_elements(),
+              ExcMessage("Number of non-zero elements in PSBLAS and PETSc "
+                         "matrices do not match."));
+
+  // Test matrix-vector product with PSBLAS
+  PSCToolkitWrappers::Vector dst_psblas(locally_owned_dofs, mpi_communicator);
+  psblas_matrix.vmult(dst_psblas, psblas_rhs_vector);
+
+  // ... with PETSc
+  PETScWrappers::MPI::Vector dst_petsc(locally_owned_dofs, mpi_communicator);
+  petsc_matrix.vmult(dst_petsc, petsc_test_vector);
+
+  double difference = 0.;
+  for (const types::global_dof_index idx : locally_owned_dofs)
+    difference += std::fabs(dst_petsc(idx) - dst_psblas(idx));
+
+  AssertThrow(Utilities::MPI::sum(difference, mpi_communicator) < 1e-15,
+              ExcMessage("Error too large."));
+  deallog << "Matrix-vector product: OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPI_Comm                         mpi_communicator = MPI_COMM_WORLD;
+  AssertThrow(Utilities::MPI::n_mpi_processes(mpi_communicator) == 2,
+              ExcMessage("This test needs to be run with 2 MPI processes."));
+
+  MPILogInitAll log;
+
+  test<2>(mpi_communicator);
+
+  return 0;
+}

--- a/tests/psblas/psblas_matrix_02.with_petsc=true.mpirun=2.output
+++ b/tests/psblas/psblas_matrix_02.with_petsc=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0::Testing PSBLAS matrix with dim=2
+DEAL:0::Matrix-vector product: OK
+
+DEAL:1::Testing PSBLAS matrix with dim=2
+DEAL:1::Matrix-vector product: OK
+

--- a/tests/psblas/psblas_matrix_03.cc
+++ b/tests/psblas/psblas_matrix_03.cc
@@ -1,0 +1,169 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2017 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/psblas_sparse_matrix.h>
+
+#include <fstream>
+#include <iostream>
+
+#include "../tests.h"
+
+// This tests local_range() and in_local_range() for the PSBLAS matrix class.
+
+using namespace dealii;
+
+template <int dim>
+void
+test()
+{
+  MPI_Comm mpi_communicator = MPI_COMM_WORLD;
+
+  deallog << "Testing PSBLAS matrix with dim=" << dim << std::endl;
+
+  // Create distributed triangulation of the unit square
+  Triangulation<dim> tria_base;
+
+  // Create a serial triangulation (here by reading an external mesh):
+  GridGenerator::hyper_cube(tria_base, 0, 1);
+  tria_base.refine_global(5);
+
+  // Partition
+  GridTools::partition_triangulation(
+    Utilities::MPI::n_mpi_processes(mpi_communicator), tria_base);
+
+  // Create building blocks:
+  const TriangulationDescription::Description<dim> description =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria_base, mpi_communicator);
+
+  // Create a fully distributed triangulation:
+  parallel::fullydistributed::Triangulation<dim> triangulation(
+    mpi_communicator);
+  triangulation.create_triangulation(description);
+
+  // Finite element and DoFHandler
+  FE_Q<dim>       fe(dim);
+  DoFHandler<dim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe);
+
+  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+
+
+  PSCToolkitWrappers::SparsityPattern sparsity_pattern(locally_owned_dofs,
+                                                       mpi_communicator);
+  PSCToolkitWrappers::SparseMatrix    psblas_matrix(sparsity_pattern,
+                                                 mpi_communicator);
+
+  // Assemble system
+  QGauss<dim>   quadrature_formula(fe.degree + 1);
+  FEValues<dim> fe_values(fe,
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int n_q_points    = quadrature_formula.size();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+  AffineConstraints<double>            constraints;
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+          cell_matrix = 0;
+
+          for (unsigned int q = 0; q < n_q_points; ++q)
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                cell_matrix(i, j) += fe_values.shape_grad(i, q) *
+                                     fe_values.shape_grad(j, q) *
+                                     fe_values.JxW(q);
+
+          cell->get_dof_indices(local_dof_indices);
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 local_dof_indices,
+                                                 psblas_matrix);
+        }
+    }
+  psblas_matrix.compress();
+
+  deallog << "Local range: " << psblas_matrix.local_range().first << " - "
+          << psblas_matrix.local_range().second << std::endl;
+  AssertThrow((psblas_matrix.in_local_range(*locally_owned_dofs.begin()) ==
+               true),
+              ExcMessage("First locally owned dof should be in local range."));
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll log;
+
+  try
+    {
+      test<2>();
+    }
+  catch (const std::exception &exc)
+    {
+      deallog << std::endl
+              << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      deallog << std::endl
+              << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/psblas/psblas_matrix_03.mpirun=2.output
+++ b/tests/psblas/psblas_matrix_03.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0::Testing PSBLAS matrix with dim=2
+DEAL:0::Local range: 0 - 2153
+
+DEAL:1::Testing PSBLAS matrix with dim=2
+DEAL:1::Local range: 2153 - 4225
+

--- a/tests/psblas/psblas_matrix_04.cc
+++ b/tests/psblas/psblas_matrix_04.cc
@@ -1,0 +1,282 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2017 - 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/types.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/petsc_sparse_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/psblas_sparse_matrix.h>
+#include <deal.II/lac/psblas_vector.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+// Test the creation of a PSBLAS matrix with a DynamicSparsityPattern. Fill a
+// stiffness matrix and rhs vector for a Poisson problem, and check that the
+// number of non-zero entries in the PSBLAS matrix matches the one in a PETSc
+// matrix created with the same sparsity pattern. We also check that the values
+// of a matrix-vector are the same for PSBLAS and PETSc.
+// In addition, we also the the vmult_add, Tvmult, and Tvmult_add functions for
+// PSBLAS matrices.
+
+template <int dim>
+void
+test()
+{
+  MPI_Comm mpi_communicator = MPI_COMM_WORLD;
+
+  deallog << "Testing PSBLAS matrix with dim=" << dim << std::endl;
+
+  // Create distributed triangulation of the unit square
+  Triangulation<dim> tria_base;
+
+  // Create a serial triangulation (here by reading an external mesh):
+  GridGenerator::hyper_cube(tria_base, 0, 1);
+  if constexpr (dim == 2)
+    tria_base.refine_global(5);
+  else if constexpr (dim == 3)
+    tria_base.refine_global(3);
+
+  // Partition
+  GridTools::partition_triangulation(
+    Utilities::MPI::n_mpi_processes(mpi_communicator), tria_base);
+
+  // Create building blocks:
+  const TriangulationDescription::Description<dim> description =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria_base, mpi_communicator);
+
+  // Create a fully distributed triangulation:
+  parallel::fullydistributed::Triangulation<dim> triangulation(
+    mpi_communicator);
+  triangulation.create_triangulation(description);
+
+  // Finite element and DoFHandler
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe);
+
+  IndexSet locally_owned_dofs = dof_handler.locally_owned_dofs();
+
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+
+  AffineConstraints<double> constraints;
+
+  // PSBLAS matrix and vectors
+  PSCToolkitWrappers::SparseMatrix psblas_matrix;
+  DynamicSparsityPattern           dsp_psblas(locally_relevant_dofs);
+
+  SparsityTools::distribute_sparsity_pattern(dsp_psblas,
+                                             locally_owned_dofs,
+                                             mpi_communicator,
+                                             locally_relevant_dofs);
+  psblas_matrix.reinit(locally_owned_dofs, dsp_psblas, mpi_communicator);
+
+  PSCToolkitWrappers::Vector psblas_rhs_vector(locally_owned_dofs,
+                                               mpi_communicator);
+
+  //  PETSc matrix and vector
+  PETScWrappers::MPI::Vector petsc_test_vector;
+  petsc_test_vector.reinit(locally_owned_dofs, mpi_communicator);
+
+  PETScWrappers::MPI::SparseMatrix petsc_matrix;
+  DynamicSparsityPattern           dsp(locally_relevant_dofs);
+
+  DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             mpi_communicator,
+                                             locally_relevant_dofs);
+
+  petsc_matrix.reinit(locally_owned_dofs,
+                      locally_owned_dofs,
+                      dsp,
+                      mpi_communicator);
+
+  QGauss<dim>   quadrature_formula(fe.degree + 1);
+  FEValues<dim> fe_values(fe,
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int n_q_points    = quadrature_formula.size();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>     cell_rhs(dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->is_locally_owned())
+        {
+          fe_values.reinit(cell);
+
+          cell_matrix = 0.;
+          cell_rhs    = 0.;
+
+          for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+            {
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                {
+                  for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                    cell_matrix(i, j) += fe_values.shape_grad(i, q_point) *
+                                         fe_values.shape_grad(j, q_point) *
+                                         fe_values.JxW(q_point);
+
+                  cell_rhs(i) += 1. * fe_values.shape_value(i, q_point) *
+                                 fe_values.JxW(q_point);
+                }
+            }
+
+          cell->get_dof_indices(local_dof_indices);
+
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 psblas_matrix,
+                                                 psblas_rhs_vector);
+
+
+
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
+                                                 local_dof_indices,
+                                                 petsc_matrix,
+                                                 petsc_test_vector);
+        }
+    }
+  petsc_test_vector.compress(VectorOperation::add);
+  petsc_matrix.compress(VectorOperation::add);
+  psblas_matrix.compress();
+  psblas_rhs_vector.compress(VectorOperation::add);
+
+  AssertThrow(psblas_matrix.n_nonzero_elements() ==
+                petsc_matrix.n_nonzero_elements(),
+              ExcMessage("Number of non-zero elements in PSBLAS and PETSc "
+                         "matrices do not match."));
+
+  // Test matrix-vector product with PSBLAS
+  PSCToolkitWrappers::Vector dst_psblas(locally_owned_dofs, mpi_communicator);
+  psblas_matrix.vmult(dst_psblas, psblas_rhs_vector);
+
+  // ... with PETSc
+  PETScWrappers::MPI::Vector dst_petsc(locally_owned_dofs, mpi_communicator);
+  petsc_matrix.vmult(dst_petsc, petsc_test_vector);
+
+  double difference = 0.;
+  for (const types::global_dof_index idx : locally_owned_dofs)
+    difference += std::fabs(dst_petsc(idx) - dst_psblas(idx));
+
+  AssertThrow(Utilities::MPI::sum(difference, mpi_communicator) < 1e-15,
+              ExcMessage("Error too large."));
+  deallog << "Matrix-vector product: OK" << std::endl;
+
+  // Test also the vmult_add(), Tvmult(), and Tvmult_add() functions.
+
+  // vmult_add
+  psblas_matrix.vmult_add(dst_psblas, psblas_rhs_vector);
+  petsc_matrix.vmult_add(dst_petsc, petsc_test_vector);
+  difference = 0.;
+  for (const types::global_dof_index idx : locally_owned_dofs)
+    difference += std::fabs(dst_petsc(idx) - dst_psblas(idx));
+  AssertThrow(Utilities::MPI::sum(difference, mpi_communicator) < 1e-15,
+              ExcMessage("Error too large in vmult_add()."));
+
+  // Tvmult
+  dst_psblas = 0.;
+  dst_petsc  = 0.;
+  psblas_matrix.Tvmult(dst_psblas, psblas_rhs_vector);
+  petsc_matrix.Tvmult(dst_petsc, petsc_test_vector);
+  difference = 0.;
+  for (const types::global_dof_index idx : locally_owned_dofs)
+    difference += std::fabs(dst_petsc(idx) - dst_psblas(idx));
+  AssertThrow(Utilities::MPI::sum(difference, mpi_communicator) < 1e-15,
+              ExcMessage("Error too large in Tvmult()."));
+
+  // Tvmult_add
+  psblas_matrix.Tvmult_add(dst_psblas, psblas_rhs_vector);
+  petsc_matrix.Tvmult_add(dst_petsc, petsc_test_vector);
+  difference = 0.;
+  for (const types::global_dof_index idx : locally_owned_dofs)
+    difference += std::fabs(dst_petsc(idx) - dst_psblas(idx));
+  AssertThrow(Utilities::MPI::sum(difference, mpi_communicator) < 1e-15,
+              ExcMessage("Error too large in Tvmult_add()."));
+
+
+  // check also trace() for both PSBLAS and PETSc matrices
+  AssertThrow(std::fabs(psblas_matrix.trace() - petsc_matrix.trace()) < 1e-15,
+              ExcMessage("Error too large in trace() function"));
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll log;
+
+  try
+    {
+      test<2>();
+      test<3>();
+    }
+  catch (const std::exception &exc)
+    {
+      deallog << std::endl
+              << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Exception on processing: " << std::endl
+              << exc.what() << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      deallog << std::endl
+              << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      deallog << "Unknown exception!" << std::endl
+              << "Aborting!" << std::endl
+              << "----------------------------------------------------"
+              << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/psblas/psblas_matrix_04.with_petsc=true.mpirun=2.output
+++ b/tests/psblas/psblas_matrix_04.with_petsc=true.mpirun=2.output
@@ -1,0 +1,11 @@
+
+DEAL:0::Testing PSBLAS matrix with dim=2
+DEAL:0::Matrix-vector product: OK
+DEAL:0::Testing PSBLAS matrix with dim=3
+DEAL:0::Matrix-vector product: OK
+
+DEAL:1::Testing PSBLAS matrix with dim=2
+DEAL:1::Matrix-vector product: OK
+DEAL:1::Testing PSBLAS matrix with dim=3
+DEAL:1::Matrix-vector product: OK
+


### PR DESCRIPTION
~To be merged after #19050.~

This PR adds support for PSBLAS sparse matrices and sparsity patterns. It also introduces a set of tests comparing results with other linear algebra backends.

Additionally, I fixed the PSBLAS configuration by marking `MPI_CXX_LIBRARIES` and `MPI_Fortran_LIBRARIES` as `OPTIONAL` instead of `REQUIRED`, since they may be empty in some setups.

~The PR is still in draft status while I continue updating the documentation and adding more tests for the matrix interface.~

@Cirdans-Home @luca-heltai @sfilippone, feel free to add comments or suggestions.