### PR TITLE
Trilinos Nox: Enable setting norm type and norm scaling

### DIFF
--- a/include/deal.II/trilinos/nox.h
+++ b/include/deal.II/trilinos/nox.h
@@ -92,6 +92,49 @@ namespace TrilinosWrappers
      */
     struct AdditionalData
     {
+      /**
+       * Type of residual norm used for absolute and relative convergence
+       * checks.
+       *
+       * These correspond to the options described in:
+       * https://trilinos.github.io/docs/nox/class_n_o_x_1_1_status_test_1_1_norm_f.html
+       */
+      enum class NormType
+      {
+        /**
+         * L1 norm of the residual.
+         */
+        L1,
+        /**
+         * L2 norm of the residual.
+         */
+        L2,
+        /**
+         * Infinity norm of the residual.
+         */
+        Linfty,
+      };
+
+      /**
+       * Scaling of the absolute residual norm used for convergence checks.
+       *
+       * These correspond to the options described in:
+       * https://trilinos.github.io/docs/nox/class_n_o_x_1_1_status_test_1_1_norm_f.html
+       */
+      enum class NormScaling
+      {
+        /**
+         * Do not scale the residual norm by the problem size.
+         */
+        Unscaled,
+        /**
+         * Scale the residual norm by the problem size.
+         * For L1 and Linfty norms, the computed norm is multiplied by 1/n.
+         * For the L2 norm, the scaling factor is sqrt(1/n).
+         */
+        Scaled
+      };
+
     public:
       /**
        * Constructor.
@@ -101,7 +144,9 @@ namespace TrilinosWrappers
                      const double       rel_tol                        = 1.e-5,
                      const unsigned int threshold_nonlinear_iterations = 1,
                      const unsigned int threshold_n_linear_iterations  = 0,
-                     const bool         reuse_solver                   = false);
+                     const bool         reuse_solver                   = false,
+                     const NormType     norm_type    = NormType::L2,
+                     const NormScaling  norm_scaling = NormScaling::Scaled);
 
       /**
        * Max number of nonlinear iterations.
@@ -109,12 +154,25 @@ namespace TrilinosWrappers
       unsigned int max_iter;
 
       /**
-       * Absolute l2 tolerance of the residual to be reached.
+       * Absolute tolerance of the residual to be reached.
+       *
+       * The residual norm is computed using the selected `norm_type` and
+       * optionally scaled depending on `norm_scaling`.
        *
        * @note Solver terminates successfully if either the absolute or
        * the relative tolerance has been reached.
        */
       double abs_tol;
+
+      /**
+       * Norm type for measuring the absolute and relative tolerance.
+       */
+      NormType norm_type;
+
+      /**
+       * Norm scaling of the absolute residual norm.
+       */
+      NormScaling norm_scaling;
 
       /**
        * Relative l2 tolerance of the residual to be reached.

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -15,6 +15,8 @@
 
 #include <deal.II/base/config.h>
 
+#include "deal.II/base/exception_macros.h"
+
 #ifdef DEAL_II_TRILINOS_WITH_NOX
 
 #  include <deal.II/trilinos/nox.h>
@@ -84,7 +86,7 @@ namespace TrilinosWrappers
        * Implementation of the abstract interface
        * NOX::Abstract::Vector for deal.II vectors. For details,
        * see
-       * https://docs.trilinos.org/dev/packages/nox/doc/html/classNOX_1_1Abstract_1_1Vector.html.
+       * https://trilinos.github.io/docs/nox/class_n_o_x_1_1_abstract_1_1_vector.html
        */
       template <typename VectorType>
       class Vector : public NOX::Abstract::Vector
@@ -341,7 +343,7 @@ namespace TrilinosWrappers
        * Implementation of the abstract interface
        * NOX::Abstract::Group for deal.II vectors and deal.II solvers. For
        * details, see
-       * https://docs.trilinos.org/dev/packages/nox/doc/html/classNOX_1_1Abstract_1_1Group.html.
+       * https://trilinos.github.io/docs/nox/class_n_o_x_1_1_abstract_1_1_group.html
        */
       template <typename VectorType>
       class Group : public NOX::Abstract::Group
@@ -913,9 +915,13 @@ namespace TrilinosWrappers
     const double       rel_tol,
     const unsigned int threshold_nonlinear_iterations,
     const unsigned int threshold_n_linear_iterations,
-    const bool         reuse_solver)
+    const bool         reuse_solver,
+    const NormType     norm_type,
+    const NormScaling  norm_scaling)
     : max_iter(max_iter)
     , abs_tol(abs_tol)
+    , norm_type(norm_type)
+    , norm_scaling(norm_scaling)
     , rel_tol(rel_tol)
     , threshold_nonlinear_iterations(threshold_nonlinear_iterations)
     , threshold_n_linear_iterations(threshold_n_linear_iterations)
@@ -1143,17 +1149,51 @@ namespace TrilinosWrappers
         check->addStatusTest(info);
       }
 
+    const auto to_nox_norm_type =
+      [](typename NOXSolver<VectorType>::AdditionalData::NormType norm_type) {
+        switch (norm_type)
+          {
+            case NOXSolver<VectorType>::AdditionalData::NormType::L1:
+              return NOX::Abstract::Vector::NormType::OneNorm;
+            case NOXSolver<VectorType>::AdditionalData::NormType::L2:
+              return NOX::Abstract::Vector::NormType::TwoNorm;
+            case NOXSolver<VectorType>::AdditionalData::NormType::Linfty:
+              return NOX::Abstract::Vector::NormType::MaxNorm;
+            default:
+              DEAL_II_ASSERT_UNREACHABLE();
+          }
+      };
+
+    const auto to_nox_norm_scaling =
+      [](typename NOXSolver<VectorType>::AdditionalData::NormScaling
+           norm_scaling) {
+        switch (norm_scaling)
+          {
+            case NOXSolver<VectorType>::AdditionalData::NormScaling::Unscaled:
+              return NOX::StatusTest::NormF::ScaleType::Unscaled;
+            case NOXSolver<VectorType>::AdditionalData::NormScaling::Scaled:
+              return NOX::StatusTest::NormF::ScaleType::Scaled;
+            default:
+              DEAL_II_ASSERT_UNREACHABLE();
+          }
+      };
+
     if (additional_data.abs_tol > 0.0)
       {
         const auto additional_data_norm_f_abs =
-          Teuchos::rcp(new NOX::StatusTest::NormF(additional_data.abs_tol));
+          Teuchos::rcp(new NOX::StatusTest::NormF(
+            additional_data.abs_tol,
+            to_nox_norm_type(additional_data.norm_type),
+            to_nox_norm_scaling(additional_data.norm_scaling)));
         check->addStatusTest(additional_data_norm_f_abs);
       }
 
     if (additional_data.rel_tol > 0.0)
       {
         const auto additional_data_norm_f_rel = Teuchos::rcp(
-          new NOX::StatusTest::RelativeNormF(additional_data.rel_tol));
+          new NOX::StatusTest::RelativeNormF(additional_data.rel_tol,
+                                             to_nox_norm_type(
+                                               additional_data.norm_type)));
         check->addStatusTest(additional_data_norm_f_rel);
       }
 


### PR DESCRIPTION
While using the NOX Wrapper, I realized that the nonlinear solver terminates earlier than expected because the L2 norm of the residual is, by default, scaled by sqrt(1/n). I did not anticipate this behavior when reading the sentence, “Absolute L2 tolerance of the residual to be reached.”

This PR preserves the current behavior as the default, but it also allows users to specify the norm type and scaling according to the options provided by the NOX package.