### PR TITLE
CellAccessor: Inline a simple accessor function

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -3918,25 +3918,6 @@ public:
   global_level_cell_index() const;
 
   /**
-   * @name Dealing with codim 1 cell orientation
-   */
-  /**
-   * @{
-   */
-
-  /**
-   * Return the orientation of this cell. This function always returns
-   * `true` if `dim==spacedim`. It can return `true` or `false` if
-   * `dim==spacedim-1`. The function cannot be called (and will abort
-   * with an error) if called for `dim<spacedim-1`.
-   *
-   * For the meaning of this flag, see
-   * @ref GlossDirectionFlag.
-   */
-  bool
-  direction_flag() const;
-
-  /**
    * Return the how many-th active cell the current cell is (assuming the
    * current cell is indeed active). This is useful, for example, if you are
    * accessing the elements of a vector with as many entries as there are
@@ -3981,6 +3962,25 @@ public:
    */
   TriaIterator<CellAccessor<dim, spacedim>>
   parent() const;
+
+  /**
+   * @name Dealing with codim 1 cell orientation
+   */
+  /**
+   * @{
+   */
+
+  /**
+   * Return the orientation of this cell. This function always returns
+   * `true` if `dim==spacedim`. It can return `true` or `false` if
+   * `dim==spacedim-1`. The function cannot be called (and will abort
+   * with an error) if called for `dim<spacedim-1`.
+   *
+   * For the meaning of this flag, see
+   * @ref GlossDirectionFlag.
+   */
+  bool
+  direction_flag() const;
 
   /**
    * @}
@@ -8185,6 +8185,26 @@ CellAccessor<dim, spacedim>::global_level_cell_index() const
 {
   return this->tria->levels[this->level()]
     ->global_level_cell_indices[this->present_index];
+}
+
+
+
+template <int dim, int spacedim>
+inline bool
+CellAccessor<dim, spacedim>::direction_flag() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  if constexpr (dim == spacedim)
+    return true;
+  else if constexpr (dim == spacedim - 1)
+    return this->tria->levels[this->level()]
+      ->direction_flags[this->present_index];
+  else
+    {
+      Assert(false,
+             ExcMessage("This function cannot be called if dim<spacedim-1."));
+      return true;
+    }
 }
 
 #endif // DOXYGEN

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2212,25 +2212,6 @@ CellAccessor<dim, spacedim>::set_level_subdomain_id(
 }
 
 
-template <int dim, int spacedim>
-bool
-CellAccessor<dim, spacedim>::direction_flag() const
-{
-  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  if constexpr (dim == spacedim)
-    return true;
-  else if constexpr (dim == spacedim - 1)
-    return this->tria->levels[this->level()]
-      ->direction_flags[this->present_index];
-  else
-    {
-      Assert(false,
-             ExcMessage("This function cannot be called if dim<spacedim-1."));
-      return true;
-    }
-}
-
-
 
 template <int dim, int spacedim>
 void


### PR DESCRIPTION
I noticed that our mesh refinement cycle uses `direction_flag` in several places. But that is a very simple function, so it seems better to make this an inline function. While there, I also tried to move the function a bit in the header because the functions next to it do not belong to the category "Dealing with codim 1 cell orientation", because the active cell index and parent index do not belong there, search for this text the documentation https://dealii.org/current/doxygen/deal.II/classCellAccessor.html .