### PR TITLE
Centralize an exception.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -694,6 +694,20 @@ namespace StandardExceptions
                  << "for more information.");
 
   /**
+   * An exception that is used when an algorithm finds that the
+   * coarsening flags set on the cells of a mesh are not consistent,
+   * presumably because the user has not yet called
+   * Triangulation::prepare_coarsening_and_refinement() after flagging
+   * some cells for refinement and/or coarsening.
+   */
+  DeclExceptionMsg(
+    ExcInconsistentCoarseningFlags,
+    "A cell is flagged for coarsening, but either not all of its siblings "
+    "are active or flagged for coarsening as well. Please clean up all "
+    "coarsen flags on your triangulation via "
+    "Triangulation::prepare_coarsening_and_refinement() beforehand!");
+
+  /**
    * Some of our numerical classes allow for setting all entries to zero using
    * the assignment operator <tt>=</tt>.
    *

--- a/include/deal.II/distributed/cell_data_transfer.templates.h
+++ b/include/deal.II/distributed/cell_data_transfer.templates.h
@@ -260,9 +260,9 @@ namespace parallel
                        ++child_index)
                     {
                       const auto &child = cell->child(child_index);
-                      Assert(child->is_active() && child->coarsen_flag_set(),
-                             typename dealii::Triangulation<
-                               dim>::ExcInconsistentCoarseningFlags());
+                      Assert(
+                        child->is_active() && child->coarsen_flag_set(),
+                        StandardExceptions::ExcInconsistentCoarseningFlags());
 
                       children_values[child_index] =
                         (**it_input)[child->active_cell_index()];

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4044,19 +4044,6 @@ public:
                  types::boundary_id,
                  << "The given boundary_id " << arg1
                  << " is not defined in this Triangulation!");
-
-  /**
-   * Exception
-   *
-   * @ingroup Exceptions
-   */
-  DeclExceptionMsg(
-    ExcInconsistentCoarseningFlags,
-    "A cell is flagged for coarsening, but either not all of its siblings "
-    "are active or flagged for coarsening as well. Please clean up all "
-    "coarsen flags on your triangulation via "
-    "Triangulation::prepare_coarsening_and_refinement() beforehand!");
-
   /** @} */
 
 protected:

--- a/include/deal.II/numerics/cell_data_transfer.templates.h
+++ b/include/deal.II/numerics/cell_data_transfer.templates.h
@@ -107,8 +107,7 @@ CellDataTransfer<dim, spacedim, VectorType>::
               for (const auto &sibling : parent->child_iterators())
                 {
                   Assert(sibling->is_active() && sibling->coarsen_flag_set(),
-                         typename dealii::Triangulation<
-                           dim>::ExcInconsistentCoarseningFlags());
+                         StandardExceptions::ExcInconsistentCoarseningFlags());
 
                   indices_children.insert(sibling->active_cell_index());
                 }

--- a/include/deal.II/numerics/solution_transfer.templates.h
+++ b/include/deal.II/numerics/solution_transfer.templates.h
@@ -376,9 +376,9 @@ SolutionTransfer<dim, VectorType, spacedim>::pack_callback(
               if constexpr (running_in_debug_mode())
                 {
                   for (const auto &child : cell->child_iterators())
-                    Assert(child->is_active() && child->coarsen_flag_set(),
-                           typename dealii::Triangulation<
-                             dim>::ExcInconsistentCoarseningFlags());
+                    Assert(
+                      child->is_active() && child->coarsen_flag_set(),
+                      StandardExceptions::ExcInconsistentCoarseningFlags());
                 }
 
               fe_index = dealii::internal::hp::DoFHandlerImplementation::
@@ -871,8 +871,7 @@ namespace Legacy
             for (const auto &child : cell->child_iterators())
               {
                 Assert(child->is_active() && child->coarsen_flag_set(),
-                       typename dealii::Triangulation<
-                         dim>::ExcInconsistentCoarseningFlags());
+                       StandardExceptions::ExcInconsistentCoarseningFlags());
 
                 fe_indices_children.insert(child->active_fe_index());
               }

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -192,8 +192,7 @@ namespace parallel
             {
               for (const auto &child : cell->child_iterators())
                 Assert(child->is_active() && child->coarsen_flag_set(),
-                       typename dealii::Triangulation<
-                         dim>::ExcInconsistentCoarseningFlags());
+                       StandardExceptions::ExcInconsistentCoarseningFlags());
             }
 
           fe_index = dealii::internal::hp::DoFHandlerImplementation::

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1504,8 +1504,8 @@ namespace internal
                             for (const auto &child : parent->child_iterators())
                               Assert(child->is_active() &&
                                        child->coarsen_flag_set(),
-                                     typename dealii::Triangulation<
-                                       dim>::ExcInconsistentCoarseningFlags());
+                                     StandardExceptions::
+                                       ExcInconsistentCoarseningFlags());
                           }
 
                         const types::fe_index fe_index = dealii::internal::hp::

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -601,9 +601,9 @@ namespace hp
                   if constexpr (running_in_debug_mode())
                     {
                       for (const auto &child : parent->child_iterators())
-                        Assert(child->is_active() && child->coarsen_flag_set(),
-                               typename Triangulation<
-                                 dim>::ExcInconsistentCoarseningFlags());
+                        Assert(
+                          child->is_active() && child->coarsen_flag_set(),
+                          StandardExceptions::ExcInconsistentCoarseningFlags());
                     }
 
                   parent_future_fe_index =
@@ -943,8 +943,7 @@ namespace hp
             for (const auto &child : parent->child_iterators())
               {
                 Assert(child->is_active() && child->coarsen_flag_set(),
-                       (typename Triangulation<dim, spacedim>::
-                          ExcInconsistentCoarseningFlags()));
+                       StandardExceptions::ExcInconsistentCoarseningFlags());
 
                 const level_type child_level = static_cast<level_type>(
                   future_levels[child->global_active_cell_index()]);


### PR DESCRIPTION
When building modules (#18071) with Clang++-23, I get linker errors about duplicated symbols that refer to the vtable of an exception class that we declare in `class Triangulation` but use elsewhere as well. I'm actually pretty sure this is a compiler error, in particular because we don't see these linker errors in non-module builds. But I don't want to fight the issue, and the exception in question -- given that it's used in a wide variety of files -- might legitimately also be part of the `StandardExceptions` namespace where we already have other triangulation-related exceptions.

So move it there.