### PR TITLE
Include what you use: Let each file include explicitly what it uses.

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -45,9 +45,11 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <list>
 #include <map>
 #include <string>
+#include <utility>
 
 // Returns a map from the keys in the expansion lists to the list itself. For
 // instance, the example above will lead to the entry

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -16,10 +16,17 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <iterator>
 #include <limits>
+#include <string>
+#include <utility>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -16,9 +16,14 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/mutex.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
+
+#include <cstddef>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -15,11 +15,20 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
+
+#include <cstddef>
+#include <ostream>
+#include <vector>
+
 #ifdef DEAL_II_WITH_GSL
 #  include <deal.II/base/function.h>
 #  include <deal.II/base/mutex.h>
 #  include <deal.II/base/point.h>
 
+#  include <gsl/gsl_interp.h>
 #  include <gsl/gsl_spline.h>
 
 #  include <memory>

--- a/include/deal.II/base/function_spherical.h
+++ b/include/deal.II/base/function_spherical.h
@@ -17,8 +17,11 @@
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/tensor.h>
 
 #include <array>
+#include <cstddef>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/base/function_tools.h
+++ b/include/deal.II/base/function_tools.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/function.h>
 
 #include <array>
+#include <iterator>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -16,14 +16,22 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/ndarray.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/std_cxx20/iota_view.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/types.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <ostream>
+#include <string>
 
 
 

--- a/include/deal.II/base/graph_coloring.h
+++ b/include/deal.II/base/graph_coloring.h
@@ -17,13 +17,18 @@
 
 #  include <deal.II/base/config.h>
 
+#  include <deal.II/base/exception_macros.h>
+#  include <deal.II/base/exceptions.h>
 #  include <deal.II/base/std_cxx20/type_traits.h>
 #  include <deal.II/base/thread_management.h>
 #  include <deal.II/base/types.h>
 
+#  include <Kokkos_Macros.hpp>
+
 #  include <algorithm>
 #  include <functional>
 #  include <set>
+#  include <string>
 #  include <unordered_map>
 #  include <unordered_set>
 #  include <vector>

--- a/include/deal.II/base/polynomials_barycentric.h
+++ b/include/deal.II/base/polynomials_barycentric.h
@@ -16,11 +16,26 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/scalar_polynomials_base.h>
 #include <deal.II/base/table.h>
+#include <deal.II/base/table_indices.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
 #include <limits>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -19,7 +19,15 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe.h>
+
+#include <deal.II/grid/cell_status.h>
+#include <deal.II/grid/tria.h>
+
 #include <boost/signals2/connection.hpp>
+
+#include <functional>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -15,7 +15,27 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/table.h>
+#include <deal.II/base/utilities.h>
+
 #include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_data.h>
+#include <deal.II/fe/fe_update_flags.h>
+#include <deal.II/fe/mapping.h>
+#include <deal.II/fe/mapping_related_data.h>
+
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/hp/q_collection.h>
+
+#include <deal.II/lac/full_matrix.h>
+
+#include <iterator>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -16,7 +16,15 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/fe/mapping.h>
 #include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/tria.h>
+
+#include <memory>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -16,9 +16,24 @@
 #  include <deal.II/base/config.h>
 
 #  include <deal.II/base/data_out_base.h>
+#  include <deal.II/base/exception_macros.h>
+#  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/point.h>
+#  include <deal.II/base/table.h>
+#  include <deal.II/base/tensor.h>
+#  include <deal.II/base/types.h>
+
+#  include <deal.II/grid/reference_cell.h>
 
 #  include <deal.II/lac/block_sparse_matrix.h>
 #  include <deal.II/lac/sparse_matrix.h>
+
+#  include <algorithm>
+#  include <array>
+#  include <cmath>
+#  include <new>
+#  include <string>
+#  include <vector>
 
 #  ifdef DEAL_II_WITH_TRILINOS
 #    include <deal.II/lac/trilinos_block_sparse_matrix.h>

--- a/include/deal.II/particles/data_out.h
+++ b/include/deal.II/particles/data_out.h
@@ -19,6 +19,8 @@
 #include <deal.II/numerics/data_component_interpretation.h>
 
 #include <string>
+#include <tuple>
+#include <variant>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -15,7 +15,7 @@
 
 #include <deal.II/base/config.h>
 
-#include "deal.II/base/exception_macros.h"
+#include <deal.II/base/exception_macros.h>
 
 #ifdef DEAL_II_TRILINOS_WITH_NOX
 

--- a/source/algorithms/general_data_storage.cc
+++ b/source/algorithms/general_data_storage.cc
@@ -11,6 +11,8 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/algorithms/general_data_storage.h>
 
 

--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -11,9 +11,14 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/algorithms/timestep_control.h>
 
 #include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/patterns.h>
+
+#include <string>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/conditional_ostream.cc
+++ b/source/base/conditional_ostream.cc
@@ -11,6 +11,8 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/conditional_ostream.h>
 
 #include <ostream>

--- a/source/base/convergence_table.cc
+++ b/source/base/convergence_table.cc
@@ -10,11 +10,20 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/convergence_table.h>
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/table_handler.h>
 
+#include <Kokkos_Macros.hpp>
+
 #include <cmath>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/discrete_time.cc
+++ b/source/base/discrete_time.cc
@@ -11,9 +11,17 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/discrete_time.h>
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <cstddef>
+#include <string>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/enable_observer_pointer.cc
+++ b/source/base/enable_observer_pointer.cc
@@ -10,14 +10,23 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/enable_observer_pointer.h>
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
 
 #include <algorithm>
+#include <atomic>
+#include <exception>
 #include <iostream>
+#include <map>
+#include <mutex>
 #include <string>
 #include <typeinfo>
+#include <utility>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/event.cc
+++ b/source/base/event.cc
@@ -11,8 +11,11 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/event.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -10,13 +10,29 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/flow_function.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/mutex.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/vector.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/function_lib.cc
+++ b/source/base/function_lib.cc
@@ -10,16 +10,36 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 #include <deal.II/base/function_bessel.h>
 #include <deal.II/base/function_lib.h>
+#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/std_cxx17/cmath.h>
+#include <deal.II/base/symmetric_tensor.h>
+#include <deal.II/base/table.h>
+#include <deal.II/base/table_indices.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/vector.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/function_lib_cutoff.cc
+++ b/source/base/function_lib_cutoff.cc
@@ -10,13 +10,26 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function.h>
 #include <deal.II/base/function_lib.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/lac/vector.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/geometry_info.cc
+++ b/source/base/geometry_info.cc
@@ -10,8 +10,13 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/geometry_info.h>
+#include <deal.II/base/ndarray.h>
 #include <deal.II/base/tensor.h>
+
+#include <array>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/graph_coloring.cc
+++ b/source/base/graph_coloring.cc
@@ -10,9 +10,14 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/graph_coloring.h>
 
+#include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/sparsity_tools.h>
+
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/job_identifier.cc
+++ b/source/base/job_identifier.cc
@@ -10,6 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/job_identifier.h>
 
 #include <ctime>

--- a/source/base/named_selection.cc
+++ b/source/base/named_selection.cc
@@ -10,8 +10,13 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/algorithms/any_data.h>
 #include <deal.II/algorithms/named_selection.h>
+
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -10,13 +10,26 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/utilities.h>
 
 #include <boost/core/demangle.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/move/utility_core.hpp>
+#include <boost/signals2/optional_last_value.hpp>
+#include <boost/smart_ptr/make_shared_object.hpp>
 
 #include <fstream>
+#include <functional>
+#include <iterator>
+#include <list>
 #include <set>
+#include <typeinfo>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/parsed_function.cc
+++ b/source/base/parsed_function.cc
@@ -10,9 +10,24 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/auto_derivative_function.h>
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/function_parser.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/parameter_handler.h>
 #include <deal.II/base/parsed_function.h>
+#include <deal.II/base/patterns.h>
 #include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -10,11 +10,26 @@
 //
 // -----------------------------------------------------------------------------
 
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/table.h>
+#include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/polynomial.h>
+#include <deal.II/base/polynomial_space.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/table.h>
+#include <deal.II/base/table_indices.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/types.h>
+#include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <array>
 #include <memory>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/polynomials_adini.cc
+++ b/source/base/polynomials_adini.cc
@@ -10,10 +10,22 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/polynomials_adini.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/table.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
 
 #include <memory>
+#include <vector>
 
 #define ENTER_COEFFICIENTS(                                   \
   koefs, z, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) \

--- a/source/base/polynomials_barycentric.cc
+++ b/source/base/polynomials_barycentric.cc
@@ -10,7 +10,12 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/polynomials_barycentric.h>
+#include <deal.II/base/scalar_polynomials_base.h>
 
 #include <deal.II/grid/reference_cell.h>
 

--- a/source/base/polynomials_bernardi_raugel.cc
+++ b/source/base/polynomials_bernardi_raugel.cc
@@ -11,9 +11,20 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_bernardi_raugel.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_polynomials_base.h>
+
+#include <Kokkos_Macros.hpp>
 
 #include <memory>
+#include <ostream>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/polynomials_bernstein.cc
+++ b/source/base/polynomials_bernstein.cc
@@ -10,10 +10,21 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_bernstein.h>
 
+#include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/binomial.hpp>
+#include <boost/math/tools/precision.hpp>
 
+#include <Kokkos_Macros.hpp>
+
+#include <cmath>
+#include <string>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/polynomials_hermite.cc
+++ b/source/base/polynomials_hermite.cc
@@ -10,8 +10,14 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_hermite.h>
 #include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/polynomials_integrated_legendre_sz.cc
+++ b/source/base/polynomials_integrated_legendre_sz.cc
@@ -11,6 +11,9 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_integrated_legendre_sz.h>
 
 #include <vector>

--- a/source/base/polynomials_p.cc
+++ b/source/base/polynomials_p.cc
@@ -11,7 +11,15 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/polynomial.h>
+#include <deal.II/base/polynomial_space.h>
 #include <deal.II/base/polynomials_p.h>
+
+#include <Kokkos_Macros.hpp>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/polynomials_piecewise.cc
+++ b/source/base/polynomials_piecewise.cc
@@ -10,8 +10,22 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_piecewise.h>
+#include <deal.II/base/types.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -11,15 +11,35 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_barycentric.h>
 #include <deal.II/base/polynomials_pyramid.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/table.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/reference_cell.h>
 
+#include <deal.II/lac/full_matrix.h>
 #include <deal.II/lac/householder.h>
 #include <deal.II/lac/vector.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/polynomials_wedge.cc
+++ b/source/base/polynomials_wedge.cc
@@ -11,8 +11,20 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/polynomials_barycentric.h>
 #include <deal.II/base/polynomials_wedge.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
+
+#include <memory>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -10,15 +10,30 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/enable_observer_pointer.h>
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/point.h>
 #include <deal.II/base/quadrature.h>
+#include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
+#include <iterator>
 #include <limits>
 #include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/quadrature_selector.cc
+++ b/source/base/quadrature_selector.cc
@@ -10,8 +10,15 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/quadrature_selector.h>
+
+#include <string>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -10,13 +10,21 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/exception_macros.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/lac/exceptions.h>
+#include <deal.II/lac/lapack_support.h>
 #include <deal.II/lac/lapack_templates.h>
 
+#include <Kokkos_Macros.hpp>
+
 #include <array>
+#include <cstddef>
+#include <string>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/tensor_product_polynomials_bubbles.cc
+++ b/source/base/tensor_product_polynomials_bubbles.cc
@@ -11,10 +11,22 @@
 // -----------------------------------------------------------------------------
 
 
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor_product_polynomials_bubbles.h>
+#include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_product_polynomials_bubbles.h>
+#include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <array>
 #include <memory>
+#include <ostream>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/tensor_product_polynomials_const.cc
+++ b/source/base/tensor_product_polynomials_const.cc
@@ -11,10 +11,21 @@
 // -----------------------------------------------------------------------------
 
 
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/tensor_product_polynomials_const.h>
+#include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/tensor_product_polynomials_const.h>
+#include <deal.II/base/utilities.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <array>
 #include <memory>
+#include <ostream>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/vectorization.cc
+++ b/source/base/vectorization.cc
@@ -10,6 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/vectorization.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -10,12 +10,22 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi_stub.h>
+#include <deal.II/base/types.h>
 
 #include <deal.II/dofs/number_cache.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <cstddef>
 #include <numeric>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/fe/block_mask.cc
+++ b/source/fe/block_mask.cc
@@ -11,11 +11,15 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/memory_consumption.h>
 
 #include <deal.II/fe/block_mask.h>
 
+#include <cstddef>
 #include <iostream>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/fe/component_mask.cc
+++ b/source/fe/component_mask.cc
@@ -11,11 +11,15 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/memory_consumption.h>
 
 #include <deal.II/fe/component_mask.h>
 
+#include <cstddef>
 #include <iostream>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -11,9 +11,36 @@
 // -----------------------------------------------------------------------------
 
 
-#include <deal.II/fe/fe_p1nc.h>
+#include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/qprojector.h>
+#include <deal.II/base/quadrature.h>
+#include <deal.II/base/table.h>
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/types.h>
+
+#include <deal.II/fe/component_mask.h>
+#include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_data.h>
+#include <deal.II/fe/fe_p1nc.h>
+#include <deal.II/fe/mapping_related_data.h>
+
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/hp/collection.h>
+#include <deal.II/hp/q_collection.h>
+
+#include <deal.II/lac/full_matrix.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <array>
 #include <memory>
+#include <ostream>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/fe/fe_values_extractors.cc
+++ b/source/fe/fe_values_extractors.cc
@@ -10,9 +10,13 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/fe/fe_values_extractors.h>
+
+#include <string>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/grid/persistent_tria.cc
+++ b/source/grid/persistent_tria.cc
@@ -10,12 +10,23 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/magic_numbers.h>
 #include <deal.II/grid/persistent_tria.h>
+#include <deal.II/grid/tria.h>
 
+#include <Kokkos_Macros.hpp>
+
+#include <cstddef>
 #include <iostream>
+#include <typeinfo>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/grid/tria_faces.cc
+++ b/source/grid/tria_faces.cc
@@ -11,9 +11,18 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
 
+#include <deal.II/grid/reference_cell.h>
 #include <deal.II/grid/tria_faces.h>
+#include <deal.II/grid/tria_objects.h>
+
+#include <cstddef>
+#include <ostream>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/grid/tria_levels.cc
+++ b/source/grid/tria_levels.cc
@@ -10,9 +10,24 @@
 //
 // -----------------------------------------------------------------------------
 
-#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/config.h>
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/types.h>
+
+#include <deal.II/grid/reference_cell.h>
 #include <deal.II/grid/tria_levels.h>
+#include <deal.II/grid/tria_objects.h>
+#include <deal.II/grid/tria_objects_orientations.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -11,9 +11,28 @@
 // -----------------------------------------------------------------------------
 
 
-#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/config.h>
 
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/table.h>
+
+#include <deal.II/lac/block_indices.h>
 #include <deal.II/lac/block_sparsity_pattern.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/sparsity_pattern_base.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -11,9 +11,28 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/enable_observer_pointer.h>
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/linear_index_iterator.h>
+
 #include <deal.II/lac/chunk_sparsity_pattern.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/exceptions.h>
 #include <deal.II/lac/full_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <istream>
+#include <memory>
+#include <string>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/lac/matrix_out.cc
+++ b/source/lac/matrix_out.cc
@@ -10,6 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
 #include <deal.II/lac/matrix_out.h>
 
 #include <string>

--- a/source/lac/precondition_block_ez.cc
+++ b/source/lac/precondition_block_ez.cc
@@ -10,8 +10,15 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/table.h>
+
+#include <deal.II/lac/precondition_block.h>
 #include <deal.II/lac/precondition_block.templates.h>
 #include <deal.II/lac/sparse_matrix_ez.h>
+
+#include <ostream>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/solver_control.cc
+++ b/source/lac/solver_control.cc
@@ -10,14 +10,25 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/patterns.h>
 #include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/types.h>
 
 #include <deal.II/lac/solver_control.h>
 
+#include <Kokkos_Macros.hpp>
+
 #include <cmath>
 #include <sstream>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/sparse_vanka.cc
+++ b/source/lac/sparse_vanka.cc
@@ -10,7 +10,18 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exceptions.h>
+
+#include <deal.II/lac/sparse_vanka.h>
 #include <deal.II/lac/sparse_vanka.templates.h>
+
+#include <taskflow/core/async.hpp>
+#include <taskflow/core/graph.hpp>
+#include <taskflow/utility/traits.hpp>
+
+#include <ostream>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/sparsity_pattern_base.cc
+++ b/source/lac/sparsity_pattern_base.cc
@@ -10,11 +10,17 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/array_view.h>
+
 #include <deal.II/lac/sparsity_pattern_base.h>
 
 #include <boost/container/small_vector.hpp>
+#include <boost/container/vector.hpp>
 
 #include <algorithm>
+#include <iterator>
 #include <utility>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/meshworker/mesh_worker.cc
+++ b/source/meshworker/mesh_worker.cc
@@ -11,10 +11,21 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/memory_consumption.h>
+
 #include <deal.II/lac/block_indices.h>
 
 #include <deal.II/meshworker/local_integrator.h>
 #include <deal.II/meshworker/local_results.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <cstddef>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/non_matching/immersed_surface_quadrature.cc
+++ b/source/non_matching/immersed_surface_quadrature.cc
@@ -10,10 +10,21 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/non_matching/immersed_surface_quadrature.h>
+
+#include <Kokkos_Macros.hpp>
+
+#include <cstdlib>
+#include <string>
+#include <vector>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/numerics/histogram.cc
+++ b/source/numerics/histogram.cc
@@ -10,14 +10,24 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
 
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/histogram.h>
 
+#include <Kokkos_Macros.hpp>
+
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
In a review for the paper on modules (see also #18071), a reviewer kindly pointed me to the include-what-you-use tool (https://github.com/include-what-you-use/include-what-you-use/tree/master) that instruments clang to track which symbols a file uses and makes sure that each file actually `#include`s everything it uses explicitly, rather than relying on the transitive closure of recursive `#include` statements.

This actually works reasonably well. There is an Ubuntu package for include-what-you-use, and CMake supports it too. I omitted most dependencies to try this out and used the following command line:
```
cmake ../dealii/ -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-Xiwyu;--comment_style=none;-Xiwyu;--no_fwd_decls;-Xiwyu;--cxx17ns" -GNinja
```
Then, when you call `ninja`, it goes to town making suggestions what includes are missing. It has a helpful Python script that then also applies these changes. But this isn't a one-shot deal. It took many rounds of suggested changes until the tool was finally happy with the list of includes. With a bit of Perl magic, one ends up with the patch here. I have no tried to track *every* added `#include` statement, but the ones I looked at were legitimate: the added include file declares classes and functions that really *are* used in the current file. As a consequence, I think that this patch is actually correct and useful.

I did think whether it's possible to make this into a CI check. The key issue is that it has many complaints about Kokkos headers, which of course we don't want to touch. There's also the issue that the script marks up quite a lot of missing (and some superfluous) headers in its output that the `fix_includes.py` script then doesn't know what to do with. In other words, I don't think this is quite ready to make into a CI check, but this patch is already a step forward.