### PR TITLE
Disallow the use of CurlType for anything other than 2d and 3d.

### DIFF
--- a/doc/news/changes/incompatibilities/20260331Bangerth
+++ b/doc/news/changes/incompatibilities/20260331Bangerth
@@ -12,4 +12,4 @@ now fixed: The data type defined by FEValuesViews::Vector::curl_type used for
 curls is not simply a scalar value for `dim==2`. For `dim==3`, it is
 unchanged from what it was before.
 <br>
-(Wolfgang Bangerth, 2025/03/31)
+(Wolfgang Bangerth, 2026/03/31)

--- a/doc/news/changes/incompatibilities/20260413Bangerth
+++ b/doc/news/changes/incompatibilities/20260413Bangerth
@@ -1,0 +1,9 @@
+Changed: There are some functions in deal.II that compute the curl of
+vector fields. The curl is only defined for vector fields in ${\mathbb
+R}^3$, or for two-dimensional vector fields on two-dimensional
+manifolds (perhaps embedded in ${\mathbb R}^3$). Historically, it was
+possible to also call these functions for `dim==1`, which made no
+sense but was syntactically allowed. However, this is now forbidden
+and will lead to syntax errors.
+<br>
+(Wolfgang Bangerth, 2026/04/13)

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -27,6 +27,7 @@
 #include <deal.II/lac/read_vector.h>
 
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -49,15 +50,25 @@ namespace internal
    * the curl is a vector that's perpendicular to the manifold; that
    * is, it's a vector whose direction is fixed, and so the only thing
    * that matters is the vector's magnitude and the curl of such a
-   * field is described by a scalar. For 1d or higher dimensions, the
-   * curl is not defined, and so we use a scalar type as a placeholder.
+   * field is described by a scalar.
    *
-   * The second argument denotes the scalar over which the vector
+   * The second template argument denotes the scalar over which the vector
    * field (and correspondingly the curl) is defined.
+   *
+   * @note The curl has no valid meaning for vector fields that are
+   *   not either defined in ${\mathbb R}^3$ or that are two-dimensional
+   *   vector fields on two-dimensional manifolds (perhaps embedded in
+   *   ${\mathbb R}^3$). As a consequence, CurlType is an invalid
+   *   type for `dim==1` or `dim>3`. For this invalid type, the
+   *   declaration here uses std::monostate, an empty class for which
+   *   one can create objects but that does not allow any arithmetic
+   *   to be done on it.
    */
   template <int dim, typename NumberType = double>
-  using CurlType =
-    std::conditional_t<dim == 3, Tensor<1, 3, NumberType>, NumberType>;
+  using CurlType = std::conditional_t<
+    dim == 3,
+    Tensor<1, 3, NumberType>,
+    std::conditional_t<dim == 2, NumberType, std::monostate>>;
 } // namespace internal
 
 

--- a/source/fe/fe_values_views.cc
+++ b/source/fe/fe_values_views.cc
@@ -871,16 +871,25 @@ namespace FEValuesViews
                     fe_values->present_cell.n_dofs_for_dof_handler());
     AssertDimension(curls.size(), fe_values->n_quadrature_points);
 
-    // get function values of dofs on this cell
-    boost::container::small_vector<Number, 200> dof_values(
-      fe_values->dofs_per_cell);
-    fe_values->present_cell.get_interpolated_dof_values(
-      fe_function, make_array_view(dof_values.begin(), dof_values.end()));
-    internal::do_function_curls<dim, spacedim>(
-      make_array_view(dof_values.cbegin(), dof_values.cend()),
-      fe_values->finite_element_output.shape_gradients,
-      shape_function_data,
-      curls);
+    if constexpr ((dim == 2) || (dim == 3))
+      {
+        // get function values of dofs on this cell
+        boost::container::small_vector<Number, 200> dof_values(
+          fe_values->dofs_per_cell);
+        fe_values->present_cell.get_interpolated_dof_values(
+          fe_function, make_array_view(dof_values.begin(), dof_values.end()));
+        internal::do_function_curls<dim, spacedim>(
+          make_array_view(dof_values.cbegin(), dof_values.cend()),
+          fe_values->finite_element_output.shape_gradients,
+          shape_function_data,
+          curls);
+      }
+    else
+      AssertThrow(false,
+                  ExcMessage("The curl is only defined for vector fields "
+                             "that are either two- or three-dimensional. "
+                             "You cannot ask for the curl for dim=" +
+                             std::to_string(dim) + "."));
   }
 
 

--- a/source/fe/fe_values_views.inst.in
+++ b/source/fe/fe_values_views.inst.in
@@ -129,10 +129,12 @@ for (S : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
         std::vector<ProductType<
           S,
           dealii::SymmetricTensor<2, deal_II_space_dimension>>::type> &) const;
+#    if deal_II_space_dimension >= 2
     template void FEValuesViews::
       Vector<deal_II_dimension, deal_II_space_dimension>::get_function_curls<S>(
         const dealii::ReadVector<S> &,
         std::vector<ProductType<S, curl_type>::type> &) const;
+#    endif
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_divergences<S>(
@@ -235,10 +237,12 @@ for (VEC : GENERAL_CONTAINER_TYPES; Number : ALL_SCALAR_TYPES;
         const VEC<Number> &, std::vector<solution_divergence_type<Number>> &)
         const;
 
+#    if deal_II_space_dimension >= 2
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_curls_from_local_dof_values<VEC<Number>>(
         const VEC<Number> &, std::vector<solution_curl_type<Number>> &) const;
+#    endif
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::

--- a/source/fe/fe_values_views_internal.inst.in
+++ b/source/fe/fe_values_views_internal.inst.in
@@ -76,6 +76,7 @@ for (S : ALL_SCALAR_TYPES; deal_II_dimension : DIMENSIONS;
           std::vector<Vector<deal_II_dimension, deal_II_space_dimension>::
                         template solution_divergence_type<S>> &);
 
+#    if deal_II_space_dimension >= 2
         template void
         do_function_curls<deal_II_dimension, deal_II_space_dimension, S>(
           const ArrayView<const S> &,
@@ -86,6 +87,7 @@ for (S : ALL_SCALAR_TYPES; deal_II_dimension : DIMENSIONS;
           std::vector<ProductType<
             S,
             dealii::internal::CurlType<deal_II_space_dimension>>::type> &);
+#    endif
 
         template void
         do_function_laplacians<deal_II_dimension, deal_II_space_dimension, S>(

--- a/tests/fe/fe_values_view_number_01.cc
+++ b/tests/fe/fe_values_view_number_01.cc
@@ -24,7 +24,7 @@ template <typename Number>
 void
 test()
 {
-  if (typeid(internal::CurlType<1, Number>) != typeid(Number))
+  if (typeid(internal::CurlType<1, Number>) != typeid(std::monostate))
     deallog << "NOT OK!" << std::endl;
   if (typeid(internal::CurlType<2, Number>) != typeid(Number))
     deallog << "NOT OK!" << std::endl;


### PR DESCRIPTION
#19482 made the curl in 2d a scalar, and #19503 simplified the declaration of the type we use to describe the curl. But these patches preserve a historical relic: `CurlType` is a valid type also for `dim==1` where it doesn't make any sense. This patch fixes this wart by ensuring that for `dim==1`, `CurlType` is something on which you can't do any arithmetic and consequently will get errors when you try.