### PR TITLE
Work around a FP exception issue in MPI initialization.

### DIFF
--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -61,6 +61,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <psb_c_base.h>
 #endif
 
+#ifdef DEAL_II_HAVE_FP_EXCEPTIONS
+#  include <cfenv>
+#endif
+
+
 #include <set>
 #include <string>
 
@@ -88,6 +93,24 @@ InitFinalize::InitFinalize([[maybe_unused]] int    &argc,
 #ifdef DEAL_II_WITH_MPI
   if (static_cast<bool>(libraries & InitializeLibrary::MPI))
     {
+#  ifdef DEAL_II_HAVE_FP_EXCEPTIONS
+      // Some MPI installations, during initializing the MPI system,
+      // read configuration files via libxml that computes some NaN
+      // constants at run time. This triggers floating point exceptions
+      // if these have been requested by the application program (or
+      // as part of our own test suite). To avoid this, save FP flags,
+      // reset these flags to allow such computations, and at the end
+      // of the block re-set the flags to the saved state.
+      //
+      // References:
+      // https://stackoverflow.com/questions/79739650/libxml2-throws-sigfpe-in-debian-13
+      fenv_t fe_state;
+      ierr = fegetenv(&fe_state);
+      AssertThrow(ierr == 0, ExcInternalError());
+
+      fedisableexcept(FE_DIVBYZERO | FE_INVALID);
+#  endif
+
       // if we have PETSc, we will initialize it and let it handle MPI.
       // Otherwise, we will do it.
       int MPI_has_been_started = 0;
@@ -110,6 +133,11 @@ InitFinalize::InitFinalize([[maybe_unused]] int    &argc,
       // Assert(max_num_threads==1 || provided != MPI_THREAD_SINGLE,
       //    ExcMessage("MPI reports that we are not allowed to use multiple
       //    threads."));
+
+#  ifdef DEAL_II_HAVE_FP_EXCEPTIONS
+      ierr = fesetenv(&fe_state);
+      AssertThrow(ierr == 0, ExcInternalError());
+#  endif
     }
 #endif
 


### PR DESCRIPTION
When running MPI-parallel tests or ASPECT, on my system, MPI initialization fails with a floating point exception:
```
==== backtrace (tid: 254025) ====
 0  /lib/x86_64-linux-gnu/libucs.so.0(ucs_handle_error+0x2ec) [0x72f8e4ec8f2c]
 1  /lib/x86_64-linux-gnu/libucs.so.0(+0x3530d) [0x72f8e4eca30d]
 2  /lib/x86_64-linux-gnu/libucs.so.0(+0x3572a) [0x72f8e4eca72a]
 3  /lib/x86_64-linux-gnu/libc.so.6(+0x458d0) [0x72f8edc458d0]
 4  /lib/x86_64-linux-gnu/libxml2.so.2(+0x61d73) [0x72f8db7e1d73]
 5  /lib/x86_64-linux-gnu/libxml2.so.2(xmlCheckVersion+0x26) [0x72f8db7b9256]
 6  /usr/lib/x86_64-linux-gnu/hwloc/hwloc_xml_libxml.so(+0x2feb) [0x72f8dc440feb]
 7  /lib/x86_64-linux-gnu/libhwloc.so.15(+0x3cd05) [0x72f8e75ccd05]
 8  /lib/x86_64-linux-gnu/libhwloc.so.15(+0x1f74f) [0x72f8e75af74f]
 9  /lib/x86_64-linux-gnu/libpmix.so.2(+0x4cc4b) [0x72f8e184cc4b]
10  /lib/x86_64-linux-gnu/libpmix.so.2(pmix_hwloc_setup_topology+0x3fc) [0x72f8e184d36c]
11  /lib/x86_64-linux-gnu/libpmix.so.2(PMIx_Init+0x2343) [0x72f8e18579c3]
12  /lib/x86_64-linux-gnu/libmpi.so.40(ompi_rte_init+0x1155) [0x72f8ee48fd45]
13  /lib/x86_64-linux-gnu/libmpi.so.40(+0x94010) [0x72f8ee494010]
14  /lib/x86_64-linux-gnu/libmpi.so.40(ompi_mpi_instance_init+0x6c) [0x72f8ee494ddc]
15  /lib/x86_64-linux-gnu/libmpi.so.40(ompi_mpi_init+0x80) [0x72f8ee48be30]
16  /lib/x86_64-linux-gnu/libmpi.so.40(PMPI_Init_thread+0x56) [0x72f8ee4be0d6]
17  /home/bangerth/p/deal.II/1/build/lib/libdeal_II.g.so.9.8.0-pre(_ZN6dealii12InitFinalizeC2ERiRPPcRKNS_17InitializeLibraryEj+0x378) [0x72f91a0fd304]
```
This is because libUCX does invalid FP arithmetic during MPI initialization, and we get into trouble in programs that set FP flags (like our own tests, or ASPECT). What a nuisance. See https://stackoverflow.com/questions/79739650/libxml2-throws-sigfpe-in-debian-13 for more on this.

This patch fixes this by saving FP flags before calling `MPI_Init_thread`, clearing FP exceptions, and restoring the flags again afterwards.