### PR TITLE
Reorganize source files for module statements.

### DIFF
--- a/source/base/function_cspline.cc
+++ b/source/base/function_cspline.cc
@@ -20,7 +20,12 @@
 #  include <cmath>
 
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_GSL
 namespace Functions
 {
   template <int dim>
@@ -149,6 +154,7 @@ namespace Functions
 
 } // namespace Functions
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/ad/ad_drivers.cc
+++ b/source/differentiation/ad/ad_drivers.cc
@@ -36,7 +36,12 @@
 #  include <vector>
 
 
+
+#endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
+
 DEAL_II_NAMESPACE_OPEN
+
+#if defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
 
 
 namespace Differentiation
@@ -2184,7 +2189,6 @@ namespace Differentiation
 #  endif
 
 
-DEAL_II_NAMESPACE_CLOSE
-
 
 #endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/ad/ad_helpers.cc
+++ b/source/differentiation/ad/ad_helpers.cc
@@ -20,7 +20,12 @@
 #  include <type_traits>
 
 
+
+#endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
+
 DEAL_II_NAMESPACE_OPEN
+
+#if defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
 
 
 namespace Differentiation
@@ -1889,6 +1894,6 @@ namespace Differentiation
 #  endif
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // defined(DEAL_II_WITH_ADOLC) || defined(DEAL_II_TRILINOS_WITH_SACADO)
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/ad/adolc_number_types.cc
+++ b/source/differentiation/ad/adolc_number_types.cc
@@ -26,7 +26,12 @@
 #    include <adolc/adtl.h>    // Tapeless double
 #  endif
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_ADOLC
 
 
 #  ifdef DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING
@@ -87,6 +92,6 @@ namespace numbers
 
 #  include "differentiation/ad/adolc_number_types.inst"
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/ad/sacado_number_types.cc
+++ b/source/differentiation/ad/sacado_number_types.cc
@@ -17,7 +17,12 @@
 
 #  include <deal.II/differentiation/ad/sacado_number_types.h>
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_SACADO
 
 /*---------------------- Explicit Instantiations ----------------------*/
 
@@ -26,6 +31,6 @@ DEAL_II_NAMESPACE_OPEN
 #    include "differentiation/ad/sacado_number_types.inst2"
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_math.cc
+++ b/source/differentiation/sd/symengine_math.cc
@@ -22,7 +22,12 @@
 #  include <symengine/mul.h>
 #  include <symengine/pow.h>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 namespace Differentiation
 {
@@ -328,6 +333,6 @@ namespace Differentiation
   } // namespace SD
 } // namespace Differentiation
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -30,7 +30,12 @@
 
 #  include <string>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 namespace Differentiation
 {
@@ -547,6 +552,6 @@ namespace Differentiation
 } // namespace Differentiation
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_number_visitor_internal.cc
+++ b/source/differentiation/sd/symengine_number_visitor_internal.cc
@@ -16,12 +16,17 @@
 
 #  include <deal.II/differentiation/sd/symengine_number_visitor_internal.h>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 /* --- Explicit instantiations --- */
 #  include "differentiation/sd/symengine_number_visitor_internal.inst"
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_optimizer.cc
+++ b/source/differentiation/sd/symengine_optimizer.cc
@@ -22,7 +22,12 @@
 
 #  include <utility>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 
 namespace Differentiation
@@ -838,6 +843,6 @@ namespace Differentiation
 #  include "differentiation/sd/symengine_optimizer.inst"
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -22,7 +22,12 @@
 
 #  include <symengine/real_double.h>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 namespace Differentiation
 {
@@ -267,6 +272,6 @@ namespace Differentiation
   } // namespace SD
 } // namespace Differentiation
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_tensor_operations.cc
+++ b/source/differentiation/sd/symengine_tensor_operations.cc
@@ -25,7 +25,12 @@
 #  include <deal.II/differentiation/sd/symengine_types.h>
 #  include <deal.II/differentiation/sd/symengine_utilities.h>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 namespace Differentiation
 {
@@ -289,6 +294,6 @@ namespace Differentiation
 
 #  include "differentiation/sd/symengine_tensor_operations.inst"
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_types.cc
+++ b/source/differentiation/sd/symengine_types.cc
@@ -21,7 +21,12 @@
 #  include <symengine/dict.h>
 
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 namespace Differentiation
 {
@@ -47,6 +52,6 @@ namespace Differentiation
 } // namespace Differentiation
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/differentiation/sd/symengine_utilities.cc
+++ b/source/differentiation/sd/symengine_utilities.cc
@@ -17,7 +17,12 @@
 #  include <deal.II/differentiation/sd/symengine_number_types.h>
 #  include <deal.II/differentiation/sd/symengine_utilities.h>
 
+
+#endif // DEAL_II_WITH_SYMENGINE
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SYMENGINE
 
 namespace Differentiation
 {
@@ -113,6 +118,6 @@ namespace Differentiation
 } // namespace Differentiation
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SYMENGINE
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_communication_pattern.cc
+++ b/source/lac/petsc_communication_pattern.cc
@@ -18,7 +18,12 @@
 
 #  include <deal.II/lac/exceptions.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 // Shorthand notation for PETSc error codes.
 #  define AssertPETSc(code)                          \
     do                                               \
@@ -533,6 +538,6 @@ namespace PETScWrappers
 // Explicit instantiations
 #  include "lac/petsc_communication_pattern.inst"
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_compatibility.cc
+++ b/source/lac/petsc_compatibility.cc
@@ -34,7 +34,12 @@
       }                                              \
     while (false)
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 
 namespace PETScWrappers
@@ -157,6 +162,6 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_full_matrix.cc
+++ b/source/lac/petsc_full_matrix.cc
@@ -17,7 +17,12 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_compatibility.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -56,6 +61,6 @@ namespace PETScWrappers
 } // namespace PETScWrappers
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -20,7 +20,12 @@
 #  include <deal.II/lac/petsc_sparse_matrix.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -820,6 +825,6 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_matrix_free.cc
+++ b/source/lac/petsc_matrix_free.cc
@@ -18,7 +18,12 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/petsc_compatibility.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -243,6 +248,6 @@ namespace PETScWrappers
 } // namespace PETScWrappers
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_parallel_block_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_block_sparse_matrix.cc
@@ -21,7 +21,12 @@
 #  include <petscmat.h>
 
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace
 {
@@ -408,6 +413,5 @@ namespace PETScWrappers
 
 
 
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_parallel_block_vector.cc
+++ b/source/lac/petsc_parallel_block_vector.cc
@@ -16,7 +16,12 @@
 
 #  include <deal.II/lac/petsc_compatibility.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -154,6 +159,6 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_parallel_sparse_matrix.cc
+++ b/source/lac/petsc_parallel_sparse_matrix.cc
@@ -22,7 +22,12 @@
 #  include <deal.II/lac/petsc_vector.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -927,6 +932,6 @@ namespace PETScWrappers
 } // namespace PETScWrappers
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -19,7 +19,12 @@
 #  include <algorithm>
 #  include <cmath>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -432,6 +437,6 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -26,7 +26,12 @@
 
 #  include <cmath>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -1233,6 +1238,6 @@ namespace PETScWrappers
 template class PETScWrappers::PreconditionBDDC<2>;
 template class PETScWrappers::PreconditionBDDC<3>;
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_snes.cc
+++ b/source/lac/petsc_snes.cc
@@ -19,7 +19,14 @@
 #    include <deal.II/lac/petsc_block_sparse_matrix.h>
 #    include <deal.II/lac/petsc_snes.templates.h>
 
+
+#  endif // DEAL_II_WITH_PETSC
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifndef DOXYGEN
+#  ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -65,7 +72,7 @@ template class PETScWrappers::NonlinearSolver<
   PETScWrappers::MPI::BlockSparseMatrix>;
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_WITH_PETSC
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -32,7 +32,12 @@
       }                                              \
     while (false)
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -724,6 +729,6 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_sparse_matrix.cc
+++ b/source/lac/petsc_sparse_matrix.cc
@@ -20,7 +20,12 @@
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/lac/sparsity_pattern.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -298,6 +303,6 @@ namespace PETScWrappers
 } // namespace PETScWrappers
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_ts.cc
+++ b/source/lac/petsc_ts.cc
@@ -19,7 +19,14 @@
 #    include <deal.II/lac/petsc_block_sparse_matrix.h>
 #    include <deal.II/lac/petsc_ts.templates.h>
 
+
+#  endif // DEAL_II_WITH_PETSC
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifndef DOXYGEN
+#  ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -87,7 +94,7 @@ template class PETScWrappers::TimeStepper<
   PETScWrappers::MPI::BlockSparseMatrix>;
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_WITH_PETSC
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -22,7 +22,12 @@
 
 #  include <cmath>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -1127,6 +1132,6 @@ namespace PETScWrappers
 
 } // namespace PETScWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_block_sparse_matrix.cc
+++ b/source/lac/trilinos_block_sparse_matrix.cc
@@ -17,7 +17,12 @@
 #  include <deal.II/lac/block_sparse_matrix.h>
 #  include <deal.II/lac/block_sparsity_pattern.h>
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -327,6 +332,6 @@ namespace TrilinosWrappers
 } // namespace TrilinosWrappers
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_block_vector.cc
+++ b/source/lac/trilinos_block_vector.cc
@@ -18,7 +18,12 @@
 #  include <deal.II/lac/trilinos_index_access.h>
 
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -201,6 +206,6 @@ namespace TrilinosWrappers
 } /* end of namespace TrilinosWrappers */
 
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_epetra_communication_pattern.cc
+++ b/source/lac/trilinos_epetra_communication_pattern.cc
@@ -22,7 +22,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace LinearAlgebra
 {
@@ -80,6 +85,6 @@ namespace LinearAlgebra
   } // namespace EpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -33,7 +33,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <memory>
 
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace LinearAlgebra
 {
@@ -675,6 +680,6 @@ namespace LinearAlgebra
   } // namespace EpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_precondition.cc
+++ b/source/lac/trilinos_precondition.cc
@@ -26,7 +26,12 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <Teuchos_RCP.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -783,6 +788,6 @@ namespace TrilinosWrappers
 #  endif // DOXYGEN
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -31,7 +31,12 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -366,6 +371,6 @@ namespace TrilinosWrappers
 
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -23,7 +23,14 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #    include <ml_MultiLevelPreconditioner.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
+
+#  endif // DEAL_II_TRILINOS_WITH_MUELU
+#endif   // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
+#  ifdef DEAL_II_TRILINOS_WITH_MUELU
 
 namespace TrilinosWrappers
 {
@@ -273,7 +280,7 @@ namespace TrilinosWrappers
 
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_MUELU
 #endif   // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_solver.cc
+++ b/source/lac/trilinos_solver.cc
@@ -34,7 +34,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <limits>
 #  include <memory>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -988,6 +993,6 @@ namespace TrilinosWrappers
   SolverBase::do_solve(const Epetra_Operator &preconditioner);
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -39,7 +39,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <memory>
 
+
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -3104,6 +3109,6 @@ namespace TrilinosWrappers
 } // namespace TrilinosWrappers
 #  endif // DOXYGEN
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -27,7 +27,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <limits>
 
+
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -1247,6 +1252,6 @@ namespace TrilinosWrappers
 
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_block_sparse_matrix.cc
+++ b/source/lac/trilinos_tpetra_block_sparse_matrix.cc
@@ -16,7 +16,12 @@
 
 #  include <deal.II/lac/trilinos_tpetra_block_sparse_matrix.templates.h>
 
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 #  ifndef DOXYGEN
 // explicit instantiations
@@ -61,6 +66,6 @@ namespace LinearAlgebra
 } // namespace LinearAlgebra
 #  endif // DOXYGEN
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_block_vector.cc
+++ b/source/lac/trilinos_tpetra_block_vector.cc
@@ -12,9 +12,9 @@
 
 #include <deal.II/lac/trilinos_tpetra_block_vector.templates.h>
 
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
-
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 namespace LinearAlgebra
 {
@@ -73,6 +73,6 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_communication_pattern.cc
+++ b/source/lac/trilinos_tpetra_communication_pattern.cc
@@ -23,7 +23,12 @@
 
 #  include <memory>
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 namespace LinearAlgebra
 {
@@ -134,6 +139,6 @@ template class LinearAlgebra::TpetraWrappers::CommunicationPattern<
 template class LinearAlgebra::TpetraWrappers::CommunicationPattern<
   MemorySpace::Host>;
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_precondition.cc
+++ b/source/lac/trilinos_tpetra_precondition.cc
@@ -13,10 +13,10 @@
 
 #include <deal.II/lac/trilinos_tpetra_precondition.templates.h>
 
+DEAL_II_NAMESPACE_OPEN
+
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #  ifdef DEAL_II_TRILINOS_WITH_IFPACK2
-
-DEAL_II_NAMESPACE_OPEN
 
 #    ifndef DOXYGEN
 // explicit instantiations
@@ -198,7 +198,7 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 
 } // namespace LinearAlgebra
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_IFPACK2
 #endif   // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_precondition_muelu.cc
+++ b/source/lac/trilinos_tpetra_precondition_muelu.cc
@@ -13,11 +13,11 @@
 
 #include <deal.II/lac/trilinos_tpetra_precondition_muelu.templates.h>
 
+DEAL_II_NAMESPACE_OPEN
+
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #  ifdef DEAL_II_TRILINOS_WITH_IFPACK2
 #    ifdef DEAL_II_TRILINOS_WITH_TPETRA_MUELU
-
-DEAL_II_NAMESPACE_OPEN
 
 #      ifndef DOXYGEN
 // explicit instantiations
@@ -54,8 +54,8 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 #      endif // def DOXYGEN
-DEAL_II_NAMESPACE_CLOSE
 
 #    endif
 #  endif // DEAL_II_TRILINOS_WITH_IFPACK2
 #endif   // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_solver_direct.cc
+++ b/source/lac/trilinos_tpetra_solver_direct.cc
@@ -12,10 +12,10 @@
 
 #include <deal.II/lac/trilinos_tpetra_solver_direct.templates.h>
 
+DEAL_II_NAMESPACE_OPEN
+
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
 #  ifdef DEAL_II_TRILINOS_WITH_AMESOS2
-
-DEAL_II_NAMESPACE_OPEN
 
 #    ifndef DOXYGEN
 // explicit instantiations
@@ -68,7 +68,7 @@ namespace LinearAlgebra
   } // namespace TpetraWrappers
 
 } // namespace LinearAlgebra
-DEAL_II_NAMESPACE_CLOSE
 
 #  endif // DEAL_II_TRILINOS_WITH_AMESOS2
 #endif   // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_sparse_matrix.cc
+++ b/source/lac/trilinos_tpetra_sparse_matrix.cc
@@ -16,7 +16,12 @@
 
 #  include <deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h>
 
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 #  ifndef DOXYGEN
 
@@ -41,6 +46,6 @@ namespace LinearAlgebra::TpetraWrappers
 
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -26,7 +26,12 @@
 
 #  include <limits>
 
+
+#endif // DEAL_II_TRILINOS_WITH_TPETRA
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 namespace LinearAlgebra
 {
@@ -1156,6 +1161,6 @@ namespace LinearAlgebra
 
 } // namespace LinearAlgebra
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_TRILINOS_WITH_TPETRA
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_tpetra_vector.cc
+++ b/source/lac/trilinos_tpetra_vector.cc
@@ -12,9 +12,9 @@
 
 #include <deal.II/lac/trilinos_tpetra_vector.templates.h>
 
-#ifdef DEAL_II_TRILINOS_WITH_TPETRA
-
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
 
 #  ifndef DOXYGEN
 namespace LinearAlgebra
@@ -128,6 +128,6 @@ namespace LinearAlgebra
 
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -34,7 +34,12 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #  include <memory>
 
 
+
+#endif // DEAL_II_WITH_TRILINOS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_TRILINOS
 
 namespace TrilinosWrappers
 {
@@ -865,6 +870,6 @@ namespace TrilinosWrappers
   } // namespace MPI
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_TRILINOS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/opencascade/manifold_lib.cc
+++ b/source/opencascade/manifold_lib.cc
@@ -35,7 +35,12 @@
 #  endif
 
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_OPENCASCADE
 
 
 namespace OpenCASCADE
@@ -576,6 +581,7 @@ namespace OpenCASCADE
 #  endif
 } // end namespace OpenCASCADE
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -83,7 +83,12 @@
 #  include <vector>
 
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_OPENCASCADE
 
 namespace OpenCASCADE
 {
@@ -925,6 +930,7 @@ namespace OpenCASCADE
 
 } // namespace OpenCASCADE
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -32,7 +32,12 @@
 #    include <deal.II/lac/petsc_vector.h>
 #  endif
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
 
 // We don't build the .inst file if deal.II isn't configured
 // with SUNDIALS, but doxygen doesn't know that and tries to find that
@@ -42,6 +47,6 @@ DEAL_II_NAMESPACE_OPEN
 #    include "sundials/arkode.inst"
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -43,7 +43,12 @@
 #  include <iomanip>
 #  include <iostream>
 
+
+#endif // DEAL_II_WITH_SUNDIALS
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
 
 namespace SUNDIALS
 {
@@ -550,6 +555,6 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_SUNDIALS
+DEAL_II_NAMESPACE_CLOSE

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -51,7 +51,12 @@
 #  include <iomanip>
 #  include <iostream>
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
 
 namespace SUNDIALS
 {
@@ -616,6 +621,6 @@ namespace SUNDIALS
 
 } // namespace SUNDIALS
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/sundials/n_vector.cc
+++ b/source/sundials/n_vector.cc
@@ -24,7 +24,12 @@
 #    include <sundials/sundials_context.h>
 #  endif
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
 
 // We don't build the .inst file if deal.II isn't configured
 // with SUNDIALS, but doxygen doesn't know that and tries to find that
@@ -34,6 +39,6 @@ DEAL_II_NAMESPACE_OPEN
 #    include "sundials/n_vector.inst"
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/sundials/sunlinsol_wrapper.cc
+++ b/source/sundials/sunlinsol_wrapper.cc
@@ -31,7 +31,12 @@
 #    include <deal.II/lac/petsc_vector.h>
 #  endif
 
+
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SUNDIALS
 
 // We don't build the .inst file if deal.II isn't configured
 // with SUNDIALS, but doxygen doesn't know that and tries to find that
@@ -41,6 +46,6 @@ DEAL_II_NAMESPACE_OPEN
 #    include "sundials/sunlinsol_wrapper.inst"
 #  endif
 
-DEAL_II_NAMESPACE_CLOSE
 
 #endif
+DEAL_II_NAMESPACE_CLOSE

--- a/source/trilinos/nox.cc
+++ b/source/trilinos/nox.cc
@@ -31,7 +31,11 @@
 
 #  include <deal.II/trilinos/nox.templates.h>
 
+#endif
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_TRILINOS_WITH_NOX
 
 namespace TrilinosWrappers
 {
@@ -44,6 +48,6 @@ namespace TrilinosWrappers
 #  endif
 } // namespace TrilinosWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
 #endif
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
#19527 was about having to pull module statements out of `#ifdef ... #endif` blocks in header files. We have to do the same for source files. Part of #18071.