### PR TITLE
Tests should not need to include config.h.

### DIFF
--- a/tests/cgal/cgal_mesh_criteria.cc
+++ b/tests/cgal/cgal_mesh_criteria.cc
@@ -12,7 +12,6 @@
 
 // Check that different `cell_size` parameter gives different number of cells.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/utilities.h>
 

--- a/tests/cgal/cgal_polygon_01.cc
+++ b/tests/cgal/cgal_polygon_01.cc
@@ -11,7 +11,6 @@
 // -----------------------------------------------------------------------------
 
 // Convert a deal.II reference cell to a cgal polygon_2.
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/polygon.h>
 

--- a/tests/cgal/cgal_polygon_02.cc
+++ b/tests/cgal/cgal_polygon_02.cc
@@ -11,7 +11,6 @@
 // -----------------------------------------------------------------------------
 
 // Convert a deal.II triangulation to a CGAL polygon_2.
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/polygon.h>
 

--- a/tests/cgal/cgal_polygon_03.cc
+++ b/tests/cgal/cgal_polygon_03.cc
@@ -11,7 +11,6 @@
 // -----------------------------------------------------------------------------
 
 // Boolean operations on polygons
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/polygon.h>
 

--- a/tests/cgal/cgal_quadrature_01.cc
+++ b/tests/cgal/cgal_quadrature_01.cc
@@ -13,7 +13,6 @@
 // Read a Surface_mesh from an .off file, then create a coarse mesh filled with
 // tets
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/utilities.h>
 

--- a/tests/cgal/cgal_quadrature_02.cc
+++ b/tests/cgal/cgal_quadrature_02.cc
@@ -13,7 +13,6 @@
 // Intersect reference cells and compute the volume of the intersection by
 // integration.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/utilities.h>
 

--- a/tests/cgal/cgal_remesh_surface.cc
+++ b/tests/cgal/cgal_remesh_surface.cc
@@ -13,7 +13,6 @@
 // Remesh the union of two deal.II hyper_spheres in order to avoid bad
 // triangles.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/point.h>
 

--- a/tests/cgal/cgal_surface_mesh_01.cc
+++ b/tests/cgal/cgal_surface_mesh_01.cc
@@ -12,7 +12,6 @@
 
 // Convert a deal.II cell to a cgal Surface_mesh.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/point.h>
 

--- a/tests/cgal/cgal_surface_mesh_02.cc
+++ b/tests/cgal/cgal_surface_mesh_02.cc
@@ -13,7 +13,6 @@
 // Read a Surface_mesh from an .off file, then create a coarse mesh filled with
 // tets
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/utilities.h>
 

--- a/tests/cgal/cgal_surface_mesh_03.cc
+++ b/tests/cgal/cgal_surface_mesh_03.cc
@@ -12,7 +12,6 @@
 
 // Perform corefinement and boolean operations between surface_meshes.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/utilities.h>
 

--- a/tests/cgal/cgal_surface_mesh_04.cc
+++ b/tests/cgal/cgal_surface_mesh_04.cc
@@ -14,7 +14,6 @@
 // the whole triangulation is a 2D surface mesh. In 3D, the surface mesh
 // describes the boundary of the deal.II Triangulation.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/point.h>
 

--- a/tests/cgal/cgal_surface_mesh_05.cc
+++ b/tests/cgal/cgal_surface_mesh_05.cc
@@ -13,7 +13,6 @@
 // Performs the following: deal.II Triangulations -> CGAL::Surface_mesh(es) ->
 // Perform boolean operation -> deal.II tria.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/point.h>
 

--- a/tests/cgal/cgal_surface_mesh_06.cc
+++ b/tests/cgal/cgal_surface_mesh_06.cc
@@ -14,7 +14,6 @@
 // orientation issues that may arise in Hexaedrons with non-standard face
 // orientations.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/surface_mesh.h>
 #include <deal.II/cgal/utilities.h>

--- a/tests/cgal/cgal_surface_mesh_07.cc
+++ b/tests/cgal/cgal_surface_mesh_07.cc
@@ -15,7 +15,6 @@
 // orientations. Make sure this works also when transforming the grid to
 // a simplex one.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/surface_mesh.h>
 #include <deal.II/cgal/utilities.h>

--- a/tests/cgal/cgal_surface_triangulation_01.cc
+++ b/tests/cgal/cgal_surface_triangulation_01.cc
@@ -13,7 +13,6 @@
 // Convert a closed CGAL::Surface_mesh or a closed CGAL::Polyhedron_3 to a
 // deal.II triangulation. The input mesh is a quad torus.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_surface_triangulation_02.cc
+++ b/tests/cgal/cgal_surface_triangulation_02.cc
@@ -13,7 +13,6 @@
 // Convert a closed CGAL::Surface_mesh or a closed CGAL::Polyhedron_3 to a
 // deal.II triangulation. The input mesh is a tripod.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_surface_triangulation_03.cc
+++ b/tests/cgal/cgal_surface_triangulation_03.cc
@@ -13,7 +13,6 @@
 // Convert a closed CGAL::Surface_mesh or a closed CGAL::Polyhedron_3 to a
 // deal.II triangulation. The input mesh is a tripod.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_triangulation_01.cc
+++ b/tests/cgal/cgal_triangulation_01.cc
@@ -12,7 +12,6 @@
 
 // Convert a vector of deal.II points to a cgal Triangulation
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_triangulation_02.cc
+++ b/tests/cgal/cgal_triangulation_02.cc
@@ -12,7 +12,6 @@
 
 // Convert a vector of deal.II points to a cgal Triangulation_2
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_triangulation_03.cc
+++ b/tests/cgal/cgal_triangulation_03.cc
@@ -12,7 +12,6 @@
 
 // Convert a cgal Triangulation_2 to a dealii::Triangulation<2, ...>
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_triangulation_04.cc
+++ b/tests/cgal/cgal_triangulation_04.cc
@@ -12,7 +12,6 @@
 
 // Convert a cgal Triangulation_3 to a dealii::Triangulation<dim, spacedim>
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_triangulation_05.cc
+++ b/tests/cgal/cgal_triangulation_05.cc
@@ -16,7 +16,6 @@
 // kernel here, since Simple_cartesian will throw an exception when trying to
 // add some almost coplanar points.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/cgal_triangulation_06.cc
+++ b/tests/cgal/cgal_triangulation_06.cc
@@ -13,7 +13,6 @@
 // Read a surface mesh, make a coarse CGAL triangulation out of it, and
 // translate the result into a deal.II Triangulation.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/surface_mesh.h>
 #include <deal.II/cgal/triangulation.h>

--- a/tests/cgal/cgal_triangulation_07.cc
+++ b/tests/cgal/cgal_triangulation_07.cc
@@ -12,7 +12,6 @@
 
 // Create a Tria<3> out of a Tria<2,3>.
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/cgal/triangulation.h>
 

--- a/tests/cgal/implicit_triangulation_01.cc
+++ b/tests/cgal/implicit_triangulation_01.cc
@@ -12,7 +12,6 @@
 
 // Create a Triangulation<3,3> from an implicit function
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
 

--- a/tests/cgal/implicit_triangulation_02.cc
+++ b/tests/cgal/implicit_triangulation_02.cc
@@ -12,7 +12,6 @@
 
 // Create a Triangulation<2,3> from an implicit function
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
 

--- a/tests/fe/2d_grid_projection_hermite.cc
+++ b/tests/fe/2d_grid_projection_hermite.cc
@@ -10,7 +10,6 @@
 //
 // -----------------------------------------------------------------------------
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/multithread_info.h>

--- a/tests/matrix_free_kokkos/basics_01.cc
+++ b/tests/matrix_free_kokkos/basics_01.cc
@@ -13,7 +13,6 @@
 
 // check that exception macros work on device
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
 

--- a/tests/matrix_free_kokkos/basics_02.cc
+++ b/tests/matrix_free_kokkos/basics_02.cc
@@ -13,7 +13,6 @@
 
 // check NumberTraits::abs() on device
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/numbers.h>

--- a/tests/matrix_free_kokkos/tensor_01.cc
+++ b/tests/matrix_free_kokkos/tensor_01.cc
@@ -13,7 +13,6 @@
 
 // check that Tensor and SymmetricTensor work on device
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/symmetric_tensor.h>

--- a/tests/performance/performance_test_driver.h
+++ b/tests/performance/performance_test_driver.h
@@ -13,7 +13,6 @@
 #ifndef dealii_performance_test_driver_h
 #define dealii_performance_test_driver_h
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/exceptions.h>

--- a/tests/performance/valgrind_instrumentation.h
+++ b/tests/performance/valgrind_instrumentation.h
@@ -13,7 +13,6 @@
 #ifndef dealii_valgrind_instrumentation_h
 #define dealii_valgrind_instrumentation_h
 
-#include <deal.II/base/config.h>
 
 #include <deal.II/base/exceptions.h>
 

--- a/tests/quick_tests/kokkos.cc
+++ b/tests/quick_tests/kokkos.cc
@@ -1,5 +1,4 @@
 
-#include <deal.II/base/config.h>
 
 #include <Kokkos_Core.hpp>
 


### PR DESCRIPTION
Every one of deal.II's .h files needs to `#include <deal.II/base/config.h>`, so it shouldn't be necessary for tests to do that as well.