### PR TITLE
Make sure MappingQ does not store invalid cell in InternalData

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -298,6 +298,8 @@ public:
      */
     InternalData(const unsigned int polynomial_degree);
 
+    ~InternalData();
+
     // Documentation see Mapping::InternalDataBase.
     virtual void
     reinit(const UpdateFlags      update_flags,
@@ -423,6 +425,15 @@ public:
      */
     mutable typename Triangulation<dim, spacedim>::cell_iterator
       cell_of_current_support_points;
+
+    /**
+     * A signal connection we use to ensure we get informed whenever the
+     * triangulation changes, such as refinement or mesh transformations. We
+     * need to know about that because it invalidates all cell iterators and,
+     * as part of that, the 'cell_of_current_support_points' iterator we keep
+     * around between subsequent calls to fill_fe_*values().
+     */
+    mutable boost::signals2::connection listener_tria_change;
 
     /**
      * The determinant of the Jacobian in each quadrature point. Filled if

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -873,12 +873,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
     data.mapping_support_points = this->compute_mapping_support_points(cell);
 
   data.cell_of_current_support_points = cell;
-  data.listener_tria_change.disconnect();
-  data.listener_tria_change =
-    cell->get_triangulation().signals.any_change.connect([&data]() {
-      data.listener_tria_change.disconnect();
-      data.mapping_support_points.clear();
-    });
+  if (!data.listener_tria_change.connected())
+    data.listener_tria_change =
+      cell->get_triangulation().signals.any_change.connect([&data]() {
+        data.listener_tria_change.disconnect();
+        data.mapping_support_points.clear();
+      });
 
   // if the order of the mapping is greater than 1, then do not reuse any cell
   // similarity information. This is necessary because the cell similarity
@@ -1109,12 +1109,12 @@ MappingQ<dim, spacedim>::fill_fe_face_values(
           this->compute_mapping_support_points(cell);
 
       data.cell_of_current_support_points = cell;
-      data.listener_tria_change.disconnect();
-      data.listener_tria_change =
-        cell->get_triangulation().signals.any_change.connect([&data]() {
-          data.listener_tria_change.disconnect();
-          data.mapping_support_points.clear();
-        });
+      if (!data.listener_tria_change.connected())
+        data.listener_tria_change =
+          cell->get_triangulation().signals.any_change.connect([&data]() {
+            data.listener_tria_change.disconnect();
+            data.mapping_support_points.clear();
+          });
     }
 
   internal::MappingQImplementation::do_fill_fe_face_values(
@@ -1176,12 +1176,12 @@ MappingQ<dim, spacedim>::fill_fe_subface_values(
           this->compute_mapping_support_points(cell);
       data.cell_of_current_support_points = cell;
 
-      data.listener_tria_change.disconnect();
-      data.listener_tria_change =
-        cell->get_triangulation().signals.any_change.connect([&data]() {
-          data.listener_tria_change.disconnect();
-          data.mapping_support_points.clear();
-        });
+      if (!data.listener_tria_change.connected())
+        data.listener_tria_change =
+          cell->get_triangulation().signals.any_change.connect([&data]() {
+            data.listener_tria_change.disconnect();
+            data.mapping_support_points.clear();
+          });
     }
 
   internal::MappingQImplementation::do_fill_fe_face_values(
@@ -1235,12 +1235,12 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     data.mapping_support_points = this->compute_mapping_support_points(cell);
 
   data.cell_of_current_support_points = cell;
-  data.listener_tria_change.disconnect();
-  data.listener_tria_change =
-    cell->get_triangulation().signals.any_change.connect([&data]() {
-      data.listener_tria_change.disconnect();
-      data.mapping_support_points.clear();
-    });
+  if (!data.listener_tria_change.connected())
+    data.listener_tria_change =
+      cell->get_triangulation().signals.any_change.connect([&data]() {
+        data.listener_tria_change.disconnect();
+        data.mapping_support_points.clear();
+      });
 
   internal::MappingQImplementation::maybe_update_q_points_Jacobians_generic(
     CellSimilarity::none,

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -57,6 +57,14 @@ MappingQ<dim, spacedim>::InternalData::InternalData(
 
 
 template <int dim, int spacedim>
+MappingQ<dim, spacedim>::InternalData::~InternalData()
+{
+  listener_tria_change.disconnect();
+}
+
+
+
+template <int dim, int spacedim>
 std::size_t
 MappingQ<dim, spacedim>::InternalData::memory_consumption() const
 {
@@ -865,6 +873,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
     data.mapping_support_points = this->compute_mapping_support_points(cell);
 
   data.cell_of_current_support_points = cell;
+  data.listener_tria_change.disconnect();
+  data.listener_tria_change =
+    cell->get_triangulation().signals.any_change.connect([&data]() {
+      data.listener_tria_change.disconnect();
+      data.mapping_support_points.clear();
+    });
 
   // if the order of the mapping is greater than 1, then do not reuse any cell
   // similarity information. This is necessary because the cell similarity
@@ -1093,7 +1107,14 @@ MappingQ<dim, spacedim>::fill_fe_face_values(
       else
         data.mapping_support_points =
           this->compute_mapping_support_points(cell);
+
       data.cell_of_current_support_points = cell;
+      data.listener_tria_change.disconnect();
+      data.listener_tria_change =
+        cell->get_triangulation().signals.any_change.connect([&data]() {
+          data.listener_tria_change.disconnect();
+          data.mapping_support_points.clear();
+        });
     }
 
   internal::MappingQImplementation::do_fill_fe_face_values(
@@ -1154,6 +1175,13 @@ MappingQ<dim, spacedim>::fill_fe_subface_values(
         data.mapping_support_points =
           this->compute_mapping_support_points(cell);
       data.cell_of_current_support_points = cell;
+
+      data.listener_tria_change.disconnect();
+      data.listener_tria_change =
+        cell->get_triangulation().signals.any_change.connect([&data]() {
+          data.listener_tria_change.disconnect();
+          data.mapping_support_points.clear();
+        });
     }
 
   internal::MappingQImplementation::do_fill_fe_face_values(
@@ -1205,7 +1233,14 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
   else
     data.mapping_support_points = this->compute_mapping_support_points(cell);
+
   data.cell_of_current_support_points = cell;
+  data.listener_tria_change.disconnect();
+  data.listener_tria_change =
+    cell->get_triangulation().signals.any_change.connect([&data]() {
+      data.listener_tria_change.disconnect();
+      data.mapping_support_points.clear();
+    });
 
   internal::MappingQImplementation::maybe_update_q_points_Jacobians_generic(
     CellSimilarity::none,

--- a/tests/fe/rt_bubbles_15.cc
+++ b/tests/fe/rt_bubbles_15.cc
@@ -47,22 +47,30 @@ test(const unsigned int degree)
 
   deallog << "Degree=" << degree << std::endl;
 
+  // Move expensive init work out of loop
+  QTrapezoid<dim - 1>  quadrature;
+  FESubfaceValues<dim> fe_values(fe_rt_bubbles, quadrature, update_gradients);
+
   for (double h = 1; h > 1. / 128; h /= 2)
     {
       deallog << "  h=" << h << std::endl;
 
       Triangulation<dim> tr;
-      GridGenerator::hyper_cube(tr, 0., h);
+      // Construct refinement situation where the first active cell is
+      // adjacent to a refined cell with face 0
+      Point<dim> l, r;
+      l[0] = -h;
+      for (unsigned int d = 0; d < dim; ++d)
+        r[d] = h;
+      std::vector<unsigned int> refine(dim, 1);
+      refine[0] = 2;
+      GridGenerator::subdivided_hyper_rectangle(tr, refine, l, r);
+      // Create refinement setting by refining second to last element one more
+      // time
+      tr.begin_active()->set_refine_flag();
+      tr.execute_coarsening_and_refinement();
 
-      DoFHandler<dim> dof(tr);
-      dof.distribute_dofs(fe_rt_bubbles);
-
-      QTrapezoid<dim - 1> quadrature;
-
-      FESubfaceValues<dim> fe_values(fe_rt_bubbles,
-                                     quadrature,
-                                     update_gradients);
-      fe_values.reinit(dof.begin_active(), 0, 0);
+      fe_values.reinit(tr.begin_active(), 0, 0);
       for (unsigned int q = 0; q < quadrature.size(); ++q)
         {
           deallog << "    Quadrature point " << q << ": ";


### PR DESCRIPTION
Poking around with some tests I realized `FEValues`/`FEFaceValues`/`FESubfaceValues` would produce invalid results when used in conjunction with `MappingQ` when the triangulation changed. What happens is that `MappingQ::InternalData` stores https://github.com/dealii/dealii/blob/3c02352437532c7863c15aee9df5ce0bb27c7439/include/deal.II/fe/mapping_q.h#L422-L425 with the intent to avoid computing the mapping support points multiple times. However, when the grid is changed, e.g. by a `GridTools::transform()` function or, worse, the triangulation disappears, this gets invalid. This is probably a corner case, but we should still make sure to deliver correct results. This PR suggests to use a signal to track the cell and invalidate it upon a reset of the triangulation, as we do in other places of the library. But I do dislike this, because the signals are pretty expensive, and we almost never need them.

I'd be much more tempted to just remove the pointer that looks at what the previous cell was and instead recompute the mapping support points every time upon `fill_fe_values()` (i.e., calling `FEValues::reinit()`), as we have learned in the past that keeping track of previous state can be tricky. Most of our use cases will not use a cell multiple times, apart from face integrals that run cell by cell.

Opinions?