### PR TITLE
Improve step 46 docs

### DIFF
--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -151,7 +151,7 @@ $\mathbf v, p$ to both the original and the extended function.
 
 For discretization, we need finite dimensional subspaces $V_h,P_h$ of
 $V, P$. For Stokes, we know from step-22 that an appropriate choice is
-$Q_{p+1}^d\times Q_P$ but this only holds for that part of the domain
+$Q_{p+1}^d\times Q_p$ but this only holds for that part of the domain
 occupied by the fluid. For the extended field, let's use the following
 subspaces defined on the triangulation $\mathbb T$:
 @f{align*}{
@@ -193,8 +193,8 @@ describe the elasticity equation. Here, for the extended variables, we
 have
 @f{align*}{
   \tilde {\mathbf u} &\in U
-   = \{\tilde {\mathbf u}|_{\Omega_s} \in H^1(\Omega_f)^d, \quad
-       \tilde {\mathbf u}|_{\Omega_f} \in Z(\Omega_s)^d \},
+   = \{\tilde {\mathbf u}|_{\Omega_s} \in H^1(\Omega_s)^d, \quad
+       \tilde {\mathbf u}|_{\Omega_f} \in Z(\Omega_f)^d \},
 @f}
 and we will typically use a finite element space of the kind
 @f{align*}{
@@ -202,7 +202,7 @@ and we will typically use a finite element space of the kind
    &= \{{\mathbf u}_h \quad | \quad
        \forall K \in {\mathbb T}:
        {\mathbf u}_h|_K \in Q_r^d\  \text{if}\ K\subset {\Omega_s}, \quad
-       {\mathbf u}_h|_{\Omega_f}\ \text{is continuous}, \quad
+       {\mathbf u}_h|_{\Omega_s}\ \text{is continuous}, \quad
        {\mathbf u}_h|_K \in Z^d\ \text{if}\ K\subset {\Omega_f}\}
    && \subset U
 @f}
@@ -247,7 +247,7 @@ number of vector components but have different polynomial degrees &mdash; this
 smells very much like what one would do in $hp$ finite element methods, and it
 is exactly what we are going to do here: we are going to (ab)use the classes
 and facilities of the hp-namespace to assign different elements to different
-cells. In other words, we will use collect the two finite elements in an
+cells. In other words, we will collect the two finite elements in an
 hp::FECollection, will integrate with an appropriate hp::QCollection using an
 hp::FEValues object, and our DoFHandler will be in <i>hp</i>-mode. You
 may wish to take a look at step-27 for an overview of all of these concepts.
@@ -281,7 +281,7 @@ mapping the problem on to the hp-framework makes sense:
 - There is essentially no cost: The trick with the FE_Nothing does not add any
   degrees of freedom to the overall problem, nor do we ever have to handle a
   shape function that belongs to these components &mdash; the FE_Nothing has
-  no degrees of freedom, not does it have shape functions, all it does is take
+  no degrees of freedom, nor does it have shape functions, all it does is take
   up vector components.
 
 

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -218,7 +218,23 @@ space:
       & y_h|_{\Omega_s} \in Z^d \times Z \times Q_r^d \}.
 @f}
 
+<h3>A note on interface values</h3>
 
+It is important to realize that while the extension by zero is a convenient tool,
+it creates a literal jump discontinuity in the global solution field at the
+interface $\Gamma_i$. This has practical implications for functions that evaluate
+the solution at specific coordinates (for example, VectorTools::point_values()).
+
+If one evaluates the pressure $p$ at a point exactly on the interface and passes an
+<b>averaging</b> flag to VectorTools::point_values(), it will return the mean of the fluid value
+and the zero-extension:
+@f[
+  p_{interface} = \frac{p|_{\Omega_f} + p|_{\Omega_s}}{2} = \frac{p|_{\Omega_f} + 0}{2}
+@f]
+
+For a fluid pressure of 1, the result will be <b>0.5</b>. While this is the
+mathematically correct average for the extended field $P_h$, it is often not the
+value a user expects for the underlying physical problem.
 
 <h3>Implementation</h3>
 


### PR DESCRIPTION
This is the first of probably several PRs to better document the interaction of the zero extension of solution fields with FE_Nothing and the interaction with functions like `VectorTools::point_values()` like reported in #19516 and for this PR especially https://github.com/dealii/dealii/issues/19516#issuecomment-4250888562.

I still wonder if keeping the current behavior of not ignoring FE_Nothing contributions to averaging operations like in `VectorTools::point_values()` is the right direction, especially considering the motivation given in step 46. 
Short summary of the motivation in step 46 for the FSI problem:
- Instead of using 2 Triangulations and 2 DoFHandlers, 1 for the fluid and 1 for the solid side where the solution would strictly live only on one of them (fluid quantities on the fluid triangulation and solid quantities on the solid triangulation), 1 Triangulation with 1 DofHandler is used, and the solution is extended by 0 to the other domain via FE_Nothing.

In essence, we want to obtain the same solution via the zero extension with FE_Nothing as we would have obtained when using 2 Triangulations and DoFHandlers. We in fact would obtain the same observable results (like the average value of the fluid pressure at the interface) if we restrict any sort of operations to the according subdomain and ignore FE_Nothing contributions.

