### PR TITLE
Replace a look-up table.

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1823,7 +1823,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
       std::string object_name;
       whole_file >> object_name;
 
-      static const std::set<std::string> known_object_names = {
+      const std::set<std::string> known_object_names = {
         "vtx", "edg", "tri", "quad", "tet", "prism"
         // TODO: Add hexahedra and pyramids once we have a sample input file
         // that contains these


### PR DESCRIPTION
Related to that last patch: We have a table where we have `ReferenceCell` objects of different dimensionalities. This works currently, but won't if we give `ReferenceCell` a template argument. It's easy to replace it, but substituting comparisons between integers to ones between strings. This isn't performance critical code, so I'm willing to take the hit.