### PR TITLE
Remove most uses of `is_valid_dim_spacedim`.

### DIFF
--- a/doc/news/changes/incompatibilities/20260418Wells
+++ b/doc/news/changes/incompatibilities/20260418Wells
@@ -1,0 +1,7 @@
+Removed: The DoFHandler and Triangulation classes no longer rely on the
+is_valid_dim_spacedim concept: instead, they implement the same check with a
+static_assert(). This change will keep older forward declarations working but
+newer forward declarations, which include a concept requires statement, will
+need to be rewritten.
+<br>
+(David Wells, 2026/04/18)

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -685,6 +685,12 @@ namespace concepts
    * - `dim<=spacedim`.
    * These are the kinds of requirements that are imposed, for
    * example, on class Triangulation.
+   *
+   * @deprecated
+   * The use of this concept has been superseded by
+   * @code
+   *     static_assert(dim >= 1 && spacedim <= 3 && dim <= spacedim)
+   * @endcode
    */
   template <int dim, int spacedim>
   concept is_valid_dim_spacedim =
@@ -882,32 +888,27 @@ namespace concepts
 } // namespace concepts
 
 
-template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+template <int, int>
 class Triangulation;
 
-template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+template <int, int>
 class DoFHandler;
 
 namespace parallel
 {
   namespace distributed
   {
-    template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    template <int, int>
     class Triangulation;
   }
   namespace shared
   {
-    template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    template <int, int>
     class Triangulation;
   }
   namespace fullydistributed
   {
-    template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    template <int, int>
     class Triangulation;
   }
 } // namespace parallel

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -102,11 +102,8 @@ namespace parallel
      * @note Currently only simple periodicity conditions (i.e. without offsets
      *       and rotation matrices - see also the documentation of
      *       GridTools::collect_periodic_faces()) are supported.
-     *
-     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation
       : public parallel::DistributedTriangulationBase<dim, spacedim>
     {

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -50,7 +50,6 @@ namespace parallel
   namespace distributed
   {
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation;
   }
 } // namespace parallel

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -98,11 +98,8 @@ namespace parallel
      * mesh.
      *
      * @ingroup distributed
-     *
-     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation
       : public dealii::parallel::TriangulationBase<dim, spacedim>
     {
@@ -436,10 +433,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     template <class Archive>
-    void Triangulation<dim, spacedim>::load(Archive           &ar,
-                                            const unsigned int version)
+    void
+    Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int version)
     {
       dealii::Triangulation<dim, spacedim>::load(ar, version);
       partition();
@@ -460,11 +456,8 @@ namespace parallel
      * Since the constructor of this class is deleted, no such objects
      * can actually be created as this would be pointless given that
      * MPI is not available.
-     *
-     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation
       : public dealii::parallel::TriangulationBase<dim, spacedim>
     {

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -292,11 +292,8 @@ namespace parallel
      *
      *
      * @ingroup distributed
-     *
-     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation
       : public dealii::parallel::DistributedTriangulationBase<dim, spacedim>
     {
@@ -919,11 +916,8 @@ namespace parallel
      * Specialization of the general template for the 1d case. There is
      * currently no support for distributing 1d triangulations. Consequently,
      * all this class does is throw an exception.
-     *
-     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<1, spacedim>)}
      */
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     class Triangulation<1, spacedim>
       : public dealii::parallel::DistributedTriangulationBase<1, spacedim>
     {
@@ -1054,11 +1048,8 @@ namespace parallel
      * Since the constructor of this class is deleted, no such objects
      * can actually be created as this would be pointless given that
      * p4est is not available.
-     *
-     * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
      */
     template <int dim, int spacedim = dim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation
       : public dealii::parallel::DistributedTriangulationBase<dim, spacedim>
     {

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -73,7 +73,6 @@ namespace parallel
    * classes derived from the current one it actually is).
    */
   template <int dim, int spacedim = dim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   class TriangulationBase : public dealii::Triangulation<dim, spacedim>
   {
   public:
@@ -464,11 +463,8 @@ namespace parallel
    *       return false;
    *   }
    * @endcode
-   *
-   * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
    */
   template <int dim, int spacedim = dim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   class DistributedTriangulationBase
     : public dealii::parallel::TriangulationBase<dim, spacedim>
   {

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -30,7 +30,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -48,7 +48,6 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int spacedim>
 class FiniteElement;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 
 namespace internal
@@ -314,11 +313,8 @@ class DoFCellAccessor;
  * parallel::distributed::SolutionTransfer for more information.
  *
  * @ingroup dofs
- *
- * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
  */
 template <int dim, int spacedim = dim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler : public EnableObserverPointer
 {
   using ActiveSelector =
@@ -327,6 +323,11 @@ class DoFHandler : public EnableObserverPointer
     dealii::internal::DoFHandlerImplementation::Iterators<dim, spacedim, true>;
 
 public:
+  static_assert(dim >= 1 && spacedim <= 3 && dim <= spacedim,
+                "This class requires that the dimension and space dimension "
+                "correspond to a 1d, 2d, or 3d structure embedded in a 1d, 2d, "
+                "or 3d space with nonnegative codimension.");
+
   /**
    * An alias that is used to identify cell iterators in DoFHandler objects.
    * The concept of iterators is discussed at length in the
@@ -1784,8 +1785,8 @@ namespace internal
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline bool DoFHandler<dim, spacedim>::has_hp_capabilities() const
+inline bool
+DoFHandler<dim, spacedim>::has_hp_capabilities() const
 {
   return hp_capability_enabled;
 }
@@ -1793,8 +1794,8 @@ inline bool DoFHandler<dim, spacedim>::has_hp_capabilities() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline bool DoFHandler<dim, spacedim>::has_level_dofs() const
+inline bool
+DoFHandler<dim, spacedim>::has_level_dofs() const
 {
   return mg_number_cache.size() > 0;
 }
@@ -1802,8 +1803,8 @@ inline bool DoFHandler<dim, spacedim>::has_level_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline bool DoFHandler<dim, spacedim>::has_active_dofs() const
+inline bool
+DoFHandler<dim, spacedim>::has_active_dofs() const
 {
   return number_cache.n_global_dofs > 0;
 }
@@ -1811,8 +1812,8 @@ inline bool DoFHandler<dim, spacedim>::has_active_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline types::global_dof_index DoFHandler<dim, spacedim>::n_dofs() const
+inline types::global_dof_index
+DoFHandler<dim, spacedim>::n_dofs() const
 {
   return number_cache.n_global_dofs;
 }
@@ -1820,9 +1821,8 @@ inline types::global_dof_index DoFHandler<dim, spacedim>::n_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 inline types::global_dof_index
-  DoFHandler<dim, spacedim>::n_dofs(const unsigned int level) const
+DoFHandler<dim, spacedim>::n_dofs(const unsigned int level) const
 {
   Assert(has_level_dofs(),
          ExcMessage(
@@ -1834,8 +1834,8 @@ inline types::global_dof_index
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-types::global_dof_index DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
+types::global_dof_index
+DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 {
   return number_cache.n_locally_owned_dofs;
 }
@@ -1843,8 +1843,8 @@ types::global_dof_index DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const IndexSet &DoFHandler<dim, spacedim>::locally_owned_dofs() const
+const IndexSet &
+DoFHandler<dim, spacedim>::locally_owned_dofs() const
 {
   return number_cache.locally_owned_dofs;
 }
@@ -1852,9 +1852,8 @@ const IndexSet &DoFHandler<dim, spacedim>::locally_owned_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const IndexSet &DoFHandler<dim, spacedim>::locally_owned_mg_dofs(
-  const unsigned int level) const
+const IndexSet &
+DoFHandler<dim, spacedim>::locally_owned_mg_dofs(const unsigned int level) const
 {
   Assert(level < this->get_triangulation().n_global_levels(),
          ExcMessage("The given level index exceeds the number of levels "
@@ -1869,9 +1868,8 @@ const IndexSet &DoFHandler<dim, spacedim>::locally_owned_mg_dofs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline const FiniteElement<dim, spacedim> &DoFHandler<dim, spacedim>::get_fe(
-  const types::fe_index number) const
+inline const FiniteElement<dim, spacedim> &
+DoFHandler<dim, spacedim>::get_fe(const types::fe_index number) const
 {
   Assert(fe_collection.size() > 0,
          ExcMessage("No finite element collection is associated with "
@@ -1882,9 +1880,8 @@ inline const FiniteElement<dim, spacedim> &DoFHandler<dim, spacedim>::get_fe(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline const hp::FECollection<dim, spacedim>
-  &DoFHandler<dim, spacedim>::get_fe_collection() const
+inline const hp::FECollection<dim, spacedim> &
+DoFHandler<dim, spacedim>::get_fe_collection() const
 {
   return fe_collection;
 }
@@ -1892,9 +1889,8 @@ inline const hp::FECollection<dim, spacedim>
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline const Triangulation<dim, spacedim>
-  &DoFHandler<dim, spacedim>::get_triangulation() const
+inline const Triangulation<dim, spacedim> &
+DoFHandler<dim, spacedim>::get_triangulation() const
 {
   Assert(tria != nullptr,
          ExcMessage("This DoFHandler object has not been associated "
@@ -1905,8 +1901,8 @@ inline const Triangulation<dim, spacedim>
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline MPI_Comm DoFHandler<dim, spacedim>::get_mpi_communicator() const
+inline MPI_Comm
+DoFHandler<dim, spacedim>::get_mpi_communicator() const
 {
   Assert(tria != nullptr,
          ExcMessage("This DoFHandler object has not been associated "
@@ -1917,8 +1913,8 @@ inline MPI_Comm DoFHandler<dim, spacedim>::get_mpi_communicator() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline MPI_Comm DoFHandler<dim, spacedim>::get_communicator() const
+inline MPI_Comm
+DoFHandler<dim, spacedim>::get_communicator() const
 {
   return get_mpi_communicator();
 }
@@ -1926,8 +1922,8 @@ inline MPI_Comm DoFHandler<dim, spacedim>::get_communicator() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline const BlockInfo &DoFHandler<dim, spacedim>::block_info() const
+inline const BlockInfo &
+DoFHandler<dim, spacedim>::block_info() const
 {
   Assert(this->hp_capability_enabled == false, ExcNotImplementedWithHP());
 
@@ -1937,9 +1933,9 @@ inline const BlockInfo &DoFHandler<dim, spacedim>::block_info() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <typename number>
-types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs(
+types::global_dof_index
+DoFHandler<dim, spacedim>::n_boundary_dofs(
   const std::map<types::boundary_id, const Function<spacedim, number> *>
     &boundary_ids) const
 {
@@ -1980,9 +1976,9 @@ namespace internal
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
+void
+DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
 {
   if (this->hp_capability_enabled)
     {
@@ -2030,9 +2026,9 @@ void DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
+void
+DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
 {
   if (this->hp_capability_enabled)
     {
@@ -2112,12 +2108,11 @@ void DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline types::global_dof_index
-  &DoFHandler<dim, spacedim>::MGVertexDoFs::access_index(
-    const unsigned int level,
-    const unsigned int dof_number,
-    const unsigned int dofs_per_vertex)
+inline types::global_dof_index &
+DoFHandler<dim, spacedim>::MGVertexDoFs::access_index(
+  const unsigned int level,
+  const unsigned int dof_number,
+  const unsigned int dofs_per_vertex)
 {
   Assert((level >= coarsest_level) && (level <= finest_level),
          ExcInvalidLevel(level));

--- a/include/deal.II/dofs/dof_handler_policy.h
+++ b/include/deal.II/dofs/dof_handler_policy.h
@@ -30,7 +30,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/dofs/dof_iterator_selector.h
+++ b/include/deal.II/dofs/dof_iterator_selector.h
@@ -31,7 +31,6 @@ template <int dim, int spacedim, bool lda>
 class DoFCellAccessor;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <typename Accessor>

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -27,7 +27,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -45,7 +45,6 @@ class Quadrature;
 template <int dim, int spacedim>
 class FiniteElement;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim>
 class FiniteElementData;

--- a/include/deal.II/fe/mapping_q_cache.h
+++ b/include/deal.II/fe/mapping_q_cache.h
@@ -32,7 +32,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/grid/cell_id.h
+++ b/include/deal.II/grid/cell_id.h
@@ -32,7 +32,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 #endif
 

--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -40,7 +40,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <int dim>
 struct CellData;

--- a/include/deal.II/grid/grid_out.h
+++ b/include/deal.II/grid/grid_out.h
@@ -29,7 +29,6 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 class ParameterHandler;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -27,7 +27,6 @@ DEAL_II_NAMESPACE_OPEN
 // forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <typename Number>
 class Vector;

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -73,7 +73,6 @@ namespace parallel
   namespace distributed
   {
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     class Triangulation;
   }
 } // namespace parallel

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -334,7 +334,6 @@ namespace internal
    * A structure that binds information about data attached to cells.
    */
   template <int dim, int spacedim = dim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   struct CellAttachedData
   {
     using cell_iterator = TriaIterator<CellAccessor<dim, spacedim>>;
@@ -373,7 +372,6 @@ namespace internal
    * It is designed to store all data buffers intended for serialization.
    */
   template <int dim, int spacedim = dim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   class CellAttachedDataSerializer
   {
   public:
@@ -1314,11 +1312,8 @@ namespace internal
  * data stored in the triangulation.
  *
  * @ingroup grid
- *
- * @dealiiConceptRequires{(concepts::is_valid_dim_spacedim<dim, spacedim>)}
  */
 template <int dim, int spacedim = dim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation : public EnableObserverPointer
 {
 private:
@@ -1330,6 +1325,11 @@ private:
     dealii::internal::TriangulationImplementation::Iterators<dim, spacedim>;
 
 public:
+  static_assert(dim >= 1 && spacedim <= 3 && dim <= spacedim,
+                "This class requires that the dimension and space dimension "
+                "correspond to a 1d, 2d, or 3d structure embedded in a 1d, 2d, "
+                "or 3d space with nonnegative codimension.");
+
   /**
    * Declare some symbolic names for mesh smoothing algorithms. The meaning of
    * these flags is documented in the Triangulation class.
@@ -4667,9 +4667,8 @@ namespace internal
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline bool Triangulation<dim, spacedim>::vertex_used(
-  const unsigned int index) const
+inline bool
+Triangulation<dim, spacedim>::vertex_used(const unsigned int index) const
 {
   AssertIndexRange(index, vertices_used.size());
   return vertices_used[index];
@@ -4678,23 +4677,23 @@ inline bool Triangulation<dim, spacedim>::vertex_used(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline unsigned int Triangulation<dim, spacedim>::n_levels() const
+inline unsigned int
+Triangulation<dim, spacedim>::n_levels() const
 {
   return number_cache.n_levels;
 }
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline unsigned int Triangulation<dim, spacedim>::n_global_levels() const
+inline unsigned int
+Triangulation<dim, spacedim>::n_global_levels() const
 {
   return number_cache.n_levels;
 }
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline unsigned int Triangulation<dim, spacedim>::n_vertices() const
+inline unsigned int
+Triangulation<dim, spacedim>::n_vertices() const
 {
   return vertices.size();
 }
@@ -4702,18 +4701,17 @@ inline unsigned int Triangulation<dim, spacedim>::n_vertices() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline const std::vector<Point<spacedim>>
-  &Triangulation<dim, spacedim>::get_vertices() const
+inline const std::vector<Point<spacedim>> &
+Triangulation<dim, spacedim>::get_vertices() const
 {
   return vertices;
 }
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
+void
+Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
 {
   // as discussed in the documentation, do not store the signals as
   // well as boundary and manifold description but everything else
@@ -4752,9 +4750,9 @@ void Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 template <class Archive>
-void Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
+void
+Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
 {
   // clear previous content. this also calls the respective signal
   clear();
@@ -4829,10 +4827,9 @@ void Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-inline unsigned int Triangulation<dim, spacedim>::
-  coarse_cell_id_to_coarse_cell_index(
-    const types::coarse_cell_id coarse_cell_id) const
+inline unsigned int
+Triangulation<dim, spacedim>::coarse_cell_id_to_coarse_cell_index(
+  const types::coarse_cell_id coarse_cell_id) const
 {
   return coarse_cell_id;
 }
@@ -4840,10 +4837,9 @@ inline unsigned int Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 inline types::coarse_cell_id
-  Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
-    const unsigned int coarse_cell_index) const
+Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
+  const unsigned int coarse_cell_index) const
 {
   return coarse_cell_index;
 }

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -42,7 +42,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <typename Accessor>
 class TriaRawIterator;
@@ -54,12 +53,10 @@ class TriaActiveIterator;
 namespace parallel
 {
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   class TriangulationBase;
 }
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, int spacedim, bool lda>
 class DoFCellAccessor;

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -30,7 +30,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <int, int, int>
 class TriaAccessorBase;

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -26,7 +26,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 template <class Accessor>
 class TriaRawIterator;

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -32,7 +32,6 @@ template <typename Number>
 class Vector;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -30,7 +30,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/multigrid/mg_tools.h
+++ b/include/deal.II/multigrid/mg_tools.h
@@ -29,7 +29,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 class MGConstrainedDoFs;
 #endif

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -35,7 +35,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -37,7 +37,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -31,7 +31,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declaration
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 #endif
 

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -30,7 +30,6 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int, int>
 class Mapping;

--- a/include/deal.II/numerics/matrix_creator.h
+++ b/include/deal.II/numerics/matrix_creator.h
@@ -44,7 +44,6 @@ class SparseMatrix;
 template <int dim, int spacedim>
 class Mapping;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 namespace hp

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -54,7 +54,6 @@ class BlockVector;
 template <int dim, int spacedim>
 class Mapping;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 namespace hp

--- a/include/deal.II/numerics/smoothness_estimator.h
+++ b/include/deal.II/numerics/smoothness_estimator.h
@@ -33,7 +33,6 @@ template <typename Number>
 class Vector;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 namespace FESeries

--- a/include/deal.II/numerics/time_dependent.h
+++ b/include/deal.II/numerics/time_dependent.h
@@ -32,7 +32,6 @@ class TimeStepBase;
 template <typename number>
 class Vector;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 #endif
 

--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -27,7 +27,6 @@ DEAL_II_NAMESPACE_OPEN
 template <typename number>
 class AffineConstraints;
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, typename Number>
 class Function;

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -23,7 +23,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <int dim, typename Number>
@@ -34,7 +33,6 @@ template <int dim>
 class Quadrature;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class Triangulation;
 
 namespace hp

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -28,7 +28,6 @@ template <typename number>
 class AffineConstraints;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <typename number>

--- a/include/deal.II/numerics/vector_tools_mean_value.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.h
@@ -27,7 +27,6 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 // forward declarations
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 template <int dim, int spacedim>
 class Mapping;

--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -24,7 +24,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <int dim, typename Number>

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -22,7 +22,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <int dim, typename Number>

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -28,7 +28,6 @@ template <typename number>
 class AffineConstraints;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <int dim, typename Number>

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -26,7 +26,6 @@ template <typename number>
 class AffineConstraints;
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 class DoFHandler;
 
 template <int dim, typename Number>

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -41,7 +41,6 @@ namespace parallel
   namespace fullydistributed
   {
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     Triangulation<dim, spacedim>::Triangulation(const MPI_Comm mpi_communicator)
       : parallel::DistributedTriangulationBase<dim, spacedim>(mpi_communicator)
       , settings(TriangulationDescription::Settings::default_setting)
@@ -57,8 +56,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::create_triangulation(
+    void
+    Triangulation<dim, spacedim>::create_triangulation(
       const TriangulationDescription::Description<dim, spacedim>
         &construction_data)
     {
@@ -218,8 +217,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::create_triangulation(
+    void
+    Triangulation<dim, spacedim>::create_triangulation(
       const std::vector<Point<spacedim>>       &vertices,
       const std::vector<dealii::CellData<dim>> &cells,
       const SubCellData                        &subcelldata)
@@ -255,8 +254,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::copy_triangulation(
+    void
+    Triangulation<dim, spacedim>::copy_triangulation(
       const dealii::Triangulation<dim, spacedim> &other_tria)
     {
       // pointer to the triangulation for which the construction data
@@ -304,8 +303,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::set_partitioner(
+    void
+    Triangulation<dim, spacedim>::set_partitioner(
       const std::function<void(dealii::Triangulation<dim, spacedim> &,
                                const unsigned int)> &partitioner,
       const TriangulationDescription::Settings      &settings)
@@ -317,8 +316,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::set_partitioner(
+    void
+    Triangulation<dim, spacedim>::set_partitioner(
       const RepartitioningPolicyTools::Base<dim, spacedim> &partitioner,
       const TriangulationDescription::Settings             &settings)
     {
@@ -329,8 +328,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::repartition()
+    void
+    Triangulation<dim, spacedim>::repartition()
     {
       // signal that repartitioning has started
       this->signals.pre_distributed_repartition();
@@ -357,8 +356,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    void
+    Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
     {
       DEAL_II_NOT_IMPLEMENTED();
     }
@@ -366,8 +365,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
+    bool
+    Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
     {
       Assert(
         currently_processing_prepare_coarsening_and_refinement_for_internal_usage,
@@ -380,8 +379,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    std::size_t Triangulation<dim, spacedim>::memory_consumption() const
+    std::size_t
+    Triangulation<dim, spacedim>::memory_consumption() const
     {
       const std::size_t mem =
         this->dealii::parallel::TriangulationBase<dim, spacedim>::
@@ -396,9 +395,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed()
-      const
+    bool
+    Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed() const
     {
       return (
         settings &
@@ -408,10 +406,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    unsigned int Triangulation<dim, spacedim>::
-      coarse_cell_id_to_coarse_cell_index(
-        const types::coarse_cell_id coarse_cell_id) const
+    unsigned int
+    Triangulation<dim, spacedim>::coarse_cell_id_to_coarse_cell_index(
+      const types::coarse_cell_id coarse_cell_id) const
     {
       const auto coarse_cell_index = std::lower_bound(
         coarse_cell_id_to_coarse_cell_index_vector.begin(),
@@ -429,10 +426,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     types::coarse_cell_id
-      Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
-        const unsigned int coarse_cell_index) const
+    Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
+      const unsigned int coarse_cell_index) const
     {
       AssertIndexRange(coarse_cell_index,
                        coarse_cell_index_to_coarse_cell_id_vector.size());
@@ -446,8 +442,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::update_cell_relations()
+    void
+    Triangulation<dim, spacedim>::update_cell_relations()
     {
       // Reorganize memory for local_cell_relations.
       this->local_cell_relations.clear();
@@ -462,8 +458,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::save(const std::string &filename) const
+    void
+    Triangulation<dim, spacedim>::save(const std::string &filename) const
     {
 #ifdef DEAL_II_WITH_MPI
 
@@ -602,8 +598,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::load(const std::string &filename)
+    void
+    Triangulation<dim, spacedim>::load(const std::string &filename)
     {
 #ifdef DEAL_II_WITH_MPI
       Assert(this->n_cells() == 0,
@@ -751,8 +747,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::update_number_cache()
+    void
+    Triangulation<dim, spacedim>::update_number_cache()
     {
       dealii::parallel::TriangulationBase<dim, spacedim>::update_number_cache();
 

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -36,7 +36,6 @@ namespace parallel
   namespace shared
   {
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     Triangulation<dim, spacedim>::Triangulation(
       const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
@@ -70,9 +69,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed()
-      const
+    bool
+    Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed() const
     {
       return (settings & construct_multigrid_hierarchy);
     }
@@ -80,8 +78,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::partition()
+    void
+    Triangulation<dim, spacedim>::partition()
     {
       if constexpr (running_in_debug_mode())
         {
@@ -319,8 +317,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::with_artificial_cells() const
+    bool
+    Triangulation<dim, spacedim>::with_artificial_cells() const
     {
       return allow_artificial_cells;
     }
@@ -328,9 +326,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const std::vector<types::subdomain_id>
-      &Triangulation<dim, spacedim>::get_true_subdomain_ids_of_cells() const
+    const std::vector<types::subdomain_id> &
+    Triangulation<dim, spacedim>::get_true_subdomain_ids_of_cells() const
     {
       return true_subdomain_ids_of_cells;
     }
@@ -338,10 +335,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const std::vector<types::subdomain_id>
-      &Triangulation<dim, spacedim>::get_true_level_subdomain_ids_of_cells(
-        const unsigned int level) const
+    const std::vector<types::subdomain_id> &
+    Triangulation<dim, spacedim>::get_true_level_subdomain_ids_of_cells(
+      const unsigned int level) const
     {
       Assert(level < true_level_subdomain_ids_of_cells.size(),
              ExcInternalError());
@@ -354,8 +350,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    void
+    Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
     {
       // make sure that all refinement/coarsening flags are the same on all
       // processes
@@ -425,8 +421,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::create_triangulation(
+    void
+    Triangulation<dim, spacedim>::create_triangulation(
       const std::vector<Point<spacedim>> &vertices,
       const std::vector<CellData<dim>>   &cells,
       const SubCellData                  &subcelldata)
@@ -451,8 +447,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::create_triangulation(
+    void
+    Triangulation<dim, spacedim>::create_triangulation(
       const TriangulationDescription::Description<dim, spacedim>
         &construction_data)
     {
@@ -464,8 +460,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::copy_triangulation(
+    void
+    Triangulation<dim, spacedim>::copy_triangulation(
       const dealii::Triangulation<dim, spacedim> &other_tria)
     {
       Assert(
@@ -490,8 +486,8 @@ namespace parallel
   namespace shared
   {
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::with_artificial_cells() const
+    bool
+    Triangulation<dim, spacedim>::with_artificial_cells() const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return true;
@@ -500,9 +496,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed()
-      const
+    bool
+    Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed() const
     {
       return false;
     }
@@ -510,9 +505,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const std::vector<unsigned int>
-      &Triangulation<dim, spacedim>::get_true_subdomain_ids_of_cells() const
+    const std::vector<unsigned int> &
+    Triangulation<dim, spacedim>::get_true_subdomain_ids_of_cells() const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return true_subdomain_ids_of_cells;
@@ -521,10 +515,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const std::vector<unsigned int>
-      &Triangulation<dim, spacedim>::get_true_level_subdomain_ids_of_cells(
-        const unsigned int) const
+    const std::vector<unsigned int> &
+    Triangulation<dim, spacedim>::get_true_level_subdomain_ids_of_cells(
+      const unsigned int) const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return true_level_subdomain_ids_of_cells;

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1690,7 +1690,6 @@ namespace parallel
   {
     /*----------------- class Triangulation<dim,spacedim> ---------------*/
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     Triangulation<dim, spacedim>::Triangulation(
       const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
@@ -1719,7 +1718,6 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     Triangulation<dim, spacedim>::~Triangulation()
     {
       try
@@ -1741,8 +1739,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::create_triangulation(
+    void
+    Triangulation<dim, spacedim>::create_triangulation(
       const std::vector<Point<spacedim>> &vertices,
       const std::vector<CellData<dim>>   &cells,
       const SubCellData                  &subcelldata)
@@ -1794,8 +1792,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::create_triangulation(
+    void
+    Triangulation<dim, spacedim>::create_triangulation(
       const TriangulationDescription::Description<dim, spacedim>
         & /*construction_data*/)
     {
@@ -1805,8 +1803,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::clear()
+    void
+    Triangulation<dim, spacedim>::clear()
     {
       triangulation_has_content = false;
 
@@ -1841,9 +1839,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed()
-      const
+    bool
+    Triangulation<dim, spacedim>::is_multilevel_hierarchy_constructed() const
     {
       return settings &
              Triangulation<dim, spacedim>::construct_multigrid_hierarchy;
@@ -1852,9 +1849,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::are_vertices_communicated_to_p4est()
-      const
+    bool
+    Triangulation<dim, spacedim>::are_vertices_communicated_to_p4est() const
     {
       return settings &
              Triangulation<dim, spacedim>::communicate_vertices_to_p4est;
@@ -1863,8 +1859,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::execute_transfer(
+    void
+    Triangulation<dim, spacedim>::execute_transfer(
       const typename dealii::internal::p4est::types<dim>::forest
         *parallel_forest,
       const typename dealii::internal::p4est::types<dim>::gloidx
@@ -1945,9 +1941,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim,
-                       spacedim>::setup_coarse_cell_to_p4est_tree_permutation()
+    void
+    Triangulation<dim, spacedim>::setup_coarse_cell_to_p4est_tree_permutation()
     {
       DynamicSparsityPattern cell_connectivity;
       dealii::GridTools::get_vertex_connectivity_of_cells(*this,
@@ -1963,8 +1958,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::write_mesh_vtk(
+    void
+    Triangulation<dim, spacedim>::write_mesh_vtk(
       const std::string &file_basename) const
     {
       Assert(parallel_forest != nullptr,
@@ -1982,9 +1977,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::save(
-      const std::string &file_basename) const
+    void
+    Triangulation<dim, spacedim>::save(const std::string &file_basename) const
     {
       Assert(
         this->cell_attached_data.n_attached_deserialize == 0,
@@ -2036,8 +2030,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::load(const std::string &file_basename)
+    void
+    Triangulation<dim, spacedim>::load(const std::string &file_basename)
     {
       Assert(
         this->n_cells() > 0,
@@ -2136,8 +2130,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::load(
+    void
+    Triangulation<dim, spacedim>::load(
       const typename dealii::internal::p4est::types<dim>::forest *forest)
     {
       Assert(this->n_cells() > 0,
@@ -2189,8 +2183,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    unsigned int Triangulation<dim, spacedim>::get_checksum() const
+    unsigned int
+    Triangulation<dim, spacedim>::get_checksum() const
     {
       Assert(parallel_forest != nullptr,
              ExcMessage(
@@ -2216,9 +2210,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const typename dealii::internal::p4est::types<dim>::forest
-      *Triangulation<dim, spacedim>::get_p4est() const
+    const typename dealii::internal::p4est::types<dim>::forest *
+    Triangulation<dim, spacedim>::get_p4est() const
     {
       Assert(parallel_forest != nullptr,
              ExcMessage("The forest has not been allocated yet."));
@@ -2228,10 +2221,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    typename dealii::internal::p4est::types<dim>::tree
-      *Triangulation<dim, spacedim>::init_tree(
-        const int dealii_coarse_cell_index) const
+    typename dealii::internal::p4est::types<dim>::tree *
+    Triangulation<dim, spacedim>::init_tree(
+      const int dealii_coarse_cell_index) const
     {
       const unsigned int tree_index =
         coarse_cell_to_p4est_tree_permutation[dealii_coarse_cell_index];
@@ -2722,8 +2714,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
+    bool
+    Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
     {
       // First exchange coarsen/refinement flags on ghost cells. After this
       // collective communication call all flags on ghost cells match the
@@ -2741,8 +2733,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::copy_local_forest_to_triangulation()
+    void
+    Triangulation<dim, spacedim>::copy_local_forest_to_triangulation()
     {
       // Disable mesh smoothing for recreating the deal.II triangulation,
       // otherwise we might not be able to reproduce the p4est mesh
@@ -3122,9 +3114,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     types::subdomain_id
-      Triangulation<dim, spacedim>::find_point_owner_rank(const Point<dim> &p)
+    Triangulation<dim, spacedim>::find_point_owner_rank(const Point<dim> &p)
     {
       // Call the other function
       std::vector<Point<dim>>          point{p};
@@ -3136,9 +3127,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    std::vector<types::subdomain_id> Triangulation<dim, spacedim>::
-      find_point_owner_rank(const std::vector<Point<dim>> &points)
+    std::vector<types::subdomain_id>
+    Triangulation<dim, spacedim>::find_point_owner_rank(
+      const std::vector<Point<dim>> &points)
     {
       // We can only use this function if vertices are communicated to p4est
       AssertThrow(this->are_vertices_communicated_to_p4est(),
@@ -3231,8 +3222,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    void
+    Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
     {
       // do not allow anisotropic refinement
       if constexpr (running_in_debug_mode())
@@ -3501,8 +3492,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::repartition()
+    void
+    Triangulation<dim, spacedim>::repartition()
     {
       if constexpr (running_in_debug_mode())
         {
@@ -3612,10 +3603,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const std::vector<types::global_dof_index>
-      &Triangulation<dim, spacedim>::get_p4est_tree_to_coarse_cell_permutation()
-        const
+    const std::vector<types::global_dof_index> &
+    Triangulation<dim, spacedim>::get_p4est_tree_to_coarse_cell_permutation()
+      const
     {
       return p4est_tree_to_coarse_cell_permutation;
     }
@@ -3623,10 +3613,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    const std::vector<types::global_dof_index>
-      &Triangulation<dim, spacedim>::get_coarse_cell_to_p4est_tree_permutation()
-        const
+    const std::vector<types::global_dof_index> &
+    Triangulation<dim, spacedim>::get_coarse_cell_to_p4est_tree_permutation()
+      const
     {
       return coarse_cell_to_p4est_tree_permutation;
     }
@@ -3634,9 +3623,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    std::vector<bool> Triangulation<dim, spacedim>::
-      mark_locally_active_vertices_on_level(const int level) const
+    std::vector<bool>
+    Triangulation<dim, spacedim>::mark_locally_active_vertices_on_level(
+      const int level) const
     {
       Assert(dim > 1, ExcNotImplemented());
 
@@ -3701,10 +3690,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    unsigned int Triangulation<dim, spacedim>::
-      coarse_cell_id_to_coarse_cell_index(
-        const types::coarse_cell_id coarse_cell_id) const
+    unsigned int
+    Triangulation<dim, spacedim>::coarse_cell_id_to_coarse_cell_index(
+      const types::coarse_cell_id coarse_cell_id) const
     {
       return p4est_tree_to_coarse_cell_permutation[coarse_cell_id];
     }
@@ -3712,10 +3700,9 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     types::coarse_cell_id
-      Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
-        const unsigned int coarse_cell_index) const
+    Triangulation<dim, spacedim>::coarse_cell_index_to_coarse_cell_id(
+      const unsigned int coarse_cell_index) const
     {
       return coarse_cell_to_p4est_tree_permutation[coarse_cell_index];
     }
@@ -3723,8 +3710,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::add_periodicity(
+    void
+    Triangulation<dim, spacedim>::add_periodicity(
       const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator>>
         &periodicity_vector)
     {
@@ -3880,8 +3867,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    std::size_t Triangulation<dim, spacedim>::memory_consumption() const
+    std::size_t
+    Triangulation<dim, spacedim>::memory_consumption() const
     {
       std::size_t mem =
         this->dealii::parallel::TriangulationBase<dim, spacedim>::
@@ -3908,8 +3895,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    std::size_t Triangulation<dim, spacedim>::memory_consumption_p4est() const
+    std::size_t
+    Triangulation<dim, spacedim>::memory_consumption_p4est() const
     {
       return dealii::internal::p4est::functions<dim>::forest_memory_used(
                parallel_forest) +
@@ -3920,8 +3907,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::copy_triangulation(
+    void
+    Triangulation<dim, spacedim>::copy_triangulation(
       const dealii::Triangulation<dim, spacedim> &other_tria)
     {
       if (const dealii::parallel::distributed::Triangulation<dim, spacedim>
@@ -3936,8 +3923,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::copy_triangulation(
+    void
+    Triangulation<dim, spacedim>::copy_triangulation(
       const dealii::Triangulation<dim, spacedim> &other_tria,
       const Settings                              settings)
     {
@@ -4022,8 +4009,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::update_cell_relations()
+    void
+    Triangulation<dim, spacedim>::update_cell_relations()
     {
       // reorganize memory for local_cell_relations
       this->local_cell_relations.resize(parallel_forest->local_num_quadrants);
@@ -4055,9 +4042,8 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    std::vector<unsigned int> Triangulation<dim, spacedim>::get_cell_weights()
-      const
+    std::vector<unsigned int>
+    Triangulation<dim, spacedim>::get_cell_weights() const
     {
       // check if local_cell_relations have been previously gathered
       // correctly
@@ -4090,7 +4076,6 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     Triangulation<1, spacedim>::Triangulation(
       const MPI_Comm mpi_communicator,
       const typename dealii::Triangulation<1, spacedim>::MeshSmoothing
@@ -4106,7 +4091,6 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     Triangulation<1, spacedim>::~Triangulation()
     {
       AssertNothrow(false, ExcNotImplemented());
@@ -4115,10 +4099,9 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    const std::vector<types::global_dof_index>
-      &Triangulation<1, spacedim>::get_p4est_tree_to_coarse_cell_permutation()
-        const
+    const std::vector<types::global_dof_index> &
+    Triangulation<1, spacedim>::get_p4est_tree_to_coarse_cell_permutation()
+      const
     {
       static std::vector<types::global_dof_index> a;
       return a;
@@ -4127,11 +4110,9 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    std::map<unsigned int,
-             std::set<dealii::types::subdomain_id>> Triangulation<1, spacedim>::
-      compute_level_vertices_with_ghost_neighbors(
-        const unsigned int /*level*/) const
+    std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+    Triangulation<1, spacedim>::compute_level_vertices_with_ghost_neighbors(
+      const unsigned int /*level*/) const
     {
       DEAL_II_NOT_IMPLEMENTED();
 
@@ -4141,9 +4122,9 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    std::vector<bool> Triangulation<1, spacedim>::
-      mark_locally_active_vertices_on_level(const unsigned int) const
+    std::vector<bool>
+    Triangulation<1, spacedim>::mark_locally_active_vertices_on_level(
+      const unsigned int) const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return std::vector<bool>();
@@ -4152,9 +4133,9 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    unsigned int Triangulation<1, spacedim>::
-      coarse_cell_id_to_coarse_cell_index(const types::coarse_cell_id) const
+    unsigned int
+    Triangulation<1, spacedim>::coarse_cell_id_to_coarse_cell_index(
+      const types::coarse_cell_id) const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return 0;
@@ -4163,10 +4144,9 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
     types::coarse_cell_id
-      Triangulation<1, spacedim>::coarse_cell_index_to_coarse_cell_id(
-        const unsigned int) const
+    Triangulation<1, spacedim>::coarse_cell_index_to_coarse_cell_id(
+      const unsigned int) const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return 0;
@@ -4175,8 +4155,8 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    void Triangulation<1, spacedim>::load(const std::string &)
+    void
+    Triangulation<1, spacedim>::load(const std::string &)
     {
       DEAL_II_NOT_IMPLEMENTED();
     }
@@ -4184,8 +4164,8 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    void Triangulation<1, spacedim>::save(const std::string &) const
+    void
+    Triangulation<1, spacedim>::save(const std::string &) const
     {
       DEAL_II_NOT_IMPLEMENTED();
     }
@@ -4193,18 +4173,8 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    bool Triangulation<1, spacedim>::is_multilevel_hierarchy_constructed() const
-    {
-      DEAL_II_NOT_IMPLEMENTED();
-      return false;
-    }
-
-
-
-    template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    bool Triangulation<1, spacedim>::are_vertices_communicated_to_p4est() const
+    bool
+    Triangulation<1, spacedim>::is_multilevel_hierarchy_constructed() const
     {
       DEAL_II_NOT_IMPLEMENTED();
       return false;
@@ -4213,8 +4183,18 @@ namespace parallel
 
 
     template <int spacedim>
-    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<1, spacedim>))
-    void Triangulation<1, spacedim>::update_cell_relations()
+    bool
+    Triangulation<1, spacedim>::are_vertices_communicated_to_p4est() const
+    {
+      DEAL_II_NOT_IMPLEMENTED();
+      return false;
+    }
+
+
+
+    template <int spacedim>
+    void
+    Triangulation<1, spacedim>::update_cell_relations()
     {
       DEAL_II_NOT_IMPLEMENTED();
     }

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -41,7 +41,6 @@ DEAL_II_NAMESPACE_OPEN
 namespace parallel
 {
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   TriangulationBase<dim, spacedim>::TriangulationBase(
     const MPI_Comm mpi_communicator,
     const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
@@ -61,8 +60,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void TriangulationBase<dim, spacedim>::copy_triangulation(
+  void
+  TriangulationBase<dim, spacedim>::copy_triangulation(
     const dealii::Triangulation<dim, spacedim> &other_tria)
   {
 #ifndef DEAL_II_WITH_MPI
@@ -86,8 +85,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  std::size_t TriangulationBase<dim, spacedim>::memory_consumption() const
+  std::size_t
+  TriangulationBase<dim, spacedim>::memory_consumption() const
   {
     std::size_t mem =
       this->dealii::Triangulation<dim, spacedim>::memory_consumption() +
@@ -102,7 +101,6 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   TriangulationBase<dim, spacedim>::~TriangulationBase()
   {
     // release unused vector memory because the vector layout is going to look
@@ -114,7 +112,6 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   TriangulationBase<dim, spacedim>::NumberCache::NumberCache()
     : n_locally_owned_active_cells(0)
     , n_global_active_cells(0)
@@ -125,9 +122,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  unsigned int TriangulationBase<dim, spacedim>::n_locally_owned_active_cells()
-    const
+  unsigned int
+  TriangulationBase<dim, spacedim>::n_locally_owned_active_cells() const
   {
     return number_cache.n_locally_owned_active_cells;
   }
@@ -135,8 +131,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  unsigned int TriangulationBase<dim, spacedim>::n_global_levels() const
+  unsigned int
+  TriangulationBase<dim, spacedim>::n_global_levels() const
   {
     return number_cache.n_global_levels;
   }
@@ -144,9 +140,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   types::global_cell_index
-    TriangulationBase<dim, spacedim>::n_global_active_cells() const
+  TriangulationBase<dim, spacedim>::n_global_active_cells() const
   {
     return number_cache.n_global_active_cells;
   }
@@ -154,8 +149,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  MPI_Comm TriangulationBase<dim, spacedim>::get_mpi_communicator() const
+  MPI_Comm
+  TriangulationBase<dim, spacedim>::get_mpi_communicator() const
   {
     return mpi_communicator;
   }
@@ -164,8 +159,8 @@ namespace parallel
 
 #ifdef DEAL_II_WITH_MPI
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void TriangulationBase<dim, spacedim>::update_number_cache()
+  void
+  TriangulationBase<dim, spacedim>::update_number_cache()
   {
     number_cache.ghost_owners.clear();
     number_cache.level_ghost_owners.clear();
@@ -301,8 +296,8 @@ namespace parallel
 #else
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void TriangulationBase<dim, spacedim>::update_number_cache()
+  void
+  TriangulationBase<dim, spacedim>::update_number_cache()
   {
     Assert(false, ExcNeedsMPI());
   }
@@ -310,9 +305,8 @@ namespace parallel
 #endif
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   types::subdomain_id
-    TriangulationBase<dim, spacedim>::locally_owned_subdomain() const
+  TriangulationBase<dim, spacedim>::locally_owned_subdomain() const
   {
     return my_subdomain;
   }
@@ -320,9 +314,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  const std::set<types::subdomain_id>
-    &TriangulationBase<dim, spacedim>::ghost_owners() const
+  const std::set<types::subdomain_id> &
+  TriangulationBase<dim, spacedim>::ghost_owners() const
   {
     return number_cache.ghost_owners;
   }
@@ -330,9 +323,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  const std::set<types::subdomain_id>
-    &TriangulationBase<dim, spacedim>::level_ghost_owners() const
+  const std::set<types::subdomain_id> &
+  TriangulationBase<dim, spacedim>::level_ghost_owners() const
   {
     return number_cache.level_ghost_owners;
   }
@@ -340,9 +332,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  std::vector<types::boundary_id> TriangulationBase<dim, spacedim>::
-    get_boundary_ids() const
+  std::vector<types::boundary_id>
+  TriangulationBase<dim, spacedim>::get_boundary_ids() const
   {
     return Utilities::MPI::compute_set_union(
       dealii::Triangulation<dim, spacedim>::get_boundary_ids(),
@@ -352,9 +343,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  std::vector<types::manifold_id> TriangulationBase<dim, spacedim>::
-    get_manifold_ids() const
+  std::vector<types::manifold_id>
+  TriangulationBase<dim, spacedim>::get_manifold_ids() const
   {
     return Utilities::MPI::compute_set_union(
       dealii::Triangulation<dim, spacedim>::get_manifold_ids(),
@@ -364,8 +354,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void TriangulationBase<dim, spacedim>::reset_global_cell_indices()
+  void
+  TriangulationBase<dim, spacedim>::reset_global_cell_indices()
   {
 #ifndef DEAL_II_WITH_MPI
     Assert(false, ExcNeedsMPI());
@@ -548,8 +538,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void TriangulationBase<dim, spacedim>::communicate_locally_moved_vertices(
+  void
+  TriangulationBase<dim, spacedim>::communicate_locally_moved_vertices(
     const std::vector<bool> &vertex_locally_moved)
   {
     AssertDimension(vertex_locally_moved.size(), this->n_vertices());
@@ -604,10 +594,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  std::weak_ptr<const Utilities::MPI::Partitioner> TriangulationBase<
-    dim,
-    spacedim>::global_active_cell_index_partitioner() const
+  std::weak_ptr<const Utilities::MPI::Partitioner>
+  TriangulationBase<dim, spacedim>::global_active_cell_index_partitioner() const
   {
     return number_cache.active_cell_index_partitioner;
   }
@@ -615,10 +603,9 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  std::weak_ptr<const Utilities::MPI::Partitioner> TriangulationBase<dim,
-                                                                     spacedim>::
-    global_level_cell_index_partitioner(const unsigned int level) const
+  std::weak_ptr<const Utilities::MPI::Partitioner>
+  TriangulationBase<dim, spacedim>::global_level_cell_index_partitioner(
+    const unsigned int level) const
   {
     Assert(this->is_multilevel_hierarchy_constructed(), ExcNotImplemented());
     AssertIndexRange(level, this->n_global_levels());
@@ -629,9 +616,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   types::coarse_cell_id
-    TriangulationBase<dim, spacedim>::n_global_coarse_cells() const
+  TriangulationBase<dim, spacedim>::n_global_coarse_cells() const
   {
     return number_cache.number_of_global_coarse_cells;
   }
@@ -639,7 +625,6 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   DistributedTriangulationBase<dim, spacedim>::DistributedTriangulationBase(
     const MPI_Comm mpi_communicator,
     const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
@@ -654,8 +639,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void TriangulationBase<dim, spacedim>::clear()
+  void
+  TriangulationBase<dim, spacedim>::clear()
   {
     dealii::Triangulation<dim, spacedim>::clear();
 
@@ -665,8 +650,8 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  bool DistributedTriangulationBase<dim, spacedim>::has_hanging_nodes() const
+  bool
+  DistributedTriangulationBase<dim, spacedim>::has_hanging_nodes() const
   {
     if (this->n_global_levels() <= 1)
       return false; // can not have hanging nodes without refined cells

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -41,7 +41,6 @@ DEAL_II_NAMESPACE_OPEN
 
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const types::fe_index DoFHandler<dim, spacedim>::default_fe_index;
 #endif
 
@@ -1710,7 +1709,6 @@ namespace internal
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::DoFHandler()
   : hp_capability_enabled(true)
   , tria(nullptr, typeid(*this).name())
@@ -1720,7 +1718,6 @@ DoFHandler<dim, spacedim>::DoFHandler()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::DoFHandler(const Triangulation<dim, spacedim> &tria)
   : DoFHandler()
 {
@@ -1730,7 +1727,6 @@ DoFHandler<dim, spacedim>::DoFHandler(const Triangulation<dim, spacedim> &tria)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::~DoFHandler()
 {
   // unsubscribe all attachments to signals of the underlying triangulation
@@ -1757,8 +1753,8 @@ DoFHandler<dim, spacedim>::~DoFHandler()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
+void
+DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
 {
   //
   // call destructor
@@ -1796,9 +1792,8 @@ void DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
 /*------------------------ Cell iterator functions ------------------------*/
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
-  DoFHandler<dim, spacedim>::begin(const unsigned int level) const
+DoFHandler<dim, spacedim>::begin(const unsigned int level) const
 {
   typename Triangulation<dim, spacedim>::cell_iterator cell =
     this->get_triangulation().begin(level);
@@ -1810,9 +1805,8 @@ typename DoFHandler<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::active_cell_iterator
-  DoFHandler<dim, spacedim>::begin_active(const unsigned int level) const
+DoFHandler<dim, spacedim>::begin_active(const unsigned int level) const
 {
   // level is checked in begin
   cell_iterator i = begin(level);
@@ -1827,9 +1821,8 @@ typename DoFHandler<dim, spacedim>::active_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
-  DoFHandler<dim, spacedim>::end() const
+DoFHandler<dim, spacedim>::end() const
 {
   return cell_iterator(&this->get_triangulation(), -1, -1, this);
 }
@@ -1837,9 +1830,8 @@ typename DoFHandler<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::cell_iterator
-  DoFHandler<dim, spacedim>::end(const unsigned int level) const
+DoFHandler<dim, spacedim>::end(const unsigned int level) const
 {
   typename Triangulation<dim, spacedim>::cell_iterator cell =
     this->get_triangulation().end(level);
@@ -1851,9 +1843,8 @@ typename DoFHandler<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::active_cell_iterator
-  DoFHandler<dim, spacedim>::end_active(const unsigned int level) const
+DoFHandler<dim, spacedim>::end_active(const unsigned int level) const
 {
   typename Triangulation<dim, spacedim>::cell_iterator cell =
     this->get_triangulation().end_active(level);
@@ -1865,9 +1856,8 @@ typename DoFHandler<dim, spacedim>::active_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::level_cell_iterator
-  DoFHandler<dim, spacedim>::begin_mg(const unsigned int level) const
+DoFHandler<dim, spacedim>::begin_mg(const unsigned int level) const
 {
   Assert(this->has_level_dofs(),
          ExcMessage("You can only iterate over mg "
@@ -1882,9 +1872,8 @@ typename DoFHandler<dim, spacedim>::level_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::level_cell_iterator
-  DoFHandler<dim, spacedim>::end_mg(const unsigned int level) const
+DoFHandler<dim, spacedim>::end_mg(const unsigned int level) const
 {
   Assert(this->has_level_dofs(),
          ExcMessage("You can only iterate over mg "
@@ -1899,9 +1888,8 @@ typename DoFHandler<dim, spacedim>::level_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename DoFHandler<dim, spacedim>::level_cell_iterator
-  DoFHandler<dim, spacedim>::end_mg() const
+DoFHandler<dim, spacedim>::end_mg() const
 {
   return level_cell_iterator(&this->get_triangulation(), -1, -1, this);
 }
@@ -1909,10 +1897,8 @@ typename DoFHandler<dim, spacedim>::level_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator> DoFHandler<
-  dim,
-  spacedim>::cell_iterators() const
+IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>
+DoFHandler<dim, spacedim>::cell_iterators() const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>(
     begin(), end());
@@ -1921,10 +1907,8 @@ IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator> DoFHandler<
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename DoFHandler<dim, spacedim>::
-                active_cell_iterator> DoFHandler<dim, spacedim>::
-  active_cell_iterators() const
+IteratorRange<typename DoFHandler<dim, spacedim>::active_cell_iterator>
+DoFHandler<dim, spacedim>::active_cell_iterators() const
 {
   return IteratorRange<
     typename DoFHandler<dim, spacedim>::active_cell_iterator>(begin_active(),
@@ -1934,10 +1918,8 @@ IteratorRange<typename DoFHandler<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<
-  typename DoFHandler<dim, spacedim>::
-    level_cell_iterator> DoFHandler<dim, spacedim>::mg_cell_iterators() const
+IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>
+DoFHandler<dim, spacedim>::mg_cell_iterators() const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>(
     begin_mg(), end_mg());
@@ -1946,10 +1928,9 @@ IteratorRange<
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator> DoFHandler<
-  dim,
-  spacedim>::cell_iterators_on_level(const unsigned int level) const
+IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>
+DoFHandler<dim, spacedim>::cell_iterators_on_level(
+  const unsigned int level) const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator>(
     begin(level), end(level));
@@ -1958,10 +1939,9 @@ IteratorRange<typename DoFHandler<dim, spacedim>::cell_iterator> DoFHandler<
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename DoFHandler<dim, spacedim>::
-                active_cell_iterator> DoFHandler<dim, spacedim>::
-  active_cell_iterators_on_level(const unsigned int level) const
+IteratorRange<typename DoFHandler<dim, spacedim>::active_cell_iterator>
+DoFHandler<dim, spacedim>::active_cell_iterators_on_level(
+  const unsigned int level) const
 {
   return IteratorRange<
     typename DoFHandler<dim, spacedim>::active_cell_iterator>(
@@ -1971,10 +1951,9 @@ IteratorRange<typename DoFHandler<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename DoFHandler<dim, spacedim>::
-                level_cell_iterator> DoFHandler<dim, spacedim>::
-  mg_cell_iterators_on_level(const unsigned int level) const
+IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>
+DoFHandler<dim, spacedim>::mg_cell_iterators_on_level(
+  const unsigned int level) const
 {
   return IteratorRange<typename DoFHandler<dim, spacedim>::level_cell_iterator>(
     begin_mg(level), end_mg(level));
@@ -1987,8 +1966,8 @@ IteratorRange<typename DoFHandler<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs() const
+types::global_dof_index
+DoFHandler<dim, spacedim>::n_boundary_dofs() const
 {
   Assert(!(dim == 2 && spacedim == 3) || hp_capability_enabled == false,
          ExcNotImplementedWithHP());
@@ -2036,8 +2015,8 @@ types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs(
+types::global_dof_index
+DoFHandler<dim, spacedim>::n_boundary_dofs(
   const std::set<types::boundary_id> &boundary_ids) const
 {
   Assert(!(dim == 2 && spacedim == 3) || hp_capability_enabled == false,
@@ -2088,8 +2067,8 @@ types::global_dof_index DoFHandler<dim, spacedim>::n_boundary_dofs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::size_t DoFHandler<dim, spacedim>::memory_consumption() const
+std::size_t
+DoFHandler<dim, spacedim>::memory_consumption() const
 {
   std::size_t mem = MemoryConsumption::memory_consumption(this->tria) +
                     MemoryConsumption::memory_consumption(this->fe_collection) +
@@ -2132,8 +2111,8 @@ std::size_t DoFHandler<dim, spacedim>::memory_consumption() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::distribute_dofs(
+void
+DoFHandler<dim, spacedim>::distribute_dofs(
   const FiniteElement<dim, spacedim> &fe)
 {
   this->distribute_dofs(hp::FECollection<dim, spacedim>(fe));
@@ -2142,8 +2121,8 @@ void DoFHandler<dim, spacedim>::distribute_dofs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::distribute_dofs(
+void
+DoFHandler<dim, spacedim>::distribute_dofs(
   const hp::FECollection<dim, spacedim> &ff)
 {
   Assert(this->tria != nullptr,
@@ -2282,8 +2261,8 @@ void DoFHandler<dim, spacedim>::distribute_dofs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::distribute_mg_dofs()
+void
+DoFHandler<dim, spacedim>::distribute_mg_dofs()
 {
   AssertThrow(hp_capability_enabled == false, ExcNotImplementedWithHP());
 
@@ -2314,8 +2293,8 @@ void DoFHandler<dim, spacedim>::distribute_mg_dofs()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::initialize_local_block_info()
+void
+DoFHandler<dim, spacedim>::initialize_local_block_info()
 {
   AssertThrow(hp_capability_enabled == false, ExcNotImplementedWithHP());
 
@@ -2325,8 +2304,8 @@ void DoFHandler<dim, spacedim>::initialize_local_block_info()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::setup_policy()
+void
+DoFHandler<dim, spacedim>::setup_policy()
 {
   // decide whether we need a sequential or a parallel distributed policy
   if (dynamic_cast<const dealii::parallel::shared::Triangulation<dim, spacedim>
@@ -2348,8 +2327,8 @@ void DoFHandler<dim, spacedim>::setup_policy()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::clear()
+void
+DoFHandler<dim, spacedim>::clear()
 {
   // release memory
   this->clear_space();
@@ -2359,8 +2338,8 @@ void DoFHandler<dim, spacedim>::clear()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::clear_space()
+void
+DoFHandler<dim, spacedim>::clear_space()
 {
   object_dof_indices.clear();
 
@@ -2375,8 +2354,8 @@ void DoFHandler<dim, spacedim>::clear_space()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::clear_mg_space()
+void
+DoFHandler<dim, spacedim>::clear_mg_space()
 {
   this->mg_levels.clear();
   this->mg_faces.reset();
@@ -2391,8 +2370,8 @@ void DoFHandler<dim, spacedim>::clear_mg_space()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::renumber_dofs(
+void
+DoFHandler<dim, spacedim>::renumber_dofs(
   const std::vector<types::global_dof_index> &new_numbers)
 {
   if (hp_capability_enabled)
@@ -2509,8 +2488,8 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::renumber_dofs(
+void
+DoFHandler<dim, spacedim>::renumber_dofs(
   const unsigned int                          level,
   const std::vector<types::global_dof_index> &new_numbers)
 {
@@ -2553,9 +2532,8 @@ void DoFHandler<dim, spacedim>::renumber_dofs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs()
-  const
+unsigned int
+DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs() const
 {
   Assert(this->fe_collection.size() > 0, ExcNoFESelected());
 
@@ -2588,8 +2566,8 @@ unsigned int DoFHandler<dim, spacedim>::max_couplings_between_boundary_dofs()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int DoFHandler<dim, spacedim>::max_couplings_between_dofs() const
+unsigned int
+DoFHandler<dim, spacedim>::max_couplings_between_dofs() const
 {
   Assert(this->fe_collection.size() > 0, ExcNoFESelected());
   return internal::DoFHandlerImplementation::Implementation::
@@ -2599,8 +2577,8 @@ unsigned int DoFHandler<dim, spacedim>::max_couplings_between_dofs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::set_active_fe_indices(
+void
+DoFHandler<dim, spacedim>::set_active_fe_indices(
   const std::vector<types::fe_index> &active_fe_indices)
 {
   Assert(active_fe_indices.size() == this->get_triangulation().n_active_cells(),
@@ -2620,8 +2598,8 @@ void DoFHandler<dim, spacedim>::set_active_fe_indices(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::set_active_fe_indices(
+void
+DoFHandler<dim, spacedim>::set_active_fe_indices(
   const std::vector<unsigned int> &active_fe_indices)
 {
   set_active_fe_indices(std::vector<types::fe_index>(active_fe_indices.begin(),
@@ -2631,9 +2609,8 @@ void DoFHandler<dim, spacedim>::set_active_fe_indices(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_active_fe_indices()
-  const
+std::vector<types::fe_index>
+DoFHandler<dim, spacedim>::get_active_fe_indices() const
 {
   std::vector<types::fe_index> active_fe_indices(
     this->get_triangulation().n_active_cells(), numbers::invalid_fe_index);
@@ -2651,8 +2628,8 @@ std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_active_fe_indices()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::set_future_fe_indices(
+void
+DoFHandler<dim, spacedim>::set_future_fe_indices(
   const std::vector<types::fe_index> &future_fe_indices)
 {
   Assert(future_fe_indices.size() == this->get_triangulation().n_active_cells(),
@@ -2674,9 +2651,8 @@ void DoFHandler<dim, spacedim>::set_future_fe_indices(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_future_fe_indices()
-  const
+std::vector<types::fe_index>
+DoFHandler<dim, spacedim>::get_future_fe_indices() const
 {
   std::vector<types::fe_index> future_fe_indices(
     this->get_triangulation().n_active_cells(), numbers::invalid_fe_index);
@@ -2694,8 +2670,8 @@ std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_future_fe_indices()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
+void
+DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
 {
   // make sure this is called during initialization in hp-mode
   Assert(hp_capability_enabled, ExcOnlyAvailableWithHP());
@@ -2781,8 +2757,8 @@ void DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::create_active_fe_table()
+void
+DoFHandler<dim, spacedim>::create_active_fe_table()
 {
   AssertThrow(hp_capability_enabled == true, ExcOnlyAvailableWithHP());
 
@@ -2832,8 +2808,8 @@ void DoFHandler<dim, spacedim>::create_active_fe_table()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::update_active_fe_table()
+void
+DoFHandler<dim, spacedim>::update_active_fe_table()
 {
   //  // Normally only one level is added, but if this Triangulation
   //  // is created by copy_triangulation, it can be more than one level.
@@ -2870,8 +2846,8 @@ void DoFHandler<dim, spacedim>::update_active_fe_table()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::pre_transfer_action()
+void
+DoFHandler<dim, spacedim>::pre_transfer_action()
 {
   Assert(this->active_fe_index_transfer == nullptr, ExcInternalError());
 
@@ -2887,8 +2863,8 @@ void DoFHandler<dim, spacedim>::pre_transfer_action()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
+void
+DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
 {
 #  ifndef DEAL_II_WITH_P4EST
   Assert(false,
@@ -2962,8 +2938,8 @@ void DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::post_transfer_action()
+void
+DoFHandler<dim, spacedim>::post_transfer_action()
 {
   update_active_fe_table();
 
@@ -2985,8 +2961,8 @@ void DoFHandler<dim, spacedim>::post_transfer_action()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::post_distributed_transfer_action()
+void
+DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 {
 #  ifndef DEAL_II_WITH_P4EST
   DEAL_II_ASSERT_UNREACHABLE();
@@ -3017,8 +2993,8 @@ void DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
+void
+DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
 {
 #  ifndef DEAL_II_WITH_P4EST
   Assert(false,
@@ -3075,8 +3051,8 @@ void DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
+void
+DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
 {
 #  ifndef DEAL_II_WITH_P4EST
   Assert(false,
@@ -3139,7 +3115,6 @@ void DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs()
   : coarsest_level(numbers::invalid_unsigned_int)
   , finest_level(0)
@@ -3148,8 +3123,8 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::MGVertexDoFs()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::MGVertexDoFs::init(
+void
+DoFHandler<dim, spacedim>::MGVertexDoFs::init(
   const unsigned int cl,
   const unsigned int fl,
   const unsigned int dofs_per_vertex)
@@ -3174,8 +3149,8 @@ void DoFHandler<dim, spacedim>::MGVertexDoFs::init(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int DoFHandler<dim, spacedim>::MGVertexDoFs::get_coarsest_level() const
+unsigned int
+DoFHandler<dim, spacedim>::MGVertexDoFs::get_coarsest_level() const
 {
   return coarsest_level;
 }
@@ -3183,8 +3158,8 @@ unsigned int DoFHandler<dim, spacedim>::MGVertexDoFs::get_coarsest_level() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int DoFHandler<dim, spacedim>::MGVertexDoFs::get_finest_level() const
+unsigned int
+DoFHandler<dim, spacedim>::MGVertexDoFs::get_finest_level() const
 {
   return finest_level;
 }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -134,15 +134,14 @@ namespace internal
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
   CellAttachedDataSerializer<dim, spacedim>::CellAttachedDataSerializer()
     : variable_size_data_stored(false)
   {}
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void CellAttachedDataSerializer<dim, spacedim>::pack_data(
+  void
+  CellAttachedDataSerializer<dim, spacedim>::pack_data(
     const std::vector<cell_relation_t> &cell_relations,
     const std::vector<
       typename internal::CellAttachedData<dim, spacedim>::pack_callback_t>
@@ -467,8 +466,8 @@ namespace internal
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void CellAttachedDataSerializer<dim, spacedim>::unpack_cell_status(
+  void
+  CellAttachedDataSerializer<dim, spacedim>::unpack_cell_status(
     std::vector<
       typename CellAttachedDataSerializer<dim, spacedim>::cell_relation_t>
       &cell_relations) const
@@ -503,8 +502,8 @@ namespace internal
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void CellAttachedDataSerializer<dim, spacedim>::unpack_data(
+  void
+  CellAttachedDataSerializer<dim, spacedim>::unpack_data(
     const std::vector<
       typename CellAttachedDataSerializer<dim, spacedim>::cell_relation_t>
                       &cell_relations,
@@ -670,8 +669,8 @@ namespace internal
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void CellAttachedDataSerializer<dim, spacedim>::save(
+  void
+  CellAttachedDataSerializer<dim, spacedim>::save(
     const unsigned int global_first_cell,
     const unsigned int global_num_cells,
     const std::string &file_basename,
@@ -901,8 +900,8 @@ namespace internal
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void CellAttachedDataSerializer<dim, spacedim>::load(
+  void
+  CellAttachedDataSerializer<dim, spacedim>::load(
     const unsigned int global_first_cell,
     const unsigned int global_num_cells,
     const unsigned int local_num_cells,
@@ -1125,8 +1124,8 @@ namespace internal
 
 
   template <int dim, int spacedim>
-  DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-  void CellAttachedDataSerializer<dim, spacedim>::clear()
+  void
+  CellAttachedDataSerializer<dim, spacedim>::clear()
   {
     variable_size_data_stored = false;
 
@@ -12790,13 +12789,11 @@ namespace internal
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const unsigned int Triangulation<dim, spacedim>::dimension;
 
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::Triangulation(
   const MeshSmoothing smooth_grid,
   const bool          check_for_distorted_cells)
@@ -12823,7 +12820,6 @@ Triangulation<dim, spacedim>::Triangulation(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::Triangulation(
   Triangulation<dim, spacedim> &&tria) noexcept
   : EnableObserverPointer(std::move(tria))
@@ -12851,8 +12847,8 @@ Triangulation<dim, spacedim>::Triangulation(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::operator=(
+Triangulation<dim, spacedim> &
+Triangulation<dim, spacedim>::operator=(
   Triangulation<dim, spacedim> &&tria) noexcept
 {
   EnableObserverPointer::operator=(std::move(tria));
@@ -12883,7 +12879,6 @@ Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::operator=(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::~Triangulation()
 {
   // notify listeners that the triangulation is going down...
@@ -12912,8 +12907,8 @@ Triangulation<dim, spacedim>::~Triangulation()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear()
+void
+Triangulation<dim, spacedim>::clear()
 {
   // notify listeners that the triangulation is going down...
   signals.clear();
@@ -12929,8 +12924,8 @@ void Triangulation<dim, spacedim>::clear()
 }
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-MPI_Comm Triangulation<dim, spacedim>::get_mpi_communicator() const
+MPI_Comm
+Triangulation<dim, spacedim>::get_mpi_communicator() const
 {
   return MPI_COMM_SELF;
 }
@@ -12938,8 +12933,8 @@ MPI_Comm Triangulation<dim, spacedim>::get_mpi_communicator() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-MPI_Comm Triangulation<dim, spacedim>::get_communicator() const
+MPI_Comm
+Triangulation<dim, spacedim>::get_communicator() const
 {
   return get_mpi_communicator();
 }
@@ -12947,9 +12942,8 @@ MPI_Comm Triangulation<dim, spacedim>::get_communicator() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::weak_ptr<const Utilities::MPI::Partitioner> Triangulation<dim, spacedim>::
-  global_active_cell_index_partitioner() const
+std::weak_ptr<const Utilities::MPI::Partitioner>
+Triangulation<dim, spacedim>::global_active_cell_index_partitioner() const
 {
   return number_cache.active_cell_index_partitioner;
 }
@@ -12957,9 +12951,9 @@ std::weak_ptr<const Utilities::MPI::Partitioner> Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::weak_ptr<const Utilities::MPI::Partitioner> Triangulation<dim, spacedim>::
-  global_level_cell_index_partitioner(const unsigned int level) const
+std::weak_ptr<const Utilities::MPI::Partitioner>
+Triangulation<dim, spacedim>::global_level_cell_index_partitioner(
+  const unsigned int level) const
 {
   AssertIndexRange(level, this->n_levels());
 
@@ -12969,8 +12963,8 @@ std::weak_ptr<const Utilities::MPI::Partitioner> Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::set_mesh_smoothing(
+void
+Triangulation<dim, spacedim>::set_mesh_smoothing(
   const MeshSmoothing mesh_smoothing)
 {
   smooth_grid = mesh_smoothing;
@@ -12979,9 +12973,8 @@ void Triangulation<dim, spacedim>::set_mesh_smoothing(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const typename Triangulation<dim, spacedim>::MeshSmoothing
-  &Triangulation<dim, spacedim>::get_mesh_smoothing() const
+const typename Triangulation<dim, spacedim>::MeshSmoothing &
+Triangulation<dim, spacedim>::get_mesh_smoothing() const
 {
   return smooth_grid;
 }
@@ -12989,8 +12982,8 @@ const typename Triangulation<dim, spacedim>::MeshSmoothing
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::set_manifold(
+void
+Triangulation<dim, spacedim>::set_manifold(
   const types::manifold_id       m_number,
   const Manifold<dim, spacedim> &manifold_object)
 {
@@ -13002,9 +12995,8 @@ void Triangulation<dim, spacedim>::set_manifold(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::reset_manifold(
-  const types::manifold_id m_number)
+void
+Triangulation<dim, spacedim>::reset_manifold(const types::manifold_id m_number)
 {
   AssertIndexRange(m_number, numbers::flat_manifold_id);
 
@@ -13017,8 +13009,8 @@ void Triangulation<dim, spacedim>::reset_manifold(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::reset_all_manifolds()
+void
+Triangulation<dim, spacedim>::reset_all_manifolds()
 {
   for (auto &m : manifolds)
     m.second = internal::TriangulationImplementation::
@@ -13028,8 +13020,8 @@ void Triangulation<dim, spacedim>::reset_all_manifolds()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::set_all_manifold_ids(
+void
+Triangulation<dim, spacedim>::set_all_manifold_ids(
   const types::manifold_id m_number)
 {
   Assert(
@@ -13043,8 +13035,8 @@ void Triangulation<dim, spacedim>::set_all_manifold_ids(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
+void
+Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
   const types::manifold_id m_number)
 {
   Assert(
@@ -13060,8 +13052,8 @@ void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
+void
+Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
   const types::boundary_id b_id,
   const types::manifold_id m_number)
 {
@@ -13099,8 +13091,8 @@ void Triangulation<dim, spacedim>::set_all_manifold_ids_on_boundary(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const Manifold<dim, spacedim> &Triangulation<dim, spacedim>::get_manifold(
+const Manifold<dim, spacedim> &
+Triangulation<dim, spacedim>::get_manifold(
   const types::manifold_id m_number) const
 {
   // check if flat manifold has been queried
@@ -13132,9 +13124,8 @@ const Manifold<dim, spacedim> &Triangulation<dim, spacedim>::get_manifold(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::vector<types::boundary_id> Triangulation<dim, spacedim>::get_boundary_ids()
-  const
+std::vector<types::boundary_id>
+Triangulation<dim, spacedim>::get_boundary_ids() const
 {
   std::set<types::boundary_id> boundary_ids;
   for (const auto &cell : active_cell_iterators())
@@ -13149,9 +13140,8 @@ std::vector<types::boundary_id> Triangulation<dim, spacedim>::get_boundary_ids()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::vector<types::manifold_id> Triangulation<dim, spacedim>::get_manifold_ids()
-  const
+std::vector<types::manifold_id>
+Triangulation<dim, spacedim>::get_manifold_ids() const
 {
   std::set<types::manifold_id> m_ids;
   for (const auto &cell : active_cell_iterators())
@@ -13180,8 +13170,8 @@ std::vector<types::manifold_id> Triangulation<dim, spacedim>::get_manifold_ids()
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::copy_triangulation(
+void
+Triangulation<dim, spacedim>::copy_triangulation(
   const Triangulation<dim, spacedim> &other_tria)
 {
   Assert((vertices.empty()) && (levels.empty()) && (faces == nullptr),
@@ -13277,8 +13267,8 @@ void Triangulation<dim, spacedim>::copy_triangulation(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::reset_policy()
+void
+Triangulation<dim, spacedim>::reset_policy()
 {
   if (this->all_reference_cells_are_hyper_cube())
     {
@@ -13301,8 +13291,8 @@ void Triangulation<dim, spacedim>::reset_policy()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::create_triangulation(
+void
+Triangulation<dim, spacedim>::create_triangulation(
   const std::vector<Point<spacedim>> &v,
   const std::vector<CellData<dim>>   &cells,
   const SubCellData                  &subcelldata)
@@ -13494,8 +13484,8 @@ void Triangulation<dim, spacedim>::create_triangulation(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::create_triangulation(
+void
+Triangulation<dim, spacedim>::create_triangulation(
   const TriangulationDescription::Description<dim, spacedim> &construction_data)
 {
   // 1) create coarse grid
@@ -13624,8 +13614,8 @@ void Triangulation<dim, spacedim>::create_triangulation(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::flip_all_direction_flags()
+void
+Triangulation<dim, spacedim>::flip_all_direction_flags()
 {
   AssertThrow(dim + 1 == spacedim,
               ExcMessage(
@@ -13637,8 +13627,8 @@ void Triangulation<dim, spacedim>::flip_all_direction_flags()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::set_all_refine_flags()
+void
+Triangulation<dim, spacedim>::set_all_refine_flags()
 {
   Assert(n_cells() > 0,
          ExcMessage("Error: An empty Triangulation can not be refined."));
@@ -13654,8 +13644,8 @@ void Triangulation<dim, spacedim>::set_all_refine_flags()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::refine_global(const unsigned int times)
+void
+Triangulation<dim, spacedim>::refine_global(const unsigned int times)
 {
   Assert(n_cells() > 0,
          ExcMessage("Error: An empty Triangulation can not be refined."));
@@ -13670,8 +13660,8 @@ void Triangulation<dim, spacedim>::refine_global(const unsigned int times)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
+void
+Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
 {
   for (unsigned int i = 0; i < times; ++i)
     {
@@ -13691,8 +13681,8 @@ void Triangulation<dim, spacedim>::coarsen_global(const unsigned int times)
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_refine_flags(std::vector<bool> &v) const
+void
+Triangulation<dim, spacedim>::save_refine_flags(std::vector<bool> &v) const
 {
   v.resize(dim * n_active_cells(), false);
   std::vector<bool>::iterator i = v.begin();
@@ -13708,8 +13698,8 @@ void Triangulation<dim, spacedim>::save_refine_flags(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_refine_flags(std::ostream &out) const
+void
+Triangulation<dim, spacedim>::save_refine_flags(std::ostream &out) const
 {
   std::vector<bool> v;
   save_refine_flags(v);
@@ -13722,8 +13712,8 @@ void Triangulation<dim, spacedim>::save_refine_flags(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_refine_flags(std::istream &in)
+void
+Triangulation<dim, spacedim>::load_refine_flags(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_refine_flags_begin, v, mn_tria_refine_flags_end, in);
@@ -13733,8 +13723,8 @@ void Triangulation<dim, spacedim>::load_refine_flags(std::istream &in)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_refine_flags(const std::vector<bool> &v)
+void
+Triangulation<dim, spacedim>::load_refine_flags(const std::vector<bool> &v)
 {
   AssertThrow(v.size() == dim * n_active_cells(), ExcGridReadError());
 
@@ -13760,9 +13750,8 @@ void Triangulation<dim, spacedim>::load_refine_flags(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_coarsen_flags(
-  std::vector<bool> &v) const
+void
+Triangulation<dim, spacedim>::save_coarsen_flags(std::vector<bool> &v) const
 {
   v.resize(n_active_cells(), false);
   std::vector<bool>::iterator i = v.begin();
@@ -13778,8 +13767,8 @@ void Triangulation<dim, spacedim>::save_coarsen_flags(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_coarsen_flags(std::ostream &out) const
+void
+Triangulation<dim, spacedim>::save_coarsen_flags(std::ostream &out) const
 {
   std::vector<bool> v;
   save_coarsen_flags(v);
@@ -13792,8 +13781,8 @@ void Triangulation<dim, spacedim>::save_coarsen_flags(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_coarsen_flags(std::istream &in)
+void
+Triangulation<dim, spacedim>::load_coarsen_flags(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_coarsen_flags_begin,
@@ -13806,9 +13795,8 @@ void Triangulation<dim, spacedim>::load_coarsen_flags(std::istream &in)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_coarsen_flags(
-  const std::vector<bool> &v)
+void
+Triangulation<dim, spacedim>::load_coarsen_flags(const std::vector<bool> &v)
 {
   Assert(v.size() == n_active_cells(), ExcGridReadError());
 
@@ -13827,8 +13815,8 @@ void Triangulation<dim, spacedim>::load_coarsen_flags(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::get_anisotropic_refinement_flag() const
+bool
+Triangulation<dim, spacedim>::get_anisotropic_refinement_flag() const
 {
   return anisotropic_refinement;
 }
@@ -13908,8 +13896,8 @@ namespace
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear_user_data()
+void
+Triangulation<dim, spacedim>::clear_user_data()
 {
   // let functions in anonymous namespace do their work
   dealii::clear_user_data(levels);
@@ -13946,8 +13934,8 @@ namespace
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear_user_flags_line()
+void
+Triangulation<dim, spacedim>::clear_user_flags_line()
 {
   dealii::clear_user_flags_line(levels, faces.get());
 }
@@ -13985,8 +13973,8 @@ namespace
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear_user_flags_quad()
+void
+Triangulation<dim, spacedim>::clear_user_flags_quad()
 {
   dealii::clear_user_flags_quad(levels, faces.get());
 }
@@ -14024,8 +14012,8 @@ namespace
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear_user_flags_hex()
+void
+Triangulation<dim, spacedim>::clear_user_flags_hex()
 {
   dealii::clear_user_flags_hex(levels, faces.get());
 }
@@ -14033,8 +14021,8 @@ void Triangulation<dim, spacedim>::clear_user_flags_hex()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear_user_flags()
+void
+Triangulation<dim, spacedim>::clear_user_flags()
 {
   clear_user_flags_line();
   clear_user_flags_quad();
@@ -14044,8 +14032,8 @@ void Triangulation<dim, spacedim>::clear_user_flags()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
+void
+Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
 {
   save_user_flags_line(out);
 
@@ -14062,8 +14050,8 @@ void Triangulation<dim, spacedim>::save_user_flags(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
+void
+Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
 {
   // clear vector and append
   // all the stuff later on
@@ -14093,8 +14081,8 @@ void Triangulation<dim, spacedim>::save_user_flags(std::vector<bool> &v) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
+void
+Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
 {
   load_user_flags_line(in);
 
@@ -14111,8 +14099,8 @@ void Triangulation<dim, spacedim>::load_user_flags(std::istream &in)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
+void
+Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
 {
   Assert(v.size() == n_lines() + n_quads() + n_hexs(), ExcInternalError());
   std::vector<bool> tmp;
@@ -14148,9 +14136,8 @@ void Triangulation<dim, spacedim>::load_user_flags(const std::vector<bool> &v)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags_line(
-  std::vector<bool> &v) const
+void
+Triangulation<dim, spacedim>::save_user_flags_line(std::vector<bool> &v) const
 {
   v.resize(n_lines(), false);
   std::vector<bool>::iterator i    = v.begin();
@@ -14164,8 +14151,8 @@ void Triangulation<dim, spacedim>::save_user_flags_line(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags_line(std::ostream &out) const
+void
+Triangulation<dim, spacedim>::save_user_flags_line(std::ostream &out) const
 {
   std::vector<bool> v;
   save_user_flags_line(v);
@@ -14178,8 +14165,8 @@ void Triangulation<dim, spacedim>::save_user_flags_line(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags_line(std::istream &in)
+void
+Triangulation<dim, spacedim>::load_user_flags_line(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_line_user_flags_begin,
@@ -14192,9 +14179,8 @@ void Triangulation<dim, spacedim>::load_user_flags_line(std::istream &in)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags_line(
-  const std::vector<bool> &v)
+void
+Triangulation<dim, spacedim>::load_user_flags_line(const std::vector<bool> &v)
 {
   Assert(v.size() == n_lines(), ExcGridReadError());
 
@@ -14271,9 +14257,8 @@ namespace
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags_quad(
-  std::vector<bool> &v) const
+void
+Triangulation<dim, spacedim>::save_user_flags_quad(std::vector<bool> &v) const
 {
   v.resize(n_quads(), false);
 
@@ -14291,8 +14276,8 @@ void Triangulation<dim, spacedim>::save_user_flags_quad(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags_quad(std::ostream &out) const
+void
+Triangulation<dim, spacedim>::save_user_flags_quad(std::ostream &out) const
 {
   std::vector<bool> v;
   save_user_flags_quad(v);
@@ -14305,8 +14290,8 @@ void Triangulation<dim, spacedim>::save_user_flags_quad(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags_quad(std::istream &in)
+void
+Triangulation<dim, spacedim>::load_user_flags_quad(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_quad_user_flags_begin,
@@ -14319,9 +14304,8 @@ void Triangulation<dim, spacedim>::load_user_flags_quad(std::istream &in)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags_quad(
-  const std::vector<bool> &v)
+void
+Triangulation<dim, spacedim>::load_user_flags_quad(const std::vector<bool> &v)
 {
   Assert(v.size() == n_quads(), ExcGridReadError());
 
@@ -14342,9 +14326,8 @@ void Triangulation<dim, spacedim>::load_user_flags_quad(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags_hex(
-  std::vector<bool> &v) const
+void
+Triangulation<dim, spacedim>::save_user_flags_hex(std::vector<bool> &v) const
 {
   v.resize(n_hexs(), false);
 
@@ -14362,8 +14345,8 @@ void Triangulation<dim, spacedim>::save_user_flags_hex(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_flags_hex(std::ostream &out) const
+void
+Triangulation<dim, spacedim>::save_user_flags_hex(std::ostream &out) const
 {
   std::vector<bool> v;
   save_user_flags_hex(v);
@@ -14376,8 +14359,8 @@ void Triangulation<dim, spacedim>::save_user_flags_hex(std::ostream &out) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags_hex(std::istream &in)
+void
+Triangulation<dim, spacedim>::load_user_flags_hex(std::istream &in)
 {
   std::vector<bool> v;
   read_bool_vector(mn_tria_hex_user_flags_begin,
@@ -14390,9 +14373,8 @@ void Triangulation<dim, spacedim>::load_user_flags_hex(std::istream &in)
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_flags_hex(
-  const std::vector<bool> &v)
+void
+Triangulation<dim, spacedim>::load_user_flags_hex(const std::vector<bool> &v)
 {
   Assert(v.size() == n_hexs(), ExcGridReadError());
 
@@ -14413,8 +14395,8 @@ void Triangulation<dim, spacedim>::load_user_flags_hex(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_indices(
+void
+Triangulation<dim, spacedim>::save_user_indices(
   std::vector<unsigned int> &v) const
 {
   // clear vector and append all the
@@ -14445,8 +14427,8 @@ void Triangulation<dim, spacedim>::save_user_indices(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_indices(
+void
+Triangulation<dim, spacedim>::load_user_indices(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_lines() + n_quads() + n_hexs(), ExcInternalError());
@@ -14483,8 +14465,8 @@ void Triangulation<dim, spacedim>::load_user_indices(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save(const std::string &file_basename) const
+void
+Triangulation<dim, spacedim>::save(const std::string &file_basename) const
 {
   // Save triangulation information.
   {
@@ -14514,8 +14496,8 @@ void Triangulation<dim, spacedim>::save(const std::string &file_basename) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load(const std::string &file_basename)
+void
+Triangulation<dim, spacedim>::load(const std::string &file_basename)
 {
   // It's probably prudent to first get rid of any all content of the
   // triangulation, rather than hope that the deserialization below
@@ -14620,8 +14602,8 @@ namespace
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_indices_line(
+void
+Triangulation<dim, spacedim>::save_user_indices_line(
   std::vector<unsigned int> &v) const
 {
   v.resize(n_lines(), 0);
@@ -14634,8 +14616,8 @@ void Triangulation<dim, spacedim>::save_user_indices_line(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_indices_line(
+void
+Triangulation<dim, spacedim>::load_user_indices_line(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_lines(), ExcGridReadError());
@@ -14648,8 +14630,8 @@ void Triangulation<dim, spacedim>::load_user_indices_line(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_indices_quad(
+void
+Triangulation<dim, spacedim>::save_user_indices_quad(
   std::vector<unsigned int> &v) const
 {
   v.resize(n_quads(), 0);
@@ -14666,8 +14648,8 @@ void Triangulation<dim, spacedim>::save_user_indices_quad(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_indices_quad(
+void
+Triangulation<dim, spacedim>::load_user_indices_quad(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_quads(), ExcGridReadError());
@@ -14683,8 +14665,8 @@ void Triangulation<dim, spacedim>::load_user_indices_quad(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_indices_hex(
+void
+Triangulation<dim, spacedim>::save_user_indices_hex(
   std::vector<unsigned int> &v) const
 {
   v.resize(n_hexs(), 0);
@@ -14701,8 +14683,8 @@ void Triangulation<dim, spacedim>::save_user_indices_hex(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_indices_hex(
+void
+Triangulation<dim, spacedim>::load_user_indices_hex(
   const std::vector<unsigned int> &v)
 {
   Assert(v.size() == n_hexs(), ExcGridReadError());
@@ -14766,9 +14748,8 @@ namespace
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_pointers(
-  std::vector<void *> &v) const
+void
+Triangulation<dim, spacedim>::save_user_pointers(std::vector<void *> &v) const
 {
   // clear vector and append all the
   // stuff later on
@@ -14798,9 +14779,8 @@ void Triangulation<dim, spacedim>::save_user_pointers(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_pointers(
-  const std::vector<void *> &v)
+void
+Triangulation<dim, spacedim>::load_user_pointers(const std::vector<void *> &v)
 {
   Assert(v.size() == n_lines() + n_quads() + n_hexs(), ExcInternalError());
   std::vector<void *> tmp;
@@ -14836,8 +14816,8 @@ void Triangulation<dim, spacedim>::load_user_pointers(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_pointers_line(
+void
+Triangulation<dim, spacedim>::save_user_pointers_line(
   std::vector<void *> &v) const
 {
   v.resize(n_lines(), nullptr);
@@ -14850,8 +14830,8 @@ void Triangulation<dim, spacedim>::save_user_pointers_line(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_pointers_line(
+void
+Triangulation<dim, spacedim>::load_user_pointers_line(
   const std::vector<void *> &v)
 {
   Assert(v.size() == n_lines(), ExcGridReadError());
@@ -14865,8 +14845,8 @@ void Triangulation<dim, spacedim>::load_user_pointers_line(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_pointers_quad(
+void
+Triangulation<dim, spacedim>::save_user_pointers_quad(
   std::vector<void *> &v) const
 {
   v.resize(n_quads(), nullptr);
@@ -14883,8 +14863,8 @@ void Triangulation<dim, spacedim>::save_user_pointers_quad(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_pointers_quad(
+void
+Triangulation<dim, spacedim>::load_user_pointers_quad(
   const std::vector<void *> &v)
 {
   Assert(v.size() == n_quads(), ExcGridReadError());
@@ -14900,8 +14880,8 @@ void Triangulation<dim, spacedim>::load_user_pointers_quad(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_user_pointers_hex(
+void
+Triangulation<dim, spacedim>::save_user_pointers_hex(
   std::vector<void *> &v) const
 {
   v.resize(n_hexs(), nullptr);
@@ -14918,8 +14898,8 @@ void Triangulation<dim, spacedim>::save_user_pointers_hex(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_user_pointers_hex(
+void
+Triangulation<dim, spacedim>::load_user_pointers_hex(
   const std::vector<void *> &v)
 {
   Assert(v.size() == n_hexs(), ExcGridReadError());
@@ -14940,9 +14920,8 @@ void Triangulation<dim, spacedim>::load_user_pointers_hex(
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_cell_iterator
-  Triangulation<dim, spacedim>::begin_raw(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_raw(const unsigned int level) const
 {
   switch (dim)
     {
@@ -14961,9 +14940,8 @@ typename Triangulation<dim, spacedim>::raw_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-  Triangulation<dim, spacedim>::begin(const unsigned int level) const
+Triangulation<dim, spacedim>::begin(const unsigned int level) const
 {
   switch (dim)
     {
@@ -14982,9 +14960,8 @@ typename Triangulation<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_cell_iterator
-  Triangulation<dim, spacedim>::begin_active(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_active(const unsigned int level) const
 {
   switch (dim)
     {
@@ -15003,9 +14980,8 @@ typename Triangulation<dim, spacedim>::active_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-  Triangulation<dim, spacedim>::last() const
+Triangulation<dim, spacedim>::last() const
 {
   const unsigned int level = levels.size() - 1;
   if (levels[level]->cells.n_objects() == 0)
@@ -15029,9 +15005,8 @@ typename Triangulation<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_cell_iterator
-  Triangulation<dim, spacedim>::last_active() const
+Triangulation<dim, spacedim>::last_active() const
 {
   // get the last used cell
   cell_iterator cell = last();
@@ -15051,10 +15026,8 @@ typename Triangulation<dim, spacedim>::active_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-  Triangulation<dim, spacedim>::create_cell_iterator(
-    const CellId &cell_id) const
+Triangulation<dim, spacedim>::create_cell_iterator(const CellId &cell_id) const
 {
   Assert(
     this->contains_cell(cell_id),
@@ -15079,8 +15052,8 @@ typename Triangulation<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::contains_cell(const CellId &cell_id) const
+bool
+Triangulation<dim, spacedim>::contains_cell(const CellId &cell_id) const
 {
   const auto coarse_cell_index =
     coarse_cell_id_to_coarse_cell_index(cell_id.get_coarse_cell_id());
@@ -15103,9 +15076,8 @@ bool Triangulation<dim, spacedim>::contains_cell(const CellId &cell_id) const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-  Triangulation<dim, spacedim>::end() const
+Triangulation<dim, spacedim>::end() const
 {
   return cell_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                        -1,
@@ -15115,9 +15087,8 @@ typename Triangulation<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_cell_iterator
-  Triangulation<dim, spacedim>::end_raw(const unsigned int level) const
+Triangulation<dim, spacedim>::end_raw(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -15145,9 +15116,8 @@ typename Triangulation<dim, spacedim>::raw_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::cell_iterator
-  Triangulation<dim, spacedim>::end(const unsigned int level) const
+Triangulation<dim, spacedim>::end(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -15175,9 +15145,8 @@ typename Triangulation<dim, spacedim>::cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_cell_iterator
-  Triangulation<dim, spacedim>::end_active(const unsigned int level) const
+Triangulation<dim, spacedim>::end_active(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -15204,10 +15173,8 @@ typename Triangulation<dim, spacedim>::active_cell_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename Triangulation<dim, spacedim>::
-                cell_iterator> Triangulation<dim, spacedim>::cell_iterators()
-  const
+IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>
+Triangulation<dim, spacedim>::cell_iterators() const
 {
   return IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>(
     begin(), end());
@@ -15215,10 +15182,8 @@ IteratorRange<typename Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename Triangulation<dim, spacedim>::
-                active_cell_iterator> Triangulation<dim, spacedim>::
-  active_cell_iterators() const
+IteratorRange<typename Triangulation<dim, spacedim>::active_cell_iterator>
+Triangulation<dim, spacedim>::active_cell_iterators() const
 {
   return IteratorRange<
     typename Triangulation<dim, spacedim>::active_cell_iterator>(begin_active(),
@@ -15228,10 +15193,9 @@ IteratorRange<typename Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename Triangulation<dim, spacedim>::
-                cell_iterator> Triangulation<dim, spacedim>::
-  cell_iterators_on_level(const unsigned int level) const
+IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>
+Triangulation<dim, spacedim>::cell_iterators_on_level(
+  const unsigned int level) const
 {
   return IteratorRange<typename Triangulation<dim, spacedim>::cell_iterator>(
     begin(level), end(level));
@@ -15240,10 +15204,9 @@ IteratorRange<typename Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename Triangulation<dim, spacedim>::
-                active_cell_iterator> Triangulation<dim, spacedim>::
-  active_cell_iterators_on_level(const unsigned int level) const
+IteratorRange<typename Triangulation<dim, spacedim>::active_cell_iterator>
+Triangulation<dim, spacedim>::active_cell_iterators_on_level(
+  const unsigned int level) const
 {
   return IteratorRange<
     typename Triangulation<dim, spacedim>::active_cell_iterator>(
@@ -15256,9 +15219,8 @@ IteratorRange<typename Triangulation<dim, spacedim>::
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::face_iterator
-  Triangulation<dim, spacedim>::begin_face() const
+Triangulation<dim, spacedim>::begin_face() const
 {
   switch (dim)
     {
@@ -15278,9 +15240,8 @@ typename Triangulation<dim, spacedim>::face_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_face_iterator
-  Triangulation<dim, spacedim>::begin_active_face() const
+Triangulation<dim, spacedim>::begin_active_face() const
 {
   switch (dim)
     {
@@ -15300,9 +15261,8 @@ typename Triangulation<dim, spacedim>::active_face_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::face_iterator
-  Triangulation<dim, spacedim>::end_face() const
+Triangulation<dim, spacedim>::end_face() const
 {
   switch (dim)
     {
@@ -15322,10 +15282,8 @@ typename Triangulation<dim, spacedim>::face_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-IteratorRange<typename Triangulation<dim, spacedim>::
-                active_face_iterator> Triangulation<dim, spacedim>::
-  active_face_iterators() const
+IteratorRange<typename Triangulation<dim, spacedim>::active_face_iterator>
+Triangulation<dim, spacedim>::active_face_iterators() const
 {
   return IteratorRange<
     typename Triangulation<dim, spacedim>::active_face_iterator>(
@@ -15336,9 +15294,8 @@ IteratorRange<typename Triangulation<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::vertex_iterator
-  Triangulation<dim, spacedim>::begin_vertex() const
+Triangulation<dim, spacedim>::begin_vertex() const
 {
   vertex_iterator i =
     raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this), 0, 0);
@@ -15354,9 +15311,8 @@ typename Triangulation<dim, spacedim>::vertex_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_vertex_iterator
-  Triangulation<dim, spacedim>::begin_active_vertex() const
+Triangulation<dim, spacedim>::begin_active_vertex() const
 {
   // every vertex is active
   return begin_vertex();
@@ -15365,9 +15321,8 @@ typename Triangulation<dim, spacedim>::active_vertex_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::vertex_iterator
-  Triangulation<dim, spacedim>::end_vertex() const
+Triangulation<dim, spacedim>::end_vertex() const
 {
   return raw_vertex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                              -1,
@@ -15382,9 +15337,8 @@ typename Triangulation<dim, spacedim>::vertex_iterator
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_line_iterator
-  Triangulation<dim, spacedim>::begin_raw_line(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_raw_line(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -15423,9 +15377,8 @@ typename Triangulation<dim, spacedim>::raw_line_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::line_iterator
-  Triangulation<dim, spacedim>::begin_line(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_line(const unsigned int level) const
 {
   // level is checked in begin_raw
   raw_line_iterator ri = begin_raw_line(level);
@@ -15440,10 +15393,8 @@ typename Triangulation<dim, spacedim>::line_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_line_iterator
-  Triangulation<dim, spacedim>::begin_active_line(
-    const unsigned int level) const
+Triangulation<dim, spacedim>::begin_active_line(const unsigned int level) const
 {
   // level is checked in begin_raw
   line_iterator i = begin_line(level);
@@ -15458,9 +15409,8 @@ typename Triangulation<dim, spacedim>::active_line_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::line_iterator
-  Triangulation<dim, spacedim>::end_line() const
+Triangulation<dim, spacedim>::end_line() const
 {
   return raw_line_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                            -1,
@@ -15474,9 +15424,8 @@ typename Triangulation<dim, spacedim>::line_iterator
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_quad_iterator
-  Triangulation<dim, spacedim>::begin_raw_quad(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_raw_quad(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -15529,9 +15478,8 @@ typename Triangulation<dim, spacedim>::raw_quad_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::quad_iterator
-  Triangulation<dim, spacedim>::begin_quad(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_quad(const unsigned int level) const
 {
   // level is checked in begin_raw
   raw_quad_iterator ri = begin_raw_quad(level);
@@ -15546,10 +15494,8 @@ typename Triangulation<dim, spacedim>::quad_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_quad_iterator
-  Triangulation<dim, spacedim>::begin_active_quad(
-    const unsigned int level) const
+Triangulation<dim, spacedim>::begin_active_quad(const unsigned int level) const
 {
   // level is checked in begin_raw
   quad_iterator i = begin_quad(level);
@@ -15564,9 +15510,8 @@ typename Triangulation<dim, spacedim>::active_quad_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::quad_iterator
-  Triangulation<dim, spacedim>::end_quad() const
+Triangulation<dim, spacedim>::end_quad() const
 {
   return raw_quad_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                            -1,
@@ -15580,9 +15525,8 @@ typename Triangulation<dim, spacedim>::quad_iterator
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::raw_hex_iterator
-  Triangulation<dim, spacedim>::begin_raw_hex(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_raw_hex(const unsigned int level) const
 {
   // This function may be called on parallel triangulations on levels
   // that exist globally, but not on the local portion of the
@@ -15627,9 +15571,8 @@ typename Triangulation<dim, spacedim>::raw_hex_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::hex_iterator
-  Triangulation<dim, spacedim>::begin_hex(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_hex(const unsigned int level) const
 {
   // level is checked in begin_raw
   raw_hex_iterator ri = begin_raw_hex(level);
@@ -15644,9 +15587,8 @@ typename Triangulation<dim, spacedim>::hex_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::active_hex_iterator
-  Triangulation<dim, spacedim>::begin_active_hex(const unsigned int level) const
+Triangulation<dim, spacedim>::begin_active_hex(const unsigned int level) const
 {
   // level is checked in begin_raw
   hex_iterator i = begin_hex(level);
@@ -15661,9 +15603,8 @@ typename Triangulation<dim, spacedim>::active_hex_iterator
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::hex_iterator
-  Triangulation<dim, spacedim>::end_hex() const
+Triangulation<dim, spacedim>::end_hex() const
 {
   return raw_hex_iterator(const_cast<Triangulation<dim, spacedim> *>(this),
                           -1,
@@ -15728,39 +15669,37 @@ namespace internal
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_cells() const
+unsigned int
+Triangulation<dim, spacedim>::n_cells() const
 {
   return internal::TriangulationImplementation::n_cells(number_cache);
 }
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_cells() const
+unsigned int
+Triangulation<dim, spacedim>::n_active_cells() const
 {
   return internal::TriangulationImplementation::n_active_cells(number_cache);
 }
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 types::global_cell_index
-  Triangulation<dim, spacedim>::n_global_active_cells() const
+Triangulation<dim, spacedim>::n_global_active_cells() const
 {
   return n_active_cells();
 }
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 types::coarse_cell_id
-  Triangulation<dim, spacedim>::n_global_coarse_cells() const
+Triangulation<dim, spacedim>::n_global_coarse_cells() const
 {
   return n_cells(0);
 }
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_faces() const
+unsigned int
+Triangulation<dim, spacedim>::n_faces() const
 {
   switch (dim)
     {
@@ -15778,8 +15717,8 @@ unsigned int Triangulation<dim, spacedim>::n_faces() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_faces() const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_faces() const
 {
   switch (dim)
     {
@@ -15797,8 +15736,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_faces() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_faces() const
+unsigned int
+Triangulation<dim, spacedim>::n_active_faces() const
 {
   switch (dim)
     {
@@ -15816,9 +15755,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_faces() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_cells(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_cells(const unsigned int level) const
 {
   switch (dim)
     {
@@ -15837,9 +15775,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_cells(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_cells(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_cells(const unsigned int level) const
 {
   switch (dim)
     {
@@ -15858,9 +15795,8 @@ unsigned int Triangulation<dim, spacedim>::n_cells(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_cells(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_active_cells(const unsigned int level) const
 {
   switch (dim)
     {
@@ -15878,8 +15814,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_cells(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::has_hanging_nodes() const
+bool
+Triangulation<dim, spacedim>::has_hanging_nodes() const
 {
   if (anisotropic_refinement == false)
     {
@@ -15899,8 +15835,8 @@ bool Triangulation<dim, spacedim>::has_hanging_nodes() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_lines() const
+unsigned int
+Triangulation<dim, spacedim>::n_lines() const
 {
   return number_cache.n_lines;
 }
@@ -15908,9 +15844,8 @@ unsigned int Triangulation<dim, spacedim>::n_lines() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_lines(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_lines(const unsigned int level) const
 {
   if (dim == 1)
     {
@@ -15924,8 +15859,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_lines(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_lines() const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_lines() const
 {
   if (dim == 1)
     {
@@ -15938,9 +15873,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_lines() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_lines(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_lines(const unsigned int level) const
 {
   AssertIndexRange(level, number_cache.n_lines_level.size());
   Assert(dim == 1, ExcFacesHaveNoLevel());
@@ -15949,17 +15883,16 @@ unsigned int Triangulation<dim, spacedim>::n_lines(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_lines() const
+unsigned int
+Triangulation<dim, spacedim>::n_active_lines() const
 {
   return number_cache.n_active_lines;
 }
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_lines(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_active_lines(const unsigned int level) const
 {
   AssertIndexRange(level, number_cache.n_lines_level.size());
   Assert(dim == 1, ExcFacesHaveNoLevel());
@@ -15970,8 +15903,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_lines(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_quads() const
+unsigned int
+Triangulation<dim, spacedim>::n_quads() const
 {
   if constexpr (dim == 1)
     return 0;
@@ -15982,9 +15915,8 @@ unsigned int Triangulation<dim, spacedim>::n_quads() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_quads(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_quads(const unsigned int level) const
 {
   (void)level;
   if constexpr (dim == 1)
@@ -16005,8 +15937,8 @@ unsigned int Triangulation<dim, spacedim>::n_quads(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_quads() const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_quads() const
 {
   if constexpr (dim == 1)
     return 0;
@@ -16023,9 +15955,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_quads() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_quads(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_quads(const unsigned int level) const
 {
   (void)level;
   if constexpr (dim == 1)
@@ -16046,8 +15977,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_quads(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_quads() const
+unsigned int
+Triangulation<dim, spacedim>::n_active_quads() const
 {
   if constexpr (dim == 1)
     return 0;
@@ -16058,9 +15989,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_quads() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_quads(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_active_quads(const unsigned int level) const
 {
   (void)level;
   if constexpr (dim == 1)
@@ -16081,8 +16011,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_quads(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_hexs() const
+unsigned int
+Triangulation<dim, spacedim>::n_hexs() const
 {
   if constexpr (dim == 3)
     return number_cache.n_hexes;
@@ -16093,9 +16023,8 @@ unsigned int Triangulation<dim, spacedim>::n_hexs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_hexs(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_hexs(const unsigned int level) const
 {
   (void)level;
   if constexpr (dim == 3)
@@ -16110,9 +16039,8 @@ unsigned int Triangulation<dim, spacedim>::n_hexs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_raw_hexs(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_raw_hexs(const unsigned int level) const
 {
   (void)level;
   if constexpr (dim == 3)
@@ -16126,8 +16054,8 @@ unsigned int Triangulation<dim, spacedim>::n_raw_hexs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_hexs() const
+unsigned int
+Triangulation<dim, spacedim>::n_active_hexs() const
 {
   if constexpr (dim == 3)
     return number_cache.n_active_hexes;
@@ -16138,9 +16066,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_hexs() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_active_hexs(
-  const unsigned int level) const
+unsigned int
+Triangulation<dim, spacedim>::n_active_hexs(const unsigned int level) const
 {
   (void)level;
   if constexpr (dim == 3)
@@ -16155,8 +16082,8 @@ unsigned int Triangulation<dim, spacedim>::n_active_hexs(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::n_used_vertices() const
+unsigned int
+Triangulation<dim, spacedim>::n_used_vertices() const
 {
   return std::count(vertices_used.begin(), vertices_used.end(), true);
 }
@@ -16164,8 +16091,8 @@ unsigned int Triangulation<dim, spacedim>::n_used_vertices() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const std::vector<bool> &Triangulation<dim, spacedim>::get_used_vertices() const
+const std::vector<bool> &
+Triangulation<dim, spacedim>::get_used_vertices() const
 {
   return vertices_used;
 }
@@ -16199,8 +16126,8 @@ Triangulation<1, 3>::max_adjacent_cells() const
 #ifndef DOXYGEN
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::max_adjacent_cells() const
+unsigned int
+Triangulation<dim, spacedim>::max_adjacent_cells() const
 {
   cell_iterator cell = begin(0),
                 endc = (n_levels() > 1 ? begin(1) : cell_iterator(end()));
@@ -16232,9 +16159,8 @@ unsigned int Triangulation<dim, spacedim>::max_adjacent_cells() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 types::subdomain_id
-  Triangulation<dim, spacedim>::locally_owned_subdomain() const
+Triangulation<dim, spacedim>::locally_owned_subdomain() const
 {
   return numbers::invalid_subdomain_id;
 }
@@ -16242,8 +16168,8 @@ types::subdomain_id
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::get_triangulation()
+Triangulation<dim, spacedim> &
+Triangulation<dim, spacedim>::get_triangulation()
 {
   return *this;
 }
@@ -16251,9 +16177,8 @@ Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::get_triangulation()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const Triangulation<dim, spacedim>
-  &Triangulation<dim, spacedim>::get_triangulation() const
+const Triangulation<dim, spacedim> &
+Triangulation<dim, spacedim>::get_triangulation() const
 {
   return *this;
 }
@@ -16261,8 +16186,8 @@ const Triangulation<dim, spacedim>
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::add_periodicity(
+void
+Triangulation<dim, spacedim>::add_periodicity(
   const std::vector<GridTools::PeriodicFacePair<cell_iterator>>
     &periodicity_vector)
 {
@@ -16277,21 +16202,20 @@ void Triangulation<dim, spacedim>::add_periodicity(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 const typename std::map<
   std::pair<typename Triangulation<dim, spacedim>::cell_iterator, unsigned int>,
   std::pair<std::pair<typename Triangulation<dim, spacedim>::cell_iterator,
                       unsigned int>,
-            types::geometric_orientation>>
-  &Triangulation<dim, spacedim>::get_periodic_face_map() const
+            types::geometric_orientation>> &
+Triangulation<dim, spacedim>::get_periodic_face_map() const
 {
   return periodic_face_map;
 }
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::update_cell_relations()
+void
+Triangulation<dim, spacedim>::update_cell_relations()
 {
   // We only update the cell relations here for serial triangulations.
   // For other triangulations, this is done at other stages of
@@ -16311,8 +16235,8 @@ void Triangulation<dim, spacedim>::update_cell_relations()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::pack_data_serial()
+void
+Triangulation<dim, spacedim>::pack_data_serial()
 {
   if (dynamic_cast<parallel::DistributedTriangulationBase<dim, spacedim> *>(
         this))
@@ -16369,8 +16293,8 @@ void Triangulation<dim, spacedim>::pack_data_serial()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::unpack_data_serial()
+void
+Triangulation<dim, spacedim>::unpack_data_serial()
 {
   if (dynamic_cast<parallel::DistributedTriangulationBase<dim, spacedim> *>(
         this))
@@ -16404,8 +16328,8 @@ void Triangulation<dim, spacedim>::unpack_data_serial()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+void
+Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
 {
   // Call our version of prepare_coarsening_and_refinement() even if a derived
   // class like parallel::distributed::Triangulation overrides it. Their
@@ -16509,8 +16433,8 @@ void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::reset_active_cell_indices()
+void
+Triangulation<dim, spacedim>::reset_active_cell_indices()
 {
   unsigned int active_cell_index = 0;
   for (raw_cell_iterator cell = begin_raw(); cell != end(); ++cell)
@@ -16528,8 +16452,8 @@ void Triangulation<dim, spacedim>::reset_active_cell_indices()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::reset_global_cell_indices()
+void
+Triangulation<dim, spacedim>::reset_global_cell_indices()
 {
   types::global_cell_index active_cell_index = 0;
   for (unsigned int l = 0; l < levels.size(); ++l)
@@ -16548,8 +16472,8 @@ void Triangulation<dim, spacedim>::reset_global_cell_indices()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
+void
+Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 {
   for (unsigned int l = 0; l < levels.size(); ++l)
     {
@@ -16651,8 +16575,8 @@ void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::update_periodic_face_map()
+void
+Triangulation<dim, spacedim>::update_periodic_face_map()
 {
   // first empty the currently stored objects
   periodic_face_map.clear();
@@ -16708,9 +16632,8 @@ void Triangulation<dim, spacedim>::update_periodic_face_map()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const std::vector<ReferenceCell<dim>>
-  &Triangulation<dim, spacedim>::get_reference_cells() const
+const std::vector<ReferenceCell<dim>> &
+Triangulation<dim, spacedim>::get_reference_cells() const
 {
   return this->reference_cells;
 }
@@ -16718,8 +16641,8 @@ const std::vector<ReferenceCell<dim>>
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
+bool
+Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
 {
   Assert(this->reference_cells.size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
@@ -16732,8 +16655,8 @@ bool Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::all_reference_cells_are_simplex() const
+bool
+Triangulation<dim, spacedim>::all_reference_cells_are_simplex() const
 {
   Assert(this->reference_cells.size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
@@ -16746,8 +16669,8 @@ bool Triangulation<dim, spacedim>::all_reference_cells_are_simplex() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::is_mixed_mesh() const
+bool
+Triangulation<dim, spacedim>::is_mixed_mesh() const
 {
   Assert(this->reference_cells.size() > 0,
          ExcMessage("You can't ask about the kinds of reference "
@@ -16761,8 +16684,8 @@ bool Triangulation<dim, spacedim>::is_mixed_mesh() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-unsigned int Triangulation<dim, spacedim>::register_data_attach(
+unsigned int
+Triangulation<dim, spacedim>::register_data_attach(
   const std::function<std::vector<char>(const cell_iterator &,
                                         const ::dealii::CellStatus)>
             &pack_callback,
@@ -16792,8 +16715,8 @@ unsigned int Triangulation<dim, spacedim>::register_data_attach(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::notify_ready_to_unpack(
+void
+Triangulation<dim, spacedim>::notify_ready_to_unpack(
   const unsigned int handle,
   const std::function<
     void(const cell_iterator &,
@@ -16835,8 +16758,8 @@ void Triangulation<dim, spacedim>::notify_ready_to_unpack(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::save_attached_data(
+void
+Triangulation<dim, spacedim>::save_attached_data(
   const unsigned int global_first_cell,
   const unsigned int global_num_cells,
   const std::string &file_basename) const
@@ -16883,8 +16806,8 @@ void Triangulation<dim, spacedim>::save_attached_data(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::load_attached_data(
+void
+Triangulation<dim, spacedim>::load_attached_data(
   const unsigned int global_first_cell,
   const unsigned int global_num_cells,
   const unsigned int local_num_cells,
@@ -16921,8 +16844,8 @@ void Triangulation<dim, spacedim>::load_attached_data(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::clear_despite_subscriptions()
+void
+Triangulation<dim, spacedim>::clear_despite_subscriptions()
 {
   levels.clear();
   faces.reset();
@@ -16955,9 +16878,8 @@ void Triangulation<dim, spacedim>::clear_despite_subscriptions()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 typename Triangulation<dim, spacedim>::DistortedCellList
-  Triangulation<dim, spacedim>::execute_refinement()
+Triangulation<dim, spacedim>::execute_refinement()
 {
   const DistortedCellList cells_with_distorted_children =
     this->policy->execute_refinement(*this, check_for_distorted_cells);
@@ -16987,8 +16909,8 @@ typename Triangulation<dim, spacedim>::DistortedCellList
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::execute_coarsening()
+void
+Triangulation<dim, spacedim>::execute_coarsening()
 {
   // first find out if there are any cells at all to be coarsened in the
   // loop below
@@ -17071,8 +16993,8 @@ void Triangulation<dim, spacedim>::execute_coarsening()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::fix_coarsen_flags()
+void
+Triangulation<dim, spacedim>::fix_coarsen_flags()
 {
   // copy a piece of code from prepare_coarsening_and_refinement that
   // ensures that the level difference at vertices is limited if so
@@ -17495,8 +17417,8 @@ namespace
 
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
+bool
+Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
 {
   // save the flags to determine whether something was changed in the
   // course of this function
@@ -18498,8 +18420,8 @@ bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::write_bool_vector(
+void
+Triangulation<dim, spacedim>::write_bool_vector(
   const unsigned int       magic_number1,
   const std::vector<bool> &v,
   const unsigned int       magic_number2,
@@ -18533,12 +18455,11 @@ void Triangulation<dim, spacedim>::write_bool_vector(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void Triangulation<dim, spacedim>::read_bool_vector(
-  const unsigned int magic_number1,
-  std::vector<bool> &v,
-  const unsigned int magic_number2,
-  std::istream      &in)
+void
+Triangulation<dim, spacedim>::read_bool_vector(const unsigned int magic_number1,
+                                               std::vector<bool> &v,
+                                               const unsigned int magic_number2,
+                                               std::istream      &in)
 {
   AssertThrow(in.fail() == false, ExcIO());
 
@@ -18572,8 +18493,8 @@ void Triangulation<dim, spacedim>::read_bool_vector(
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-std::size_t Triangulation<dim, spacedim>::memory_consumption() const
+std::size_t
+Triangulation<dim, spacedim>::memory_consumption() const
 {
   std::size_t mem = 0;
   mem += sizeof(MeshSmoothing);
@@ -18597,7 +18518,6 @@ std::size_t Triangulation<dim, spacedim>::memory_consumption() const
 
 
 template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList() noexcept =
   default;
 


### PR DESCRIPTION
While this is an incompatibility (with newer forward declarations), I think it is the right thing to do for a few reasons:

1. Old forward declarations don't work with C++20 due to this concept requirement.
2. It is really unfortunate that we have to repeat the concept for all member functions.
3. We aren't consistent: most of the classes (e.g., Mapping) with a dim-spacedim pair were not updated to use this concept.

We can achieve the same constraint with a `static_assert()`. I think it is quite revealing that we can enforce the same constraint with 200 fewer lines of code and a better error message.

All that being said - I think we had a long discussion about this three years ago and I'm happy to discuss the change or (if it is the majority opinion) revert it.