### PR TITLE
Geometric coarsening sequence: Test case for multigrid on a non-partitioned tria

### DIFF
--- a/tests/multigrid-global-coarsening/create_coarsening.cc
+++ b/tests/multigrid-global-coarsening/create_coarsening.cc
@@ -1,0 +1,63 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2020 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Test that
+// MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence works
+// in case the initial parallel distributed triangulation disables automatic
+// repartitioning.
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/multigrid/mg_transfer_global_coarsening.h>
+
+#include "../tests.h"
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    parallel::distributed::Triangulation<dim>::no_automatic_repartitioning);
+
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(3);
+  tria.repartition();
+
+  deallog << "Test in " << dim << "d" << std::endl;
+  auto triangulations =
+    MGTransferGlobalCoarseningTools::create_geometric_coarsening_sequence(tria);
+  for (const auto tr : triangulations)
+    deallog << "Active cells in level triangulation: "
+            << tr->n_global_active_cells() << std::endl;
+  deallog << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  mpi_initlog();
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+
+  test<2>();
+  test<3>();
+}

--- a/tests/multigrid-global-coarsening/create_coarsening.with_p4est=true.mpirun=2.output
+++ b/tests/multigrid-global-coarsening/create_coarsening.with_p4est=true.mpirun=2.output
@@ -1,0 +1,13 @@
+
+DEAL::Test in 2d
+DEAL::Active cells in level triangulation: 1
+DEAL::Active cells in level triangulation: 4
+DEAL::Active cells in level triangulation: 16
+DEAL::Active cells in level triangulation: 64
+DEAL::
+DEAL::Test in 3d
+DEAL::Active cells in level triangulation: 1
+DEAL::Active cells in level triangulation: 8
+DEAL::Active cells in level triangulation: 64
+DEAL::Active cells in level triangulation: 512
+DEAL::


### PR DESCRIPTION
This is a test for the fix proposed in #19444: We might have special settings in the `parallel::distributed::Triangulation`, but when creating the coarsening we should just require the default mesh properties in our opinion.

FYI @vivimie

I will rebase this once #19444 is merged, right now this test case will fail with the following exception:
```
 An error occurred in line <3314> of file </home/martin/deal/deal.II/source/distributed/tria.cc> in function
     virtual void dealii::parallel::distributed::Triangulation<2, 2>::execute_coarsening_and_refinement() [dim = 2, spacedim = 2]
 The violated condition was: 
     refine_and_coarsen_list.pointers_are_at_end()
```