### PR TITLE
Serial solution transfer: Avoid quadratic complexity loop

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -16624,30 +16624,9 @@ void Triangulation<dim, spacedim>::pack_data_serial()
         this))
     return;
 
-  std::vector<CellId> active_cell_old;
-
   // pack data before triangulation gets updated
   if (this->cell_attached_data.n_attached_data_sets > 0)
     {
-      // store old active cells to determine cell status after
-      // coarsening/refinement
-      active_cell_old.reserve(this->n_active_cells());
-
-      for (const auto &cell : this->active_cell_iterators())
-        {
-          const bool children_will_be_coarsened =
-            (cell->level() > 0) && (cell->coarsen_flag_set());
-
-          if (children_will_be_coarsened == false)
-            active_cell_old.emplace_back(cell->id());
-          else
-            {
-              if (cell->parent()->child(0) == cell)
-                active_cell_old.emplace_back(cell->parent()->id());
-            }
-        }
-
-      // update cell relations
       this->local_cell_relations.clear();
       this->local_cell_relations.reserve(this->n_global_active_cells());
 
@@ -16657,39 +16636,27 @@ void Triangulation<dim, spacedim>::pack_data_serial()
                     cell_relation_t>>
         local_cell_relations_tmp;
 
+      unsigned int index_cell = 0;
       for (const auto &cell : this->active_cell_iterators())
         {
-          if (std::find(active_cell_old.begin(),
-                        active_cell_old.end(),
-                        cell->id()) != active_cell_old.end())
-            {
-              const unsigned int index =
-                std::distance(active_cell_old.begin(),
-                              std::find(active_cell_old.begin(),
-                                        active_cell_old.end(),
-                                        cell->id()));
+          const bool children_will_be_coarsened =
+            (cell->level() > 0) && (cell->coarsen_flag_set());
 
+          if (children_will_be_coarsened == false)
+            {
               ::dealii::CellStatus status =
                 cell->refine_flag_set() ?
                   ::dealii::CellStatus::cell_will_be_refined :
                   ::dealii::CellStatus::cell_will_persist;
 
               local_cell_relations_tmp.emplace_back(
-                index,
+                index_cell,
                 typename internal::CellAttachedDataSerializer<dim, spacedim>::
                   cell_relation_t{cell, status});
+              ++index_cell;
             }
-          else if (cell->level() > 0 &&
-                   std::find(active_cell_old.begin(),
-                             active_cell_old.end(),
-                             cell->parent()->id()) != active_cell_old.end())
+          else
             {
-              const unsigned int index =
-                std::distance(active_cell_old.begin(),
-                              std::find(active_cell_old.begin(),
-                                        active_cell_old.end(),
-                                        cell->parent()->id()));
-
               ::dealii::CellStatus status;
 
               if (cell->parent()->child_iterator_to_index(cell) == 0)
@@ -16698,13 +16665,15 @@ void Triangulation<dim, spacedim>::pack_data_serial()
                 status = ::dealii::CellStatus::cell_invalid;
 
               local_cell_relations_tmp.emplace_back(
-                index,
+                index_cell,
                 typename internal::CellAttachedDataSerializer<dim, spacedim>::
                   cell_relation_t{cell->parent(), status});
-            }
-          else
-            {
-              AssertThrow(false, ExcNotImplemented());
+
+              // increment counter if the current cell is the last child of
+              // the parent
+              if (cell ==
+                  cell->parent()->child(cell->parent()->n_children() - 1))
+                ++index_cell;
             }
         }
 


### PR DESCRIPTION
Fixes #19404.

I looked at the code in question and do not understand why we had the search causing the quadratic complexity: After all, we just run through the mesh once, store the indices to certain cells, and then run through the mesh in the same order again. We can directly set the same number, if I understand things correctly. This is experimental, I'd like to see if any of the CI tests complains about it.