### PR TITLE
Update CMake policies and CMake required version in README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,17 +36,12 @@ cmake_minimum_required(VERSION 3.13.4)
 #
 cmake_policy(VERSION 3.13.4)
 
-if(POLICY CMP0074)
-  # Introduced in CMake 3.12: find_package(<PackageName>) also searches
-  # <PackageName>_ROOT CMake and environment variables when set to NEW.
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if(POLICY CMP0075)
-  # Introduced in CMake 3.12: Use CMAKE_REQUIRED_LIBRARIES also in include
-  # file checks. We set the policy to NEW explicitly in order to avoid
-  # spurious configure warnings.
-  cmake_policy(SET CMP0075 NEW)
+if(POLICY CMP0144)
+  # Introduced in CMake 3.27: find_package(<PackageName>) searches
+  # prefixes specified by upper-case <PACKAGENAME>_ROOT CMake and
+  # environment variables in addition to the case-preserved
+  # <PackageName>_ROOT variables.
+  cmake_policy(SET CMP0144 NEW)
 endif()
 
 if(POLICY CMP0167)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -92,7 +92,7 @@
     </p>
     <ul>
         <li>
-            <a href="https://www.cmake.org/" target="_top">CMake</a> version 3.3.0 or later
+            <a href="https://www.cmake.org/" target="_top">CMake</a> version 3.13.4 or later
         </li>
 
         <li>


### PR DESCRIPTION
- Set policy CMP0144 explicitly. Fixes the CMake warning for `FindDEAL_II_BOOST.cmake`
- Remove explicitly setting CMP0074/75 as they are already set via `cmake_policy(VERSION 3.13.4)`

Regarding the CMake policies I wondered if it would make sense to use `cmake_policy(VERSION 3.13.4...3.31)` to say we require CMake 3.13.4, but the project is safe to use with policies from up to CMake 3.31. (Just a thought)

- Update CMake min. required in docs.