### PR TITLE
Add Assert to real_to_unit_cell_affine_approximation to catch non-hypercubes

### DIFF
--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1685,6 +1685,8 @@ Point<structdim>
 TriaAccessor<structdim, dim, spacedim>::real_to_unit_cell_affine_approximation(
   const Point<spacedim> &point) const
 {
+  Assert(this->reference_cell().is_hyper_cube(), ExcNotImplemented());
+
   std::array<Point<spacedim>, GeometryInfo<structdim>::vertices_per_cell>
     vertices;
   for (const unsigned int v : this->vertex_indices())


### PR DESCRIPTION
Added the assertion for this error: https://github.com/dealii/dealii/issues/19319 



