### PR TITLE
Gitignore: Ignore direnv files and CMake presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ examples/step-*/cmake_install.cmake
 examples/step-*/step-?
 examples/step-*/step-??
 install/
+
+# direnv
+.env
+.envrc
+
+# CMake presets
+CMakeUserPresets.json


### PR DESCRIPTION
- Ignore [direnv](https://direnv.net/) related files. (direnv is a great tool to set up a project specific environment, I primarily use it to load certain environment module files on the compute cluster when I cd into a directory)
- Ignore CMake user presets (using CMake presets is decoupled from the minimum CMake version required by the project)