### PR TITLE
MUMPS: Add support for block matrices

### DIFF
--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -34,11 +34,15 @@
 #endif
 
 #ifdef DEAL_II_WITH_TRILINOS
+#  include <deal.II/lac/trilinos_block_sparse_matrix.h>
+#  include <deal.II/lac/trilinos_parallel_block_vector.h>
 #  include <deal.II/lac/trilinos_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_vector.h>
 #endif
 
 #ifdef DEAL_II_WITH_PETSC
+#  include <deal.II/lac/petsc_block_sparse_matrix.h>
+#  include <deal.II/lac/petsc_block_vector.h>
 #  include <deal.II/lac/petsc_sparse_matrix.h>
 #  include <deal.II/lac/petsc_vector.h>
 #endif
@@ -676,6 +680,13 @@ private:
    * IndexSet storing the locally owned rows of the matrix.
    */
   IndexSet locally_owned_rows;
+
+  /**
+   * Pointer array for MUMPS block format (ICNTL(15)=1).
+   * blkptr[iblk] gives the 1-based index of the first variable in block iblk.
+   * Dimension: nblk+1.
+   */
+  std::vector<types::mumps_index> blkptr;
 
   /**
    * This function initializes a MUMPS instance and hands over the system's

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -610,30 +610,29 @@ public:
    * square, i.e. the sum of block row sizes must equal the sum of block column
    * sizes.
    *
-   * @p BlockMatrixType is the type of the individual sparse matrices (e.g.
+   * @p MatrixBlockType is the type of the individual sparse matrices (e.g.
    * <tt>TrilinosWrappers::SparseMatrix</tt> or
    * <tt>PETScWrappers::MPI::SparseMatrix</tt>).
    *
    * Null pointers are allowed and are treated as zero blocks. The corresponding
-   * block is simply skipped during assembly. The block dimensions are inferred
-   * from the non-null blocks in the same row/column position.
+   * block is simply skipped during copying information into MUMPS data
+   * structures. The block dimensions are inferred from the non-null blocks in
+   * the same row/column position.
    *
-   *If case of a 2 by 2 block system for Stokes problem, the usage looks as
-   *follows:
+   * In the case of a 2 by 2 block Stokes system, the usage looks as follows:
    * @code
-   *     std::vector<const PETScWrappers::MPI::SparseMatrix *> blocks = {
-      &system_matrix.block(0, 0),
-      &system_matrix.block(0, 1),
-      &system_matrix.block(1, 0),
-      nullptr};
-    solver.initialize_from_individual_blocks(blocks, 2, 2);
-   sparse_direct.initialize_from_individual_blocks(blocks, 2, 2);
+   * std::vector<const PETScWrappers::MPI::SparseMatrix *> blocks = {
+   *   &system_matrix.block(0, 0),
+   *   &system_matrix.block(0, 1),
+   *   &system_matrix.block(1, 0),
+   *   nullptr};
+   * solver.initialize_from_individual_blocks(blocks, 2, 2);
    * @endcode
    */
-  template <class BlockMatrixType>
+  template <class MatrixBlockType>
   void
   initialize_from_individual_blocks(
-    const std::vector<const BlockMatrixType *> &blocks,
+    const std::vector<const MatrixBlockType *> &blocks,
     const unsigned int                          n_block_rows,
     const unsigned int                          n_block_cols);
 
@@ -720,9 +719,14 @@ private:
   IndexSet locally_owned_rows;
 
   /**
-   * Pointer array for MUMPS block format (ICNTL(15)=1).
+   * Integer pointer array exploited by MUMPS when the input matrix is in block
+   * format (ICNTL(15)=1).
    * blkptr[iblk] gives the 1-based index of the first variable in block iblk.
-   * Dimension: nblk+1.
+   * The dimension of this vector is nblk+1, where nblk is the number of blocks
+   * in the matrix.
+   *
+   * @note This variable is used only if the MUMPS option ICNTL(15) is set to
+   * 1, which means that the matrix is stored in a user-provided block format.
    */
   std::vector<types::mumps_index> blkptr;
 
@@ -738,10 +742,10 @@ private:
    * This function initializes a MUMPS instance from individual block matrices
    * stored in a row-major order. Used by initialize_from_individual_blocks().
    */
-  template <class BlockMatrixType>
+  template <class MatrixBlockType>
   void
   initialize_matrix_from_individual_blocks(
-    const std::vector<const BlockMatrixType *> &blocks,
+    const std::vector<const MatrixBlockType *> &blocks,
     const unsigned int                          n_block_rows,
     const unsigned int                          n_block_cols);
 

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -600,6 +600,44 @@ public:
   initialize(const Matrix &matrix);
 
   /**
+   * Initialize the MUMPS solver from individual block matrices. The blocks are
+   * provided as a flat vector ordered row-major. In case of a 2 by 2 block
+   * system, the vector must contain 4 pointers to individual sparse matrices,
+   * stored as <tt>{A,B,C,D}</tt>.
+   *
+   * This is useful when the individual blocks have been assembled separately
+   * rather than into a monolithic block matrix. The overall system must be
+   * square, i.e. the sum of block row sizes must equal the sum of block column
+   * sizes.
+   *
+   * @p BlockMatrixType is the type of the individual sparse matrices (e.g.
+   * <tt>TrilinosWrappers::SparseMatrix</tt> or
+   * <tt>PETScWrappers::MPI::SparseMatrix</tt>).
+   *
+   * Null pointers are allowed and are treated as zero blocks. The corresponding
+   * block is simply skipped during assembly. The block dimensions are inferred
+   * from the non-null blocks in the same row/column position.
+   *
+   *If case of a 2 by 2 block system for Stokes problem, the usage looks as
+   *follows:
+   * @code
+   *     std::vector<const PETScWrappers::MPI::SparseMatrix *> blocks = {
+      &system_matrix.block(0, 0),
+      &system_matrix.block(0, 1),
+      &system_matrix.block(1, 0),
+      nullptr};
+    solver.initialize_from_individual_blocks(blocks, 2, 2);
+   sparse_direct.initialize_from_individual_blocks(blocks, 2, 2);
+   * @endcode
+   */
+  template <class BlockMatrixType>
+  void
+  initialize_from_individual_blocks(
+    const std::vector<const BlockMatrixType *> &blocks,
+    const unsigned int                          n_block_rows,
+    const unsigned int                          n_block_cols);
+
+  /**
    * Apply the inverse of the matrix to the input vector <tt>src</tt> and store
    * the solution in the output vector <tt>dst</tt>.
    */
@@ -695,6 +733,17 @@ private:
   template <class Matrix>
   void
   initialize_matrix(const Matrix &matrix);
+
+  /**
+   * This function initializes a MUMPS instance from individual block matrices
+   * stored in a row-major order. Used by initialize_from_individual_blocks().
+   */
+  template <class BlockMatrixType>
+  void
+  initialize_matrix_from_individual_blocks(
+    const std::vector<const BlockMatrixType *> &blocks,
+    const unsigned int                          n_block_rows,
+    const unsigned int                          n_block_cols);
 
   /**
    * Copy the computed solution into the solution vector.

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -1351,230 +1351,25 @@ SparseDirectMUMPS::initialize_matrix(const Matrix &matrix)
                   ExcMessage("The matrix communicator must match the MUMPS "
                              "communicator."));
 
-      // Distributed block matrix case
-      id.icntl[17] = 3; // distributed matrix assembly
+      // extract individual block pointers and delegate to
+      // initialize_matrix_from_individual_blocks()
+      using MatrixBlockType = std::conditional_t<
+        std::is_same_v<Matrix, TrilinosWrappers::BlockSparseMatrix>,
+        TrilinosWrappers::SparseMatrix,
+        PETScWrappers::MPI::SparseMatrix>;
 
       const unsigned int n_block_rows = matrix.n_block_rows();
       const unsigned int n_block_cols = matrix.n_block_cols();
 
-      // Compute row and column offsets for each block
-      std::vector<size_type> row_block_offset(n_block_rows + 1, 0);
-      std::vector<size_type> col_block_offset(n_block_cols + 1, 0);
-      for (unsigned int br = 0; br < n_block_rows; ++br)
-        row_block_offset[br + 1] =
-          row_block_offset[br] + matrix.block(br, 0).m();
-      for (unsigned int bc = 0; bc < n_block_cols; ++bc)
-        col_block_offset[bc + 1] =
-          col_block_offset[bc] + matrix.block(0, bc).n();
-
-      // activate MUMPS block format and describe the block structure
-      id.icntl[14] = 1; // ICNTL(15) = 1:user-provided block format
-      id.nblk      = n_block_rows;
-
-      // blkptr[iblk] gives the position of the first variable in block iblk.
-      blkptr.resize(n_block_rows + 1);
-      for (unsigned int br = 0; br <= n_block_rows; ++br)
-        blkptr[br] = row_block_offset[br] + 1; // 1-based Fortran indexing
-      id.blkptr = blkptr.data();
-
-      // blkvar = nullptr means identity permutation. Variables are assumed to
-      // be already in block order, which is the case for deal.II block matrices
-      // with component-wise DoF renumbering.
-      id.blkvar = nullptr;
-
-      // count total nonzeros across all blocks
-      types::mumps_nnz total_nnz = 0;
+      std::vector<const MatrixBlockType *> block_ptrs(n_block_rows *
+                                                      n_block_cols);
       for (unsigned int br = 0; br < n_block_rows; ++br)
         for (unsigned int bc = 0; bc < n_block_cols; ++bc)
-          total_nnz += matrix.block(br, bc).n_nonzero_elements();
-      id.nnz = total_nnz;
-      nnz    = total_nnz;
+          block_ptrs[br * n_block_cols + bc] = &matrix.block(br, bc);
 
-      // Count local nonzeros and local rows
-      size_type total_local_non_zeros = 0;
-      size_type total_local_rows      = 0;
-
-      for (unsigned int br = 0; br < n_block_rows; ++br)
-        for (unsigned int bc = 0; bc < n_block_cols; ++bc)
-          {
-            const auto &block = matrix.block(br, bc);
-            if constexpr (std::is_same_v<Matrix,
-                                         TrilinosWrappers::BlockSparseMatrix>)
-              total_local_non_zeros += block.trilinos_matrix().NumMyNonzeros();
-            else if constexpr (std::is_same_v<
-                                 Matrix,
-                                 PETScWrappers::MPI::BlockSparseMatrix>)
-              {
-#  ifdef DEAL_II_WITH_PETSC
-                Mat &petsc_mat =
-                  const_cast<PETScWrappers::MPI::SparseMatrix &>(block)
-                    .petsc_matrix();
-                MatInfo info;
-                MatGetInfo(petsc_mat, MAT_LOCAL, &info);
-                total_local_non_zeros += static_cast<size_type>(info.nz_used);
-#  endif
-              }
-          }
-
-      for (unsigned int br = 0; br < n_block_rows; ++br)
-        {
-          const auto &block = matrix.block(br, 0);
-          if constexpr (std::is_same_v<Matrix,
-                                       TrilinosWrappers::BlockSparseMatrix>)
-            total_local_rows += block.trilinos_matrix().NumMyRows();
-          else if constexpr (std::is_same_v<
-                               Matrix,
-                               PETScWrappers::MPI::BlockSparseMatrix>)
-            {
-#  ifdef DEAL_II_WITH_PETSC
-              Mat &petsc_mat =
-                const_cast<PETScWrappers::MPI::SparseMatrix &>(block)
-                  .petsc_matrix();
-              PetscInt rstart, rend;
-              MatGetOwnershipRange(petsc_mat, &rstart, &rend);
-              total_local_rows += (rend - rstart);
-#  endif
-            }
-        }
-
-      // Allocate COO arrays
-      irn = std::make_unique<MUMPS_INT[]>(total_local_non_zeros);
-      jcn = std::make_unique<MUMPS_INT[]>(total_local_non_zeros);
-      a   = std::make_unique<double[]>(total_local_non_zeros);
-      irhs_loc.resize(total_local_rows);
-
-      size_type n_non_zero_local = 0;
-      locally_owned_rows         = IndexSet(n);
-      size_type irhs_idx         = 0;
-
-      // Iterate over all blocks and fill coordinate arrays
-      for (unsigned int br = 0; br < n_block_rows; ++br)
-        {
-          const size_type row_offset = row_block_offset[br];
-
-          if constexpr (std::is_same_v<Matrix,
-                                       TrilinosWrappers::BlockSparseMatrix>)
-            {
-              const auto block_owned =
-                matrix.block(br, 0).locally_owned_range_indices();
-
-              for (const auto &local_row_idx : block_owned)
-                locally_owned_rows.add_index(row_offset + local_row_idx);
-
-              for (unsigned int bc = 0; bc < n_block_cols; ++bc)
-                {
-                  const size_type col_offset = col_block_offset[bc];
-                  const auto     &trilinos_mat =
-                    matrix.block(br, bc).trilinos_matrix();
-
-                  for (int local_row = 0; local_row < trilinos_mat.NumMyRows();
-                       ++local_row)
-                    {
-                      int     num_entries;
-                      double *values;
-                      int    *local_cols;
-                      int     ierr = trilinos_mat.ExtractMyRowView(local_row,
-                                                               num_entries,
-                                                               values,
-                                                               local_cols);
-                      (void)ierr;
-                      Assert(ierr == 0,
-                             ExcMessage(
-                               "Error extracting row view from Trilinos block "
-                               "matrix."));
-
-                      const int global_row = trilinos_mat.GRID(local_row);
-
-                      for (int j = 0; j < num_entries; ++j)
-                        {
-                          const int global_col =
-                            trilinos_mat.GCID(local_cols[j]);
-
-                          if (additional_data.symmetric &&
-                              (col_offset + global_col) <
-                                (row_offset + global_row))
-                            continue;
-
-                          irn[n_non_zero_local] = row_offset + global_row + 1;
-                          jcn[n_non_zero_local] = col_offset + global_col + 1;
-                          a[n_non_zero_local]   = values[j];
-                          ++n_non_zero_local;
-                        }
-                    }
-                }
-
-              for (const auto &local_row_idx : block_owned)
-                irhs_loc[irhs_idx++] = row_offset + local_row_idx + 1;
-            }
-          else if constexpr (std::is_same_v<
-                               Matrix,
-                               PETScWrappers::MPI::BlockSparseMatrix>)
-            {
-#  ifdef DEAL_II_WITH_PETSC
-              Mat &first_block_mat =
-                const_cast<PETScWrappers::MPI::SparseMatrix &>(
-                  matrix.block(br, 0))
-                  .petsc_matrix();
-              PetscInt rstart, rend;
-              MatGetOwnershipRange(first_block_mat, &rstart, &rend);
-
-              for (PetscInt i = rstart; i < rend; ++i)
-                locally_owned_rows.add_index(row_offset + i);
-
-              for (unsigned int bc = 0; bc < n_block_cols; ++bc)
-                {
-                  const size_type col_offset = col_block_offset[bc];
-                  Mat            &petsc_mat =
-                    const_cast<PETScWrappers::MPI::SparseMatrix &>(
-                      matrix.block(br, bc))
-                      .petsc_matrix();
-
-                  PetscInt block_rstart, block_rend;
-                  MatGetOwnershipRange(petsc_mat, &block_rstart, &block_rend);
-
-                  for (PetscInt i = block_rstart; i < block_rend; ++i)
-                    {
-                      PetscInt           p_n_cols;
-                      const PetscInt    *cols;
-                      const PetscScalar *values;
-                      MatGetRow(petsc_mat, i, &p_n_cols, &cols, &values);
-
-                      for (PetscInt j = 0; j < p_n_cols; ++j)
-                        {
-                          if (additional_data.symmetric &&
-                              (col_offset + cols[j]) < (row_offset + i))
-                            continue;
-
-                          irn[n_non_zero_local] = row_offset + i + 1;
-                          jcn[n_non_zero_local] = col_offset + cols[j] + 1;
-                          a[n_non_zero_local]   = values[j];
-                          ++n_non_zero_local;
-                        }
-                      MatRestoreRow(petsc_mat, i, &p_n_cols, &cols, &values);
-                    }
-                }
-
-              for (PetscInt i = rstart; i < rend; ++i)
-                irhs_loc[irhs_idx++] = row_offset + i + 1;
-#  endif
-            }
-        }
-
-      locally_owned_rows.compress();
-
-      // Hand over local arrays to MUMPS
-      id.nnz_loc  = n_non_zero_local;
-      id.irn_loc  = irn.get();
-      id.jcn_loc  = jcn.get();
-      id.a_loc    = a.get();
-      id.irhs_loc = irhs_loc.data();
-
-      // rhs parameters
-      id.icntl[19] = 10; // distributed rhs
-      id.icntl[20] = 0;  // centralized solution, stored on rank 0 by MUMPS
-      id.nrhs      = 1;
-      id.lrhs_loc  = n;
-      id.nloc_rhs  = locally_owned_rows.n_elements();
+      initialize_matrix_from_individual_blocks(block_ptrs,
+                                               n_block_rows,
+                                               n_block_cols);
     }
   else
     {
@@ -1636,10 +1431,10 @@ SparseDirectMUMPS::initialize(const Matrix &matrix)
 
 
 
-template <class BlockMatrixType>
+template <class MatrixBlockType>
 void
 SparseDirectMUMPS::initialize_from_individual_blocks(
-  const std::vector<const BlockMatrixType *> &blocks,
+  const std::vector<const MatrixBlockType *> &blocks,
   const unsigned int                          n_block_rows,
   const unsigned int                          n_block_cols)
 {
@@ -1652,10 +1447,10 @@ SparseDirectMUMPS::initialize_from_individual_blocks(
 
 
 
-template <class BlockMatrixType>
+template <class MatrixBlockType>
 void
 SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
-  const std::vector<const BlockMatrixType *> &blocks,
+  const std::vector<const MatrixBlockType *> &blocks,
   const unsigned int                          n_block_rows,
   const unsigned int                          n_block_cols)
 {
@@ -1670,7 +1465,7 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
   for (unsigned int br = 0; br < n_block_rows; ++br)
     for (unsigned int bc = 0; bc < n_block_cols; ++bc)
       {
-        const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+        const MatrixBlockType *block = blocks[br * n_block_cols + bc];
         if (block != nullptr)
           {
             if (block_row_size[br] == 0)
@@ -1721,7 +1516,7 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
   for (unsigned int br = 0; br < n_block_rows; ++br)
     for (unsigned int bc = 0; bc < n_block_cols; ++bc)
       {
-        const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+        const MatrixBlockType *block = blocks[br * n_block_cols + bc];
         if (block != nullptr)
           total_nnz += block->n_nonzero_elements();
       }
@@ -1735,21 +1530,21 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
   for (unsigned int br = 0; br < n_block_rows; ++br)
     for (unsigned int bc = 0; bc < n_block_cols; ++bc)
       {
-        const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+        const MatrixBlockType *block = blocks[br * n_block_cols + bc];
         if (block == nullptr)
           continue;
 
-        if constexpr (std::is_same_v<BlockMatrixType,
+        if constexpr (std::is_same_v<MatrixBlockType,
                                      TrilinosWrappers::SparseMatrix>)
           {
             total_local_non_zeros += block->trilinos_matrix().NumMyNonzeros();
           }
-        else if constexpr (std::is_same_v<BlockMatrixType,
+        else if constexpr (std::is_same_v<MatrixBlockType,
                                           PETScWrappers::MPI::SparseMatrix>)
           {
 #  ifdef DEAL_II_WITH_PETSC
             Mat &petsc_mat =
-              const_cast<BlockMatrixType &>(*block).petsc_matrix();
+              const_cast<MatrixBlockType &>(*block).petsc_matrix();
             MatInfo info;
             MatGetInfo(petsc_mat, MAT_LOCAL, &info);
             total_local_non_zeros += static_cast<size_type>(info.nz_used);
@@ -1764,7 +1559,7 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
   for (unsigned int br = 0; br < n_block_rows; ++br)
     {
       // Find the first non-null block in this row to determine local rows
-      const BlockMatrixType *first_block = nullptr;
+      const MatrixBlockType *first_block = nullptr;
       for (unsigned int bc = 0; bc < n_block_cols; ++bc)
         {
           first_block = blocks[br * n_block_cols + bc];
@@ -1774,17 +1569,17 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
       if (first_block == nullptr)
         continue;
 
-      if constexpr (std::is_same_v<BlockMatrixType,
+      if constexpr (std::is_same_v<MatrixBlockType,
                                    TrilinosWrappers::SparseMatrix>)
         {
           total_local_rows += first_block->trilinos_matrix().NumMyRows();
         }
-      else if constexpr (std::is_same_v<BlockMatrixType,
+      else if constexpr (std::is_same_v<MatrixBlockType,
                                         PETScWrappers::MPI::SparseMatrix>)
         {
 #  ifdef DEAL_II_WITH_PETSC
           Mat &petsc_mat =
-            const_cast<BlockMatrixType &>(*first_block).petsc_matrix();
+            const_cast<MatrixBlockType &>(*first_block).petsc_matrix();
           PetscInt rstart, rend;
           MatGetOwnershipRange(petsc_mat, &rstart, &rend);
           total_local_rows += (rend - rstart);
@@ -1807,11 +1602,11 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
     {
       const size_type row_offset = row_block_offset[br];
 
-      if constexpr (std::is_same_v<BlockMatrixType,
+      if constexpr (std::is_same_v<MatrixBlockType,
                                    TrilinosWrappers::SparseMatrix>)
         {
           // Find the first non-null block in this row to get owned rows
-          const BlockMatrixType *first_block = nullptr;
+          const MatrixBlockType *first_block = nullptr;
           for (unsigned int bc = 0; bc < n_block_cols; ++bc)
             {
               first_block = blocks[br * n_block_cols + bc];
@@ -1828,7 +1623,7 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
 
           for (unsigned int bc = 0; bc < n_block_cols; ++bc)
             {
-              const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+              const MatrixBlockType *block = blocks[br * n_block_cols + bc];
               if (block == nullptr)
                 continue;
 
@@ -1871,12 +1666,12 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
           for (const auto &local_row_idx : block_owned)
             irhs_loc[irhs_idx++] = row_offset + local_row_idx + 1;
         }
-      else if constexpr (std::is_same_v<BlockMatrixType,
+      else if constexpr (std::is_same_v<MatrixBlockType,
                                         PETScWrappers::MPI::SparseMatrix>)
         {
 #  ifdef DEAL_II_WITH_PETSC
           // Find the first non-null block in this row
-          const BlockMatrixType *first_block = nullptr;
+          const MatrixBlockType *first_block = nullptr;
           for (unsigned int bc = 0; bc < n_block_cols; ++bc)
             {
               first_block = blocks[br * n_block_cols + bc];
@@ -1887,7 +1682,7 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
             continue;
 
           Mat &first_block_mat =
-            const_cast<BlockMatrixType &>(*first_block).petsc_matrix();
+            const_cast<MatrixBlockType &>(*first_block).petsc_matrix();
           PetscInt rstart, rend;
           MatGetOwnershipRange(first_block_mat, &rstart, &rend);
 
@@ -1896,13 +1691,13 @@ SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
 
           for (unsigned int bc = 0; bc < n_block_cols; ++bc)
             {
-              const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+              const MatrixBlockType *block = blocks[br * n_block_cols + bc];
               if (block == nullptr)
                 continue;
 
               const size_type col_offset = col_block_offset[bc];
               Mat            &petsc_mat =
-                const_cast<BlockMatrixType &>(*block).petsc_matrix();
+                const_cast<MatrixBlockType &>(*block).petsc_matrix();
 
               PetscInt block_rstart, block_rend;
               MatGetOwnershipRange(petsc_mat, &block_rstart, &block_rend);

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -1636,6 +1636,324 @@ SparseDirectMUMPS::initialize(const Matrix &matrix)
 
 
 
+template <class BlockMatrixType>
+void
+SparseDirectMUMPS::initialize_from_individual_blocks(
+  const std::vector<const BlockMatrixType *> &blocks,
+  const unsigned int                          n_block_rows,
+  const unsigned int                          n_block_cols)
+{
+  initialize_matrix_from_individual_blocks(blocks, n_block_rows, n_block_cols);
+
+  // Start analysis + factorization
+  id.job = 4;
+  dmumps_c(&id);
+}
+
+
+
+template <class BlockMatrixType>
+void
+SparseDirectMUMPS::initialize_matrix_from_individual_blocks(
+  const std::vector<const BlockMatrixType *> &blocks,
+  const unsigned int                          n_block_rows,
+  const unsigned int                          n_block_cols)
+{
+  Assert(blocks.size() == n_block_rows * n_block_cols,
+         ExcMessage("The number of blocks must equal "
+                    "n_block_rows * n_block_cols."));
+
+  // Determine block row sizes from the first non-null block in each row
+  std::vector<size_type> block_row_size(n_block_rows, 0);
+  std::vector<size_type> block_col_size(n_block_cols, 0);
+
+  for (unsigned int br = 0; br < n_block_rows; ++br)
+    for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+      {
+        const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+        if (block != nullptr)
+          {
+            if (block_row_size[br] == 0)
+              block_row_size[br] = block->m();
+            else
+              Assert(block_row_size[br] == block->m(),
+                     ExcDimensionMismatch(block_row_size[br], block->m()));
+
+            if (block_col_size[bc] == 0)
+              block_col_size[bc] = block->n();
+            else
+              Assert(block_col_size[bc] == block->n(),
+                     ExcDimensionMismatch(block_col_size[bc], block->n()));
+          }
+      }
+
+  // Compute total size and row/column offsets
+  std::vector<size_type> row_block_offset(n_block_rows + 1, 0);
+  std::vector<size_type> col_block_offset(n_block_cols + 1, 0);
+  for (unsigned int br = 0; br < n_block_rows; ++br)
+    row_block_offset[br + 1] = row_block_offset[br] + block_row_size[br];
+  for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+    col_block_offset[bc + 1] = col_block_offset[bc] + block_col_size[bc];
+
+  const size_type total_rows = row_block_offset[n_block_rows];
+  const size_type total_cols = col_block_offset[n_block_cols];
+  Assert(total_rows == total_cols,
+         ExcMessage("The assembled block system must be square."));
+
+  n    = total_rows;
+  id.n = n;
+
+  // Distributed matrix assembly
+  id.icntl[17] = 3;
+
+  // MUMPS block format (ICNTL(15) = 1)
+  id.icntl[14] = 1;
+  id.nblk      = n_block_rows;
+
+  blkptr.resize(n_block_rows + 1);
+  for (unsigned int br = 0; br <= n_block_rows; ++br)
+    blkptr[br] = row_block_offset[br] + 1; // 1-based Fortran indexing
+  id.blkptr = blkptr.data();
+  id.blkvar = nullptr; // identity permutation
+
+  // Count total nonzeros across all blocks
+  types::mumps_nnz total_nnz = 0;
+  for (unsigned int br = 0; br < n_block_rows; ++br)
+    for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+      {
+        const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+        if (block != nullptr)
+          total_nnz += block->n_nonzero_elements();
+      }
+  id.nnz = total_nnz;
+  nnz    = total_nnz;
+
+  // Count local nonzeros and local rows
+  size_type total_local_non_zeros = 0;
+  size_type total_local_rows      = 0;
+
+  for (unsigned int br = 0; br < n_block_rows; ++br)
+    for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+      {
+        const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+        if (block == nullptr)
+          continue;
+
+        if constexpr (std::is_same_v<BlockMatrixType,
+                                     TrilinosWrappers::SparseMatrix>)
+          {
+            total_local_non_zeros += block->trilinos_matrix().NumMyNonzeros();
+          }
+        else if constexpr (std::is_same_v<BlockMatrixType,
+                                          PETScWrappers::MPI::SparseMatrix>)
+          {
+#  ifdef DEAL_II_WITH_PETSC
+            Mat &petsc_mat =
+              const_cast<BlockMatrixType &>(*block).petsc_matrix();
+            MatInfo info;
+            MatGetInfo(petsc_mat, MAT_LOCAL, &info);
+            total_local_non_zeros += static_cast<size_type>(info.nz_used);
+#  endif
+          }
+        else
+          {
+            DEAL_II_NOT_IMPLEMENTED();
+          }
+      }
+
+  for (unsigned int br = 0; br < n_block_rows; ++br)
+    {
+      // Find the first non-null block in this row to determine local rows
+      const BlockMatrixType *first_block = nullptr;
+      for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+        {
+          first_block = blocks[br * n_block_cols + bc];
+          if (first_block != nullptr)
+            break;
+        }
+      if (first_block == nullptr)
+        continue;
+
+      if constexpr (std::is_same_v<BlockMatrixType,
+                                   TrilinosWrappers::SparseMatrix>)
+        {
+          total_local_rows += first_block->trilinos_matrix().NumMyRows();
+        }
+      else if constexpr (std::is_same_v<BlockMatrixType,
+                                        PETScWrappers::MPI::SparseMatrix>)
+        {
+#  ifdef DEAL_II_WITH_PETSC
+          Mat &petsc_mat =
+            const_cast<BlockMatrixType &>(*first_block).petsc_matrix();
+          PetscInt rstart, rend;
+          MatGetOwnershipRange(petsc_mat, &rstart, &rend);
+          total_local_rows += (rend - rstart);
+#  endif
+        }
+    }
+
+  // Allocate COO arrays
+  irn = std::make_unique<MUMPS_INT[]>(total_local_non_zeros);
+  jcn = std::make_unique<MUMPS_INT[]>(total_local_non_zeros);
+  a   = std::make_unique<double[]>(total_local_non_zeros);
+  irhs_loc.resize(total_local_rows);
+
+  size_type n_non_zero_local = 0;
+  locally_owned_rows         = IndexSet(n);
+  size_type irhs_idx         = 0;
+
+  // Iterate over all blocks and fill coordinate arrays
+  for (unsigned int br = 0; br < n_block_rows; ++br)
+    {
+      const size_type row_offset = row_block_offset[br];
+
+      if constexpr (std::is_same_v<BlockMatrixType,
+                                   TrilinosWrappers::SparseMatrix>)
+        {
+          // Find the first non-null block in this row to get owned rows
+          const BlockMatrixType *first_block = nullptr;
+          for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+            {
+              first_block = blocks[br * n_block_cols + bc];
+              if (first_block != nullptr)
+                break;
+            }
+          if (first_block == nullptr)
+            continue;
+
+          const auto block_owned = first_block->locally_owned_range_indices();
+
+          for (const auto &local_row_idx : block_owned)
+            locally_owned_rows.add_index(row_offset + local_row_idx);
+
+          for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+            {
+              const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+              if (block == nullptr)
+                continue;
+
+              const size_type col_offset   = col_block_offset[bc];
+              const auto     &trilinos_mat = block->trilinos_matrix();
+
+              for (int local_row = 0; local_row < trilinos_mat.NumMyRows();
+                   ++local_row)
+                {
+                  int     num_entries;
+                  double *values;
+                  int    *local_cols;
+                  int     ierr = trilinos_mat.ExtractMyRowView(local_row,
+                                                           num_entries,
+                                                           values,
+                                                           local_cols);
+                  (void)ierr;
+                  Assert(ierr == 0,
+                         ExcMessage("Error extracting row view from Trilinos "
+                                    "matrix."));
+
+                  const int global_row = trilinos_mat.GRID(local_row);
+
+                  for (int j = 0; j < num_entries; ++j)
+                    {
+                      const int global_col = trilinos_mat.GCID(local_cols[j]);
+
+                      if (additional_data.symmetric &&
+                          (col_offset + global_col) < (row_offset + global_row))
+                        continue;
+
+                      irn[n_non_zero_local] = row_offset + global_row + 1;
+                      jcn[n_non_zero_local] = col_offset + global_col + 1;
+                      a[n_non_zero_local]   = values[j];
+                      ++n_non_zero_local;
+                    }
+                }
+            }
+
+          for (const auto &local_row_idx : block_owned)
+            irhs_loc[irhs_idx++] = row_offset + local_row_idx + 1;
+        }
+      else if constexpr (std::is_same_v<BlockMatrixType,
+                                        PETScWrappers::MPI::SparseMatrix>)
+        {
+#  ifdef DEAL_II_WITH_PETSC
+          // Find the first non-null block in this row
+          const BlockMatrixType *first_block = nullptr;
+          for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+            {
+              first_block = blocks[br * n_block_cols + bc];
+              if (first_block != nullptr)
+                break;
+            }
+          if (first_block == nullptr)
+            continue;
+
+          Mat &first_block_mat =
+            const_cast<BlockMatrixType &>(*first_block).petsc_matrix();
+          PetscInt rstart, rend;
+          MatGetOwnershipRange(first_block_mat, &rstart, &rend);
+
+          for (PetscInt i = rstart; i < rend; ++i)
+            locally_owned_rows.add_index(row_offset + i);
+
+          for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+            {
+              const BlockMatrixType *block = blocks[br * n_block_cols + bc];
+              if (block == nullptr)
+                continue;
+
+              const size_type col_offset = col_block_offset[bc];
+              Mat            &petsc_mat =
+                const_cast<BlockMatrixType &>(*block).petsc_matrix();
+
+              PetscInt block_rstart, block_rend;
+              MatGetOwnershipRange(petsc_mat, &block_rstart, &block_rend);
+
+              for (PetscInt i = block_rstart; i < block_rend; ++i)
+                {
+                  PetscInt           p_n_cols;
+                  const PetscInt    *cols;
+                  const PetscScalar *values;
+                  MatGetRow(petsc_mat, i, &p_n_cols, &cols, &values);
+
+                  for (PetscInt j = 0; j < p_n_cols; ++j)
+                    {
+                      if (additional_data.symmetric &&
+                          (col_offset + cols[j]) < (row_offset + i))
+                        continue;
+
+                      irn[n_non_zero_local] = row_offset + i + 1;
+                      jcn[n_non_zero_local] = col_offset + cols[j] + 1;
+                      a[n_non_zero_local]   = values[j];
+                      ++n_non_zero_local;
+                    }
+                  MatRestoreRow(petsc_mat, i, &p_n_cols, &cols, &values);
+                }
+            }
+
+          for (PetscInt i = rstart; i < rend; ++i)
+            irhs_loc[irhs_idx++] = row_offset + i + 1;
+#  endif
+        }
+    }
+
+  locally_owned_rows.compress();
+
+  // Hand over local arrays to MUMPS
+  id.nnz_loc  = n_non_zero_local;
+  id.irn_loc  = irn.get();
+  id.jcn_loc  = jcn.get();
+  id.a_loc    = a.get();
+  id.irhs_loc = irhs_loc.data();
+
+  // rhs parameters
+  id.icntl[19] = 10; // distributed rhs
+  id.icntl[20] = 0;  // centralized solution, stored on rank 0 by MUMPS
+  id.nrhs      = 1;
+  id.lrhs_loc  = n;
+  id.nloc_rhs  = locally_owned_rows.n_elements();
+}
+
+
+
 template <typename VectorType>
 void
 SparseDirectMUMPS::vmult(VectorType &dst, const VectorType &src) const
@@ -1953,6 +2271,18 @@ InstantiateMUMPSMatVec(TrilinosWrappers::MPI::Vector)
   // InstantiateMUMPS(SparseMatrixEZ<float>)
   InstantiateMUMPS(BlockSparseMatrix<double>)
     InstantiateMUMPS(BlockSparseMatrix<float>)
+
+#  define InstantiateMUMPSBlocks(BLOCKMATRIX)                           \
+    template void SparseDirectMUMPS::initialize_from_individual_blocks( \
+      const std::vector<const BLOCKMATRIX *> &,                         \
+      const unsigned int,                                               \
+      const unsigned int);
+#  ifdef DEAL_II_WITH_TRILINOS
+      InstantiateMUMPSBlocks(TrilinosWrappers::SparseMatrix)
+#  endif
+#  ifdef DEAL_II_WITH_PETSC
+        InstantiateMUMPSBlocks(PETScWrappers::MPI::SparseMatrix)
+#  endif
 #endif
 
-      DEAL_II_NAMESPACE_CLOSE
+          DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -34,12 +34,23 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+namespace TrilinosWrappers
+{
+  class SparseMatrix;
+  namespace MPI
+  {
+    class SparseMatrix;
+    class Vector;
+  } // namespace MPI
+} // namespace TrilinosWrappers
 namespace PETScWrappers
 {
   namespace MPI
   {
     class SparseMatrix;
+    class BlockSparseMatrix;
     class Vector;
+    class BlockVector;
   } // namespace MPI
 } // namespace PETScWrappers
 
@@ -1327,6 +1338,244 @@ SparseDirectMUMPS::initialize_matrix(const Matrix &matrix)
       id.lrhs_loc  = n;
       id.nloc_rhs  = locally_owned_rows.n_elements();
     }
+  else if constexpr (std::is_same_v<Matrix,
+                                    TrilinosWrappers::BlockSparseMatrix> ||
+                     std::is_same_v<Matrix,
+                                    PETScWrappers::MPI::BlockSparseMatrix>)
+    {
+      int result;
+      MPI_Comm_compare(mpi_communicator,
+                       matrix.get_mpi_communicator(),
+                       &result);
+      AssertThrow(result == MPI_IDENT,
+                  ExcMessage("The matrix communicator must match the MUMPS "
+                             "communicator."));
+
+      // Distributed block matrix case
+      id.icntl[17] = 3; // distributed matrix assembly
+
+      const unsigned int n_block_rows = matrix.n_block_rows();
+      const unsigned int n_block_cols = matrix.n_block_cols();
+
+      // Compute row and column offsets for each block
+      std::vector<size_type> row_block_offset(n_block_rows + 1, 0);
+      std::vector<size_type> col_block_offset(n_block_cols + 1, 0);
+      for (unsigned int br = 0; br < n_block_rows; ++br)
+        row_block_offset[br + 1] =
+          row_block_offset[br] + matrix.block(br, 0).m();
+      for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+        col_block_offset[bc + 1] =
+          col_block_offset[bc] + matrix.block(0, bc).n();
+
+      // activate MUMPS block format and describe the block structure
+      id.icntl[14] = 1; // ICNTL(15) = 1:user-provided block format
+      id.nblk      = n_block_rows;
+
+      // blkptr[iblk] gives the position of the first variable in block iblk.
+      blkptr.resize(n_block_rows + 1);
+      for (unsigned int br = 0; br <= n_block_rows; ++br)
+        blkptr[br] = row_block_offset[br] + 1; // 1-based Fortran indexing
+      id.blkptr = blkptr.data();
+
+      // blkvar = nullptr means identity permutation. Variables are assumed to
+      // be already in block order, which is the case for deal.II block matrices
+      // with component-wise DoF renumbering.
+      id.blkvar = nullptr;
+
+      // count total nonzeros across all blocks
+      types::mumps_nnz total_nnz = 0;
+      for (unsigned int br = 0; br < n_block_rows; ++br)
+        for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+          total_nnz += matrix.block(br, bc).n_nonzero_elements();
+      id.nnz = total_nnz;
+      nnz    = total_nnz;
+
+      // Count local nonzeros and local rows
+      size_type total_local_non_zeros = 0;
+      size_type total_local_rows      = 0;
+
+      for (unsigned int br = 0; br < n_block_rows; ++br)
+        for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+          {
+            const auto &block = matrix.block(br, bc);
+            if constexpr (std::is_same_v<Matrix,
+                                         TrilinosWrappers::BlockSparseMatrix>)
+              total_local_non_zeros += block.trilinos_matrix().NumMyNonzeros();
+            else if constexpr (std::is_same_v<
+                                 Matrix,
+                                 PETScWrappers::MPI::BlockSparseMatrix>)
+              {
+#  ifdef DEAL_II_WITH_PETSC
+                Mat &petsc_mat =
+                  const_cast<PETScWrappers::MPI::SparseMatrix &>(block)
+                    .petsc_matrix();
+                MatInfo info;
+                MatGetInfo(petsc_mat, MAT_LOCAL, &info);
+                total_local_non_zeros += static_cast<size_type>(info.nz_used);
+#  endif
+              }
+          }
+
+      for (unsigned int br = 0; br < n_block_rows; ++br)
+        {
+          const auto &block = matrix.block(br, 0);
+          if constexpr (std::is_same_v<Matrix,
+                                       TrilinosWrappers::BlockSparseMatrix>)
+            total_local_rows += block.trilinos_matrix().NumMyRows();
+          else if constexpr (std::is_same_v<
+                               Matrix,
+                               PETScWrappers::MPI::BlockSparseMatrix>)
+            {
+#  ifdef DEAL_II_WITH_PETSC
+              Mat &petsc_mat =
+                const_cast<PETScWrappers::MPI::SparseMatrix &>(block)
+                  .petsc_matrix();
+              PetscInt rstart, rend;
+              MatGetOwnershipRange(petsc_mat, &rstart, &rend);
+              total_local_rows += (rend - rstart);
+#  endif
+            }
+        }
+
+      // Allocate COO arrays
+      irn = std::make_unique<MUMPS_INT[]>(total_local_non_zeros);
+      jcn = std::make_unique<MUMPS_INT[]>(total_local_non_zeros);
+      a   = std::make_unique<double[]>(total_local_non_zeros);
+      irhs_loc.resize(total_local_rows);
+
+      size_type n_non_zero_local = 0;
+      locally_owned_rows         = IndexSet(n);
+      size_type irhs_idx         = 0;
+
+      // Iterate over all blocks and fill coordinate arrays
+      for (unsigned int br = 0; br < n_block_rows; ++br)
+        {
+          const size_type row_offset = row_block_offset[br];
+
+          if constexpr (std::is_same_v<Matrix,
+                                       TrilinosWrappers::BlockSparseMatrix>)
+            {
+              const auto block_owned =
+                matrix.block(br, 0).locally_owned_range_indices();
+
+              for (const auto &local_row_idx : block_owned)
+                locally_owned_rows.add_index(row_offset + local_row_idx);
+
+              for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+                {
+                  const size_type col_offset = col_block_offset[bc];
+                  const auto     &trilinos_mat =
+                    matrix.block(br, bc).trilinos_matrix();
+
+                  for (int local_row = 0; local_row < trilinos_mat.NumMyRows();
+                       ++local_row)
+                    {
+                      int     num_entries;
+                      double *values;
+                      int    *local_cols;
+                      int     ierr = trilinos_mat.ExtractMyRowView(local_row,
+                                                               num_entries,
+                                                               values,
+                                                               local_cols);
+                      (void)ierr;
+                      Assert(ierr == 0,
+                             ExcMessage(
+                               "Error extracting row view from Trilinos block "
+                               "matrix."));
+
+                      const int global_row = trilinos_mat.GRID(local_row);
+
+                      for (int j = 0; j < num_entries; ++j)
+                        {
+                          const int global_col =
+                            trilinos_mat.GCID(local_cols[j]);
+
+                          if (additional_data.symmetric &&
+                              (col_offset + global_col) <
+                                (row_offset + global_row))
+                            continue;
+
+                          irn[n_non_zero_local] = row_offset + global_row + 1;
+                          jcn[n_non_zero_local] = col_offset + global_col + 1;
+                          a[n_non_zero_local]   = values[j];
+                          ++n_non_zero_local;
+                        }
+                    }
+                }
+
+              for (const auto &local_row_idx : block_owned)
+                irhs_loc[irhs_idx++] = row_offset + local_row_idx + 1;
+            }
+          else if constexpr (std::is_same_v<
+                               Matrix,
+                               PETScWrappers::MPI::BlockSparseMatrix>)
+            {
+#  ifdef DEAL_II_WITH_PETSC
+              Mat &first_block_mat =
+                const_cast<PETScWrappers::MPI::SparseMatrix &>(
+                  matrix.block(br, 0))
+                  .petsc_matrix();
+              PetscInt rstart, rend;
+              MatGetOwnershipRange(first_block_mat, &rstart, &rend);
+
+              for (PetscInt i = rstart; i < rend; ++i)
+                locally_owned_rows.add_index(row_offset + i);
+
+              for (unsigned int bc = 0; bc < n_block_cols; ++bc)
+                {
+                  const size_type col_offset = col_block_offset[bc];
+                  Mat            &petsc_mat =
+                    const_cast<PETScWrappers::MPI::SparseMatrix &>(
+                      matrix.block(br, bc))
+                      .petsc_matrix();
+
+                  PetscInt block_rstart, block_rend;
+                  MatGetOwnershipRange(petsc_mat, &block_rstart, &block_rend);
+
+                  for (PetscInt i = block_rstart; i < block_rend; ++i)
+                    {
+                      PetscInt           p_n_cols;
+                      const PetscInt    *cols;
+                      const PetscScalar *values;
+                      MatGetRow(petsc_mat, i, &p_n_cols, &cols, &values);
+
+                      for (PetscInt j = 0; j < p_n_cols; ++j)
+                        {
+                          if (additional_data.symmetric &&
+                              (col_offset + cols[j]) < (row_offset + i))
+                            continue;
+
+                          irn[n_non_zero_local] = row_offset + i + 1;
+                          jcn[n_non_zero_local] = col_offset + cols[j] + 1;
+                          a[n_non_zero_local]   = values[j];
+                          ++n_non_zero_local;
+                        }
+                      MatRestoreRow(petsc_mat, i, &p_n_cols, &cols, &values);
+                    }
+                }
+
+              for (PetscInt i = rstart; i < rend; ++i)
+                irhs_loc[irhs_idx++] = row_offset + i + 1;
+#  endif
+            }
+        }
+
+      locally_owned_rows.compress();
+
+      // Hand over local arrays to MUMPS
+      id.nnz_loc  = n_non_zero_local;
+      id.irn_loc  = irn.get();
+      id.jcn_loc  = jcn.get();
+      id.a_loc    = a.get();
+      id.irhs_loc = irhs_loc.data();
+
+      // rhs parameters
+      id.icntl[19] = 10; // distributed rhs
+      id.icntl[20] = 0;  // centralized solution, stored on rank 0 by MUMPS
+      id.nrhs      = 1;
+      id.lrhs_loc  = n;
+      id.nloc_rhs  = locally_owned_rows.n_elements();
+    }
   else
     {
       DEAL_II_NOT_IMPLEMENTED();
@@ -1505,6 +1754,82 @@ SparseDirectMUMPS::vmult(VectorType &dst, const VectorType &src) const
 
       rhs.resize(0); // remove rhs again
     }
+  else if constexpr (std::is_same_v<VectorType,
+                                    TrilinosWrappers::MPI::BlockVector> ||
+                     std::is_same_v<VectorType,
+                                    PETScWrappers::MPI::BlockVector>)
+    {
+      // For block vectors, copy local data from each block into a flat
+      // rhs_loc buffer.  The order must match how irhs_loc was filled in
+      // initialize_matrix: block 0 local rows, then block 1, etc.
+      const unsigned int  n_blocks = src.n_blocks();
+      std::vector<double> local_rhs;
+      local_rhs.reserve(locally_owned_rows.n_elements());
+
+      for (unsigned int b = 0; b < n_blocks; ++b)
+        {
+          if constexpr (std::is_same_v<VectorType,
+                                       TrilinosWrappers::MPI::BlockVector>)
+            {
+              const auto &bv = src.block(b);
+              for (auto it = bv.begin(); it != bv.end(); ++it)
+                local_rhs.push_back(*it);
+            }
+          else if constexpr (std::is_same_v<VectorType,
+                                            PETScWrappers::MPI::BlockVector>)
+            {
+#  ifdef DEAL_II_WITH_PETSC
+              PetscScalar *local_array;
+              PetscInt     local_size;
+              VecGetArray(const_cast<PETScWrappers::MPI::Vector &>(src.block(b))
+                            .petsc_vector(),
+                          &local_array);
+              VecGetLocalSize(const_cast<PETScWrappers::MPI::Vector &>(
+                                src.block(b))
+                                .petsc_vector(),
+                              &local_size);
+              for (PetscInt i = 0; i < local_size; ++i)
+                local_rhs.push_back(local_array[i]);
+              VecRestoreArray(const_cast<PETScWrappers::MPI::Vector &>(
+                                src.block(b))
+                                .petsc_vector(),
+                              &local_array);
+#  endif
+            }
+        }
+
+      id.rhs_loc = local_rhs.data();
+
+      if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
+        {
+          rhs.resize(n);
+          id.rhs = rhs.data();
+        }
+
+      // Start solver
+      id.job = 3;
+      dmumps_c(&id);
+
+      // Broadcast the full centralized solution from rank 0 to all processes.
+      if (Utilities::MPI::this_mpi_process(mpi_communicator) != 0)
+        rhs.resize(n);
+      MPI_Bcast(rhs.data(), n, MPI_DOUBLE, 0, mpi_communicator);
+
+      // Write solution back into the block vector
+      std::vector<size_type> block_offset(n_blocks + 1, 0);
+      for (unsigned int b = 0; b < n_blocks; ++b)
+        block_offset[b + 1] = block_offset[b] + dst.block(b).size();
+
+      for (unsigned int b = 0; b < n_blocks; ++b)
+        {
+          const IndexSet &block_owned = dst.block(b).locally_owned_elements();
+          for (const auto &idx : block_owned)
+            dst.block(b)[idx] = rhs[block_offset[b] + idx];
+          dst.block(b).compress(VectorOperation::insert);
+        }
+
+      rhs.resize(0);
+    }
   else
     {
       DEAL_II_NOT_IMPLEMENTED();
@@ -1601,24 +1926,28 @@ InstantiateUMFPACK(BlockSparseMatrix<std::complex<float>>);
     template void SparseDirectMUMPS::Tvmult(VECTOR &, const VECTOR &) const;
 #  ifdef DEAL_II_WITH_TRILINOS
 InstantiateMUMPSMatVec(TrilinosWrappers::MPI::Vector)
+  InstantiateMUMPSMatVec(TrilinosWrappers::MPI::BlockVector)
 #  endif
 #  ifdef DEAL_II_WITH_PETSC
-  InstantiateMUMPSMatVec(PETScWrappers::MPI::Vector)
+    InstantiateMUMPSMatVec(PETScWrappers::MPI::Vector)
+      InstantiateMUMPSMatVec(PETScWrappers::MPI::BlockVector)
 #  endif
-    InstantiateMUMPSMatVec(Vector<double>)
-      InstantiateMUMPSMatVec(LinearAlgebra::distributed::Vector<double>)
+        InstantiateMUMPSMatVec(Vector<double>)
+          InstantiateMUMPSMatVec(LinearAlgebra::distributed::Vector<double>)
 
 #  define InstantiateMUMPS(MATRIX) \
     template void SparseDirectMUMPS::initialize(const MATRIX &);
 
-        InstantiateMUMPS(SparseMatrix<double>)
-          InstantiateMUMPS(SparseMatrix<float>)
+            InstantiateMUMPS(SparseMatrix<double>)
+              InstantiateMUMPS(SparseMatrix<float>)
 #  ifdef DEAL_II_WITH_TRILINOS
-            InstantiateMUMPS(TrilinosWrappers::SparseMatrix)
+                InstantiateMUMPS(TrilinosWrappers::SparseMatrix)
+                  InstantiateMUMPS(TrilinosWrappers::BlockSparseMatrix)
 #  endif
 #  ifdef DEAL_II_WITH_PETSC
-              InstantiateMUMPS(PETScWrappers::SparseMatrix)
-                InstantiateMUMPS(PETScWrappers::MPI::SparseMatrix)
+                    InstantiateMUMPS(PETScWrappers::SparseMatrix)
+                      InstantiateMUMPS(PETScWrappers::MPI::SparseMatrix)
+                        InstantiateMUMPS(PETScWrappers::MPI::BlockSparseMatrix)
 #  endif
   // InstantiateMUMPS(SparseMatrixEZ<double>)
   // InstantiateMUMPS(SparseMatrixEZ<float>)

--- a/tests/mumps/mumps_07.cc
+++ b/tests/mumps/mumps_07.cc
@@ -1,0 +1,223 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// test the mumps sparse direct solver in parallel on
+// TrilinosWrappers::BlockSparseMatrix and PETScWrappers::MPI::BlockSparseMatrix
+// with their respective block vectors
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/petsc_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_sparse_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparsity_tools.h>
+#include <deal.II/lac/trilinos_block_sparse_matrix.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_vector.h>
+
+#include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+
+#include "../tests/tests.h"
+
+
+// Test MUMPS with block matrices and block vectors.
+
+template <int dim, typename MatrixType, typename VectorType>
+void
+test()
+{
+  deallog << dim << 'd' << std::endl;
+
+  MPI_Comm mpi_communicator = MPI_COMM_WORLD;
+
+  parallel::distributed::Triangulation<dim> tria(mpi_communicator);
+  GridGenerator::hyper_cube(tria, -1, 1);
+  tria.refine_global(1);
+
+  // Destroy the uniformity of the mesh by refining one cell
+  tria.begin_active()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.refine_global(8 - 2 * dim);
+
+  // Use a FESystem with 2 components to create a block structure
+  const FESystem<dim> fe(FE_Q<dim>(1), 2);
+  DoFHandler<dim>     dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  // Renumber in block structure
+  DoFRenumbering::component_wise(dof_handler);
+
+  const std::vector<types::global_dof_index> dofs_per_component =
+    DoFTools::count_dofs_per_fe_component(dof_handler);
+  const unsigned int n_u = dofs_per_component[0];
+  const unsigned int n_v = dofs_per_component[1];
+
+  deallog << "Number of dofs = " << dof_handler.n_dofs() << " (" << n_u << " + "
+          << n_v << ")" << std::endl;
+
+  const auto locally_owned_dofs = dof_handler.locally_owned_dofs();
+  const auto locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(dof_handler);
+
+  // Create block index sets
+  std::vector<IndexSet> locally_owned_partitioning(2);
+  std::vector<IndexSet> locally_relevant_partitioning(2);
+
+  locally_owned_partitioning[0] = locally_owned_dofs.get_view(0, n_u);
+  locally_owned_partitioning[1] = locally_owned_dofs.get_view(n_u, n_u + n_v);
+
+  locally_relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
+  locally_relevant_partitioning[1] =
+    locally_relevant_dofs.get_view(n_u, n_u + n_v);
+
+  // Build block sparsity pattern
+  BlockDynamicSparsityPattern dsp(2, 2);
+  dsp.block(0, 0).reinit(n_u, n_u);
+  dsp.block(0, 1).reinit(n_u, n_v);
+  dsp.block(1, 0).reinit(n_v, n_u);
+  dsp.block(1, 1).reinit(n_v, n_v);
+  dsp.collect_sizes();
+
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
+
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             mpi_communicator,
+                                             locally_relevant_dofs);
+
+  // Create block matrix
+  MatrixType B;
+  B.reinit(locally_owned_partitioning, dsp, mpi_communicator);
+
+  QGauss<dim>   qr(2);
+  FEValues<dim> fe_values(
+    fe, qr, update_values | update_JxW_values | update_quadrature_points);
+
+  const FEValuesExtractors::Scalar comp_0(0);
+  const FEValuesExtractors::Scalar comp_1(1);
+
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
+  const unsigned int n_q_points    = qr.size();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        fe_values.reinit(cell);
+        cell_matrix = 0;
+
+        for (unsigned int q = 0; q < n_q_points; ++q)
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            for (unsigned int j = 0; j < dofs_per_cell; ++j)
+              cell_matrix(i, j) +=
+                (fe_values[comp_0].value(i, q) * fe_values[comp_0].value(j, q) +
+                 fe_values[comp_1].value(i, q) *
+                   fe_values[comp_1].value(j, q)) *
+                fe_values.JxW(q);
+
+        cell->get_dof_indices(local_dof_indices);
+        constraints.distribute_local_to_global(cell_matrix,
+                                               local_dof_indices,
+                                               B);
+      }
+  B.compress(VectorOperation::add);
+
+  // Initialize MUMPS with the block matrix
+  SparseDirectMUMPS::AdditionalData data;
+  data.output_details = false;
+  data.symmetric      = true;
+  data.posdef         = true;
+  SparseDirectMUMPS Binv(data, B.get_mpi_communicator());
+  Binv.initialize(B);
+
+  // same as mumps_07
+  for (unsigned int i = 0; i < 3; ++i)
+    {
+      VectorType solution(locally_owned_partitioning, mpi_communicator);
+      VectorType x(locally_owned_partitioning, mpi_communicator);
+      VectorType b(locally_owned_partitioning, mpi_communicator);
+
+      for (const types::global_dof_index idx : dof_handler.locally_owned_dofs())
+        {
+          if (idx < n_u)
+            solution.block(0)(idx) = idx + idx * (i + 1) * (i + 1);
+          else
+            solution.block(1)(idx - n_u) =
+              (idx - n_u) + (idx - n_u) * (i + 1) * (i + 1);
+        }
+      solution.compress(VectorOperation::insert);
+
+      B.vmult(b, solution);
+
+      Binv.vmult(x, b);
+
+      x -= solution;
+      deallog << "relative norm distance = " << x.l2_norm() / solution.l2_norm()
+              << std::endl;
+      deallog << "absolute norms = " << x.l2_norm() << ' ' << solution.l2_norm()
+              << std::endl;
+      Assert(x.l2_norm() / solution.l2_norm() < 1e-8, ExcInternalError());
+    }
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, numbers::invalid_unsigned_int);
+
+  MPILogInitAll log(true);
+
+  deallog << "Trilinos block matrices and vectors" << std::endl;
+  test<2,
+       TrilinosWrappers::BlockSparseMatrix,
+       TrilinosWrappers::MPI::BlockVector>();
+  test<3,
+       TrilinosWrappers::BlockSparseMatrix,
+       TrilinosWrappers::MPI::BlockVector>();
+
+  deallog << "PETSc block matrices and vectors" << std::endl;
+  test<2,
+       PETScWrappers::MPI::BlockSparseMatrix,
+       PETScWrappers::MPI::BlockVector>();
+  test<3,
+       PETScWrappers::MPI::BlockSparseMatrix,
+       PETScWrappers::MPI::BlockVector>();
+}

--- a/tests/mumps/mumps_07.with_p4est=true.with_trilinos=true.with_petsc=true.mpirun=2.output
+++ b/tests/mumps/mumps_07.with_p4est=true.with_trilinos=true.with_petsc=true.mpirun=2.output
@@ -1,0 +1,71 @@
+
+DEAL:0::Trilinos block matrices and vectors
+DEAL:0::2d
+DEAL:0::Number of dofs = 3778 (1889 + 1889)
+DEAL:0::relative norm distance = 4.70784e-16
+DEAL:0::absolute norms = 6.30930e-11 134017.
+DEAL:0::relative norm distance = 4.50873e-16
+DEAL:0::absolute norms = 1.51062e-10 335042.
+DEAL:0::relative norm distance = 4.50873e-16
+DEAL:0::absolute norms = 3.02123e-10 670085.
+DEAL:0::3d
+DEAL:0::Number of dofs = 2666 (1333 + 1333)
+DEAL:0::relative norm distance = 1.39130e-15
+DEAL:0::absolute norms = 1.10511e-10 79430.1
+DEAL:0::relative norm distance = 1.21668e-15
+DEAL:0::absolute norms = 2.41603e-10 198575.
+DEAL:0::relative norm distance = 1.21668e-15
+DEAL:0::absolute norms = 4.83206e-10 397151.
+DEAL:0::PETSc block matrices and vectors
+DEAL:0::2d
+DEAL:0::Number of dofs = 3778 (1889 + 1889)
+DEAL:0::relative norm distance = 4.09725e-16
+DEAL:0::absolute norms = 5.49101e-11 134017.
+DEAL:0::relative norm distance = 4.21333e-16
+DEAL:0::absolute norms = 1.41164e-10 335042.
+DEAL:0::relative norm distance = 4.21333e-16
+DEAL:0::absolute norms = 2.82329e-10 670085.
+DEAL:0::3d
+DEAL:0::Number of dofs = 2666 (1333 + 1333)
+DEAL:0::relative norm distance = 9.67728e-16
+DEAL:0::absolute norms = 7.68667e-11 79430.1
+DEAL:0::relative norm distance = 9.74352e-16
+DEAL:0::absolute norms = 1.93482e-10 198575.
+DEAL:0::relative norm distance = 9.74352e-16
+DEAL:0::absolute norms = 3.86965e-10 397151.
+
+DEAL:1::Trilinos block matrices and vectors
+DEAL:1::2d
+DEAL:1::Number of dofs = 3778 (1889 + 1889)
+DEAL:1::relative norm distance = 4.70784e-16
+DEAL:1::absolute norms = 6.30930e-11 134017.
+DEAL:1::relative norm distance = 4.50873e-16
+DEAL:1::absolute norms = 1.51062e-10 335042.
+DEAL:1::relative norm distance = 4.50873e-16
+DEAL:1::absolute norms = 3.02123e-10 670085.
+DEAL:1::3d
+DEAL:1::Number of dofs = 2666 (1333 + 1333)
+DEAL:1::relative norm distance = 1.39130e-15
+DEAL:1::absolute norms = 1.10511e-10 79430.1
+DEAL:1::relative norm distance = 1.21668e-15
+DEAL:1::absolute norms = 2.41603e-10 198575.
+DEAL:1::relative norm distance = 1.21668e-15
+DEAL:1::absolute norms = 4.83206e-10 397151.
+DEAL:1::PETSc block matrices and vectors
+DEAL:1::2d
+DEAL:1::Number of dofs = 3778 (1889 + 1889)
+DEAL:1::relative norm distance = 4.09725e-16
+DEAL:1::absolute norms = 5.49101e-11 134017.
+DEAL:1::relative norm distance = 4.21333e-16
+DEAL:1::absolute norms = 1.41164e-10 335042.
+DEAL:1::relative norm distance = 4.21333e-16
+DEAL:1::absolute norms = 2.82329e-10 670085.
+DEAL:1::3d
+DEAL:1::Number of dofs = 2666 (1333 + 1333)
+DEAL:1::relative norm distance = 9.67728e-16
+DEAL:1::absolute norms = 7.68667e-11 79430.1
+DEAL:1::relative norm distance = 9.74352e-16
+DEAL:1::absolute norms = 1.93482e-10 198575.
+DEAL:1::relative norm distance = 9.74352e-16
+DEAL:1::absolute norms = 3.86965e-10 397151.
+

--- a/tests/mumps/mumps_08.cc
+++ b/tests/mumps/mumps_08.cc
@@ -1,0 +1,451 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// Test MUMPS as a direct solver for the Stokes (saddle-point) system,
+// based on the Kovasznay flow problem from step-55. It uses
+// PETScWrappers::MPI::BlockSparseMatrix and PETScWrappers::MPI::BlockVector on
+// 2 MPI processes.
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/petsc_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparsity_tools.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+
+#include "../tests/tests.h"
+
+// Test the MUMPS wrappers for the block system of the Stokes equations.
+
+namespace StokesTest
+{
+  using namespace dealii;
+
+  // Kovasznay exact solution (2D, dim+1 components: u_x, u_y, p)
+  template <int dim>
+  class ExactSolution : public Function<dim>
+  {
+  public:
+    ExactSolution()
+      : Function<dim>(dim + 1)
+    {}
+
+    virtual void
+    vector_value(const Point<dim> &p, Vector<double> &values) const override;
+  };
+
+  template <int dim>
+  void
+  ExactSolution<dim>::vector_value(const Point<dim> &p,
+                                   Vector<double>   &values) const
+  {
+    const double R_x = p[0];
+    const double R_y = p[1];
+
+    const double pi  = numbers::PI;
+    const double pi2 = pi * pi;
+
+    values[0] =
+      -exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * cos(2 * R_y * pi) + 1;
+    values[1] = (1.0L / 2.0L) * (-sqrt(25.0 + 4 * pi2) + 5.0) *
+                exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * sin(2 * R_y * pi) /
+                pi;
+    values[2] =
+      -1.0L / 2.0L * exp(R_x * (-2 * sqrt(25.0 + 4 * pi2) + 10.0)) -
+      2.0 *
+        (-6538034.74494422 +
+         0.0134758939981709 * exp(4 * sqrt(25.0 + 4 * pi2))) /
+        (-80.0 * exp(3 * sqrt(25.0 + 4 * pi2)) +
+         16.0 * sqrt(25.0 + 4 * pi2) * exp(3 * sqrt(25.0 + 4 * pi2))) -
+      1634508.68623606 * exp(-3.0 * sqrt(25.0 + 4 * pi2)) /
+        (-10.0 + 2.0 * sqrt(25.0 + 4 * pi2)) +
+      (-0.00673794699908547 * exp(sqrt(25.0 + 4 * pi2)) +
+       3269017.37247211 * exp(-3 * sqrt(25.0 + 4 * pi2))) /
+        (-8 * sqrt(25.0 + 4 * pi2) + 40.0) +
+      0.00336897349954273 * exp(1.0 * sqrt(25.0 + 4 * pi2)) /
+        (-10.0 + 2.0 * sqrt(25.0 + 4 * pi2));
+  }
+
+
+  // Kovasznay right-hand side (body force for Stokes with viscosity=0.1)
+  template <int dim>
+  class RightHandSide : public Function<dim>
+  {
+  public:
+    RightHandSide()
+      : Function<dim>(dim + 1)
+    {}
+
+    virtual void
+    vector_value(const Point<dim> &p, Vector<double> &values) const override;
+  };
+
+  template <int dim>
+  void
+  RightHandSide<dim>::vector_value(const Point<dim> &p,
+                                   Vector<double>   &values) const
+  {
+    const double R_x = p[0];
+    const double R_y = p[1];
+
+    const double pi  = numbers::PI;
+    const double pi2 = pi * pi;
+
+    values[0] =
+      -1.0L / 2.0L * (-2 * sqrt(25.0 + 4 * pi2) + 10.0) *
+        exp(R_x * (-2 * sqrt(25.0 + 4 * pi2) + 10.0)) -
+      0.4 * pi2 * exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * cos(2 * R_y * pi) +
+      0.1 * pow(-sqrt(25.0 + 4 * pi2) + 5.0, 2) *
+        exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * cos(2 * R_y * pi);
+    values[1] = 0.2 * pi * (-sqrt(25.0 + 4 * pi2) + 5.0) *
+                  exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * sin(2 * R_y * pi) -
+                0.05 * pow(-sqrt(25.0 + 4 * pi2) + 5.0, 3) *
+                  exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * sin(2 * R_y * pi) /
+                  pi;
+    values[2] = 0;
+  }
+
+
+  template <int dim>
+  class StokesProblem
+  {
+  public:
+    StokesProblem(unsigned int velocity_degree);
+    void
+    run();
+
+  private:
+    void
+    setup_system();
+    void
+    assemble_system();
+    void
+    solve();
+    void
+    compute_errors() const;
+
+    const unsigned int velocity_degree;
+    const double       viscosity;
+    MPI_Comm           mpi_communicator;
+
+    parallel::distributed::Triangulation<dim> triangulation;
+    FESystem<dim>                             fe;
+    DoFHandler<dim>                           dof_handler;
+
+    std::vector<IndexSet> owned_partitioning;
+    std::vector<IndexSet> relevant_partitioning;
+
+    AffineConstraints<double> constraints;
+
+    PETScWrappers::MPI::BlockSparseMatrix system_matrix;
+    PETScWrappers::MPI::BlockVector       locally_relevant_solution;
+    PETScWrappers::MPI::BlockVector       system_rhs;
+  };
+
+
+  template <int dim>
+  StokesProblem<dim>::StokesProblem(unsigned int velocity_degree)
+    : velocity_degree(velocity_degree)
+    , viscosity(0.1)
+    , mpi_communicator(MPI_COMM_WORLD)
+    , triangulation(mpi_communicator,
+                    typename Triangulation<dim>::MeshSmoothing(
+                      Triangulation<dim>::smoothing_on_refinement |
+                      Triangulation<dim>::smoothing_on_coarsening))
+    , fe(FE_Q<dim>(velocity_degree), dim, FE_Q<dim>(velocity_degree - 1), 1)
+    , dof_handler(triangulation)
+  {}
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::setup_system()
+  {
+    dof_handler.distribute_dofs(fe);
+
+    std::vector<unsigned int> stokes_sub_blocks(dim + 1, 0);
+    stokes_sub_blocks[dim] = 1;
+    DoFRenumbering::component_wise(dof_handler, stokes_sub_blocks);
+
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
+
+    const unsigned int n_u = dofs_per_block[0];
+    const unsigned int n_p = dofs_per_block[1];
+
+    deallog << "Number of dofs = " << dof_handler.n_dofs() << " (" << n_u
+            << " + " << n_p << ")" << std::endl;
+
+    owned_partitioning.resize(2);
+    owned_partitioning[0] = dof_handler.locally_owned_dofs().get_view(0, n_u);
+    owned_partitioning[1] =
+      dof_handler.locally_owned_dofs().get_view(n_u, n_u + n_p);
+
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
+    relevant_partitioning.resize(2);
+    relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
+    relevant_partitioning[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);
+
+    {
+      constraints.reinit(dof_handler.locally_owned_dofs(),
+                         locally_relevant_dofs);
+
+      const FEValuesExtractors::Vector velocities(0);
+      DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+      VectorTools::interpolate_boundary_values(dof_handler,
+                                               0,
+                                               ExactSolution<dim>(),
+                                               constraints,
+                                               fe.component_mask(velocities));
+      constraints.close();
+    }
+
+    // System matrix sparsity
+    {
+      system_matrix.clear();
+
+      Table<2, DoFTools::Coupling> coupling(dim + 1, dim + 1);
+      for (unsigned int c = 0; c < dim + 1; ++c)
+        for (unsigned int d = 0; d < dim + 1; ++d)
+          if (c == dim && d == dim)
+            coupling[c][d] = DoFTools::none;
+          else if (c == dim || d == dim || c == d)
+            coupling[c][d] = DoFTools::always;
+          else
+            coupling[c][d] = DoFTools::none;
+
+      BlockDynamicSparsityPattern dsp(dofs_per_block, dofs_per_block);
+
+      DoFTools::make_sparsity_pattern(
+        dof_handler, coupling, dsp, constraints, false);
+
+      SparsityTools::distribute_sparsity_pattern(
+        dsp,
+        dof_handler.locally_owned_dofs(),
+        mpi_communicator,
+        locally_relevant_dofs);
+
+      system_matrix.reinit(owned_partitioning, dsp, mpi_communicator);
+    }
+
+    locally_relevant_solution.reinit(owned_partitioning,
+                                     relevant_partitioning,
+                                     mpi_communicator);
+    system_rhs.reinit(owned_partitioning, mpi_communicator);
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::assemble_system()
+  {
+    system_matrix = 0;
+    system_rhs    = 0;
+
+    const QGauss<dim> quadrature_formula(velocity_degree + 1);
+
+    FEValues<dim> fe_values(fe,
+                            quadrature_formula,
+                            update_values | update_gradients |
+                              update_quadrature_points | update_JxW_values);
+
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
+    const unsigned int n_q_points    = quadrature_formula.size();
+
+    FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>     cell_rhs(dofs_per_cell);
+
+    const RightHandSide<dim>    right_hand_side;
+    std::vector<Vector<double>> rhs_values(n_q_points, Vector<double>(dim + 1));
+
+    std::vector<Tensor<2, dim>> grad_phi_u(dofs_per_cell);
+    std::vector<double>         div_phi_u(dofs_per_cell);
+    std::vector<double>         phi_p(dofs_per_cell);
+
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+    const FEValuesExtractors::Vector     velocities(0);
+    const FEValuesExtractors::Scalar     pressure(dim);
+
+    for (const auto &cell : dof_handler.active_cell_iterators() |
+                              IteratorFilters::LocallyOwnedCell())
+      {
+        cell_matrix = 0;
+        cell_rhs    = 0;
+
+        fe_values.reinit(cell);
+        right_hand_side.vector_value_list(fe_values.get_quadrature_points(),
+                                          rhs_values);
+
+        for (unsigned int q = 0; q < n_q_points; ++q)
+          {
+            for (unsigned int k = 0; k < dofs_per_cell; ++k)
+              {
+                grad_phi_u[k] = fe_values[velocities].gradient(k, q);
+                div_phi_u[k]  = fe_values[velocities].divergence(k, q);
+                phi_p[k]      = fe_values[pressure].value(k, q);
+              }
+
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                  {
+                    cell_matrix(i, j) +=
+                      (viscosity *
+                         scalar_product(grad_phi_u[i], grad_phi_u[j]) -
+                       div_phi_u[i] * phi_p[j] - phi_p[i] * div_phi_u[j]) *
+                      fe_values.JxW(q);
+                  }
+
+                const unsigned int component_i =
+                  fe.system_to_component_index(i).first;
+                cell_rhs(i) += fe_values.shape_value(i, q) *
+                               rhs_values[q](component_i) * fe_values.JxW(q);
+              }
+          }
+
+        cell->get_dof_indices(local_dof_indices);
+        constraints.distribute_local_to_global(
+          cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+      }
+
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::solve()
+  {
+    // Stokes system is indefinite
+    SparseDirectMUMPS::AdditionalData data;
+    data.output_details = false;
+    data.symmetric      = false;
+    data.posdef         = false;
+    SparseDirectMUMPS solver(data, system_matrix.get_mpi_communicator());
+    solver.initialize(system_matrix);
+
+    PETScWrappers::MPI::BlockVector distributed_solution(owned_partitioning,
+                                                         mpi_communicator);
+
+    solver.vmult(distributed_solution, system_rhs);
+
+    constraints.distribute(distributed_solution);
+
+    // Subtract mean pressure to match the exact solution
+    locally_relevant_solution = distributed_solution;
+    const double mean_pressure =
+      VectorTools::compute_mean_value(dof_handler,
+                                      QGauss<dim>(velocity_degree + 2),
+                                      locally_relevant_solution,
+                                      dim);
+    distributed_solution.block(1).add(-mean_pressure);
+    locally_relevant_solution.block(1) = distributed_solution.block(1);
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::compute_errors() const
+  {
+    const ComponentSelectFunction<dim> pressure_mask(dim, dim + 1);
+    const ComponentSelectFunction<dim> velocity_mask(std::make_pair(0, dim),
+                                                     dim + 1);
+
+    Vector<double>    cellwise_errors(triangulation.n_active_cells());
+    const QGauss<dim> quadrature(velocity_degree + 2);
+
+    VectorTools::integrate_difference(dof_handler,
+                                      locally_relevant_solution,
+                                      ExactSolution<dim>(),
+                                      cellwise_errors,
+                                      quadrature,
+                                      VectorTools::L2_norm,
+                                      &velocity_mask);
+
+    const double error_u_l2 =
+      VectorTools::compute_global_error(triangulation,
+                                        cellwise_errors,
+                                        VectorTools::L2_norm);
+
+    VectorTools::integrate_difference(dof_handler,
+                                      locally_relevant_solution,
+                                      ExactSolution<dim>(),
+                                      cellwise_errors,
+                                      quadrature,
+                                      VectorTools::L2_norm,
+                                      &pressure_mask);
+
+    const double error_p_l2 =
+      VectorTools::compute_global_error(triangulation,
+                                        cellwise_errors,
+                                        VectorTools::L2_norm);
+
+    deallog << "error: u_0: " << error_u_l2 << " p_0: " << error_p_l2
+            << std::endl;
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::run()
+  {
+    GridGenerator::hyper_cube(triangulation, -0.5, 1.5);
+    triangulation.refine_global(3);
+
+    setup_system();
+    assemble_system();
+    solve();
+    compute_errors();
+  }
+} // namespace StokesTest
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll log(true);
+
+  {
+    using namespace StokesTest;
+    StokesProblem<2> problem(2);
+    problem.run();
+  }
+
+  return 0;
+}

--- a/tests/mumps/mumps_08.with_p4est=true.with_petsc=true.mpirun=2.output
+++ b/tests/mumps/mumps_08.with_p4est=true.with_petsc=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0::Number of dofs = 659 (578 + 81)
+DEAL:0::error: u_0: 0.0806514 p_0: 0.348625
+
+DEAL:1::Number of dofs = 659 (578 + 81)
+DEAL:1::error: u_0: 0.0806514 p_0: 0.348625
+

--- a/tests/mumps/mumps_09.cc
+++ b/tests/mumps/mumps_09.cc
@@ -1,0 +1,462 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// Test MUMPS initialize_from_individual_blocks() for the Stokes
+// (saddle-point) system, based on the Kovasznay flow problem from step-55.
+// Instead of passing a monolithic PETScWrappers::MPI::BlockSparseMatrix to
+// initialize(), this test passes pointers to the individual
+// PETScWrappers::MPI::SparseMatrix sub-blocks into
+// initialize_from_individual_blocks(). The (1,1) pressure-pressure block is
+// passed as nullptr to exercise the zero-block code path.
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_renumbering.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/petsc_block_sparse_matrix.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparsity_tools.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+
+#include "../tests/tests.h"
+
+// Same as mumps_08.cc, but with initialize_from_individual_blocks()
+// function. Blocks are given separately to MUMPS.
+
+namespace StokesTest
+{
+  using namespace dealii;
+
+  // Kovasznay exact solution (2D, dim+1 components: u_x, u_y, p)
+  template <int dim>
+  class ExactSolution : public Function<dim>
+  {
+  public:
+    ExactSolution()
+      : Function<dim>(dim + 1)
+    {}
+
+    virtual void
+    vector_value(const Point<dim> &p, Vector<double> &values) const override;
+  };
+
+  template <int dim>
+  void
+  ExactSolution<dim>::vector_value(const Point<dim> &p,
+                                   Vector<double>   &values) const
+  {
+    const double R_x = p[0];
+    const double R_y = p[1];
+
+    const double pi  = numbers::PI;
+    const double pi2 = pi * pi;
+
+    values[0] =
+      -exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * cos(2 * R_y * pi) + 1;
+    values[1] = (1.0L / 2.0L) * (-sqrt(25.0 + 4 * pi2) + 5.0) *
+                exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * sin(2 * R_y * pi) /
+                pi;
+    values[2] =
+      -1.0L / 2.0L * exp(R_x * (-2 * sqrt(25.0 + 4 * pi2) + 10.0)) -
+      2.0 *
+        (-6538034.74494422 +
+         0.0134758939981709 * exp(4 * sqrt(25.0 + 4 * pi2))) /
+        (-80.0 * exp(3 * sqrt(25.0 + 4 * pi2)) +
+         16.0 * sqrt(25.0 + 4 * pi2) * exp(3 * sqrt(25.0 + 4 * pi2))) -
+      1634508.68623606 * exp(-3.0 * sqrt(25.0 + 4 * pi2)) /
+        (-10.0 + 2.0 * sqrt(25.0 + 4 * pi2)) +
+      (-0.00673794699908547 * exp(sqrt(25.0 + 4 * pi2)) +
+       3269017.37247211 * exp(-3 * sqrt(25.0 + 4 * pi2))) /
+        (-8 * sqrt(25.0 + 4 * pi2) + 40.0) +
+      0.00336897349954273 * exp(1.0 * sqrt(25.0 + 4 * pi2)) /
+        (-10.0 + 2.0 * sqrt(25.0 + 4 * pi2));
+  }
+
+
+  // Kovasznay right-hand side (body force for Stokes with viscosity=0.1)
+  template <int dim>
+  class RightHandSide : public Function<dim>
+  {
+  public:
+    RightHandSide()
+      : Function<dim>(dim + 1)
+    {}
+
+    virtual void
+    vector_value(const Point<dim> &p, Vector<double> &values) const override;
+  };
+
+  template <int dim>
+  void
+  RightHandSide<dim>::vector_value(const Point<dim> &p,
+                                   Vector<double>   &values) const
+  {
+    const double R_x = p[0];
+    const double R_y = p[1];
+
+    const double pi  = numbers::PI;
+    const double pi2 = pi * pi;
+
+    values[0] =
+      -1.0L / 2.0L * (-2 * sqrt(25.0 + 4 * pi2) + 10.0) *
+        exp(R_x * (-2 * sqrt(25.0 + 4 * pi2) + 10.0)) -
+      0.4 * pi2 * exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * cos(2 * R_y * pi) +
+      0.1 * pow(-sqrt(25.0 + 4 * pi2) + 5.0, 2) *
+        exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * cos(2 * R_y * pi);
+    values[1] = 0.2 * pi * (-sqrt(25.0 + 4 * pi2) + 5.0) *
+                  exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * sin(2 * R_y * pi) -
+                0.05 * pow(-sqrt(25.0 + 4 * pi2) + 5.0, 3) *
+                  exp(R_x * (-sqrt(25.0 + 4 * pi2) + 5.0)) * sin(2 * R_y * pi) /
+                  pi;
+    values[2] = 0;
+  }
+
+
+  template <int dim>
+  class StokesProblem
+  {
+  public:
+    StokesProblem(unsigned int velocity_degree);
+    void
+    run();
+
+  private:
+    void
+    setup_system();
+    void
+    assemble_system();
+    void
+    solve();
+    void
+    compute_errors() const;
+
+    const unsigned int velocity_degree;
+    const double       viscosity;
+    MPI_Comm           mpi_communicator;
+
+    parallel::distributed::Triangulation<dim> triangulation;
+    FESystem<dim>                             fe;
+    DoFHandler<dim>                           dof_handler;
+
+    std::vector<IndexSet> owned_partitioning;
+    std::vector<IndexSet> relevant_partitioning;
+
+    AffineConstraints<double> constraints;
+
+    PETScWrappers::MPI::BlockSparseMatrix system_matrix;
+    PETScWrappers::MPI::BlockVector       locally_relevant_solution;
+    PETScWrappers::MPI::BlockVector       system_rhs;
+  };
+
+
+  template <int dim>
+  StokesProblem<dim>::StokesProblem(unsigned int velocity_degree)
+    : velocity_degree(velocity_degree)
+    , viscosity(0.1)
+    , mpi_communicator(MPI_COMM_WORLD)
+    , triangulation(mpi_communicator,
+                    typename Triangulation<dim>::MeshSmoothing(
+                      Triangulation<dim>::smoothing_on_refinement |
+                      Triangulation<dim>::smoothing_on_coarsening))
+    , fe(FE_Q<dim>(velocity_degree), dim, FE_Q<dim>(velocity_degree - 1), 1)
+    , dof_handler(triangulation)
+  {}
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::setup_system()
+  {
+    dof_handler.distribute_dofs(fe);
+
+    std::vector<unsigned int> stokes_sub_blocks(dim + 1, 0);
+    stokes_sub_blocks[dim] = 1;
+    DoFRenumbering::component_wise(dof_handler, stokes_sub_blocks);
+
+    const std::vector<types::global_dof_index> dofs_per_block =
+      DoFTools::count_dofs_per_fe_block(dof_handler, stokes_sub_blocks);
+
+    const unsigned int n_u = dofs_per_block[0];
+    const unsigned int n_p = dofs_per_block[1];
+
+    deallog << "Number of dofs = " << dof_handler.n_dofs() << " (" << n_u
+            << " + " << n_p << ")" << std::endl;
+
+    owned_partitioning.resize(2);
+    owned_partitioning[0] = dof_handler.locally_owned_dofs().get_view(0, n_u);
+    owned_partitioning[1] =
+      dof_handler.locally_owned_dofs().get_view(n_u, n_u + n_p);
+
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
+    relevant_partitioning.resize(2);
+    relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
+    relevant_partitioning[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);
+
+    {
+      constraints.reinit(dof_handler.locally_owned_dofs(),
+                         locally_relevant_dofs);
+
+      const FEValuesExtractors::Vector velocities(0);
+      DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+      VectorTools::interpolate_boundary_values(dof_handler,
+                                               0,
+                                               ExactSolution<dim>(),
+                                               constraints,
+                                               fe.component_mask(velocities));
+      constraints.close();
+    }
+
+    {
+      system_matrix.clear();
+
+      Table<2, DoFTools::Coupling> coupling(dim + 1, dim + 1);
+      for (unsigned int c = 0; c < dim + 1; ++c)
+        for (unsigned int d = 0; d < dim + 1; ++d)
+          if (c == dim && d == dim)
+            coupling[c][d] = DoFTools::none;
+          else if (c == dim || d == dim || c == d)
+            coupling[c][d] = DoFTools::always;
+          else
+            coupling[c][d] = DoFTools::none;
+
+      BlockDynamicSparsityPattern dsp(dofs_per_block, dofs_per_block);
+
+      DoFTools::make_sparsity_pattern(
+        dof_handler, coupling, dsp, constraints, false);
+
+      SparsityTools::distribute_sparsity_pattern(
+        dsp,
+        dof_handler.locally_owned_dofs(),
+        mpi_communicator,
+        locally_relevant_dofs);
+
+      system_matrix.reinit(owned_partitioning, dsp, mpi_communicator);
+    }
+
+    locally_relevant_solution.reinit(owned_partitioning,
+                                     relevant_partitioning,
+                                     mpi_communicator);
+    system_rhs.reinit(owned_partitioning, mpi_communicator);
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::assemble_system()
+  {
+    system_matrix = 0;
+    system_rhs    = 0;
+
+    const QGauss<dim> quadrature_formula(velocity_degree + 1);
+
+    FEValues<dim> fe_values(fe,
+                            quadrature_formula,
+                            update_values | update_gradients |
+                              update_quadrature_points | update_JxW_values);
+
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
+    const unsigned int n_q_points    = quadrature_formula.size();
+
+    FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+    Vector<double>     cell_rhs(dofs_per_cell);
+
+    const RightHandSide<dim>    right_hand_side;
+    std::vector<Vector<double>> rhs_values(n_q_points, Vector<double>(dim + 1));
+
+    std::vector<Tensor<2, dim>> grad_phi_u(dofs_per_cell);
+    std::vector<double>         div_phi_u(dofs_per_cell);
+    std::vector<double>         phi_p(dofs_per_cell);
+
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+    const FEValuesExtractors::Vector     velocities(0);
+    const FEValuesExtractors::Scalar     pressure(dim);
+
+    for (const auto &cell : dof_handler.active_cell_iterators() |
+                              IteratorFilters::LocallyOwnedCell())
+      {
+        cell_matrix = 0;
+        cell_rhs    = 0;
+
+        fe_values.reinit(cell);
+        right_hand_side.vector_value_list(fe_values.get_quadrature_points(),
+                                          rhs_values);
+
+        for (unsigned int q = 0; q < n_q_points; ++q)
+          {
+            for (unsigned int k = 0; k < dofs_per_cell; ++k)
+              {
+                grad_phi_u[k] = fe_values[velocities].gradient(k, q);
+                div_phi_u[k]  = fe_values[velocities].divergence(k, q);
+                phi_p[k]      = fe_values[pressure].value(k, q);
+              }
+
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                  {
+                    cell_matrix(i, j) +=
+                      (viscosity *
+                         scalar_product(grad_phi_u[i], grad_phi_u[j]) -
+                       div_phi_u[i] * phi_p[j] - phi_p[i] * div_phi_u[j]) *
+                      fe_values.JxW(q);
+                  }
+
+                const unsigned int component_i =
+                  fe.system_to_component_index(i).first;
+                cell_rhs(i) += fe_values.shape_value(i, q) *
+                               rhs_values[q](component_i) * fe_values.JxW(q);
+              }
+          }
+
+        cell->get_dof_indices(local_dof_indices);
+        constraints.distribute_local_to_global(
+          cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+      }
+
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::solve()
+  {
+    // Stokes system is indefinite
+    SparseDirectMUMPS::AdditionalData data;
+    data.output_details = false;
+    data.symmetric      = false;
+    data.posdef         = false;
+    SparseDirectMUMPS solver(data, system_matrix.get_mpi_communicator());
+
+    // Instead of solver.initialize(system_matrix), pass individual blocks.
+    // The (1,1) pressure-pressure block is zero, so we pass nullptr.
+    std::vector<const PETScWrappers::MPI::SparseMatrix *> blocks = {
+      &system_matrix.block(0, 0),
+      &system_matrix.block(0, 1),
+      &system_matrix.block(1, 0),
+      nullptr};
+    solver.initialize_from_individual_blocks(blocks, 2, 2);
+
+    PETScWrappers::MPI::BlockVector distributed_solution(owned_partitioning,
+                                                         mpi_communicator);
+
+    solver.vmult(distributed_solution, system_rhs);
+
+    constraints.distribute(distributed_solution);
+
+    // Subtract mean pressure to match the exact solution
+    locally_relevant_solution = distributed_solution;
+    const double mean_pressure =
+      VectorTools::compute_mean_value(dof_handler,
+                                      QGauss<dim>(velocity_degree + 2),
+                                      locally_relevant_solution,
+                                      dim);
+    distributed_solution.block(1).add(-mean_pressure);
+    locally_relevant_solution.block(1) = distributed_solution.block(1);
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::compute_errors() const
+  {
+    const ComponentSelectFunction<dim> pressure_mask(dim, dim + 1);
+    const ComponentSelectFunction<dim> velocity_mask(std::make_pair(0, dim),
+                                                     dim + 1);
+
+    Vector<double>    cellwise_errors(triangulation.n_active_cells());
+    const QGauss<dim> quadrature(velocity_degree + 2);
+
+    VectorTools::integrate_difference(dof_handler,
+                                      locally_relevant_solution,
+                                      ExactSolution<dim>(),
+                                      cellwise_errors,
+                                      quadrature,
+                                      VectorTools::L2_norm,
+                                      &velocity_mask);
+
+    const double error_u_l2 =
+      VectorTools::compute_global_error(triangulation,
+                                        cellwise_errors,
+                                        VectorTools::L2_norm);
+
+    VectorTools::integrate_difference(dof_handler,
+                                      locally_relevant_solution,
+                                      ExactSolution<dim>(),
+                                      cellwise_errors,
+                                      quadrature,
+                                      VectorTools::L2_norm,
+                                      &pressure_mask);
+
+    const double error_p_l2 =
+      VectorTools::compute_global_error(triangulation,
+                                        cellwise_errors,
+                                        VectorTools::L2_norm);
+
+    deallog << "error: u_0: " << error_u_l2 << " p_0: " << error_p_l2
+            << std::endl;
+  }
+
+
+  template <int dim>
+  void
+  StokesProblem<dim>::run()
+  {
+    GridGenerator::hyper_cube(triangulation, -0.5, 1.5);
+    triangulation.refine_global(3);
+
+    setup_system();
+    assemble_system();
+    solve();
+    compute_errors();
+  }
+} // namespace StokesTest
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll log(true);
+
+  {
+    using namespace StokesTest;
+    StokesProblem<2> problem(2);
+    problem.run();
+  }
+
+  return 0;
+}

--- a/tests/mumps/mumps_09.with_p4est=true.with_petsc=true.mpirun=2.output
+++ b/tests/mumps/mumps_09.with_p4est=true.with_petsc=true.mpirun=2.output
@@ -1,0 +1,7 @@
+
+DEAL:0::Number of dofs = 659 (578 + 81)
+DEAL:0::error: u_0: 0.0806514 p_0: 0.348625
+
+DEAL:1::Number of dofs = 659 (578 + 81)
+DEAL:1::error: u_0: 0.0806514 p_0: 0.348625
+


### PR DESCRIPTION
This PR extends the MUMPS wrapper to support distributed block sparse matrices. The implementation works by explicitly providing MUMPS with information about the block structure of the underlying system, allowing it to correctly interpret and factorize the matrix.

The current interface supports two types of input:

- a classically assembled block matrix (e.g. Stokes problems),
- individual blocks provided separately as a vector of pointers to sparse matrices (assumed to be in row-major order).

This functionality is implemented in initialize_from_individual_blocks(). For the Stokes problem, usage is as follows:
```C++
    // assume system_matrix to be a block sparse matrix previously assembled. 
    std::vector<const PETScWrappers::MPI::SparseMatrix *> blocks = {
      &system_matrix.block(0, 0),
      &system_matrix.block(0, 1),
      &system_matrix.block(1, 0),
      nullptr /*(2,2) block is 0*/};
    solver.initialize_from_individual_blocks(blocks, 2, 2);
```

Three tests have been added:
- a simple block-structured system,
- a step-55 Stokes example using an assembled block sparse matrix,
- a step-55 variant where only individual blocks are provided.

Once merged, this can be integrated into step-80 (#18888), trimming the number of lines a bit more by using initialize_from_individual_blocks(). @luca-heltai @blaisb