### PR TITLE
Make header guards uniform.

### DIFF
--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-#ifndef dealii_fe_tools_H
-#define dealii_fe_tools_H
+#ifndef dealii_fe_tools_h
+#define dealii_fe_tools_h
 
 
 
@@ -1594,4 +1594,4 @@ namespace FETools
 
 DEAL_II_NAMESPACE_CLOSE
 
-#endif /* dealii_fe_tools_H */
+#endif /* dealii_fe_tools_h */

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-#ifndef dealii_fe_tools_templates_H
-#define dealii_fe_tools_templates_H
+#ifndef dealii_fe_tools_templates_h
+#define dealii_fe_tools_templates_h
 
 
 #include <deal.II/base/config.h>
@@ -3411,4 +3411,4 @@ namespace FETools
 
 DEAL_II_NAMESPACE_CLOSE
 
-#endif /* dealii_fe_tools_templates_H */
+#endif /* dealii_fe_tools_templates_h */

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-#ifndef dealii_fe_tools_extrapolate_templates_H
-#define dealii_fe_tools_extrapolate_templates_H
+#ifndef dealii_fe_tools_extrapolate_templates_h
+#define dealii_fe_tools_extrapolate_templates_h
 
 
 #include <deal.II/base/config.h>

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -10,8 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
-#ifndef dealii_fe_tools_interpolate_templates_H
-#define dealii_fe_tools_interpolate_templates_H
+#ifndef dealii_fe_tools_interpolate_templates_h
+#define dealii_fe_tools_interpolate_templates_h
 
 
 #include <deal.II/base/config.h>


### PR DESCRIPTION
I have to deal programmatically with header guards to deal with modules (#18071) for newer Clang compilers, and these files here use a `_H` suffix where all the others use `_h`. Fix this.