### PR TITLE
Avoid including .templates.h files in tests where possible

### DIFF
--- a/tests/lac/parallel_vector_26.cc
+++ b/tests/lac/parallel_vector_26.cc
@@ -17,7 +17,7 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/lac/la_parallel_vector.templates.h>
+#include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
 

--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -21,7 +21,6 @@
 #include <deal.II/lac/solver_richardson.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparse_matrix_ez.h>
-#include <deal.II/lac/sparse_matrix_ez.templates.h>
 #include <deal.II/lac/sparse_vanka.h>
 #include <deal.II/lac/vector.h>
 

--- a/tests/lac/vector_data.cc
+++ b/tests/lac/vector_data.cc
@@ -14,7 +14,6 @@
 // test Vector::data
 
 #include <deal.II/lac/vector.h>
-#include <deal.II/lac/vector.templates.h>
 
 #include "../tests.h"
 

--- a/tests/lac/vector_reinit_04.cc
+++ b/tests/lac/vector_reinit_04.cc
@@ -19,9 +19,7 @@
 #include <deal.II/base/mpi.h>
 
 #include <deal.II/lac/la_parallel_vector.h>
-#include <deal.II/lac/la_parallel_vector.templates.h>
 #include <deal.II/lac/vector_memory.h>
-#include <deal.II/lac/vector_memory.templates.h>
 
 #include "../tests.h"
 

--- a/tests/lapack/solver_cg.cc
+++ b/tests/lapack/solver_cg.cc
@@ -17,7 +17,6 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparse_matrix.templates.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 

--- a/tests/matrix_free/matrix_vector_rt_common.h
+++ b/tests/matrix_free/matrix_vector_rt_common.h
@@ -39,11 +39,11 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
-#include <deal.II/matrix_free/matrix_free.templates.h>
 
 #include <deal.II/numerics/vector_tools.h>
 

--- a/tests/matrix_free/matrix_vector_rt_face_common.h
+++ b/tests/matrix_free/matrix_vector_rt_face_common.h
@@ -39,11 +39,11 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
-#include <deal.II/matrix_free/matrix_free.templates.h>
 
 #include <deal.II/numerics/vector_tools.h>
 

--- a/tests/mpi/renumber_cuthill_mckee.cc
+++ b/tests/mpi/renumber_cuthill_mckee.cc
@@ -17,7 +17,6 @@
 
 
 #include <deal.II/base/mpi.h>
-#include <deal.II/base/mpi.templates.h>
 
 #include <deal.II/distributed/tria.h>
 

--- a/tests/mpi/renumber_cuthill_mckee_02.cc
+++ b/tests/mpi/renumber_cuthill_mckee_02.cc
@@ -17,7 +17,6 @@
 
 
 #include <deal.II/base/mpi.h>
-#include <deal.II/base/mpi.templates.h>
 
 #include <deal.II/distributed/tria.h>
 

--- a/tests/numerics/no_flux_06.cc
+++ b/tests/numerics/no_flux_06.cc
@@ -31,7 +31,6 @@
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>
-#include <deal.II/numerics/vector_tools.templates.h>
 
 #include "../tests.h"
 


### PR DESCRIPTION
Writing the test for #19465, I noticed that we included a `.templates.h` file. I went through the test suite and removed those where I think they are unnecessary. We have a few places where we actively need to include `.templates.h` files to assess additional features, but some tests just contain spurious includes.

Let's wait for the CI to see whether or not I was too aggressive.