### PR TITLE
Optimizing Tpetra vector element-wise access

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1106,11 +1106,20 @@ namespace LinearAlgebra
        */
       dealii::IndexSet local_entries;
 
+      using dual_view_type =
+        typename TpetraTypes::VectorType<Number, MemorySpace>::dual_view_type;
+      using host_view_type = typename dual_view_type::t_host;
+
+      using array_view_type =
+        Kokkos::Subview<host_view_type,
+                        std::remove_const_t<decltype(Kokkos::ALL)>,
+                        unsigned>;
       /**
-       * To avoid creating new views for element-wise access, store
-       * a const host view.
+       * To avoid creating new views during element-wise access, store
+       * views to the vector.
        */
-      Teuchos::ArrayRCP<const Number> const_1d_host_view;
+      host_view_type  vector_2d;
+      array_view_type vector_1d;
 
       /**
        * CommunicationPattern for the communication between the
@@ -1205,18 +1214,7 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::add;
 
-      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-
-      // Having extracted a view into the multivectors above, now also
-      // extract a view into the one vector we actually store. We can
-      // do this right away for the locally owned part. We defer creating
-      // the view into the nonlocal part to when we know that we actually
-      // need it; this also makes sure that we correctly deal with the
-      // case where we do not actually store a nonlocal part.
-      auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
-      using ViewType1d     = decltype(vector_1d_local);
-      std::optional<ViewType1d> vector_1d_nonlocal;
+      std::optional<array_view_type> vector_1d_nonlocal;
 
       for (size_type i = 0; i < n_elements; ++i)
         {
@@ -1229,7 +1227,7 @@ namespace LinearAlgebra
                 vector->getMap()->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
-              vector_1d_local(local_row) += values[i];
+              vector_1d(local_row) += values[i];
 
               // Set the compressed state to false only if there is nonlocal
               // part in this distributed vector, otherwise it's always
@@ -1315,18 +1313,7 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::insert;
 
-      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-
-      // Having extracted a view into the multivectors above, now also
-      // extract a view into the one vector we actually store. We can
-      // do this right away for the locally owned part. We defer creating
-      // the view into the nonlocal part to when we know that we actually
-      // need it; this also makes sure that we correctly deal with the
-      // case where we do not actually store a nonlocal part.
-      auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
-      using ViewType1d     = decltype(vector_1d_local);
-      std::optional<ViewType1d> vector_1d_nonlocal;
+      std::optional<array_view_type> vector_1d_nonlocal;
 
       for (size_type i = 0; i < n_elements; ++i)
         {
@@ -1339,7 +1326,7 @@ namespace LinearAlgebra
                 vector->getMap()->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
-              vector_1d_local(local_row) = values[i];
+              vector_1d(local_row) = values[i];
 
               // Set the compressed state to false only if there is nonlocal
               // part in this distributed vector, otherwise it's always

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1107,6 +1107,12 @@ namespace LinearAlgebra
       dealii::IndexSet local_entries;
 
       /**
+       * To avoid creating new views for element-wise access, store
+       * a const host view.
+       */
+      Teuchos::ArrayRCP<const Number> const_1d_host_view;
+
+      /**
        * CommunicationPattern for the communication between the
        * source_stored_elements IndexSet and the current vector.
        */

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1107,6 +1107,14 @@ namespace LinearAlgebra
        */
       dealii::IndexSet local_entries;
 
+      using dual_view_type =
+        typename TpetraTypes::VectorType<Number, MemorySpace>::dual_view_type;
+      using host_view_type = typename dual_view_type::t_host;
+
+      using array_view_type =
+        Kokkos::Subview<host_view_type,
+                        std::remove_const_t<decltype(Kokkos::ALL)>,
+                        unsigned>;
       /**
        * Indices of the non-local elements that are cached and will
        * be communicated to their owners upon calling compress().
@@ -1124,6 +1132,18 @@ namespace LinearAlgebra
        * nonlocal_cached_indices.
        */
       std::vector<Number> nonlocal_cached_values;
+
+      /**
+       * To avoid creating new views during element-wise access, store
+       * a view to the vector.
+       */
+      array_view_type vector_1d_view;
+
+      /**
+       * To avoid creating new views during element-wise access, store
+       * a view to the nonlocal vector.
+       */
+      array_view_type nonlocal_vector_1d_view;
 
       /**
        * CommunicationPattern for the communication between the
@@ -1175,6 +1195,8 @@ namespace LinearAlgebra
       std::swap(last_action, v.last_action);
       vector.swap(v.vector);
       nonlocal_vector.swap(v.nonlocal_vector);
+      std::swap(vector_1d_view, v.vector_1d_view);
+      std::swap(nonlocal_vector_1d_view, v.nonlocal_vector_1d_view);
       std::swap(source_stored_elements, v.source_stored_elements);
       std::swap(local_entries, v.local_entries);
       std::swap(nonlocal_cached_indices, v.nonlocal_cached_indices);
@@ -1229,19 +1251,6 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::add;
 
-      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-
-      // Having extracted a view into the multivectors above, now also
-      // extract a view into the one vector we actually store. We can
-      // do this right away for the locally owned part. We defer creating
-      // the view into the nonlocal part to when we know that we actually
-      // need it; this also makes sure that we correctly deal with the
-      // case where we do not actually store a nonlocal part.
-      auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
-      using ViewType1d     = decltype(vector_1d_local);
-      std::optional<ViewType1d> vector_1d_nonlocal;
-
       for (size_type i = 0; i < n_elements; ++i)
         {
           const size_type row = indices[i];
@@ -1253,7 +1262,7 @@ namespace LinearAlgebra
                 vector->getMap()->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
-              vector_1d_local(local_row) += values[i];
+              vector_1d_view(local_row) += values[i];
 
               // Set the compressed state to false only if there is nonlocal
               // part in this distributed vector, otherwise it's always
@@ -1297,20 +1306,7 @@ namespace LinearAlgebra
 
 #  endif
 
-              // Having asserted that it is, write into the nonlocal part.
-              // To do so, we first need to make sure that we have a view
-              // of the nonlocal part of the vectors, since we have
-              // deferred creating this view previously:
-              if (!vector_1d_nonlocal)
-                {
-                  auto vector_2d_nonlocal =
-                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-                      Tpetra::Access::ReadWriteStruct{});
-
-                  vector_1d_nonlocal =
-                    Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
-                }
-              (*vector_1d_nonlocal)(nonlocal_row) += values[i];
+              nonlocal_vector_1d_view(nonlocal_row) += values[i];
               compressed = false;
             }
         }
@@ -1349,19 +1345,6 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::insert;
 
-      auto vector_2d_local = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-
-      // Having extracted a view into the multivectors above, now also
-      // extract a view into the one vector we actually store. We can
-      // do this right away for the locally owned part. We defer creating
-      // the view into the nonlocal part to when we know that we actually
-      // need it; this also makes sure that we correctly deal with the
-      // case where we do not actually store a nonlocal part.
-      auto vector_1d_local = Kokkos::subview(vector_2d_local, Kokkos::ALL(), 0);
-      using ViewType1d     = decltype(vector_1d_local);
-      std::optional<ViewType1d> vector_1d_nonlocal;
-
       for (size_type i = 0; i < n_elements; ++i)
         {
           const size_type row = indices[i];
@@ -1373,7 +1356,7 @@ namespace LinearAlgebra
                 vector->getMap()->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
-              vector_1d_local(local_row) = values[i];
+              vector_1d_view(local_row) = values[i];
 
               // Set the compressed state to false only if there is nonlocal
               // part in this distributed vector, otherwise it's always
@@ -1417,21 +1400,8 @@ namespace LinearAlgebra
 
 #  endif
 
-              // Having asserted that it is, write into the nonlocal part.
-              // To do so, we first need to make sure that we have a view
-              // of the nonlocal part of the vectors, since we have
-              // deferred creating this view previously:
-              if (!vector_1d_nonlocal)
-                {
-                  auto vector_2d_nonlocal =
-                    nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-                      Tpetra::Access::ReadWriteStruct{});
-
-                  vector_1d_nonlocal =
-                    Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
-                }
-              (*vector_1d_nonlocal)(nonlocal_row) = values[i];
-              compressed                          = false;
+              nonlocal_vector_1d_view(nonlocal_row) = values[i];
+              compressed                            = false;
             }
         }
     }

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -720,32 +720,20 @@ namespace LinearAlgebra
         vector->getMap()->getLocalElement(
           static_cast<TrilinosWrappers::types::int_type>(index));
 
-      Number value = 0.0;
-
       // If the element is not present on the current processor, we can't
       // continue. This is the main difference to the el() function.
-      if (local_index == Teuchos::OrdinalTraits<int>::invalid())
-        {
+      Assert(local_index != Teuchos::OrdinalTraits<int>::invalid(),
+             ExcAccessToNonLocalElement(index,
 #  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
-          Assert(
-            false,
-            ExcAccessToNonLocalElement(index,
-                                       vector->getMap()->getLocalNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
-#  else
-          Assert(
-            false,
-            ExcAccessToNonLocalElement(index,
-                                       vector->getMap()->getNodeNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
-#  endif
-        }
-      else
-        value = const_1d_host_view[local_index];
 
-      return value;
+                                        vector->getMap()->getLocalNumElements(),
+#  else
+                                         vector->getMap()->getNodeNumElements(),
+#  endif
+                                        vector->getMap()->getMinLocalIndex(),
+                                        vector->getMap()->getMaxLocalIndex()));
+
+      return const_1d_host_view[local_index];
     }
 
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -104,7 +104,8 @@ namespace LinearAlgebra
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.nonlocal_vector,
                                                           Teuchos::Copy);
         }
-      local_entries = V.local_entries;
+      local_entries      = V.local_entries;
+      const_1d_host_view = vector->get1dView();
     }
 
 
@@ -116,7 +117,9 @@ namespace LinearAlgebra
       , has_ghost(V->getMap()->isOneToOne() == false)
       , last_action(VectorOperation::unknown)
       , vector(V)
-    {}
+    {
+      const_1d_host_view = vector->get1dView();
+    }
 
 
 
@@ -131,7 +134,9 @@ namespace LinearAlgebra
           parallel_partitioner.make_tpetra_map_rcp<
             TpetraTypes::NodeType<MemorySpace>>(communicator, true)))
       , local_entries(parallel_partitioner)
-    {}
+    {
+      const_1d_host_view = vector->get1dView();
+    }
 
 
 
@@ -174,7 +179,8 @@ namespace LinearAlgebra
                 communicator, true));
         }
 
-      has_ghost = (vector->getMap()->isOneToOne() == false);
+      has_ghost          = (vector->getMap()->isOneToOne() == false);
+      const_1d_host_view = vector->get1dView();
 
       if constexpr (running_in_debug_mode())
         {
@@ -222,7 +228,8 @@ namespace LinearAlgebra
         parallel_partitioner
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
             communicator, true));
-      local_entries = parallel_partitioner;
+      local_entries      = parallel_partitioner;
+      const_1d_host_view = vector->get1dView();
     }
 
 
@@ -278,9 +285,10 @@ namespace LinearAlgebra
                 communicator, true));
         }
 
-      has_ghost   = (vector->getMap()->isOneToOne() == false);
-      compressed  = true;
-      last_action = VectorOperation::unknown;
+      has_ghost          = (vector->getMap()->isOneToOne() == false);
+      compressed         = true;
+      last_action        = VectorOperation::unknown;
+      const_1d_host_view = vector->get1dView();
     }
 
 
@@ -328,10 +336,11 @@ namespace LinearAlgebra
                omit_zeroing_entries == false)
         nonlocal_vector->putScalar(Number(0));
 
-      has_ghost     = V.has_ghost;
-      local_entries = V.local_entries;
-      compressed    = true;
-      last_action   = VectorOperation::unknown;
+      has_ghost          = V.has_ghost;
+      local_entries      = V.local_entries;
+      compressed         = true;
+      last_action        = VectorOperation::unknown;
+      const_1d_host_view = vector->get1dView();
 
       // Cached import state depends on previous source layouts and should
       // not survive reinitialization.
@@ -734,7 +743,7 @@ namespace LinearAlgebra
 #  endif
         }
       else
-        value = vector->getData()[local_index];
+        value = const_1d_host_view[local_index];
 
       return value;
     }

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -104,8 +104,10 @@ namespace LinearAlgebra
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.nonlocal_vector,
                                                           Teuchos::Copy);
         }
-      local_entries      = V.local_entries;
-      const_1d_host_view = vector->get1dView();
+      local_entries = V.local_entries;
+      vector_2d     = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -118,7 +120,9 @@ namespace LinearAlgebra
       , last_action(VectorOperation::unknown)
       , vector(V)
     {
-      const_1d_host_view = vector->get1dView();
+      vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -135,7 +139,9 @@ namespace LinearAlgebra
             TpetraTypes::NodeType<MemorySpace>>(communicator, true)))
       , local_entries(parallel_partitioner)
     {
-      const_1d_host_view = vector->get1dView();
+      vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -179,8 +185,10 @@ namespace LinearAlgebra
                 communicator, true));
         }
 
-      has_ghost          = (vector->getMap()->isOneToOne() == false);
-      const_1d_host_view = vector->get1dView();
+      has_ghost = (vector->getMap()->isOneToOne() == false);
+      vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       if constexpr (running_in_debug_mode())
         {
@@ -228,8 +236,10 @@ namespace LinearAlgebra
         parallel_partitioner
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
             communicator, true));
-      local_entries      = parallel_partitioner;
-      const_1d_host_view = vector->get1dView();
+      local_entries = parallel_partitioner;
+      vector_2d     = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -285,10 +295,12 @@ namespace LinearAlgebra
                 communicator, true));
         }
 
-      has_ghost          = (vector->getMap()->isOneToOne() == false);
-      compressed         = true;
-      last_action        = VectorOperation::unknown;
-      const_1d_host_view = vector->get1dView();
+      has_ghost   = (vector->getMap()->isOneToOne() == false);
+      compressed  = true;
+      last_action = VectorOperation::unknown;
+      vector_2d   = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -336,11 +348,13 @@ namespace LinearAlgebra
                omit_zeroing_entries == false)
         nonlocal_vector->putScalar(Number(0));
 
-      has_ghost          = V.has_ghost;
-      local_entries      = V.local_entries;
-      compressed         = true;
-      last_action        = VectorOperation::unknown;
-      const_1d_host_view = vector->get1dView();
+      has_ghost     = V.has_ghost;
+      local_entries = V.local_entries;
+      compressed    = true;
+      last_action   = VectorOperation::unknown;
+      vector_2d     = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       // Cached import state depends on previous source layouts and should
       // not survive reinitialization.
@@ -357,10 +371,6 @@ namespace LinearAlgebra
       const ArrayView<Number>                        &elements) const
     {
       AssertDimension(indices.size(), elements.size());
-
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
-      auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       for (unsigned int i = 0; i < indices.size(); ++i)
         {
@@ -418,15 +428,8 @@ namespace LinearAlgebra
           auto source_vector_1d =
             Kokkos::subview(source_vector_2d, Kokkos::ALL(), 0);
 
-          // Create a read/write Kokkos view from the target vector
-          auto target_vector_2d =
-            vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
-          auto target_vector_1d =
-            Kokkos::subview(target_vector_2d, Kokkos::ALL(), 0);
-
           // Copy the data
-          Kokkos::deep_copy(target_vector_1d, source_vector_1d);
+          Kokkos::deep_copy(vector_1d, source_vector_1d);
         }
       else if (size() == V.size())
         {
@@ -728,12 +731,12 @@ namespace LinearAlgebra
 
                                         vector->getMap()->getLocalNumElements(),
 #  else
-                                         vector->getMap()->getNodeNumElements(),
+                                        vector->getMap()->getNodeNumElements(),
 #  endif
                                         vector->getMap()->getMinLocalIndex(),
                                         vector->getMap()->getMaxLocalIndex()));
 
-      return const_1d_host_view[local_index];
+      return vector_1d[local_index];
     }
 
 
@@ -747,10 +750,6 @@ namespace LinearAlgebra
       // if we have ghost values, do not allow
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
-
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       const size_t localLength = vector->getLocalLength();
       for (size_t k = 0; k < localLength; ++k)
@@ -1011,16 +1010,13 @@ namespace LinearAlgebra
       if (this_local_length != other_local_length)
         return false;
 
-      auto this_vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
       auto other_vector_2d = v.vector->template getLocalView<Kokkos::HostSpace>(
         Tpetra::Access::ReadOnlyStruct{});
 
-      auto this_vector_1d  = Kokkos::subview(this_vector_2d, Kokkos::ALL(), 0);
       auto other_vector_1d = Kokkos::subview(other_vector_2d, Kokkos::ALL(), 0);
 
       for (size_type i = 0; i < this_local_length; ++i)
-        if (this_vector_1d(i) != other_vector_1d(i))
+        if (vector_1d(i) != other_vector_1d(i))
           return false;
 
       return true;
@@ -1261,10 +1257,6 @@ namespace LinearAlgebra
       else
         out.setf(std::ios::fixed, std::ios::floatfield);
 
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
-
-      auto         vector_1d    = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
       const size_t local_length = vector->getLocalLength();
 
       if (size() != local_length)

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -98,11 +98,20 @@ namespace LinearAlgebra
                TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                              Teuchos::Copy))
     {
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+
       if (!V.nonlocal_vector.is_null())
         {
           nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.nonlocal_vector,
                                                           Teuchos::Copy);
+          auto nonlocal_vector_2d =
+            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+          nonlocal_vector_1d_view =
+            Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
         }
       source_stored_elements  = V.source_stored_elements;
       local_entries           = V.local_entries;
@@ -121,6 +130,10 @@ namespace LinearAlgebra
       , last_action(VectorOperation::unknown)
       , vector(V)
     {
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+
       // If there are ghost entries, we do not know which process owns which
       // entries. Assume no one owns any entries, which will allow read access,
       // but no write access.
@@ -143,7 +156,11 @@ namespace LinearAlgebra
           parallel_partitioner.make_tpetra_map_rcp<
             TpetraTypes::NodeType<MemorySpace>>(communicator, true)))
       , local_entries(parallel_partitioner)
-    {}
+    {
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+    }
 
 
 
@@ -167,6 +184,9 @@ namespace LinearAlgebra
             parallel_partitioner
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
+          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+            Tpetra::Access::ReadWriteStruct{});
+          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
         }
       else
         {
@@ -176,6 +196,9 @@ namespace LinearAlgebra
                 communicator, false);
           vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(map);
+          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+            Tpetra::Access::ReadWriteStruct{});
+          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
           IndexSet nonlocal_entries = ghost_entries;
           nonlocal_entries.subtract_set(locally_owned_entries);
@@ -184,6 +207,12 @@ namespace LinearAlgebra
             nonlocal_entries
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
+
+          auto nonlocal_vector_2d =
+            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+          nonlocal_vector_1d_view =
+            Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
         }
 
       has_ghost = (vector->getMap()->isOneToOne() == false);
@@ -209,10 +238,17 @@ namespace LinearAlgebra
         Utilities::Trilinos::internal::make_rcp<
           TpetraTypes::MapType<MemorySpace>>(
           0, 0, Utilities::Trilinos::tpetra_comm_self()));
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+
       has_ghost   = false;
       compressed  = true;
       last_action = VectorOperation::unknown;
+
       nonlocal_vector.reset();
+      nonlocal_vector_1d_view = array_view_type();
+
       source_stored_elements.clear();
       local_entries.clear();
       local_entries.set_size(0);
@@ -230,21 +266,26 @@ namespace LinearAlgebra
                                         const bool /*omit_zeroing_entries*/)
     {
       vector.reset();
+      vector_1d_view = array_view_type();
       nonlocal_vector.reset();
+      nonlocal_vector_1d_view = array_view_type();
       source_stored_elements.clear();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
       tpetra_comm_pattern = Teuchos::null;
 
-      compressed  = true;
-      has_ghost   = false;
-      last_action = VectorOperation::unknown;
-      vector      = Utilities::Trilinos::internal::make_rcp<
+      compressed    = true;
+      has_ghost     = false;
+      last_action   = VectorOperation::unknown;
+      local_entries = parallel_partitioner;
+      vector        = Utilities::Trilinos::internal::make_rcp<
         TpetraTypes::VectorType<Number, MemorySpace>>(
         parallel_partitioner
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
             communicator, true));
-      local_entries = parallel_partitioner;
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -258,6 +299,7 @@ namespace LinearAlgebra
     {
       // release memory before reallocation
       nonlocal_vector.reset();
+      nonlocal_vector_1d_view = array_view_type();
       source_stored_elements.clear();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
@@ -277,6 +319,9 @@ namespace LinearAlgebra
             parallel_partitioner
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
+          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+            Tpetra::Access::ReadWriteStruct{});
+          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
         }
       else
         {
@@ -290,6 +335,9 @@ namespace LinearAlgebra
               vector.reset();
               vector = Utilities::Trilinos::internal::make_rcp<
                 TpetraTypes::VectorType<Number, MemorySpace>>(map);
+              auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
+              vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
             }
           else
             vector->putScalar(0);
@@ -302,6 +350,11 @@ namespace LinearAlgebra
             nonlocal_entries
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
+          auto nonlocal_vector_2d =
+            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+          nonlocal_vector_1d_view =
+            Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
         }
 
       has_ghost   = (vector->getMap()->isOneToOne() == false);
@@ -326,8 +379,13 @@ namespace LinearAlgebra
       // If V has a different distribution, construct a new vector,
       // otherwise just zero out this vector if so requested.
       if (!same_vector_map)
-        vector = Utilities::Trilinos::internal::make_rcp<
-          TpetraTypes::VectorType<Number, MemorySpace>>(V.vector->getMap());
+        {
+          vector = Utilities::Trilinos::internal::make_rcp<
+            TpetraTypes::VectorType<Number, MemorySpace>>(V.vector->getMap());
+          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+            Tpetra::Access::ReadWriteStruct{});
+          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+        }
       else if (vector.get() != nullptr && omit_zeroing_entries == false)
         vector->putScalar(Number(0));
 
@@ -344,11 +402,21 @@ namespace LinearAlgebra
       if (!same_nonlocal_map)
         {
           if (V.nonlocal_vector.get() != nullptr)
-            nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
-              TpetraTypes::VectorType<Number, MemorySpace>>(
-              V.nonlocal_vector->getMap());
+            {
+              nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
+                TpetraTypes::VectorType<Number, MemorySpace>>(
+                V.nonlocal_vector->getMap());
+              auto nonlocal_vector_2d_view =
+                nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                  Tpetra::Access::ReadWriteStruct{});
+              nonlocal_vector_1d_view =
+                Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
+            }
           else
-            nonlocal_vector.reset();
+            {
+              nonlocal_vector.reset();
+              nonlocal_vector_1d_view = array_view_type();
+            }
         }
       else if (nonlocal_vector.get() != nullptr &&
                omit_zeroing_entries == false)
@@ -377,10 +445,6 @@ namespace LinearAlgebra
     {
       AssertDimension(indices.size(), elements.size());
 
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
-      auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
-
       for (unsigned int i = 0; i < indices.size(); ++i)
         {
           AssertIndexRange(indices[i], size());
@@ -407,7 +471,7 @@ namespace LinearAlgebra
 #  endif
 
           if (local_row != Teuchos::OrdinalTraits<int>::invalid())
-            elements[i] = vector_1d(local_row);
+            elements[i] = vector_1d_view(local_row);
         }
     }
 
@@ -434,18 +498,11 @@ namespace LinearAlgebra
             V.vector->template getLocalView<Kokkos::HostSpace>(
               Tpetra::Access::ReadOnlyStruct{});
 
-          auto source_vector_1d =
+          auto source_vector_1d_view =
             Kokkos::subview(source_vector_2d, Kokkos::ALL(), 0);
 
-          // Create a read/write Kokkos view from the target vector
-          auto target_vector_2d =
-            vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
-          auto target_vector_1d =
-            Kokkos::subview(target_vector_2d, Kokkos::ALL(), 0);
-
           // Copy the data
-          Kokkos::deep_copy(target_vector_1d, source_vector_1d);
+          Kokkos::deep_copy(vector_1d_view, source_vector_1d_view);
         }
       else if (size() == V.size())
         {
@@ -490,13 +547,24 @@ namespace LinearAlgebra
           vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                           Teuchos::Copy);
+          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+            Tpetra::Access::ReadWriteStruct{});
+          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
           nonlocal_vector.reset();
+          nonlocal_vector_1d_view = array_view_type();
+
           if (!V.nonlocal_vector.is_null())
             {
               nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
                 TpetraTypes::VectorType<Number, MemorySpace>>(
                 *V.nonlocal_vector, Teuchos::Copy);
+
+              auto nonlocal_vector_2d =
+                nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                  Tpetra::Access::ReadWriteStruct{});
+              nonlocal_vector_1d_view =
+                Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
             }
 
           compressed             = V.compressed;
@@ -528,6 +596,8 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator=(const dealii::Vector<OtherNumber> &V)
     {
       vector.reset();
+      vector_1d_view = array_view_type();
+
       nonlocal_vector.reset();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
@@ -538,6 +608,9 @@ namespace LinearAlgebra
         V.locally_owned_elements()
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(),
         vector_data);
+      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadWriteStruct{});
+      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       local_entries = V.locally_owned_elements();
 
@@ -622,14 +695,16 @@ namespace LinearAlgebra
         tpetra_export->getSourceMap());
 
       {
-        auto x_2d = source_vector.template getLocalView<Kokkos::HostSpace>(
-          Tpetra::Access::ReadWriteStruct{});
-        auto x_1d = Kokkos::subview(x_2d, Kokkos::ALL(), 0);
+        auto source_vector_2d_view =
+          source_vector.template getLocalView<Kokkos::HostSpace>(
+            Tpetra::Access::ReadWriteStruct{});
+        auto source_vector_1d_view =
+          Kokkos::subview(source_vector_2d_view, Kokkos::ALL(), 0);
 
         const size_t localLength = source_vector.getLocalLength();
         auto         values_it   = V.begin();
         for (size_t k = 0; k < localLength; ++k)
-          x_1d(k) = *values_it++;
+          source_vector_1d_view(k) = *values_it++;
       }
       Tpetra::CombineMode tpetra_operation = Tpetra::ZERO;
       if (operation == VectorOperation::insert)
@@ -763,32 +838,24 @@ namespace LinearAlgebra
         vector->getMap()->getLocalElement(
           static_cast<TrilinosWrappers::types::int_type>(index));
 
-      Number value = 0.0;
-
-      // If the element is not present on the current processor, we can't
-      // continue. This is the main difference to the el() function.
-      if (local_index == Teuchos::OrdinalTraits<int>::invalid())
-        {
+// If the element is not present on the current processor, we can't
+// continue. This is the main difference to the el() function.
 #  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
-          Assert(
-            false,
-            ExcAccessToNonLocalElement(index,
-                                       vector->getMap()->getLocalNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
+      Assert(local_index != Teuchos::OrdinalTraits<int>::invalid(),
+             ExcAccessToNonLocalElement(index,
+                                        vector->getMap()->getLocalNumElements(),
+                                        vector->getMap()->getMinLocalIndex(),
+                                        vector->getMap()->getMaxLocalIndex()));
 #  else
-          Assert(
-            false,
-            ExcAccessToNonLocalElement(index,
-                                       vector->getMap()->getNodeNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
+      Assert(local_index != Teuchos::OrdinalTraits<int>::invalid(),
+             ExcAccessToNonLocalElement(index,
+                                        vector->getMap()->getLocalNumElements(),
+                                        vector->getMap()->getNodeNumElements(),
+                                        vector->getMap()->getMinLocalIndex(),
+                                        vector->getMap()->getMaxLocalIndex()));
 #  endif
-        }
-      else
-        value = vector->getData()[local_index];
 
-      return value;
+      return vector_1d_view[local_index];
     }
 
 
@@ -803,14 +870,10 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      auto vector_1d = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
-
       const size_t localLength = vector->getLocalLength();
       for (size_t k = 0; k < localLength; ++k)
         {
-          vector_1d(k) += a;
+          vector_1d_view(k) += a;
         }
     }
 
@@ -1084,16 +1147,15 @@ namespace LinearAlgebra
       if (this_local_length != other_local_length)
         return false;
 
-      auto this_vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
-      auto other_vector_2d = v.vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
+      auto other_vector_2d_view =
+        v.vector->template getLocalView<Kokkos::HostSpace>(
+          Tpetra::Access::ReadOnlyStruct{});
 
-      auto this_vector_1d  = Kokkos::subview(this_vector_2d, Kokkos::ALL(), 0);
-      auto other_vector_1d = Kokkos::subview(other_vector_2d, Kokkos::ALL(), 0);
+      auto other_vector_1d_view =
+        Kokkos::subview(other_vector_2d_view, Kokkos::ALL(), 0);
 
       for (size_type i = 0; i < this_local_length; ++i)
-        if (this_vector_1d(i) != other_vector_1d(i))
+        if (vector_1d_view(i) != other_vector_1d_view(i))
           return false;
 
       return true;
@@ -1276,12 +1338,12 @@ namespace LinearAlgebra
           // Now fill the nonlocal vector with the cached entries
           {
             // Extract a view into the vector in order to modify it
-            auto vector_2d_nonlocal =
+            auto nonlocal_vector_2d_view =
               nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
                 Tpetra::Access::ReadWriteStruct{});
 
-            auto vector_1d_nonlocal =
-              Kokkos::subview(vector_2d_nonlocal, Kokkos::ALL(), 0);
+            nonlocal_vector_1d_view =
+              Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
 
             const auto n_elements = nonlocal_cached_indices.size();
             for (size_type i = 0; i < n_elements; ++i)
@@ -1295,9 +1357,11 @@ namespace LinearAlgebra
                        ExcInternalError());
 
                 if (operation == VectorOperation::insert)
-                  vector_1d_nonlocal(local_row) = nonlocal_cached_values[i];
+                  nonlocal_vector_1d_view(local_row) =
+                    nonlocal_cached_values[i];
                 else if (operation == VectorOperation::add)
-                  vector_1d_nonlocal(local_row) += nonlocal_cached_values[i];
+                  nonlocal_vector_1d_view(local_row) +=
+                    nonlocal_cached_values[i];
                 else
                   DEAL_II_NOT_IMPLEMENTED();
               }
@@ -1328,6 +1392,7 @@ namespace LinearAlgebra
       if (nonlocal_vector_is_temporary)
         {
           nonlocal_vector.reset();
+          nonlocal_vector_1d_view = array_view_type();
           nonlocal_cached_values.clear();
           nonlocal_cached_indices.clear();
         }
@@ -1401,10 +1466,6 @@ namespace LinearAlgebra
       else
         out.setf(std::ios::fixed, std::ios::floatfield);
 
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadOnlyStruct{});
-
-      auto         vector_1d    = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
       const size_t local_length = vector->getLocalLength();
 
       if (size() != local_length)
@@ -1415,17 +1476,18 @@ namespace LinearAlgebra
             {
               const TrilinosWrappers::types::int_type global_row =
                 vector->getMap()->getGlobalElement(i);
-              out << "[" << global_row << "]: " << vector_1d(i) << std::endl;
+              out << "[" << global_row << "]: " << vector_1d_view(i)
+                  << std::endl;
             }
         }
       else
         {
           if (across)
             for (unsigned int i = 0; i < local_length; ++i)
-              out << vector_1d(i) << ' ';
+              out << vector_1d_view(i) << ' ';
           else
             for (unsigned int i = 0; i < local_length; ++i)
-              out << vector_1d(i) << std::endl;
+              out << vector_1d_view(i) << std::endl;
           out << std::endl;
         }
 

--- a/tests/trilinos_tpetra/slowness_05.cc
+++ b/tests/trilinos_tpetra/slowness_05.cc
@@ -1,0 +1,157 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2005 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+// this is part of a whole suite of tests that checks the relative speed of
+// using Trilinos as compared to the speed of our own
+// library. the tests therefore may not all actually use Trilinos, but they are
+// meant to compare it
+//
+// this test compares element-wise vector operations in a random order
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/trilinos_tpetra_vector.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+template <typename VectorType>
+void
+set(const std::vector<unsigned int> &permutation, VectorType &vector)
+{
+  const unsigned int N = vector.size();
+
+  for (unsigned int i = 0; i < N; ++i)
+    vector(permutation[i]) = i;
+}
+
+template <typename VectorType>
+void
+add(const std::vector<unsigned int> &permutation, VectorType &vector)
+{
+  const unsigned int N = vector.size();
+
+  for (unsigned int i = 0; i < N; ++i)
+    vector(permutation[i]) += i;
+}
+
+template <typename VectorType>
+double
+read(const std::vector<unsigned int> &permutation, const VectorType &vector)
+{
+  double             sum = 0.0;
+  const unsigned int N   = vector.size();
+
+  for (unsigned int i = 0; i < N; ++i)
+    sum += static_cast<const double>(vector(permutation[i]));
+
+  return sum;
+}
+
+template <typename VectorType>
+void
+test()
+{
+  // Vector entries
+  const unsigned int N = 40000;
+
+  // first find a random permutation of the
+  // indices
+  std::vector<unsigned int> permutation(N);
+  {
+    std::vector<unsigned int> unused_indices(N);
+    for (unsigned int i = 0; i < N; ++i)
+      unused_indices[i] = i;
+
+    for (unsigned int i = 0; i < N; ++i)
+      {
+        // pick a random element among the
+        // unused indices
+        const unsigned int k = Testing::rand() % (N - i);
+        permutation[i]       = unused_indices[k];
+
+        // then swap this used element to the
+        // end where we won't consider it any
+        // more
+        std::swap(unused_indices[k], unused_indices[N - i - 1]);
+      }
+  }
+
+  // build the vector
+  IndexSet   indices = complete_index_set(N);
+  VectorType vector(indices, MPI_COMM_WORLD);
+
+  // element-wise write access
+  set(permutation, vector);
+
+  // element-wise addition
+  add(permutation, vector);
+
+  // element-wise read
+  const double sum = read(permutation, vector);
+
+  deallog << "Vector norm: " << vector.l2_norm() << ". Vector sum: " << sum
+          << std::endl;
+
+  deallog << "Ok." << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+
+  try
+    {
+      {
+        test<
+          LinearAlgebra::TpetraWrappers::Vector<double, MemorySpace::Host>>();
+        test<LinearAlgebra::distributed::Vector<double, MemorySpace::Host>>();
+      }
+    }
+  catch (const std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    };
+  return 0;
+}

--- a/tests/trilinos_tpetra/slowness_05.output
+++ b/tests/trilinos_tpetra/slowness_05.output
@@ -1,0 +1,5 @@
+
+DEAL::Vector norm: 9.23743e+06. Vector sum: 1.59996e+09
+DEAL::Ok.
+DEAL::Vector norm: 9.23743e+06. Vector sum: 1.59996e+09
+DEAL::Ok.


### PR DESCRIPTION
So this is WIP, but I would like to ask for an opinion.

When testing #19449 I noticed that the TpetraWrappers vector element wise access functions are orders of magnitude slower than for the deal.II and the Epetra vectors. So much so that a full model computation (incl. solvers and matrix vector products) was slower by 2-3x just because of the assembly.

Using the attached test it quickly showed that creating and destroying the necessary views during element-wise access was the culprit, and the attached patch solves this by permanently storing a Kokkos view in the `TpetraWrappers::Vector` class instead of creating temporary views during each access. 

The attached test is now 4x faster than before (`operator()` is now 16x faster, `add` and `set` 3x each, and `add` and `set` have additional potential I didnt implement yet). With this patch the model I described above as 2x-3x slower now is roughly the same speed as before with Epetra vectors (it also changed to Tpetra matrices, preconditioners, solvers, so it is not exactly easy to compare accurately).

My question is whether this is a viable approach (in particular considering device support in the future). I am too unfamiliar with Kokkos to say if it is a problem to keep around these views during the lifetime of the vector object, and also I am hard-coding the host view at the moment. On the other hand it looks to me as if `LinearAlgebra::distributed::Vector` is doing something similar inside the `data` object (in `dealii::MemorySpace::MemorySpaceData<Number, MemorySpace> data;`, although I am unsure about the memory spaces it uses).

If this is viable I will clean this up and also consider what to do about `VectorReference`, which also creates views for individual element accesses.