### PR TITLE
Remove outdated compatibility code

### DIFF
--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -639,13 +639,8 @@ namespace LinearAlgebra
     //         backward.
     target_vector.doImport(vector, tpetra_export, Tpetra::INSERT);
 
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
     auto vector_2d = target_vector.template getLocalView<Kokkos::HostSpace>(
       Tpetra::Access::ReadOnlyStruct{});
-#  else
-    target_vector.template sync<Kokkos::HostSpace>();
-    auto vector_2d = target_vector.template getLocalView<Kokkos::HostSpace>();
-#  endif
     auto new_values = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     auto size       = target_vector.getLocalLength();
 

--- a/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
@@ -269,13 +269,11 @@ namespace LinearAlgebra
       const std::string &preconditioner_type)
       : preconditioner_type(preconditioner_type)
     {
-#    if DEAL_II_TRILINOS_VERSION_GTE(13, 0, 0)
       Ifpack2::Factory factory;
       AssertThrow(
         (factory.isSupported<TpetraTypes::MatrixType<Number, MemorySpace>>(
           preconditioner_type)),
         ExcTrilinosIpack2PreconditionerUnsupported(preconditioner_type));
-#    endif
     }
 
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1192,12 +1192,6 @@ namespace LinearAlgebra
       using ViewType1d     = decltype(vector_1d_local);
       std::optional<ViewType1d> vector_1d_nonlocal;
 
-#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      // Mark vector as to-be-modified. We may do the same with
-      // the nonlocal part too if we end up writing into it.
-      vector->template modify<Kokkos::HostSpace>();
-#  endif
-
       for (size_type i = 0; i < n_elements; ++i)
         {
           const size_type row = indices[i];
@@ -1249,40 +1243,17 @@ namespace LinearAlgebra
               // deferred creating this view previously:
               if (!vector_1d_nonlocal)
                 {
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
                   auto vector_2d_nonlocal =
                     nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
                       Tpetra::Access::ReadWriteStruct{});
-#  else
-                  auto vector_2d_nonlocal =
-                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
-#  endif
 
                   vector_1d_nonlocal =
                     Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
-
-#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-                  // Mark the nonlocal vector as to-be-modified as well.
-                  nonlocal_vector->template modify<Kokkos::HostSpace>();
-#  endif
                 }
               (*vector_1d_nonlocal)(nonlocal_row) += values[i];
               compressed = false;
             }
         }
-
-#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      vector->template sync<
-        typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
-          device_type::memory_space>();
-
-      // If we have created a view to the nonlocal part, then we have also
-      // written into it. Flush these modifications.
-      if (vector_1d_nonlocal)
-        nonlocal_vector->template sync<
-          typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
-            device_type::memory_space>();
-#  endif
     }
 
 
@@ -1308,14 +1279,8 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
       auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
         Tpetra::Access::ReadWriteStruct{});
-#  else
-      vector->template sync<Kokkos::HostSpace>();
-
-      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>();
-#  endif
 
       // Having extracted a view into the multivectors above, now also
       // extract a view into the one vector we actually store. We can
@@ -1326,12 +1291,6 @@ namespace LinearAlgebra
       auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
       using ViewType1d     = decltype(vector_1d_local);
       std::optional<ViewType1d> vector_1d_nonlocal;
-
-#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      // Mark vector as to-be-modified. We may do the same with
-      // the nonlocal part too if we end up writing into it.
-      vector->template modify<Kokkos::HostSpace>();
-#  endif
 
       for (size_type i = 0; i < n_elements; ++i)
         {
@@ -1384,40 +1343,17 @@ namespace LinearAlgebra
               // deferred creating this view previously:
               if (!vector_1d_nonlocal)
                 {
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
                   auto vector_2d_nonlocal =
                     nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
                       Tpetra::Access::ReadWriteStruct{});
-#  else
-                  auto vector_2d_nonlocal =
-                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>();
-#  endif
 
                   vector_1d_nonlocal =
                     Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
-
-#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-                  // Mark the nonlocal vector as to-be-modified as well.
-                  nonlocal_vector->template modify<Kokkos::HostSpace>();
-#  endif
                 }
               (*vector_1d_nonlocal)(nonlocal_row) = values[i];
               compressed                          = false;
             }
         }
-
-#  if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-      vector->template sync<
-        typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
-          device_type::memory_space>();
-
-      // If we have created a view to the nonlocal part, then we have also
-      // written into it. Flush these modifications.
-      if (vector_1d_nonlocal)
-        nonlocal_vector->template sync<
-          typename Tpetra::Vector<Number, int, types::signed_global_dof_index>::
-            device_type::memory_space>();
-#  endif
     }
 
 

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -208,15 +208,9 @@ Vector<Number>::Vector(
       localized_vector.doImport(v.trilinos_vector(), *importer, Tpetra::INSERT);
 
       // get a kokkos view from the localized_vector
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
       auto localized_vector_2d =
         localized_vector.template getLocalView<Kokkos::HostSpace>(
           Tpetra::Access::ReadOnlyStruct{});
-#  else
-      localized_vector.template sync<Kokkos::HostSpace>();
-      auto localized_vector_2d =
-        localized_vector.template getLocalView<Kokkos::HostSpace>();
-#  endif
       auto localized_vector_1d =
         Kokkos::subview(localized_vector_2d, Kokkos::ALL(), 0);
       const size_t local_length = localized_vector.getLocalLength();
@@ -895,15 +889,9 @@ Vector<Number>::operator=(
       localized_vector.doImport(v.trilinos_vector(), *importer, Tpetra::INSERT);
 
       // get a kokkos view from the localized_vector
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
       auto localized_vector_2d =
         localized_vector.template getLocalView<Kokkos::HostSpace>(
           Tpetra::Access::ReadOnlyStruct{});
-#  else
-      localized_vector.template sync<Kokkos::HostSpace>();
-      auto localized_vector_2d =
-        localized_vector.template getLocalView<Kokkos::HostSpace>();
-#  endif
       auto localized_vector_1d =
         Kokkos::subview(localized_vector_2d, Kokkos::ALL(), 0);
       const size_t local_length = localized_vector.getLocalLength();

--- a/include/deal.II/lac/vector_element_access.h
+++ b/include/deal.II/lac/vector_element_access.h
@@ -163,24 +163,10 @@ namespace internal
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));
 
-#      if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
     auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>(
       Tpetra::Access::ReadWriteStruct{});
-#      else
-    vector.template sync<Kokkos::HostSpace>();
-    auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>();
-#      endif
     auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
-#      if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-    // We're going to modify the data on host.
-    vector.template modify<Kokkos::HostSpace>();
-#      endif
     vector_1d(trilinos_i) += value;
-#      if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-    vector.template sync<
-      typename Tpetra::Vector<NumberType, int, types::signed_global_dof_index>::
-        device_type::memory_space>();
-#      endif
   }
 
 
@@ -199,24 +185,11 @@ namespace internal
       vector.getMap()->getLocalElement(
         static_cast<TrilinosWrappers::types::int_type>(i));
 
-#      if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
     auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>(
       Tpetra::Access::ReadWriteStruct{});
-#      else
-    vector.template sync<Kokkos::HostSpace>();
-    auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>();
-#      endif
     auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     // We're going to modify the data on host.
-#      if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-    vector.template modify<Kokkos::HostSpace>();
-#      endif
     vector_1d(trilinos_i) = value;
-#      if !DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
-    vector.template sync<
-      typename Tpetra::Vector<NumberType, int, types::signed_global_dof_index>::
-        device_type::memory_space>();
-#      endif
   }
 
 
@@ -230,15 +203,9 @@ namespace internal
         const types::global_dof_index                                         i)
   {
     // Extract local indices in the vector.
-#      if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
     const auto &vector    = V.trilinos_vector();
     auto        vector_2d = vector.template getLocalView<Kokkos::HostSpace>(
       Tpetra::Access::ReadOnlyStruct{});
-#      else
-    auto vector    = V.trilinos_vector();
-    vector.template sync<Kokkos::HostSpace>();
-    auto vector_2d = vector.template getLocalView<Kokkos::HostSpace>();
-#      endif
     auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     TrilinosWrappers::types::int_type trilinos_i =
       vector.getMap()->getLocalElement(

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -847,12 +847,8 @@ namespace LinearAlgebra
       size_type local_b = 0;
       for (int i = 0; i < static_cast<int>(local_size()); ++i)
         {
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
           typename TpetraTypes::GraphType<
             MemorySpace>::local_inds_host_view_type indices;
-#  else
-          Teuchos::ArrayView<const int> indices;
-#  endif
 
           graph->getLocalRowView(i, indices);
           const auto num_entries = indices.size();
@@ -1014,12 +1010,8 @@ namespace LinearAlgebra
           for (unsigned int i = 0; i < graph->getNodeNumRows(); ++i)
 #  endif
             {
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
               typename TpetraTypes::GraphType<
                 MemorySpace>::local_inds_host_view_type indices;
-#  else
-              Teuchos::ArrayView<const int> indices;
-#  endif
               graph->getLocalRowView(i, indices);
               int num_entries = indices.size();
               for (int j = 0; j < num_entries; ++j)
@@ -1042,12 +1034,9 @@ namespace LinearAlgebra
 
       for (unsigned int row = 0; row < local_size(); ++row)
         {
-#  if DEAL_II_TRILINOS_VERSION_GTE(13, 2, 0)
           typename TpetraTypes::GraphType<
             MemorySpace>::local_inds_host_view_type indices;
-#  else
-          Teuchos::ArrayView<const int> indices;
-#  endif
+
           graph->getLocalRowView(row, indices);
           int num_entries = indices.size();
 

--- a/tests/rol/adaptor_02.cc
+++ b/tests/rol/adaptor_02.cc
@@ -90,7 +90,6 @@ test(const double x, const double y)
 
   ROL::ParameterList parlist;
 
-#if DEAL_II_TRILINOS_VERSION_GTE(12, 18, 0)
   // Define algorithm in three intuitive and easy steps.
   //
   // For the future developer: if this ever fails again, copy the relevant
@@ -102,10 +101,6 @@ test(const double x, const double y)
   ROL::Ptr<ROL::StatusTest<RealT>> status =
     ROL::makePtr<ROL::StatusTest<RealT>>(parlist);
   ROL::Algorithm<RealT> algo(step, status, false);
-#else
-  // Define algorithm.
-  ROL::Algorithm<RealT> algo("Line Search", parlist);
-#endif
 
   // Set parameters.
   parlist.sublist("Secant").set("Use as Preconditioner", false);


### PR DESCRIPTION
Since #18272 we require Trilinos 13.2. Remove some leftover compatibility code.