### PR TITLE
Trilinos: Silence some trilinos deprecation warnings

### DIFF
--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -18,8 +18,10 @@
 #    include <deal.II/lac/sparse_matrix.h>
 #    include <deal.II/lac/trilinos_sparse_matrix.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #    include <MueLu_CreateEpetraPreconditioner.hpp>
 #    include <ml_MultiLevelPreconditioner.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
- Deprecation warnings appear with gcc 13.2 and Trilinos 16.1