### PR TITLE
Reorganize headers to make them work with modules.

### DIFF
--- a/include/deal.II/arborx/access_traits.h
+++ b/include/deal.II/arborx/access_traits.h
@@ -22,9 +22,11 @@
 
 #  include <utility>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_ARBORX
 namespace ArborXWrappers
 {
 #  if ARBORX_VERSION_MAJOR < 2
@@ -660,7 +662,6 @@ namespace ArborXWrappers
 #  endif
 } // namespace ArborXWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 /**
  * This namespace contains the implementation of AccessTraits used by ArborX.
@@ -1426,14 +1427,8 @@ namespace ArborX
 #  endif
 } // namespace ArborX
 
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/arborx/bvh.h
+++ b/include/deal.II/arborx/bvh.h
@@ -22,8 +22,11 @@
 #  include <ArborX_LinearBVH.hpp>
 #  include <Kokkos_Core.hpp>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_ARBORX
 /**
  * This namespace contains wrappers for the ArborX library.
  */
@@ -309,15 +312,7 @@ namespace ArborXWrappers
 #  endif
 } // namespace ArborXWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/arborx/distributed_tree.h
+++ b/include/deal.II/arborx/distributed_tree.h
@@ -23,8 +23,11 @@
 #  include <ArborX_DistributedTree.hpp>
 #  include <Kokkos_Core.hpp>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#if defined(DEAL_II_ARBORX_WITH_MPI) && defined(DEAL_II_WITH_MPI)
 namespace ArborXWrappers
 {
   /**
@@ -226,15 +229,7 @@ namespace ArborXWrappers
 #  endif
 } // namespace ArborXWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -24,8 +24,11 @@
 
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_GSL
 namespace Functions
 {
   DeclException1(ExcCSplineEmpty,
@@ -131,16 +134,8 @@ namespace Functions
   };
 } // namespace Functions
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -25,8 +25,11 @@
 
 #  include <numeric>
 
+#endif // DEAL_II_WITH_HDF5
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_HDF5
 // It is necessary to turn clang-format off in order to maintain the Doxygen
 // links because they are longer than 80 characters
 // clang-format off
@@ -2245,17 +2248,8 @@ namespace HDF5
   }
 } // namespace HDF5
 
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_HDF5
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_hdf5_h

--- a/include/deal.II/base/mpi_large_count.h
+++ b/include/deal.II/base/mpi_large_count.h
@@ -32,8 +32,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 // required for std::numeric_limits used below.
 #  include <limits>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_MPI
 namespace Utilities
 {
   namespace MPI
@@ -440,15 +443,7 @@ namespace Utilities
   }   // namespace MPI
 } // namespace Utilities
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/base/mpi_stub.h
+++ b/include/deal.II/base/mpi_stub.h
@@ -25,16 +25,17 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <mpi.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
+#endif
 
-#else
+
+DEAL_II_NAMESPACE_OPEN
+
+#ifndef DEAL_II_WITH_MPI
 
 // Without MPI, we would still like to use some constructs with MPI
 // data types. Therefore, create some dummies. Since we only ever use
 // them inside our own constructs, the right thing to do is to put
 // them into namespace dealii:
-DEAL_II_NAMESPACE_OPEN
 
 using MPI_Comm     = int;
 using MPI_Request  = int;
@@ -50,8 +51,8 @@ constexpr MPI_Op      MPI_MAX          = 0;
 constexpr MPI_Op      MPI_SUM          = 0;
 constexpr MPI_Op      MPI_LAND         = 0;
 constexpr MPI_Op      MPI_LOR          = 0;
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
 
-#endif
 #endif

--- a/include/deal.II/base/process_grid.h
+++ b/include/deal.II/base/process_grid.h
@@ -18,11 +18,9 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/mpi.h>
 
-#ifdef DEAL_II_WITH_SCALAPACK
-
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SCALAPACK
 // Forward declaration of class ScaLAPACKMatrix for ProcessGrid
 #  ifndef DOXYGEN
 template <typename NumberType>
@@ -257,17 +255,8 @@ namespace Utilities
 
 } // end of namespace Utilities
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SCALAPACK
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/cgal/additional_data.h
+++ b/include/deal.II/cgal/additional_data.h
@@ -18,7 +18,6 @@
 #include <deal.II/base/exceptions.h>
 
 #ifdef DEAL_II_WITH_CGAL
-
 #  include <CGAL/version.h>
 #  if CGAL_VERSION_MAJOR >= 6
 #    include <CGAL/Installation/internal/disable_deprecation_warnings_and_errors.h>
@@ -26,8 +25,13 @@
 #  include <CGAL/Mesh_facet_topology.h>
 
 #  include <limits>
+#endif
+
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_CGAL
+
 namespace CGALWrappers
 {
   enum class FacetTopology
@@ -203,11 +207,9 @@ namespace CGALWrappers
   };
 
 } // namespace CGALWrappers
-DEAL_II_NAMESPACE_CLOSE
 
 #else
 
-DEAL_II_NAMESPACE_OPEN
 namespace CGALWrappers
 {
   /**
@@ -218,7 +220,9 @@ namespace CGALWrappers
   {};
 } // namespace CGALWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
+
 
 #endif

--- a/include/deal.II/cgal/point_conversion.h
+++ b/include/deal.II/cgal/point_conversion.h
@@ -28,8 +28,11 @@
 #  include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #  include <CGAL/Simple_cartesian.h>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_CGAL
 namespace CGALWrappers
 {
   /**
@@ -100,15 +103,7 @@ namespace CGALWrappers
 
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/cgal/polygon.h
+++ b/include/deal.II/cgal/polygon.h
@@ -26,9 +26,11 @@
 #  include <CGAL/Polygon_2.h>
 #  include <CGAL/Polygon_with_holes_2.h>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_CGAL
 namespace CGALWrappers
 {
   /**
@@ -118,15 +120,7 @@ namespace CGALWrappers
     const BooleanOperation                       &boolean_operation);
 } // namespace CGALWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/cgal/surface_mesh.h
+++ b/include/deal.II/cgal/surface_mesh.h
@@ -30,9 +30,11 @@
 #  include <CGAL/Polygon_mesh_processing/stitch_borders.h>
 #  include <CGAL/Surface_mesh.h>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_CGAL
 namespace CGALWrappers
 {
   /**
@@ -92,17 +94,7 @@ namespace CGALWrappers
     CGAL::Surface_mesh<CGALPointType>          &mesh);
 } // namespace CGALWrappers
 
-
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/cgal/triangulation.h
+++ b/include/deal.II/cgal/triangulation.h
@@ -47,8 +47,11 @@
 #  include <CGAL/make_mesh_3.h>
 #  include <CGAL/make_surface_mesh.h>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_CGAL
 namespace CGALWrappers
 {
   /**
@@ -565,15 +568,7 @@ namespace CGALWrappers
 } // namespace CGALWrappers
 #  endif // doxygen
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -62,9 +62,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <limits>
 #  include <type_traits>
 
-
+#endif
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_CGAL
 /**
  * Interface to the Computational Geometry Algorithm Library (CGAL).
  *
@@ -694,15 +696,7 @@ namespace CGALWrappers
 } // namespace CGALWrappers
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -38,8 +38,11 @@
 #  include <iterator>
 #  include <numeric>
 
+#endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
+
 DEAL_II_NAMESPACE_OPEN
 
+#if defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
 namespace Differentiation
 {
   namespace AD
@@ -4133,17 +4136,8 @@ namespace Differentiation
 
 #  endif // DOXYGEN
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_differentiation_ad_ad_helpers_h

--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -24,10 +24,12 @@
 
 #  include <cmath>
 
-
-#  ifndef DOXYGEN
+#endif // DEAL_II_WITH_ADOLC
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_ADOLC
+#  ifndef DOXYGEN
 /**
  * Implementation of the complementary error function for adol-c adouble
  * numbers.
@@ -73,17 +75,10 @@ abs(const adtl::adouble &x)
   return adtl::fabs(x);
 }
 
-DEAL_II_NAMESPACE_CLOSE
 #  endif // DOXYGEN
 
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_ADOLC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/ad/adolc_product_types.h
+++ b/include/deal.II/differentiation/ad/adolc_product_types.h
@@ -24,10 +24,11 @@
 
 #  include <complex>
 
+#endif // DEAL_II_WITH_ADOLC
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_ADOLC
 /* ------ ADOL-C taped (Differentiation::AD::NumberTypes::adolc_taped) ----- */
 
 
@@ -272,17 +273,8 @@ struct EnableIfScalar<std::complex<adtl::adouble>>
   using type = std::complex<adtl::adouble>;
 };
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_ADOLC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -22,10 +22,12 @@
 #  include <deal.II/differentiation/ad/ad_number_traits.h>
 #  include <deal.II/differentiation/ad/sacado_number_types.h>
 
-
-#  ifndef DOXYGEN
+#endif // DEAL_II_TRILINOS_WITH_SACADO
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_SACADO
+#  ifndef DOXYGEN
 /**
  * Implementation of the error function for real-valued Sacado numbers.
  */
@@ -87,18 +89,11 @@ erfc(const ADNumberType &x)
   return 1.0 - std::erf(x);
 }
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DOXYGEN
 
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_SACADO
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/ad/sacado_product_types.h
+++ b/include/deal.II/differentiation/ad/sacado_product_types.h
@@ -28,9 +28,11 @@
 // Reverse AD classes (templated)
 #  include <Sacado_trad.hpp>
 
+#endif // DEAL_II_TRILINOS_WITH_SACADO
+
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_TRILINOS_WITH_SACADO
 /* -------------- Sacado::Fad::DFad
  * (Differentiation::AD::NumberTypes::[sacado_fad/sacado_fad_fad])
  * -------------- */
@@ -248,17 +250,8 @@ struct EnableIfScalar<Sacado::Rad::ADvari<T>>
   using type = Sacado::Rad::ADvari<T>;
 };
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_SACADO
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/sd.h
+++ b/include/deal.II/differentiation/sd.h
@@ -27,8 +27,11 @@
 #  include <deal.II/differentiation/sd/symengine_types.h>
 #  include <deal.II/differentiation/sd/symengine_utilities.h>
 
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SYMENGINE
 namespace Differentiation
 {
   /**
@@ -49,16 +52,8 @@ namespace Differentiation
   } // namespace SD
 } // namespace Differentiation
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_differentiation_sd_h

--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -30,8 +30,11 @@
 #  include <deal.II/lac/trilinos_vector.h>
 #  include <deal.II/lac/vector.h>
 
+#endif /* DEAL_II_WITH_P4EST */
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_P4EST
 namespace parallel
 {
   namespace distributed
@@ -348,17 +351,8 @@ namespace parallel
   } // namespace distributed
 } // namespace parallel
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif /* DEAL_II_WITH_P4EST */
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif /* dealii_distributed_cell_data_transfer_templates_h */

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -38,8 +38,11 @@
 
 #  include <limits>
 
+#endif // DEAL_II_WITH_P4EST
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_P4EST
 // Forward declaration
 #  ifndef DOXYGEN
 namespace parallel
@@ -646,16 +649,8 @@ namespace internal
   } // namespace p4est
 } // namespace internal
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_P4EST
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_p4est_wrappers_h

--- a/include/deal.II/gmsh/utilities.h
+++ b/include/deal.II/gmsh/utilities.h
@@ -27,8 +27,13 @@
 
 #  include <deal.II/grid/tria.h>
 
+#endif
+
+
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_GMSH
 #  ifndef DOXYGEN
 class ParameterHandler;
 #  endif
@@ -92,15 +97,8 @@ namespace Gmsh
 #  endif
 } // namespace Gmsh
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
+
 #endif

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -25,11 +25,9 @@
 #include <cstring>
 
 
-#ifdef DEAL_II_WITH_ARPACK
-
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_ARPACK
 extern "C" void
 dnaupd_(int          *ido,
         char         *bmat,
@@ -897,16 +895,7 @@ ArpackSolver::control() const
   return solver_control;
 }
 
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/lac/ginkgo_solver.h
+++ b/include/deal.II/lac/ginkgo_solver.h
@@ -28,8 +28,11 @@
 
 #  include <memory>
 
+#endif // DEAL_II_WITH_GINKGO
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_GINKGO
 namespace GinkgoWrappers
 {
   /**
@@ -553,16 +556,8 @@ namespace GinkgoWrappers
 
 } // namespace GinkgoWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_GINKGO
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -25,10 +25,9 @@
 #include <cstring>
 
 
-#ifdef DEAL_II_ARPACK_WITH_PARPACK
-
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_ARPACK_WITH_PARPACK
 extern "C"
 {
   // http://www.mathkeisan.com/usersguide/man/pdnaupd.html
@@ -1159,16 +1158,7 @@ PArpackSolver<VectorType>::control() const
   return solver_control;
 }
 
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/lac/petsc_block_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_block_sparse_matrix.h
@@ -27,10 +27,11 @@
 #  include <cmath>
 #  include <cstddef>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
-
-
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   namespace MPI
@@ -468,18 +469,8 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_petsc_block_sparse_matrix_h

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -26,9 +26,11 @@
 
 #  include <cstddef>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   // forward declaration
@@ -722,17 +724,8 @@ template <>
 struct is_serial_vector<PETScWrappers::MPI::BlockVector> : std::false_type
 {};
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_communication_pattern.h
+++ b/include/deal.II/lac/petsc_communication_pattern.h
@@ -27,8 +27,11 @@
 
 #  include <vector>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 /**
  * @addtogroup PETScWrappers
  * @{
@@ -365,16 +368,8 @@ namespace PETScWrappers
 
 /** @} */
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_compatibility.h
+++ b/include/deal.II/lac/petsc_compatibility.h
@@ -40,8 +40,11 @@
 
 #  include <string>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   /**
@@ -215,15 +218,7 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 #endif // dealii_petsc_compatibility_h

--- a/include/deal.II/lac/petsc_full_matrix.h
+++ b/include/deal.II/lac/petsc_full_matrix.h
@@ -21,10 +21,11 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_matrix_base.h>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
-
-
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   /**
@@ -86,17 +87,8 @@ namespace PETScWrappers
   /** @} */
 } // namespace PETScWrappers
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -35,8 +35,11 @@
 #  include <optional>
 #  include <vector>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 // Forward declarations
 #  ifndef DOXYGEN
 template <typename Matrix>
@@ -1661,18 +1664,8 @@ namespace PETScWrappers
 #  endif // DOXYGEN
 } // namespace PETScWrappers
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_matrix_free.h
+++ b/include/deal.II/lac/petsc_matrix_free.h
@@ -20,10 +20,12 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_vector.h>
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
-
-
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   /**
@@ -271,19 +273,10 @@ namespace PETScWrappers
   };
 
 
-
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -28,10 +28,11 @@
 
 #  include <functional>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
-
-
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   // forward declarations
@@ -1168,18 +1169,8 @@ namespace PETScWrappers
   };
 } // namespace PETScWrappers
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_snes.h
+++ b/include/deal.II/lac/petsc_snes.h
@@ -32,9 +32,11 @@
 #    include <concepts>
 #  endif
 
+#endif // DEAL_II_WITH_PETSC
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   /**
@@ -488,16 +490,8 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_snes.templates.h
+++ b/include/deal.II/lac/petsc_snes.templates.h
@@ -26,8 +26,11 @@
 #  include <petscerror.h>
 #  include <petscsnes.h>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 // Shorthand notation for PETSc error codes.
 // This is used in deal.II code to raise exceptions
 #  define AssertPETSc(code)                          \
@@ -705,16 +708,8 @@ namespace PETScWrappers
 #    undef undefPetscCall
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -26,9 +26,11 @@
 
 #  include <petscksp.h>
 
+#endif // DEAL_II_WITH_PETSC
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 // Forward declarations
 #  ifndef DOXYGEN
 #    ifdef DEAL_II_WITH_SLEPC
@@ -828,16 +830,8 @@ namespace PETScWrappers
   };
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_sparse_matrix.h
+++ b/include/deal.II/lac/petsc_sparse_matrix.h
@@ -28,7 +28,11 @@
 #  include <cstddef>
 #  include <vector>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 // forward declaration
 #  ifndef DOXYGEN
 template <typename MatrixType>
@@ -661,16 +665,8 @@ namespace PETScWrappers
   } // namespace MPI
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_ts.h
+++ b/include/deal.II/lac/petsc_ts.h
@@ -32,8 +32,11 @@
 #    include <concepts>
 #  endif
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 namespace PETScWrappers
 {
   /**
@@ -773,16 +776,8 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_ts.templates.h
+++ b/include/deal.II/lac/petsc_ts.templates.h
@@ -26,8 +26,11 @@
 #  include <petscerror.h>
 #  include <petscts.h>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 // Shorthand notation for PETSc error codes.
 // This is used in deal.II code to raise exceptions
 #  define AssertPETSc(code)                          \
@@ -1324,16 +1327,8 @@ namespace PETScWrappers
 #    undef undefPetscCall
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -28,9 +28,11 @@
 #  include <deal.II/lac/vector_operation.h>
 #  include <deal.II/lac/vector_type_traits.h>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_PETSC
 /**
  * @addtogroup PETScWrappers
  * @{
@@ -565,17 +567,8 @@ template <>
 struct is_serial_vector<PETScWrappers::MPI::Vector> : std::false_type
 {};
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -32,8 +32,11 @@
 #  include <utility>
 #  include <vector>
 
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PETSC
 // forward declaration
 #  ifndef DOXYGEN
 template <typename number>
@@ -1395,16 +1398,8 @@ namespace PETScWrappers
 #  endif // DOXYGEN
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_PETSC
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/psblas_vector.h
+++ b/include/deal.II/lac/psblas_vector.h
@@ -32,8 +32,11 @@
 #  include <psb_c_base.h>
 #  include <psb_c_dbase.h>
 
+#endif // DEAL_II_WITH_PSBLAS
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PSBLAS
 namespace PSCToolkitWrappers
 {
 
@@ -1103,15 +1106,8 @@ namespace PSCToolkitWrappers
 template <>
 struct is_serial_vector<PSCToolkitWrappers::Vector> : std::false_type
 {};
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PSBLAS
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/lac/scalapack.h
+++ b/include/deal.II/lac/scalapack.h
@@ -30,8 +30,11 @@
 #  include <limits>
 #  include <memory>
 
+#endif // DEAL_II_WITH_SCALAPACK
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SCALAPACK
 /**
  * A wrapper class around ScaLAPACK parallel dense linear algebra.
  *
@@ -1043,16 +1046,8 @@ ScaLAPACKMatrix<NumberType>::local_n() const
 
 #  endif // DOXYGEN
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SCALAPACK
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -29,8 +29,11 @@
 
 #    include <memory>
 
+#  endif // DEAL_II_WITH_SLEPC
+
 DEAL_II_NAMESPACE_OPEN
 
+#  ifdef DEAL_II_WITH_SLEPC
 /**
  * Base namespace for solver classes using the SLEPc solvers which are
  * selected based on flags passed to the eigenvalue problem solver context.
@@ -851,17 +854,9 @@ namespace SLEPcWrappers
 
 } // namespace SLEPcWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#  else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #  endif // DEAL_II_WITH_SLEPC
+
+DEAL_II_NAMESPACE_CLOSE
 
 /*----------------------------   slepc_solver.h  ---------------------------*/
 

--- a/include/deal.II/lac/slepc_spectral_transformation.h
+++ b/include/deal.II/lac/slepc_spectral_transformation.h
@@ -28,8 +28,11 @@
 
 #    include <memory>
 
+#  endif // DEAL_II_WITH_SLEPC
+
 DEAL_II_NAMESPACE_OPEN
 
+#  ifdef DEAL_II_WITH_SLEPC
 // Forward declaration
 #    ifndef DOXYGEN
 namespace PETScWrappers
@@ -243,17 +246,9 @@ namespace SLEPcWrappers
 
 } // namespace SLEPcWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#  else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #  endif // DEAL_II_WITH_SLEPC
+
+DEAL_II_NAMESPACE_CLOSE
 
 /*--------------------   slepc_spectral_transformation.h   ------------------*/
 

--- a/include/deal.II/lac/trilinos_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_block_sparse_matrix.h
@@ -21,14 +21,9 @@
 #  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.h>
 #  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
+#endif
 
-#else
-
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #  include <deal.II/base/template_constraints.h>
 
 #  include <deal.II/lac/block_matrix_base.h>
@@ -39,8 +34,11 @@ DEAL_II_NAMESPACE_CLOSE
 
 #  include <cmath>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 // forward declarations
 #  ifndef DOXYGEN
 class BlockSparsityPattern;
@@ -622,9 +620,8 @@ namespace TrilinosWrappers
 
 } /* namespace TrilinosWrappers */
 
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif // dealii_trilinos_block_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -26,8 +26,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 namespace LinearAlgebra
 {
   namespace EpetraWrappers
@@ -103,16 +106,8 @@ namespace LinearAlgebra
   } // end of namespace EpetraWrappers
 } // end of namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -32,8 +32,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 namespace LinearAlgebra
 {
   // Forward declaration
@@ -830,16 +833,8 @@ template <>
 struct is_serial_vector<LinearAlgebra::EpetraWrappers::Vector> : std::false_type
 {};
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_index_access.h
+++ b/include/deal.II/lac/trilinos_index_access.h
@@ -27,8 +27,11 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Epetra_MultiVector.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 namespace TrilinosWrappers
 {
   /**
@@ -197,15 +200,7 @@ namespace TrilinosWrappers
   }
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_TRILINOS
+
+DEAL_II_NAMESPACE_CLOSE
 #endif // dealii_trilinos_index_access_h

--- a/include/deal.II/lac/trilinos_linear_operator.h
+++ b/include/deal.II/lac/trilinos_linear_operator.h
@@ -21,8 +21,11 @@
 #  include <deal.II/lac/linear_operator.h>
 #  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_TRILINOS
 namespace TrilinosWrappers
 {
   // Forward declarations:
@@ -300,15 +303,7 @@ namespace TrilinosWrappers
 
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_TRILINOS
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/lac/trilinos_parallel_block_vector.h
+++ b/include/deal.II/lac/trilinos_parallel_block_vector.h
@@ -20,12 +20,9 @@
 #  include <deal.II/lac/trilinos_tpetra_block_vector.h>
 #  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-#else
+#endif
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #  include <deal.II/lac/block_indices.h>
 #  include <deal.II/lac/block_vector_base.h>
 #  include <deal.II/lac/exceptions.h>
@@ -33,8 +30,11 @@ DEAL_II_NAMESPACE_CLOSE
 
 #  include <functional>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 // forward declaration
 #  ifndef DOXYGEN
 template <typename Number>
@@ -503,8 +503,8 @@ template <>
 struct is_serial_vector<TrilinosWrappers::MPI::BlockVector> : std::false_type
 {};
 
-DEAL_II_NAMESPACE_CLOSE
+#endif
 
-#endif // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -21,14 +21,9 @@
 #  include <deal.II/lac/trilinos_tpetra_precondition.h>
 #  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
+#endif
 
-#else
-
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #  include <deal.II/base/enable_observer_pointer.h>
 
 #  include <deal.II/lac/la_parallel_vector.h>
@@ -55,8 +50,11 @@ namespace ML_Epetra
 }
 #  endif
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 // forward declarations
 #  ifndef DOXYGEN
 template <typename number>
@@ -2195,8 +2193,8 @@ namespace TrilinosWrappers
 
 /** @} */
 
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
 
-#endif
 #endif

--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -50,9 +50,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 
+#endif // DEAL_II_WITH_TRILINOS
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 namespace TrilinosWrappers
 {
 
@@ -1407,16 +1409,8 @@ namespace TrilinosWrappers
 
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_TRILINOS
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -20,13 +20,9 @@
 #    include <deal.II/lac/trilinos_tpetra_sparse_matrix.h>
 #    include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-#  else
+#  endif
 
+#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #    include <deal.II/base/enable_observer_pointer.h>
 #    include <deal.II/base/index_set.h>
 #    include <deal.II/base/mpi_stub.h>
@@ -56,8 +52,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #    include <type_traits>
 #    include <vector>
 
+#  endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
 // forward declarations
 #    ifndef DOXYGEN
 template <typename MatrixType>
@@ -3326,11 +3325,9 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
 } /* namespace TrilinosWrappers */
 
+#  endif
 
 DEAL_II_NAMESPACE_CLOSE
-
-
-#  endif // DEAL_II_WITH_TRILINOS
 
 #endif
 /*-----------------------   trilinos_sparse_matrix.h     --------------------*/

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -19,12 +19,9 @@
 #  include <deal.II/lac/trilinos_tpetra_sparsity_pattern.h>
 #  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-#else
+#endif
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #  include <deal.II/base/enable_observer_pointer.h>
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
@@ -43,9 +40,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <memory>
 #  include <vector>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 // forward declarations
 #  ifndef DOXYGEN
 class SparsityPattern;
@@ -1415,9 +1414,8 @@ namespace TrilinosWrappers
 #  endif // DOXYGEN
 } // namespace TrilinosWrappers
 
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif // DEAL_II_WITH_TRILINOS
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.h
@@ -29,8 +29,11 @@
 
 #  include <cmath>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 // forward declarations
 #  ifndef DOXYGEN
 class BlockSparsityPattern;
@@ -452,17 +455,8 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_tpetra_trilinos_block_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h
@@ -16,11 +16,13 @@
 #include <deal.II/base/config.h>
 
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
-
 #  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.h>
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
 
@@ -332,16 +334,8 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_tpetra_trilinos_block_sparse_matrix_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.h
@@ -21,8 +21,11 @@
 #  include <deal.II/lac/block_vector_base.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
   /**
@@ -236,16 +239,8 @@ struct is_serial_vector<
   : std::false_type
 {};
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_trilinos_tpetra_block_vector_h

--- a/include/deal.II/lac/trilinos_tpetra_block_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_block_vector.templates.h
@@ -22,8 +22,11 @@
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/trilinos_utilities.h>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -228,16 +231,8 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_trilinos_tpetra_block_vector_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -30,8 +30,11 @@
 
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -130,16 +133,8 @@ namespace LinearAlgebra
   } // end of namespace TpetraWrappers
 } // end of namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_precondition.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.h
@@ -34,9 +34,11 @@
 #  include <Teuchos_RCPDecl.hpp>
 #  include <Tpetra_Operator.hpp>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -1437,17 +1439,8 @@ namespace LinearAlgebra
   }      // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.templates.h
@@ -38,9 +38,13 @@
 #    include <Tpetra_CrsMatrix_decl.hpp>
 #    include <Tpetra_Vector_decl.hpp>
 
+#  endif // DEAL_II_TRILINOS_WITH_IFPACK2
+#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  ifdef DEAL_II_TRILINOS_WITH_IFPACK2
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -805,17 +809,11 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_IFPACK2
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_precondition_muelu.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition_muelu.templates.h
@@ -33,9 +33,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <string>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA_MUELU
+
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA_MUELU
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -241,15 +243,8 @@ namespace LinearAlgebra
   }      // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
 #endif // DEAL_II_TRILINOS_WITH_TPETRA_MUELU
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.h
@@ -37,8 +37,13 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #    include <Teuchos_RCPDecl.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+#  endif // DEAL_II_TRILINOS_WITH_AMESOS2
+#endif   // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  ifdef DEAL_II_TRILINOS_WITH_AMESOS2
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -308,17 +313,11 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_AMESOS2
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.templates.h
@@ -29,9 +29,13 @@
 
 #    include <deal.II/lac/trilinos_tpetra_solver_direct.h>
 
+#  endif // DEAL_II_TRILINOS_WITH_AMESOS2
+#endif   // DEAL_II_TRILINOS_WITH_TPETRA
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  ifdef DEAL_II_TRILINOS_WITH_AMESOS2
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -208,17 +212,11 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_AMESOS2
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.h
@@ -33,9 +33,11 @@
 
 #  include <type_traits>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 // forward declarations
 
 template <typename Number>
@@ -2377,16 +2379,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_trilinos_tpetra_sparse_matrix_h

--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -28,8 +28,11 @@
 
 #  include <Tpetra_computeRowAndColumnOneNorms.hpp>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
 
@@ -1651,16 +1654,8 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_trilinos_tpetra_sparse_matrix_templates_h

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -34,9 +34,11 @@
 #  include <memory>
 #  include <vector>
 
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 // forward declarations
 #  ifndef DOXYGEN
 class DynamicSparsityPattern;
@@ -1352,18 +1354,8 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_types.h
+++ b/include/deal.II/lac/trilinos_tpetra_types.h
@@ -41,8 +41,11 @@
 #    include <Tpetra_Vector_fwd.hpp>
 #  endif
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -174,16 +177,9 @@ namespace LinearAlgebra
     } // namespace TpetraTypes
   }   // namespace TpetraWrappers
 } // namespace LinearAlgebra
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -40,8 +40,11 @@
 #  include <memory>
 #  include <optional>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 /**
  * Type trait indicating if a certain number type has been explicitly
  * instantiated in Tpetra. deal.II only supports those number types in Tpetra
@@ -1583,16 +1586,8 @@ struct is_serial_vector<
   LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace>> : std::false_type
 {};
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -34,9 +34,11 @@
 
 #  include <memory>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 namespace LinearAlgebra
 {
   namespace TpetraWrappers
@@ -1332,16 +1334,8 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -20,13 +20,9 @@
 #  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 #  include <deal.II/lac/trilinos_tpetra_vector.h>
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
+#endif
 
-#else
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #  include <deal.II/base/index_set.h>
 #  include <deal.II/base/mpi_stub.h>
 #  include <deal.II/base/partitioner.h>
@@ -49,8 +45,11 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <utility>
 #  include <vector>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 // Forward declarations
 #  ifndef DOXYGEN
 namespace LinearAlgebra
@@ -2374,9 +2373,8 @@ template <>
 struct is_serial_vector<TrilinosWrappers::MPI::Vector> : std::false_type
 {};
 
+#endif
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif
 
 #endif

--- a/include/deal.II/opencascade/manifold_lib.h
+++ b/include/deal.II/opencascade/manifold_lib.h
@@ -31,8 +31,11 @@
 #  include <BRepAdaptor_Curve.hxx>
 #  undef HAVE_CONFIG_H
 
+#endif // DEAL_II_WITH_OPENCASCADE
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_OPENCASCADE
 /**
  * @addtogroup OpenCASCADE
  * @{
@@ -417,16 +420,7 @@ namespace OpenCASCADE
 
 /** @} */
 
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_OPENCASCADE
+
+DEAL_II_NAMESPACE_CLOSE
 #endif // dealii_occ_manifold_lib_h

--- a/include/deal.II/opencascade/utilities.h
+++ b/include/deal.II/opencascade/utilities.h
@@ -41,10 +41,11 @@
 #  include <gp_Pnt.hxx>
 #  undef HAVE_CONFIG_H
 
-
+#endif // DEAL_II_WITH_OPENCASCADE
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_OPENCASCADE
 /**
  * We collect in this namespace all utilities which operate on OpenCASCADE
  * entities. OpenCASCADE splits every object into a topological description
@@ -461,17 +462,8 @@ namespace OpenCASCADE
   DeclException0(ExcUnsupportedShape);
 } // namespace OpenCASCADE
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_OPENCASCADE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/optimization/rol/vector_adaptor.h
+++ b/include/deal.II/optimization/rol/vector_adaptor.h
@@ -18,9 +18,11 @@
 #ifdef DEAL_II_TRILINOS_WITH_ROL
 #  include <deal.II/trilinos/rol_adaptor.h>
 
+#endif // DEAL_II_TRILINOS_WITH_ROL
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_ROL
 namespace Rol
 {
   /**
@@ -34,16 +36,8 @@ namespace Rol
     dealii::TrilinosWrappers::ROLAdaptor<VectorType>;
 } // namespace Rol
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_ROL
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_optimization_rol_vector_adaptor_h

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -50,10 +50,11 @@
 #  include <exception>
 #  include <memory>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SUNDIALS
 /**
  * A namespace for dealing with ODE solvers through the SUNDIALS package.
  */
@@ -1179,17 +1180,9 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 
 #endif

--- a/include/deal.II/sundials/arkode.templates.h
+++ b/include/deal.II/sundials/arkode.templates.h
@@ -33,8 +33,11 @@
 
 #  include <iostream>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
   template <typename VectorType>
@@ -745,15 +748,7 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/sundials/ida.h
+++ b/include/deal.II/sundials/ida.h
@@ -46,10 +46,11 @@
 
 #  include <memory>
 
+#endif // DEAL_II_WITH_SUNDIALS
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
   /**
@@ -1137,16 +1138,8 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -38,10 +38,11 @@
 #  include <exception>
 #  include <memory>
 
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
   /**
@@ -765,17 +766,8 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -22,8 +22,11 @@
 #  include <functional>
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SUNDIALS
 #  ifndef DOXYGEN
 namespace SUNDIALS
 {
@@ -230,16 +233,7 @@ namespace SUNDIALS
   } // namespace internal
 } // namespace SUNDIALS
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -39,8 +39,11 @@
 
 #  include <limits>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
   namespace internal
@@ -1382,15 +1385,7 @@ namespace SUNDIALS
   } // namespace internal
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/sundials/sundials_types.h
+++ b/include/deal.II/sundials/sundials_types.h
@@ -18,8 +18,11 @@
 #ifdef DEAL_II_WITH_SUNDIALS
 #  include <sundials/sundials_types.h>
 
+#endif // DEAL_II_WITH_SUNDIALS
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
 /**
@@ -34,15 +37,7 @@ namespace SUNDIALS
 #  endif
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
 #endif // dealii_sundials_types_h

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -24,8 +24,11 @@
 #  include <functional>
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
 #  ifndef DOXYGEN
@@ -251,15 +254,7 @@ namespace SUNDIALS
   } // namespace internal
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/sundials/sunlinsol_wrapper.templates.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.templates.h
@@ -28,10 +28,11 @@
 #  include <sundials/sundials_iterative.h>
 #  include <sundials/sundials_linearsolver.h>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
-
-
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
   DeclException1(ExcSundialsSolverError,
@@ -458,15 +459,7 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/include/deal.II/sundials/utilities.h
+++ b/include/deal.II/sundials/utilities.h
@@ -22,9 +22,11 @@
 #ifdef DEAL_II_WITH_SUNDIALS
 #  include <exception>
 
+#endif // DEAL_II_WITH_SUNDIALS
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SUNDIALS
 namespace SUNDIALS
 {
   namespace Utilities
@@ -99,16 +101,8 @@ namespace SUNDIALS
   } // namespace Utilities
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SUNDIALS
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/trilinos/nox.h
+++ b/include/deal.II/trilinos/nox.h
@@ -26,8 +26,11 @@
 #  include <exception>
 #  include <functional>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_NOX
 namespace TrilinosWrappers
 {
   // Indicate that NOXSolver has not converged.
@@ -464,16 +467,8 @@ namespace TrilinosWrappers
   };
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/trilinos/nox.templates.h
+++ b/include/deal.II/trilinos/nox.templates.h
@@ -32,8 +32,11 @@
 
 #  include <memory>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_NOX
 #  ifndef DOXYGEN
 
 namespace TrilinosWrappers
@@ -1298,16 +1301,8 @@ namespace TrilinosWrappers
 
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/trilinos/rol_adaptor.h
+++ b/include/deal.II/trilinos/rol_adaptor.h
@@ -27,9 +27,11 @@
 #  include <tuple>
 #  include <type_traits>
 
+#endif // DEAL_II_TRILINOS_WITH_ROL
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_TRILINOS_WITH_ROL
 namespace TrilinosWrappers
 {
   /**
@@ -659,18 +661,8 @@ namespace TrilinosWrappers
 
 } // namespace TrilinosWrappers
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_TRILINOS_WITH_ROL
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_trilinos_rol_adaptor_h

--- a/include/deal.II/vtk/utilities.h
+++ b/include/deal.II/vtk/utilities.h
@@ -35,8 +35,11 @@
 
 #  include <string>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_VTK
 /**
  * Interface to the Visualization Toolkit (VTK).
  *
@@ -439,15 +442,7 @@ namespace VTKWrappers
 
 } // namespace VTKWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/source/gmsh/utilities.cc
+++ b/source/gmsh/utilities.cc
@@ -22,14 +22,16 @@
 #include <cstdio>
 
 #ifdef DEAL_II_WITH_GMSH
-
-
 #  ifdef DEAL_II_WITH_OPENCASCADE
 #    include <TopoDS_Edge.hxx>
 #  endif
+#endif
+
+
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_GMSH
 namespace Gmsh
 {
   AdditionalParameters::AdditionalParameters(
@@ -152,7 +154,7 @@ namespace Gmsh
 #    include "gmsh/utilities.inst"
 #  endif
 } // namespace Gmsh
+#endif
+
 
 DEAL_II_NAMESPACE_CLOSE
-
-#endif

--- a/source/vtk/utilities.cc
+++ b/source/vtk/utilities.cc
@@ -72,8 +72,11 @@
 #  include <fstream>
 #  include <stdexcept>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_VTK
 namespace VTKWrappers
 {
   namespace internal
@@ -638,14 +641,6 @@ namespace VTKWrappers
 
 } // namespace VTKWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
This patch addresses the conclusion of #19527. Needed for #18071. It undoes good parts of #17932 and related patches.

This patch is not easy to read, but it compiles on all of my systems with whatever dependencies are enabled there. 