### PR TITLE
Make a function a template.

### DIFF
--- a/include/deal.II/fe/fe_data.h
+++ b/include/deal.II/fe/fe_data.h
@@ -708,9 +708,9 @@ namespace internal
    * Utility function to convert "dofs per object" information
    * of a @p dim dimensional reference cell @p reference_cell.
    */
+  template <int dim>
   internal::GenericDoFsPerObject
-  expand(const unsigned int               dim,
-         const std::vector<unsigned int> &dofs_per_object,
+  expand(const std::vector<unsigned int> &dofs_per_object,
          const ReferenceCell              reference_cell);
 } // namespace internal
 

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -18,9 +18,9 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace internal
 {
+  template <int dim>
   internal::GenericDoFsPerObject
-  expand(const unsigned int               dim,
-         const std::vector<unsigned int> &dofs_per_object,
+  expand(const std::vector<unsigned int> &dofs_per_object,
          const ReferenceCell              cell_type)
   {
     internal::GenericDoFsPerObject result;
@@ -135,7 +135,7 @@ FiniteElementData<dim>::FiniteElementData(
   const unsigned int               degree,
   const Conformity                 conformity,
   const BlockIndices              &block_indices)
-  : FiniteElementData(internal::expand(dim, dofs_per_object, cell_type),
+  : FiniteElementData(internal::expand<dim>(dofs_per_object, cell_type),
                       cell_type,
                       n_components,
                       degree,

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -189,9 +189,8 @@ namespace
 
     if (conformity == FiniteElementData<dim>::L2)
       {
-        dpo = internal::expand(3,
-                               {{0, 0, 0, compute_n_dofs(dim, degree)}},
-                               ReferenceCells::Pyramid);
+        dpo = internal::expand<3>({{0, 0, 0, compute_n_dofs(dim, degree)}},
+                                  ReferenceCells::Pyramid);
       }
     else if (conformity == FiniteElementData<dim>::H1)
       {

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -73,7 +73,7 @@ namespace
     else
       DEAL_II_NOT_IMPLEMENTED();
 
-    return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCells::Wedge);
+    return internal::expand<3>({{0, 0, 0, n_dofs}}, ReferenceCells::Wedge);
   }
 } // namespace
 


### PR DESCRIPTION
We have a function `expand()` that takes as first argument the dimension. In all places where it is called, the dimension is a compile-time constant because the surrounding functions are templates on `dim`. It turns out to be convenient for other things I'm doing to turn `expand()` into a template as well.