### PR TITLE
Avoid compiler warnings by restricting compilation of a function to 2d.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -5272,12 +5272,23 @@ namespace internal
 
 
 
-      template <int dim, int spacedim>
-      static typename Triangulation<dim, spacedim>::DistortedCellList
-      execute_refinement_isotropic(Triangulation<dim, spacedim> &triangulation,
+      template <int spacedim>
+      static typename Triangulation<1, spacedim>::DistortedCellList
+      execute_refinement_isotropic(
+        Triangulation<1, spacedim> & /*triangulation*/,
+        const bool /*check_for_distorted_cells*/)
+      {
+        DEAL_II_ASSERT_UNREACHABLE();
+      }
+
+
+
+      template <int spacedim>
+      static typename Triangulation<2, spacedim>::DistortedCellList
+      execute_refinement_isotropic(Triangulation<2, spacedim> &triangulation,
                                    const bool check_for_distorted_cells)
       {
-        AssertDimension(dim, 2);
+        constexpr int dim = 2;
 
         // Check whether a new level is needed. We have to check for
         // this on the highest level only


### PR DESCRIPTION
With a recent clang compiler, I get warnings about accessing `subcells[3]` in a function that is really only meant to be used in 2d (see the assertion at the top), but is apparently also called in 1d. This patch replaces the general template by an overload for 2d and a separate overload for 1d that just triggers an assertion (as the general template would previously also have done). There is a separate overload for 3d already.

This is a long function, so the result should even mean shorter compile times and smaller code.