### PR TITLE
Make two tests cheaper

### DIFF
--- a/tests/grid/project_to_object_01.cc
+++ b/tests/grid/project_to_object_01.cc
@@ -240,7 +240,7 @@ main()
 
   // refine in 3D a few times so that we can observe that the projection error
   // drops proportionally as the grid is refined
-  for (unsigned int n_refinements = 4; n_refinements < 7; ++n_refinements)
+  for (unsigned int n_refinements = 4; n_refinements < 6; ++n_refinements)
     {
       deallog << "====================================================="
               << std::endl

--- a/tests/grid/project_to_object_01.output
+++ b/tests/grid/project_to_object_01.output
@@ -19,7 +19,7 @@ DEAL::
 DEAL::Project the convex combination of two vertices:
 DEAL::projected point:          1.98114 0.274025
 DEAL::Convex combination point: 1.98114 0.274025
-DEAL::Distance:                 5.55112e-17
+DEAL::Distance:                 2.48253e-16
 DEAL::
 DEAL::Check that projecting with spacedim == structdim
 DEAL::is the identity map:
@@ -71,7 +71,7 @@ DEAL::trial point distance from origin:     2.00000
 DEAL::projected point distance from origin: 2.00000
 DEAL::projected point: -1.15464 -1.15473 -1.15473
 DEAL::trial point:     -1.15464 -1.15473 -1.15473
-DEAL::distance:        2.51280e-13
+DEAL::distance:        3.62779e-13
 DEAL::
 DEAL::Project a weighed face point onto the same face in 3D:
 DEAL::
@@ -145,62 +145,6 @@ DEAL::Project a weighed line point onto the same line in 3D:
 DEAL::
 DEAL::trial point:                          -1.18152 -1.09909 -1.18152
 DEAL::projected point:                      -1.18152 -1.09909 -1.18152
-DEAL::trial point distance from origin:     2.00000
-DEAL::projected point distance from origin: 2.00000
-DEAL::Error less than 1.0e-7:               1
-DEAL::=====================================================
-DEAL::Number of global refinements: 6
-DEAL::=====================================================
-DEAL::
-DEAL::Project a reweighed center onto a face in 3D:
-DEAL::
-DEAL::vertex 0 distance from origin: 2.00000
-DEAL::vertex 1 distance from origin: 2.00000
-DEAL::trial point distance from origin: 2.19979
-DEAL::projected point distance from origin: 2.00000
-DEAL::projected point:    -1.14669 -1.14669 -1.17055
-DEAL::true line midpoint: -1.14669 -1.14669 -1.17055
-DEAL::distance less than 5.0e-6: 1
-DEAL::
-DEAL::Check that projecting with spacedim == structdim is the identity map:
-DEAL::
-DEAL::trial point:     0.417941 4.24242e+09 1.00000
-DEAL::projected point: 0.417941 4.24242e+09 1.00000
-DEAL::
-DEAL::Project a vertex:
-DEAL::
-DEAL::vertex 0 distance from origin:        2.00000
-DEAL::trial point distance from origin:     2.00000
-DEAL::projected point distance from origin: 2.00000
-DEAL::projected point: -1.15470 -1.15470 -1.15470
-DEAL::actual vertex:   -1.15470 -1.15470 -1.15470
-DEAL::distance:        0.00000
-DEAL::
-DEAL::Project a point near a vertex:
-DEAL::
-DEAL::vertex 0 distance from origin:        2.00000
-DEAL::trial point distance from origin:     2.00000
-DEAL::projected point distance from origin: 2.00000
-DEAL::projected point: -1.15469 -1.15471 -1.15471
-DEAL::trial point:     -1.15469 -1.15471 -1.15471
-DEAL::distance:        1.53899e-10
-DEAL::
-DEAL::Project a weighed face point onto the same face in 3D:
-DEAL::
-DEAL::trial point distance from origin:     2.00000
-DEAL::projected point distance from origin: 2.00000
-DEAL::Error is less than 1.0e-3:           1
-DEAL::
-DEAL::Project a point offset from the face onto the face in 3D:
-DEAL::
-DEAL::trial point distance from origin:     2.20000
-DEAL::projected point distance from origin: 2.00000
-DEAL::Error (vs. going along the normal) less than 0.01: 1
-DEAL::
-DEAL::Project a weighed line point onto the same line in 3D:
-DEAL::
-DEAL::trial point:                          -1.16828 -1.12706 -1.16828
-DEAL::projected point:                      -1.16828 -1.12706 -1.16828
 DEAL::trial point distance from origin:     2.00000
 DEAL::projected point distance from origin: 2.00000
 DEAL::Error less than 1.0e-7:               1

--- a/tests/simplex/stokes-sv.cc
+++ b/tests/simplex/stokes-sv.cc
@@ -27,7 +27,7 @@
 #include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
-#include <deal.II/fe/mapping_fe.h>
+#include <deal.II/fe/mapping_p1.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
@@ -349,7 +349,7 @@ namespace Step56
 #ifdef HEX
     MappingQ1<dim> mapping;
 #else
-    MappingFE<dim> mapping;
+    MappingP1<dim> mapping;
 #endif
 
     FESystem<dim>   velocity_fe;
@@ -377,7 +377,6 @@ namespace Step56
     , velocity_fe(FE_Q<dim>(pressure_degree + 1), dim)
     , fe(velocity_fe, 1, FE_Q<dim>(pressure_degree), 1)
 #else
-    , mapping(FE_SimplexP<dim>(1))
     , velocity_fe(FE_SimplexP<dim>(pressure_degree + 1), dim)
     , fe(velocity_fe, 1, FE_SimplexDGP<dim>(pressure_degree), 1)
 #endif
@@ -652,33 +651,6 @@ namespace Step56
 
   template <int dim>
   void
-  StokesProblem<dim>::output_results(const unsigned int refinement_cycle) const
-  {
-    std::vector<std::string> solution_names(dim, "velocity");
-    solution_names.emplace_back("pressure");
-
-    std::vector<DataComponentInterpretation::DataComponentInterpretation>
-      data_component_interpretation(
-        dim, DataComponentInterpretation::component_is_part_of_vector);
-    data_component_interpretation.push_back(
-      DataComponentInterpretation::component_is_scalar);
-
-    DataOut<dim> data_out;
-    data_out.attach_dof_handler(dof_handler);
-    data_out.add_data_vector(solution,
-                             solution_names,
-                             DataOut<dim>::type_dof_data,
-                             data_component_interpretation);
-    data_out.build_patches();
-
-    std::ofstream output("solution-" +
-                         Utilities::int_to_string(refinement_cycle, 2) +
-                         "-dim-" + Utilities::int_to_string(dim, 2) + ".vtk");
-    data_out.write_vtk(output);
-  }
-
-  template <int dim>
-  void
   StokesProblem<dim>::run()
   {
     // For Scott-Vogelius elements in 3D, we must use a cubic velocity space and
@@ -692,7 +664,7 @@ namespace Step56
 
         Triangulation<dim> s_tria;
         GridGenerator::subdivided_hyper_cube_with_simplices<dim, dim>(
-          s_tria, std::pow(1 + refinement_cycle, 2));
+          s_tria, std::pow(2, refinement_cycle));
         triangulation.clear();
         GridGenerator::alfeld_split_of_simplex_mesh(s_tria, triangulation);
 
@@ -706,8 +678,6 @@ namespace Step56
         solve();
 
         compute_errors();
-
-        output_results(refinement_cycle);
       }
   }
 } // namespace Step56

--- a/tests/simplex/stokes-sv.output
+++ b/tests/simplex/stokes-sv.output
@@ -11,6 +11,16 @@ DEAL::   Velocity H1 Error: 2.13131
 DEAL::   Velocity Hdiv Err: 3.33043e-09
 DEAL::Refinement cycle 1
 DEAL::   Set-up...
+DEAL::	Number of active cells: 24
+DEAL::	Number of degrees of freedom: 186 (114+72)
+DEAL::   Assembling...
+DEAL::   Solving...
+DEAL::   Velocity L2 Error: 0.0604192
+DEAL::   Pressure L2 Error: 2.47989
+DEAL::   Velocity H1 Error: 0.970329
+DEAL::   Velocity Hdiv Err: 6.76097e-08
+DEAL::Refinement cycle 2
+DEAL::   Set-up...
 DEAL::	Number of active cells: 96
 DEAL::	Number of degrees of freedom: 706 (418+288)
 DEAL::   Assembling...
@@ -19,16 +29,6 @@ DEAL::   Velocity L2 Error: 0.00815750
 DEAL::   Pressure L2 Error: 0.782868
 DEAL::   Velocity H1 Error: 0.275850
 DEAL::   Velocity Hdiv Err: 1.64529e-08
-DEAL::Refinement cycle 2
-DEAL::   Set-up...
-DEAL::	Number of active cells: 486
-DEAL::	Number of degrees of freedom: 3476 (2018+1458)
-DEAL::   Assembling...
-DEAL::   Solving...
-DEAL::   Velocity L2 Error: 0.000739254
-DEAL::   Pressure L2 Error: 0.190631
-DEAL::   Velocity H1 Error: 0.0599330
-DEAL::   Velocity Hdiv Err: 6.61221e-09
 DEAL::Refinement cycle 0
 DEAL::   Set-up...
 DEAL::	Number of active cells: 20
@@ -38,14 +38,14 @@ DEAL::   Solving...
 DEAL::   Velocity L2 Error: 0.155024
 DEAL::   Pressure L2 Error: 12.3846
 DEAL::   Velocity H1 Error: 2.71669
-DEAL::   Velocity Hdiv Err: 6.54647e-08
+DEAL::   Velocity Hdiv Err: 6.54648e-08
 DEAL::Refinement cycle 1
 DEAL::   Set-up...
-DEAL::	Number of active cells: 1280
-DEAL::	Number of degrees of freedom: 33023 (20223+12800)
+DEAL::	Number of active cells: 160
+DEAL::	Number of degrees of freedom: 4333 (2733+1600)
 DEAL::   Assembling...
 DEAL::   Solving...
-DEAL::   Velocity L2 Error: 0.000420642
-DEAL::   Pressure L2 Error: 0.0644518
-DEAL::   Velocity H1 Error: 0.0207581
-DEAL::   Velocity Hdiv Err: 7.31178e-08
+DEAL::   Velocity L2 Error: 0.00761237
+DEAL::   Pressure L2 Error: 0.766696
+DEAL::   Velocity H1 Error: 0.205460
+DEAL::   Velocity Hdiv Err: 1.03650e-07


### PR DESCRIPTION
Make two tests cheaper: For the `project_to_object_01` test, we created a spherical shell mesh with up to 6 refinement levels in 3d, i.e., more than a million cells. The tests wants to assess some convergence, but this is good enough with 5 refinement levels, which still has almost 200k cells.

For the `simplex/stokes_sv` test, there was a strange rule to create refinements, which lead to a mesh with many cells in 3d and 33023 DoFs. Choosing a more reasonable size leads to 4333 dofs, still showing what we but but with more appropriate run time.