### PR TITLE
Modify a header file so it plays more nicely with modules.

### DIFF
--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -21,8 +21,11 @@
 
 #  include <type_traits>
 
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_SYMENGINE
 namespace Differentiation
 {
   namespace SD
@@ -699,14 +702,20 @@ namespace Differentiation
   } // namespace SD
 } // namespace Differentiation
 
-DEAL_II_NAMESPACE_CLOSE
+#endif // DEAL_II_WITH_SYMENGINE
 
+// Close the dealii namespace, but do not close the export{} block yet if we
+// are building C++20 modules:
+DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
+
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 #  ifndef DOXYGEN
 
-// Import math operations into standard namespace.
-// This gives us the ability to use them within the Tensor class.
-namespace std
+  // Import math operations into standard namespace.
+  // This gives us the ability to use them within the Tensor class.
+  namespace std
 {
   /**
    * Expose SymEngine wrapper math functions
@@ -774,14 +783,11 @@ namespace std
 
 #  endif // DOXYGEN
 
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SYMENGINE
+
+// Re-open and then close the namespace, and this time also close the
+// export{} block if we are building C++20 modules:
+DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
+  DEAL_II_NAMESPACE_CLOSE
 
 #endif


### PR DESCRIPTION
This is the one file I split out of #19541 to fix #19527 (part of #18071). I *think* I figured out why this didn't work, namely because we have a file where we put things into `namespace std`. Let's see if this works now.