### PR TITLE
Also export operator<=> from the std module.

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -709,6 +709,7 @@ export
     using std::operator>=;
     using std::operator<;
     using std::operator>;
+    using std::operator<=>;
   } // namespace std
 
 #if defined(__GLIBCXX__) // For GCC's support library


### PR DESCRIPTION
Needed now for #18071.

`operator<=>` is a C++20 thing, but of course module descriptions are also only relevant for C++20, so this is fine. (I ran into this because somewhere deep in the guts of the matrixfree framework, we compare `std::array` objects against each other. C++20 has removed the individual comparison operators for `std::array` in favor of a single `operator<=>`, which is now called in that place.)