### PR TITLE
Re-define curl.

### DIFF
--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -40,47 +40,24 @@ class FEValuesBase;
 namespace internal
 {
   /**
-   * A class whose specialization is used to define what type the curl of a
-   * vector valued function corresponds to.
+   * A type that represents the curl of a vector field in `dim` space
+   * dimensions. For 3d, the curl of a vector field is a vector
+   * itself, so if `dim==3`, then `CurlType = Tensor<1,3>`. In 2d,
+   * i.e., for vector fields that are confined to a two-dimensional
+   * manifold (which could be the two-dimensional plane, or a curved
+   * two-dimensional manifold embedded in higher-dimensional space),
+   * the curl is a vector that's perpendicular to the manifold; that
+   * is, it's a vector whose direction is fixed, and so the only thing
+   * that matters is the vector's magnitude and the curl of such a
+   * field is described by a scalar. For 1d or higher dimensions, the
+   * curl is not defined, and so we use a scalar type as a placeholder.
+   *
+   * The second argument denotes the scalar over which the vector
+   * field (and correspondingly the curl) is defined.
    */
   template <int dim, typename NumberType = double>
-  struct CurlType;
-
-  /**
-   * A class whose specialization is used to define what type the curl of a
-   * vector valued function corresponds to.
-   *
-   * In 1d, the curl is a scalar.
-   */
-  template <typename NumberType>
-  struct CurlType<1, NumberType>
-  {
-    using type = NumberType;
-  };
-
-  /**
-   * A class whose specialization is used to define what type the curl of a
-   * vector valued function corresponds to.
-   *
-   * In 2d, the curl is a scalar.
-   */
-  template <typename NumberType>
-  struct CurlType<2, NumberType>
-  {
-    using type = NumberType;
-  };
-
-  /**
-   * A class whose specialization is used to define what type the curl of a
-   * vector valued function corresponds to.
-   *
-   * In 3d, the curl is a vector.
-   */
-  template <typename NumberType>
-  struct CurlType<3, NumberType>
-  {
-    using type = Tensor<1, 3, NumberType>;
-  };
+  using CurlType =
+    std::conditional_t<dim == 3, Tensor<1, 3, NumberType>, NumberType>;
 } // namespace internal
 
 
@@ -634,10 +611,10 @@ namespace FEValuesViews
     /**
      * An alias for the type of the curl of the view this class represents.
      * Here, for a set of <code>spacedim=2</code> components of the finite
-     * element, the curl is a <code>Tensor@<1, 1@></code>. For
+     * element, the curl is a scalar. For
      * <code>spacedim=3</code> it is a <code>Tensor@<1, dim@></code>.
      */
-    using curl_type = typename dealii::internal::CurlType<spacedim>::type;
+    using curl_type = typename dealii::internal::CurlType<spacedim>;
 
     /**
      * An alias for the type of second derivatives of the view this class

--- a/include/deal.II/fe/fe_values_views_internal.h
+++ b/include/deal.II/fe/fe_values_views_internal.h
@@ -148,9 +148,10 @@ namespace FEValuesViews
       const Table<2, dealii::Tensor<1, spacedim>> &shape_gradients,
       const std::vector<typename Vector<dim, spacedim>::ShapeFunctionData>
         &shape_function_data,
-      std::vector<typename ProductType<
-        Number,
-        typename dealii::internal::CurlType<spacedim>::type>::type> &curls);
+      std::vector<
+        typename ProductType<Number,
+                             dealii::internal::CurlType<spacedim>>::type>
+        &curls);
 
     /**
      * Compute Laplacian values for Vectors.

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -106,7 +106,7 @@ public:
       n_components_ == dim,
       Tensor<2, dim, VectorizedArrayType>,
       Tensor<1, n_components_, Tensor<1, dim, VectorizedArrayType>>>>;
-  using curl_type = typename internal::CurlType<dim, VectorizedArrayType>::type;
+  using curl_type    = internal::CurlType<dim, VectorizedArrayType>;
   using hessian_type = std::conditional_t<
     n_components_ == 1,
     Tensor<2, dim, VectorizedArrayType>,

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -76,7 +76,7 @@ namespace internal
         n_components == spacedim,
         Tensor<2, spacedim, Number>,
         Tensor<1, n_components, Tensor<1, spacedim, Number>>>;
-      using curl_type = typename internal::CurlType<dim, Number>::type;
+      using curl_type = internal::CurlType<dim, Number>;
       using scalar_unit_gradient_type =
         Tensor<1, n_components, Tensor<1, dim, ScalarNumber>>;
       using vectorized_unit_gradient_type =
@@ -257,12 +257,12 @@ namespace internal
       using VectorizedArrayType =
         typename dealii::internal::VectorizedArrayTrait<
           Number>::vectorized_value_type;
-      using value_type            = Number;
-      using scalar_value_type     = ScalarNumber;
-      using vectorized_value_type = VectorizedArrayType;
-      using unit_gradient_type    = Tensor<1, dim, Number>;
-      using real_gradient_type    = Tensor<1, spacedim, Number>;
-      using curl_type = typename internal::CurlType<dim, Number>::type;
+      using value_type                    = Number;
+      using scalar_value_type             = ScalarNumber;
+      using vectorized_value_type         = VectorizedArrayType;
+      using unit_gradient_type            = Tensor<1, dim, Number>;
+      using real_gradient_type            = Tensor<1, spacedim, Number>;
+      using curl_type                     = internal::CurlType<dim, Number>;
       using scalar_unit_gradient_type     = Tensor<1, dim, ScalarNumber>;
       using vectorized_unit_gradient_type = Tensor<1, dim, VectorizedArrayType>;
       using interface_vectorized_unit_gradient_type =
@@ -436,7 +436,7 @@ namespace internal
       using real_gradient_type            = unit_gradient_type;
       using scalar_unit_gradient_type     = Tensor<2, dim, ScalarNumber>;
       using vectorized_unit_gradient_type = Tensor<2, dim, VectorizedArrayType>;
-      using curl_type = typename internal::CurlType<dim, Number>::type;
+      using curl_type                     = internal::CurlType<dim, Number>;
       using interface_vectorized_unit_gradient_type =
         Tensor<1, dim, Tensor<1, dim, VectorizedArrayType>>;
 

--- a/source/fe/fe_values_views_internal.cc
+++ b/source/fe/fe_values_views_internal.cc
@@ -457,7 +457,7 @@ namespace FEValuesViews
         &shape_function_data,
       std::vector<typename ProductType<
         Number,
-        typename dealii::internal::CurlType<spacedim>::type>::type> &curls)
+        typename dealii::internal::CurlType<spacedim>>::type> &curls)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = curls.size();
@@ -466,7 +466,7 @@ namespace FEValuesViews
                 curls.end(),
                 typename ProductType<
                   Number,
-                  typename dealii::internal::CurlType<spacedim>::type>::type());
+                  typename dealii::internal::CurlType<spacedim>>::type());
 
       if constexpr (spacedim == 1)
         {

--- a/source/fe/fe_values_views_internal.inst.in
+++ b/source/fe/fe_values_views_internal.inst.in
@@ -85,8 +85,7 @@ for (S : ALL_SCALAR_TYPES; deal_II_dimension : DIMENSIONS;
             &,
           std::vector<ProductType<
             S,
-            dealii::internal::CurlType<deal_II_space_dimension>>::type>
-            &);
+            dealii::internal::CurlType<deal_II_space_dimension>>::type> &);
 
         template void
         do_function_laplacians<deal_II_dimension, deal_II_space_dimension, S>(

--- a/source/fe/fe_values_views_internal.inst.in
+++ b/source/fe/fe_values_views_internal.inst.in
@@ -85,7 +85,7 @@ for (S : ALL_SCALAR_TYPES; deal_II_dimension : DIMENSIONS;
             &,
           std::vector<ProductType<
             S,
-            dealii::internal::CurlType<deal_II_space_dimension>::type>::type>
+            dealii::internal::CurlType<deal_II_space_dimension>>::type>
             &);
 
         template void

--- a/tests/fe/fe_values_view_26.cc
+++ b/tests/fe/fe_values_view_26.cc
@@ -73,10 +73,9 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   // let the FEValues object compute the
   // divergences at quadrature points
-  std::vector<typename dealii::internal::CurlType<dim>::type> curls(
-    quadrature.size());
-  std::vector<Tensor<2, dim>>      grads(quadrature.size());
-  const FEValuesExtractors::Vector extractor(0);
+  std::vector<dealii::internal::CurlType<dim>> curls(quadrature.size());
+  std::vector<Tensor<2, dim>>                  grads(quadrature.size());
+  const FEValuesExtractors::Vector             extractor(0);
   fe_values[extractor].get_function_curls(fe_function, curls);
   fe_values[extractor].get_function_gradients(fe_function, grads);
 

--- a/tests/fe/fe_values_view_27.cc
+++ b/tests/fe/fe_values_view_27.cc
@@ -73,10 +73,9 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   // let the FEValues object compute the
   // divergences at quadrature points
-  std::vector<typename dealii::internal::CurlType<dim>::type> curls(
-    quadrature.size());
-  std::vector<Tensor<2, dim>>      grads(quadrature.size());
-  const FEValuesExtractors::Vector extractor(0);
+  std::vector<dealii::internal::CurlType<dim>> curls(quadrature.size());
+  std::vector<Tensor<2, dim>>                  grads(quadrature.size());
+  const FEValuesExtractors::Vector             extractor(0);
   fe_values[extractor].get_function_curls(fe_function, curls);
   fe_values[extractor].get_function_gradients(fe_function, grads);
 

--- a/tests/fe/fe_values_view_28.cc
+++ b/tests/fe/fe_values_view_28.cc
@@ -95,10 +95,9 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   // let the FEValues object compute the
   // divergences at quadrature points
-  std::vector<typename dealii::internal::CurlType<dim>::type> curls(
-    quadrature.size());
-  std::vector<Tensor<2, dim>>      grads(quadrature.size());
-  const FEValuesExtractors::Vector extractor(0);
+  std::vector<dealii::internal::CurlType<dim>> curls(quadrature.size());
+  std::vector<Tensor<2, dim>>                  grads(quadrature.size());
+  const FEValuesExtractors::Vector             extractor(0);
   fe_values[extractor].get_function_curls(fe_function, curls);
   fe_values[extractor].get_function_gradients(fe_function, grads);
 

--- a/tests/fe/fe_values_view_29.cc
+++ b/tests/fe/fe_values_view_29.cc
@@ -97,10 +97,9 @@ test(const Triangulation<dim> &tr,
 
   // let the FEValues object compute the
   // divergences at quadrature points
-  std::vector<typename dealii::internal::CurlType<dim>::type> curls(
-    quadrature.size());
-  std::vector<Tensor<2, dim>>      grads(quadrature.size());
-  const FEValuesExtractors::Vector extractor(0);
+  std::vector<dealii::internal::CurlType<dim>> curls(quadrature.size());
+  std::vector<Tensor<2, dim>>                  grads(quadrature.size());
+  const FEValuesExtractors::Vector             extractor(0);
   fe_values[extractor].get_function_curls(fe_function, curls);
   fe_values[extractor].get_function_gradients(fe_function, grads);
 

--- a/tests/fe/fe_values_view_number_01.cc
+++ b/tests/fe/fe_values_view_number_01.cc
@@ -24,12 +24,11 @@ template <typename Number>
 void
 test()
 {
-  if (typeid(typename internal::CurlType<1, Number>::type) != typeid(Number))
+  if (typeid(internal::CurlType<1, Number>) != typeid(Number))
     deallog << "NOT OK!" << std::endl;
-  if (typeid(typename internal::CurlType<2, Number>::type) != typeid(Number))
+  if (typeid(internal::CurlType<2, Number>) != typeid(Number))
     deallog << "NOT OK!" << std::endl;
-  if (typeid(typename internal::CurlType<3, Number>::type) !=
-      typeid(Tensor<1, 3, Number>))
+  if (typeid(internal::CurlType<3, Number>) != typeid(Tensor<1, 3, Number>))
     deallog << "NOT OK!" << std::endl;
   deallog << "OK" << std::endl;
 }


### PR DESCRIPTION
`std::conditional_t` allows us to do things more easily. The patch also updates the documentation of `CurlType` to reflect the changes in #19482 .