### PR TITLE
Reorganize headers to make them work with modules.

### DIFF
--- a/include/deal.II/differentiation/sd/symengine_number_visitor_internal.h
+++ b/include/deal.II/differentiation/sd/symengine_number_visitor_internal.h
@@ -31,10 +31,11 @@
 #  include <symengine/symengine_rcp.h>
 #  include <symengine/visitor.h>
 
+#endif // DEAL_II_WITH_SYMENGINE
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SYMENGINE
 namespace Differentiation
 {
   namespace SD
@@ -998,17 +999,8 @@ namespace Differentiation
   }   // namespace SD
 } // namespace Differentiation
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif // dealii_differentiation_sd_symengine_number_visitor_internal_h

--- a/include/deal.II/differentiation/sd/symengine_optimizer.h
+++ b/include/deal.II/differentiation/sd/symengine_optimizer.h
@@ -49,10 +49,11 @@
 #  include <utility>
 #  include <vector>
 
+#endif // DEAL_II_WITH_SYMENGINE
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SYMENGINE
 namespace Differentiation
 {
   namespace SD
@@ -2567,17 +2568,8 @@ namespace Differentiation
   } // namespace SD
 } // namespace Differentiation
 
-
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_product_types.h
+++ b/include/deal.II/differentiation/sd/symengine_product_types.h
@@ -28,10 +28,11 @@
 
 #  include <type_traits>
 
+#endif // DEAL_II_WITH_SYMENGINE
 
 DEAL_II_NAMESPACE_OPEN
 
-
+#ifdef DEAL_II_WITH_SYMENGINE
 template <>
 struct EnableIfScalar<Differentiation::SD::Expression>
 {
@@ -125,16 +126,8 @@ namespace internal
 
 } // namespace internal
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -30,8 +30,11 @@
 #  include <utility>
 #  include <vector>
 
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SYMENGINE
 namespace Differentiation
 {
   namespace SD
@@ -1924,16 +1927,8 @@ namespace Differentiation
 
 #  endif // DOXYGEN
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -27,8 +27,11 @@
 #  include <utility>
 #  include <vector>
 
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SYMENGINE
 namespace Differentiation
 {
   namespace SD
@@ -1566,16 +1569,8 @@ namespace Differentiation
 
 #  endif // DOXYGEN
 
-DEAL_II_NAMESPACE_CLOSE
-
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+DEAL_II_NAMESPACE_CLOSE
 
 #endif


### PR DESCRIPTION
In a first iteration of #19535 (addressing #19527, see #18071), I had also included changes to files in `include/deal.II/differentiation/sd` that somehow broke builds with symengine: To me, the error messages seemed to indicate that we `#include` external files in a place where we still have `namespace dealii` open (perhaps because the previous file included didn't close its namespace), but I couldn't find out last night where that might have been because it's all layered in `#ifdef DEAL_II_WITH...`. So I took these files out of #19535, but I still would like to make these changes work.

I will use this PR to iterate on the files that have changes, including/excluding files until I know which file has the problem. Don't merge yet.