### PR TITLE
Allow Tpetra to add to non-local elements of distributed vector

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1104,6 +1104,24 @@ namespace LinearAlgebra
       dealii::IndexSet local_entries;
 
       /**
+       * Indices of the non-local elements that are cached and will
+       * be communicated to their owners upon calling compress().
+       * Note, that these indices are not the set of entries in
+       * nonlocal_vector. Rather it enables a cache for fully
+       * distributed vectors to allow writing into entries
+       * that are not locally owned (i.e. it supports cases where
+       * the size of the non-local vector is not known at the time
+       * this vector is constructed).
+       */
+      std::vector<types::global_dof_index> nonlocal_cached_indices;
+
+      /**
+       * Values of the non-local cached elements specified in
+       * nonlocal_cached_indices.
+       */
+      std::vector<Number> nonlocal_cached_values;
+
+      /**
        * CommunicationPattern for the communication between the
        * source_stored_elements IndexSet and the current vector.
        */
@@ -1228,12 +1246,22 @@ namespace LinearAlgebra
               if (nonlocal_vector.get() != nullptr)
                 compressed = false;
             }
+          else if (nonlocal_vector.get() == nullptr)
+            {
+              // The element is not in the locally owned part, and
+              // there is no specified nonlocal_vector, i.e. this is
+              // a fully distributed vector with a nonlocal cache.
+              // Add the element to the cache.
+              nonlocal_cached_indices.push_back(row);
+              nonlocal_cached_values.push_back(values[i]);
+              compressed = false;
+            }
           else
             {
               // If the element was not in the locally owned part,
-              // we need to figure out whether it is in the nonlocal
+              // and we have a predetermined nonlocal buffer, we need
+              // to figure out whether it is in the nonlocal
               // part. It better be:
-              Assert(nonlocal_vector.get() != nullptr, ExcInternalError());
               TrilinosWrappers::types::int_type nonlocal_row =
                 nonlocal_vector->getMap()->getLocalElement(row);
 
@@ -1338,12 +1366,22 @@ namespace LinearAlgebra
               if (nonlocal_vector.get() != nullptr)
                 compressed = false;
             }
+          else if (nonlocal_vector.get() == nullptr)
+            {
+              // The element is not in the locally owned part, and
+              // there is no specified nonlocal_vector, i.e. this is
+              // a fully distributed vector with a nonlocal cache.
+              // Add the element to the cache.
+              nonlocal_cached_indices.push_back(row);
+              nonlocal_cached_values.push_back(values[i]);
+              compressed = false;
+            }
           else
             {
               // If the element was not in the locally owned part,
-              // we need to figure out whether it is in the nonlocal
+              // and we have a predetermined nonlocal buffer, we need
+              // to figure out whether it is in the nonlocal
               // part. It better be:
-              Assert(nonlocal_vector.get() != nullptr, ExcInternalError());
               TrilinosWrappers::types::int_type nonlocal_row =
                 nonlocal_vector->getMap()->getLocalElement(row);
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1173,7 +1173,71 @@ namespace LinearAlgebra
                         "VectorOperation before this compress() call."));
         }
 
-      if (!nonlocal_vector.is_null())
+      bool nonlocal_vector_is_temporary = false;
+      if (nonlocal_vector.is_null())
+        {
+          // Use a temporary vector created from cached entries
+          nonlocal_vector_is_temporary = true;
+
+          Assert(nonlocal_cached_indices.size() ==
+                   nonlocal_cached_values.size(),
+                 ExcInternalError());
+
+          // First create the index set of ghost indices we will need to
+          // ship to other processes.
+          IndexSet ghost_indices(local_entries.size());
+          for (const auto &index : nonlocal_cached_indices)
+            ghost_indices.add_index(index);
+
+          ghost_indices.compress();
+
+          // Create a temporary nonlocal vector with a map that corresponds
+          // to the cached entries stored on this process.
+          // Create an overlapping map, because we dont know
+          // how many processes may write into one entry.
+          nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(
+            ghost_indices
+              .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
+                get_mpi_communicator(), true));
+
+          // Now fill the nonlocal vector with the cached entries
+          {
+            // Extract a view into the vector in order to modify it
+            auto vector_2d_nonlocal =
+              nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
+
+            auto vector_1d_nonlocal =
+              Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
+
+            const auto n_elements = nonlocal_cached_indices.size();
+            for (size_type i = 0; i < n_elements; ++i)
+              {
+                const size_type row = nonlocal_cached_indices[i];
+                const TrilinosWrappers::types::int_type local_row =
+                  nonlocal_vector->getMap()->getLocalElement(row);
+
+                // We created nonlocal_vector to contain this entry locally
+                Assert(local_row != Teuchos::OrdinalTraits<int>::invalid(),
+                       ExcInternalError());
+
+                if (operation == VectorOperation::insert)
+                  vector_1d_nonlocal(local_row) = nonlocal_cached_values[i];
+                else if (operation == VectorOperation::add)
+                  vector_1d_nonlocal(local_row) += nonlocal_cached_values[i];
+                else
+                  DEAL_II_NOT_IMPLEMENTED();
+              }
+          }
+        }
+
+      // Handle vector additions
+      // If the nonlocal vector is permanent (=fixed-size) we cannot guarantee
+      // that all processes that store an entry have written into it. Therefore
+      // only perform insertions if the nonlocal vector is temporary, because
+      // then only processes that have modified it, will try to write into it.
+      if (nonlocal_vector_is_temporary || operation == VectorOperation::add)
         {
           Tpetra::CombineMode tpetra_operation = Tpetra::ZERO;
           if (operation == VectorOperation::insert)
@@ -1183,17 +1247,20 @@ namespace LinearAlgebra
           else
             DEAL_II_NOT_IMPLEMENTED();
 
-          // Handle vector additions
-          if (operation == VectorOperation::add)
-            {
-              Teuchos::RCP<const TpetraTypes::ExportType<MemorySpace>>
-                exporter = Tpetra::createExport(nonlocal_vector->getMap(),
-                                                vector->getMap());
-              vector->doExport(*nonlocal_vector, *exporter, tpetra_operation);
-            }
-
-          nonlocal_vector->putScalar(Number(0));
+          Teuchos::RCP<const TpetraTypes::ExportType<MemorySpace>> exporter =
+            Tpetra::createExport(nonlocal_vector->getMap(), vector->getMap());
+          vector->doExport(*nonlocal_vector, *exporter, tpetra_operation);
         }
+
+      // And reset or destroy the temporary nonlocal_vector again
+      if (nonlocal_vector_is_temporary)
+        {
+          nonlocal_vector.reset();
+          nonlocal_cached_values.clear();
+          nonlocal_cached_indices.clear();
+        }
+      else
+        nonlocal_vector->putScalar(Number(0));
 
       compressed  = true;
       last_action = VectorOperation::unknown;

--- a/tests/trilinos_tpetra/vector_nonlocal_addition_03.cc
+++ b/tests/trilinos_tpetra/vector_nonlocal_addition_03.cc
@@ -1,0 +1,171 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+// Test distributed vector operations across multiple processes with non-local
+// entries to verify correct handling and compression states.
+// This test is like vector_nonlocal_addition_02, but uses a nonlocal buffer
+// that was not specified explicitly in the constructor of the vector.
+// I.e. this test uses a fully-distributed vector, not a vector that stores
+// writable ghost entries.
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/trilinos_tpetra_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  unsigned int my_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+
+  IndexSet locally_owned(8);
+
+  // Distribution of vector entries across processes:
+  // Process 0 and Process 1 have non-local entries, while Process 2 does not.
+
+  // Entry Index  |  Process Access        |  Owned by
+  // ------------ | -----------------------| ----------
+  //  0           |      0                 |     0
+  //  1           |      0                 |     0
+  //  2           |      0, 1              |     0
+  //  3           |      0, 1              |     1
+  //  4           |         1              |     1
+  //  5           |         1, 2           |     2
+  //  6           |            2           |     2
+  //  7           |            2           |     2
+
+
+  if (my_rank == 0)
+    {
+      locally_owned.add_range(0, 3);
+    }
+  if (my_rank == 1)
+    {
+      locally_owned.add_range(3, 5);
+    }
+  if (my_rank == 2)
+    {
+      // no nonlocal entries on rank 2
+      locally_owned.add_range(5, 8);
+    }
+  locally_owned.compress();
+
+  // Create a vector with writable entries
+  LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Default>
+    vector_with_nonlocal_entries;
+
+  vector_with_nonlocal_entries.reinit(locally_owned, MPI_COMM_WORLD);
+
+  vector_with_nonlocal_entries = 0.0;
+
+  if (my_rank == 0)
+    {
+      // Add to both local and non-local parts
+      vector_with_nonlocal_entries[0] += 1.0;
+      vector_with_nonlocal_entries[1] += 1.0;
+      vector_with_nonlocal_entries[2] += 1.0;
+      vector_with_nonlocal_entries[3] += 1.0;
+    }
+  if (my_rank == 1)
+    {
+      // Add to both local and non-local parts
+      vector_with_nonlocal_entries[2] += 2.0;
+      vector_with_nonlocal_entries[3] += 2.0;
+      vector_with_nonlocal_entries[4] += 2.0;
+      vector_with_nonlocal_entries[5] += 2.0;
+    }
+  if (my_rank == 2)
+    {
+      // Add to only local part, there's no nonlocal part on rank 2
+      vector_with_nonlocal_entries[5] += 3.0;
+      vector_with_nonlocal_entries[6] += 3.0;
+      vector_with_nonlocal_entries[7] += 3.0;
+    }
+  vector_with_nonlocal_entries.compress(VectorOperation::add);
+
+  // change entries again after compress(), this used to lead to a
+  // deadlock, because other ranks would not participate in compress()
+  if (my_rank == 1)
+    {
+      // Add to both local and non-local parts
+      vector_with_nonlocal_entries[2] += 0.5;
+    }
+  vector_with_nonlocal_entries.compress(VectorOperation::add);
+
+  // Expected Results:
+  // Entry Index  |  Additions     |  Result
+  // ------------ | -------------- | -------
+  //  0           |   +1           |   1.0
+  //  1           |   +1           |   1.0
+  //  2           |   +1, +2, +.5  |   3.5
+  //  3           |   +1, +2       |   3.0
+  //  4           |       +2       |   2.0
+  //  5           |       +2, +3   |   5.0
+  //  6           |           +3   |   3.0
+  //  7           |           +3   |   3.0
+
+  // Print the result on each process
+  vector_with_nonlocal_entries.print(deallog.get_file_stream());
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+  MPILogInitAll log;
+
+  try
+    {
+      test();
+    }
+  catch (const std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    };
+}

--- a/tests/trilinos_tpetra/vector_nonlocal_addition_03.mpirun=3.output
+++ b/tests/trilinos_tpetra/vector_nonlocal_addition_03.mpirun=3.output
@@ -1,0 +1,19 @@
+
+size:8 locally_stored_size:3 :
+[0]: 1.000e+00
+[1]: 1.000e+00
+[2]: 3.500e+00
+DEAL:0::OK
+
+size:8 locally_stored_size:2 :
+[3]: 3.000e+00
+[4]: 2.000e+00
+DEAL:1::OK
+
+
+size:8 locally_stored_size:3 :
+[5]: 5.000e+00
+[6]: 3.000e+00
+[7]: 3.000e+00
+DEAL:2::OK
+

--- a/tests/trilinos_tpetra/vector_nonlocal_insertion_03.cc
+++ b/tests/trilinos_tpetra/vector_nonlocal_insertion_03.cc
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+// Test distributed vector operations across multiple processes with non-local
+// entries to verify correct handling and compression states.
+// This tests the minimal operation to insert into a parallel distributed vector
+// while not setting all non-local entries. Like vector_nonlocal_insertion_02,
+// but without preallocated nonlocal buffer.
+
+#include <deal.II/base/index_set.h>
+
+#include <deal.II/lac/trilinos_tpetra_vector.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  unsigned int my_rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  unsigned int n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+
+  IndexSet locally_owned(3);
+
+  // Distribution of vector entries across processes:
+
+  // Entry Index  |  Process Distribution  |  Owned by
+  // ------------ | -----------------------| ----------
+  //  0           |      0, 1              |     0
+  //  1           |      0, 1              |     0
+  //  2           |      0, 1              |     1
+
+
+  if (my_rank == 0)
+    {
+      locally_owned.add_range(0, 2);
+    }
+  if (my_rank == 1)
+    {
+      locally_owned.add_range(2, 3);
+    }
+
+  locally_owned.compress();
+
+  // Create a vector with writable entries
+  LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Default>
+    vector_with_nonlocal_entries;
+
+  vector_with_nonlocal_entries.reinit(locally_owned, MPI_COMM_WORLD);
+
+  vector_with_nonlocal_entries = 0.0;
+
+  if (my_rank == 0)
+    {
+      // Set all entries, assume all are locally active
+      vector_with_nonlocal_entries[0] = 1.0;
+      vector_with_nonlocal_entries[1] = 1.0;
+      vector_with_nonlocal_entries[2] = 1.0;
+    }
+  if (my_rank == 1)
+    {
+      // we dont set index 0, this used to lead to
+      // overwriting index 0 on rank 0.
+      vector_with_nonlocal_entries[1] = 2.0;
+      vector_with_nonlocal_entries[2] = 2.0;
+    }
+
+  vector_with_nonlocal_entries.compress(VectorOperation::insert);
+
+  // Expected Results:
+  // Entry Index  |  Operations    |  Result
+  // ------------ | -------------- | -------
+  //  0           |   =1           |   1.0
+  //  1           |   =1,=2        |   2.0
+  //  2           |   =2,=1        |   1.0
+
+  // Print the result on each process
+  deallog << "After operation:" << std::endl;
+  vector_with_nonlocal_entries.print(deallog.get_file_stream());
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+  MPILogInitAll log;
+
+  try
+    {
+      test();
+    }
+  catch (const std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    };
+}

--- a/tests/trilinos_tpetra/vector_nonlocal_insertion_03.mpirun=2.output
+++ b/tests/trilinos_tpetra/vector_nonlocal_insertion_03.mpirun=2.output
@@ -1,0 +1,12 @@
+
+DEAL:0::After operation:
+size:3 locally_stored_size:2 :
+[0]: 1.000e+00
+[1]: 2.000e+00
+DEAL:0::OK
+
+DEAL:1::After operation:
+size:3 locally_stored_size:1 :
+[2]: 1.000e+00
+DEAL:1::OK
+

--- a/tests/trilinos_tpetra/vector_tools_interpolate_01.cc
+++ b/tests/trilinos_tpetra/vector_tools_interpolate_01.cc
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2010 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+// test distributed VectorTools::interpolate with Tpetra vectors
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/intergrid_map.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/trilinos_tpetra_vector.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+template <int dim>
+class MyFunction : public Function<dim>
+{
+public:
+  MyFunction()
+    : Function<dim>(){};
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int) const
+  {
+    double f = p[0] * 2.0 + 1.0;
+    if (dim > 1)
+      f *= p[1] * 3.3 - 1.0;
+    if (dim > 2)
+      f *= p[2] * 5.0;
+    return f;
+  };
+};
+
+template <int dim, typename VectorType>
+void
+test()
+{
+  MyFunction<dim>                           func;
+  MappingQ<dim>                             mapping(1);
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube(tr);
+  tr.refine_global(2);
+  DoFHandler<dim>        dof_handler(tr);
+  static const FE_Q<dim> fe(1);
+  dof_handler.distribute_dofs(fe);
+
+  const auto locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+
+  VectorType solution_distributed(dof_handler.locally_owned_dofs(),
+                                  MPI_COMM_WORLD);
+  VectorTools::interpolate(mapping, dof_handler, func, solution_distributed);
+
+  solution_distributed.compress(VectorOperation::insert);
+
+  VectorType solution_ghosted(dof_handler.locally_owned_dofs(),
+                              locally_relevant_set,
+                              MPI_COMM_WORLD);
+  solution_ghosted = solution_distributed;
+
+  deallog << "norm: " << solution_distributed.l2_norm() << std::endl;
+  dealii::Vector<double> difference(tr.n_active_cells());
+
+  VectorTools::integrate_difference(mapping,
+                                    dof_handler,
+                                    solution_ghosted,
+                                    func,
+                                    difference,
+                                    QGauss<dim>(2),
+                                    VectorTools::L2_norm);
+
+  deallog << "error: " << difference.l2_norm() << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  mpi_initlog();
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+  deallog.push("2d:TrilinosWrappers");
+  test<2, TrilinosWrappers::MPI::Vector>();
+  deallog.pop();
+
+  deallog.push("3d:TrilinosWrappers");
+  test<3, TrilinosWrappers::MPI::Vector>();
+  deallog.pop();
+#endif
+
+  deallog.push("2d:TpetraWrappers::Host");
+  test<2, LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Host>>();
+  deallog.pop();
+
+  deallog.push("3d:TpetraWrappers::Host");
+  test<3, LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Host>>();
+  deallog.pop();
+
+  deallog.push("2d:TpetraWrappers::Default");
+  test<2,
+       LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Default>>();
+  deallog.pop();
+
+  deallog.push("3d:TpetraWrappers::Default");
+  test<3,
+       LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Default>>();
+  deallog.pop();
+}

--- a/tests/trilinos_tpetra/vector_tools_interpolate_01.with_p4est=true.mpirun=2.output
+++ b/tests/trilinos_tpetra/vector_tools_interpolate_01.with_p4est=true.mpirun=2.output
@@ -1,0 +1,13 @@
+
+DEAL:2d:TrilinosWrappers::norm: 14.1659
+DEAL:2d:TrilinosWrappers::error: 1.23083e-16
+DEAL:3d:TrilinosWrappers::norm: 96.9871
+DEAL:3d:TrilinosWrappers::error: 3.37034e-16
+DEAL:2d:TpetraWrappers::Host::norm: 14.1659
+DEAL:2d:TpetraWrappers::Host::error: 1.23083e-16
+DEAL:3d:TpetraWrappers::Host::norm: 96.9871
+DEAL:3d:TpetraWrappers::Host::error: 3.37034e-16
+DEAL:2d:TpetraWrappers::Default::norm: 14.1659
+DEAL:2d:TpetraWrappers::Default::error: 1.23083e-16
+DEAL:3d:TpetraWrappers::Default::norm: 96.9871
+DEAL:3d:TpetraWrappers::Default::error: 3.37034e-16


### PR DESCRIPTION
An attempt at a fix for #19447.

This copies the behavior of `TrilinosWrappers::MPI::Vector` into `TpetraWrappers::Vector`.

However, I have two problems I cant seem to figure out:
1. I can call `sumIntoGlobalValue` for non locally-owned elements without problem, but I need to communicate them during `compress`. The Epetra vector does that with the `globalAssemble` function, but there does not seem to be a similar function for `Tpetra::Vector`, and our current `vector->doExport` does not work, because there is no `nonlocal_vector`.

2. I need the modification in `Vector<Number, MemorySpace>::reinit(V,omit_zeroing_entries)` to make the test work, but I do not quite understand why. It looks like this function is (accidentally?) dropping all ghost or non local entries of the vector `V` during the reinit. But my test case shouldnt even have any such entries at the time `reinit` is called (inside `VectorTools::interpolate`).

Insights would be appreciated. Do I need to implement `compress` using a different function? Or can we not use this approach at all with Tpetra, and instead I need to create a `nonlocal_vector` inside `Vector<Number, MemorySpace>::add` if necessary?



