### PR TITLE
Fix a compile warning for number of lines of a cell

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2445,14 +2445,11 @@ namespace parallel
       const unsigned int deal_to_p4est_line_index[12] = {
         4, 5, 0, 1, 6, 7, 2, 3, 8, 9, 10, 11};
 
-      for (Triangulation<dim, spacedim>::active_cell_iterator cell =
-             this->begin_active();
-           cell != this->end();
-           ++cell)
+      for (const auto &cell : this->active_cell_iterators())
         {
           const unsigned int index =
             coarse_cell_to_p4est_tree_permutation[cell->index()];
-          for (unsigned int e = 0; e < GeometryInfo<3>::lines_per_cell; ++e)
+          for (unsigned int e = 0; e < cell->n_lines(); ++e)
             connectivity->tree_to_edge[index * GeometryInfo<3>::lines_per_cell +
                                        deal_to_p4est_line_index[e]] =
               cell->line(e)->index();


### PR DESCRIPTION
My clang-20 compiler complained about some possible out-of-bound index. It does not happen because the code in question is only run for hex elements, but it gets rid of a use of `GeometryInfo` so I count this as a win in any case. While there, also convert the surrounding loop to a range-based for loop.