### PR TITLE
DoFHandler hp: Convert some data structures from map to vector

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1429,14 +1429,15 @@ private:
      * Container to temporarily store the iterator and future active FE index
      * of cells that persist.
      */
-    std::map<const cell_iterator, const types::fe_index>
+    std::vector<std::pair<const cell_iterator, const types::fe_index>>
       persisting_cells_fe_index;
 
     /**
      * Container to temporarily store the iterator and future active FE index
      * of cells that will be refined.
      */
-    std::map<const cell_iterator, const types::fe_index> refined_cells_fe_index;
+    std::vector<std::pair<const cell_iterator, const types::fe_index>>
+      refined_cells_fe_index;
 
     /**
      * Container to temporarily store the iterator and future active FE index

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1477,8 +1477,8 @@ namespace internal
                     // Store the active FE index of each cell that will be
                     // refined to and distribute it later on its children.
                     // Pick their future index if flagged for p-refinement.
-                    fe_transfer->refined_cells_fe_index.insert(
-                      {cell, cell->future_fe_index()});
+                    fe_transfer->refined_cells_fe_index.emplace_back(
+                      cell, cell->future_fe_index());
                   }
                 else if (cell->coarsen_flag_set())
                   {
@@ -1523,8 +1523,8 @@ namespace internal
                     // However, it may have p-refinement indicators, so we
                     // choose a new active FE index based on its flags.
                     if (cell->future_fe_index_set() == true)
-                      fe_transfer->persisting_cells_fe_index.insert(
-                        {cell, cell->future_fe_index()});
+                      fe_transfer->persisting_cells_fe_index.emplace_back(
+                        cell, cell->future_fe_index());
                   }
               }
         }


### PR DESCRIPTION
Looking at the benchmark step-3, I noticed that our triangulation refinement does a lot of manipulations in an `std::map`, and could trace it back to the handling of the hp FE indices. We have three cases, the remaining indices, the ones appearing after refinement and the ones after coarsening. Two out of the three just represent a plain traversal through the mesh, for which a `std::vector` is a much better data structure than a `std::map` (most importantly: fewer memory allocations). The coarsening part is more tricky, so I left that one in.