### PR TITLE
Use 'if constexpr' in a couple more places.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5239,11 +5239,11 @@ template <int structdim, int dim, int spacedim>
 inline ReferenceCell
 TriaAccessor<structdim, dim, spacedim>::reference_cell() const
 {
-  if (structdim == 0)
+  if constexpr (structdim == 0)
     return ReferenceCells::Vertex;
-  else if (structdim == 1)
+  else if constexpr (structdim == 1)
     return ReferenceCells::Line;
-  else if (structdim == dim)
+  else if constexpr (structdim == dim)
     return this->tria->levels[this->level()]
       ->reference_cell[this->present_index];
   else

--- a/include/deal.II/matrix_free/util.h
+++ b/include/deal.II/matrix_free/util.h
@@ -67,7 +67,7 @@ namespace internal
             }
         }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int i = 1; i <= 3; ++i)
           if (quad == QGaussWedge<dim>(i))
             {
@@ -79,7 +79,7 @@ namespace internal
                 dealii::hp::QCollection<dim - 1>(tri, tri, quad, quad, quad)};
             }
 
-      if (dim == 3)
+      if constexpr (dim == 3)
         for (unsigned int i = 1; i <= 2; ++i)
           if (quad == QGaussPyramid<dim>(i))
             {

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -288,12 +288,14 @@ namespace internal
 
           if (needs_simplex_setup)
             {
-              if (dim == 2)
+              if constexpr (dim == 2)
                 quadrature_simplex = std::make_unique<Quadrature<dim>>(
                   generate_simplex_evaluation_points<dim>(n_subdivisions));
-              else
+              else if constexpr (dim == 3)
                 quadrature_simplex = std::make_unique<Quadrature<dim>>(
                   FE_SimplexP<dim>(n_subdivisions).get_unit_support_points());
+              else
+                DEAL_II_ASSERT_UNREACHABLE();
             }
 
           if (needs_hypercube_setup)
@@ -303,21 +305,23 @@ namespace internal
                                                  n_subdivisions);
             }
 
-          if (needs_wedge_setup)
-            {
-              Assert(n_subdivisions == 1, ExcNotImplemented());
+          if constexpr (dim == 3)
+            if (needs_wedge_setup)
+              {
+                Assert(n_subdivisions == 1, ExcNotImplemented());
 
-              quadrature_wedge = std::make_unique<Quadrature<dim>>(
-                ReferenceCells::Wedge.get_nodal_type_quadrature<dim>());
-            }
+                quadrature_wedge = std::make_unique<Quadrature<dim>>(
+                  ReferenceCells::Wedge.get_nodal_type_quadrature<dim>());
+              }
 
-          if (needs_pyramid_setup)
-            {
-              Assert(n_subdivisions == 1, ExcNotImplemented());
+          if constexpr (dim == 3)
+            if (needs_pyramid_setup)
+              {
+                Assert(n_subdivisions == 1, ExcNotImplemented());
 
-              quadrature_pyramid = std::make_unique<Quadrature<dim>>(
-                ReferenceCells::Pyramid.get_nodal_type_quadrature<dim>());
-            }
+                quadrature_pyramid = std::make_unique<Quadrature<dim>>(
+                  ReferenceCells::Pyramid.get_nodal_type_quadrature<dim>());
+              }
 
           x_fe_values.resize(finite_elements.size());
           for (unsigned int i = 0; i < finite_elements.size(); ++i)


### PR DESCRIPTION
I need this for a separate endeavor, but it doesn't hurt by itself: We might as well not compile some stuff if it's not needed in a particular dimension.