### PR TITLE
Track Tpetra vector last action

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1074,6 +1074,14 @@ namespace LinearAlgebra
       bool has_ghost;
 
       /**
+       * The operation that was last performed on the elements of the vector.
+       * The reset state is represented by VectorOperation::unknown, which means
+       * no element-wise modification has been done locally since creation or
+       * the last call to compress().
+       */
+      VectorOperation::values last_action;
+
+      /**
        * Teuchos::RCP to the actual Tpetra vector object.
        */
       Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>> vector;
@@ -1179,6 +1187,16 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
+      Assert(
+        nonlocal_vector.is_null() ||
+          (last_action == VectorOperation::unknown) ||
+          (last_action == VectorOperation::add),
+        ExcMessage(
+          "Cannot mix add and insert operations on a Tpetra vector "
+          "with non-locally owned entries without calling compress() in between."));
+
+      last_action = VectorOperation::add;
+
       auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
         Tpetra::Access::ReadWriteStruct{});
 
@@ -1278,6 +1296,16 @@ namespace LinearAlgebra
       // if we have ghost values, do not allow
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      Assert(
+        nonlocal_vector.is_null() ||
+          (last_action == VectorOperation::unknown) ||
+          (last_action == VectorOperation::insert),
+        ExcMessage(
+          "Cannot mix add and insert operations on a Tpetra vector "
+          "with non-locally owned entries without calling compress() in between."));
+
+      last_action = VectorOperation::insert;
 
       auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
         Tpetra::Access::ReadWriteStruct{});

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -78,6 +78,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::Vector()
       : compressed(true)
       , has_ghost(false)
+      , last_action(VectorOperation::unknown)
       , vector(Utilities::Trilinos::internal::make_rcp<
                TpetraTypes::VectorType<Number, MemorySpace>>(
           Utilities::Trilinos::internal::make_rcp<TpetraTypes::MapType<
@@ -90,6 +91,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::Vector(const Vector<Number, MemorySpace> &V)
       : compressed(V.compressed)
       , has_ghost(V.has_ghost)
+      , last_action(VectorOperation::unknown)
       , vector(Utilities::Trilinos::internal::make_rcp<
                TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                              Teuchos::Copy))
@@ -110,6 +112,7 @@ namespace LinearAlgebra
       const Teuchos::RCP<TpetraTypes::VectorType<Number, MemorySpace>> V)
       : compressed(true)
       , has_ghost(V->getMap()->isOneToOne() == false)
+      , last_action(VectorOperation::unknown)
       , vector(V)
     {}
 
@@ -120,6 +123,7 @@ namespace LinearAlgebra
                                         const MPI_Comm  communicator)
       : compressed(true)
       , has_ghost(false)
+      , last_action(VectorOperation::unknown)
       , vector(Utilities::Trilinos::internal::make_rcp<
                TpetraTypes::VectorType<Number, MemorySpace>>(
           parallel_partitioner.make_tpetra_map_rcp<
@@ -134,6 +138,7 @@ namespace LinearAlgebra
                                         const IndexSet &ghost_entries,
                                         const MPI_Comm  communicator,
                                         const bool      vector_writable)
+      : last_action(VectorOperation::unknown)
     {
       local_entries = locally_owned_entries;
       compressed    = true;
@@ -190,8 +195,9 @@ namespace LinearAlgebra
         Utilities::Trilinos::internal::make_rcp<
           TpetraTypes::MapType<MemorySpace>>(
           0, 0, Utilities::Trilinos::tpetra_comm_self()));
-      has_ghost  = false;
-      compressed = true;
+      has_ghost   = false;
+      compressed  = true;
+      last_action = VectorOperation::unknown;
       nonlocal_vector.reset();
     }
 
@@ -206,9 +212,10 @@ namespace LinearAlgebra
       vector.reset();
       nonlocal_vector.reset();
 
-      compressed = true;
-      has_ghost  = false;
-      vector     = Utilities::Trilinos::internal::make_rcp<
+      compressed  = true;
+      has_ghost   = false;
+      last_action = VectorOperation::unknown;
+      vector      = Utilities::Trilinos::internal::make_rcp<
         TpetraTypes::VectorType<Number, MemorySpace>>(
         parallel_partitioner
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
@@ -269,8 +276,9 @@ namespace LinearAlgebra
                 communicator, true));
         }
 
-      has_ghost  = (vector->getMap()->isOneToOne() == false);
-      compressed = true;
+      has_ghost   = (vector->getMap()->isOneToOne() == false);
+      compressed  = true;
+      last_action = VectorOperation::unknown;
     }
 
 
@@ -345,6 +353,8 @@ namespace LinearAlgebra
           source_stored_elements.clear();
           tpetra_comm_pattern = Teuchos::null;
         }
+
+      last_action = VectorOperation::unknown;
     }
 
 
@@ -477,6 +487,8 @@ namespace LinearAlgebra
           tpetra_comm_pattern    = V.tpetra_comm_pattern;
         }
 
+      last_action = VectorOperation::unknown;
+
       return *this;
     }
 
@@ -497,8 +509,9 @@ namespace LinearAlgebra
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(),
         vector_data);
 
-      has_ghost  = false;
-      compressed = true;
+      has_ghost   = false;
+      compressed  = true;
+      last_action = VectorOperation::unknown;
 
       return *this;
     }
@@ -523,6 +536,8 @@ namespace LinearAlgebra
       // that for the ghost entries of the vector.
       if (!nonlocal_vector.is_null())
         nonlocal_vector->putScalar(Number(0));
+
+      last_action = VectorOperation::unknown;
 
       return *this;
     }
@@ -1141,6 +1156,43 @@ namespace LinearAlgebra
                "not make sense to call compress() for such "
                "vectors."));
 
+      Assert(
+        (operation == VectorOperation::insert) ||
+          (operation == VectorOperation::add),
+        ExcMessage(
+          "Only VectorOperation::add and VectorOperation::insert are allowed."));
+
+      // If there were no local operations, assume the input argument is
+      // the correct operation to perform globally.
+      if (last_action == VectorOperation::unknown)
+        last_action = operation;
+
+      Assert(last_action == operation,
+             ExcMessage(
+               "The last operation on the vector and the given operation in "
+               "compress() do not agree."));
+
+      if constexpr (running_in_debug_mode())
+        {
+          // Check that all processors agree that last_action is the same
+          int my_int_last_action = last_action;
+          int all_int_last_action;
+
+          const int ierr = MPI_Allreduce(&my_int_last_action,
+                                         &all_int_last_action,
+                                         1,
+                                         MPI_INT,
+                                         MPI_BOR,
+                                         get_mpi_communicator());
+          AssertThrowMPI(ierr);
+
+          AssertThrow(all_int_last_action !=
+                        (VectorOperation::add | VectorOperation::insert),
+                      ExcMessage(
+                        "Not all processors agree on the last "
+                        "VectorOperation before this compress() call."));
+        }
+
       if (!nonlocal_vector.is_null())
         {
           Tpetra::CombineMode tpetra_operation = Tpetra::ZERO;
@@ -1163,7 +1215,8 @@ namespace LinearAlgebra
           nonlocal_vector->putScalar(Number(0));
         }
 
-      compressed = true;
+      compressed  = true;
+      last_action = VectorOperation::unknown;
     }
 
 


### PR DESCRIPTION
This PR enhances security checks in `TpetraWrappers::Vector` and should not affect any behavior.

`TpetraWrappers::Vector` now tracks the last element-wise action that was performed, as is already done in the Trilinos Epetra vectors and the PETSc vectors (in fact I ported a lot of code from there).

This change ensures that:
1. `add` and `set` are always separated by `compress` (unless there exists no non-local buffer, in which case we are free to change locally owned entries at will)
2. all processes agree among each other on the operation in `compress`
3. all processes check that the user-provided vector operation in `compress()` is consistent with the actual operation that was performed last (at least locally)

Note that 1. means the Tpetra vector behaves differently from `TrilinosWrappers::MPI::Vector`, which allows to dynamically switch between add/insert and performs global communication if necessary. I didnt port this functionality, because I think it is dangerous. If one process doesnt switch between the modes (e.g. because it doesnt own any entries) then this behavior may cause a deadlock. I think it is reasonable for the user to separate add and insert operations with compress, which is also what PETSc vectors require.