### PR TITLE
Move an exception that is used in only one place.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -4755,8 +4755,17 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_fe() const
   const auto &fe = this->dof_handler->get_fe(active_fe_index());
 
   Assert(this->reference_cell() == fe.reference_cell(),
-         internal::ExcNonMatchingReferenceCellTypes(this->reference_cell(),
-                                                    fe.reference_cell()));
+         ExcMessage(
+           "The reference-cell type used on this cell (" +
+           this->reference_cell().to_string() +
+           ") does not match the reference-cell type of the finite element "
+           "associated with this cell (" +
+           fe.reference_cell().to_string() +
+           "). "
+           "Did you accidentally use simplex elements on hypercube meshes "
+           "(or the other way around), or are you using a mixed mesh and "
+           "assigned a simplex element to a hypercube cell (or the other "
+           "way around) via the active_fe_index?"));
 
   return fe;
 }

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -4206,24 +4206,6 @@ namespace internal
     const ArrayView<const T> vertices_1;
   };
 
-  /**
-   * This exception is raised whenever the types of two reference cell objects
-   * were assumed to be equal, but were not.
-   *
-   * Parameters to the constructor are the first and second reference cells,
-   * both of type <tt>ReferenceCell</tt>.
-   */
-  DeclException2(
-    ExcNonMatchingReferenceCellTypes,
-    ReferenceCell,
-    ReferenceCell,
-    << "The reference-cell type used on this cell (" << arg1.to_string()
-    << ") does not match the reference-cell type of the finite element "
-    << "associated with this cell (" << arg2.to_string() << "). "
-    << "Did you accidentally use simplex elements on hypercube meshes "
-    << "(or the other way around), or are you using a mixed mesh and "
-    << "assigned a simplex element to a hypercube cell (or the other "
-    << "way around) via the active_fe_index?");
 } // namespace internal
 
 


### PR DESCRIPTION
`reference_cell.h` declares an exception that is used in only one place. This patch inlines the use of this exception into that location instead.