### PR TITLE
Include what you use: Remove unused header includes in .h files.

### DIFF
--- a/include/deal.II/base/auto_derivative_function.h
+++ b/include/deal.II/base/auto_derivative_function.h
@@ -16,7 +16,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -16,7 +16,6 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/auto_derivative_function.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/function.h>
 
 #include <vector>

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -17,10 +17,8 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/auto_derivative_function.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/mu_parser_internal.h>
 #include <deal.II/base/point.h>
-#include <deal.II/base/tensor.h>
 
 #include <map>
 #include <vector>

--- a/include/deal.II/base/function_time.h
+++ b/include/deal.II/base/function_time.h
@@ -16,7 +16,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/exceptions.h>
 
 DEAL_II_NAMESPACE_OPEN
 /**

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -19,7 +19,6 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/thread_local_storage.h>
 

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -16,7 +16,6 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/enable_observer_pointer.h>
-#include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/types.h>

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -30,7 +30,6 @@
 
 #include <boost/container/small_vector.hpp>
 
-#include <limits>
 #include <set>
 #include <type_traits>
 #include <vector>

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -16,21 +16,17 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/function.h>
-#include <deal.II/base/quadrature.h>
-#include <deal.II/base/symmetric_tensor.h>
 
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe.h>
 #include <deal.II/fe/fe_nothing.h>
-#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_update_flags.h>
 
 #include <deal.II/hp/fe_collection.h>
 
 #include <map>
-#include <numeric>
 #include <set>
 #include <utility>
 #include <vector>

--- a/include/deal.II/fe/fe_nedelec_sz.h
+++ b/include/deal.II/fe/fe_nedelec_sz.h
@@ -17,11 +17,8 @@
 
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/polynomials_integrated_legendre_sz.h>
-#include <deal.II/base/qprojector.h>
-#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/fe/fe.h>
-#include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/fe/mapping_q.h>
 
-#include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -26,8 +26,6 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_element_access.h>
 
-#include <boost/range/iterator_range.hpp>
-
 #include <algorithm>
 #include <set>
 #include <type_traits>

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -21,11 +21,6 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/enable_observer_pointer.h>
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/observer_pointer.h>
-#include <deal.II/base/table.h>
-
 #include <deal.II/lac/block_indices.h>
 #include <deal.II/lac/block_matrix_base.h>
 #include <deal.II/lac/sparse_matrix_ez.h>

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -16,7 +16,6 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/communication_pattern_base.h>
-#include <deal.II/base/enable_observer_pointer.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/memory_space_data.h>
 #include <deal.II/base/mpi_stub.h>
@@ -25,7 +24,6 @@
 #include <deal.II/base/partitioner.h>
 
 #include <deal.II/lac/read_vector.h>
-#include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 #include <deal.II/lac/vector_operation.h>
 #include <deal.II/lac/vector_type_traits.h>
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -18,8 +18,6 @@
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/index_set.h>
-#include <deal.II/base/memory_consumption.h>
-#include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/parallel.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/types.h>
@@ -28,8 +26,6 @@
 #include <deal.II/lac/vector_operation.h>
 
 #include <cstdlib>
-#include <cstring>
-#include <iomanip>
 
 #ifdef DEAL_II_WITH_TRILINOS
 #  include <deal.II/lac/trilinos_epetra_communication_pattern.h>

--- a/include/deal.II/numerics/data_postprocessor.h
+++ b/include/deal.II/numerics/data_postprocessor.h
@@ -18,14 +18,10 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/enable_observer_pointer.h>
-#include <deal.II/base/point.h>
-#include <deal.II/base/tensor.h>
 
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_update_flags.h>
-
-#include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/data_component_interpretation.h>
 

--- a/source/base/function_time.cc
+++ b/source/base/function_time.cc
@@ -10,8 +10,10 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/function_time.h>
 #include <deal.II/base/function_time.templates.h>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -11,6 +11,8 @@
 // -----------------------------------------------------------------------------
 
 
+#include <deal.II/base/qprojector.h>
+
 #include <deal.II/fe/fe_nedelec_sz.h>
 #include <deal.II/fe/fe_tools.h>
 

--- a/tests/fe/fe_nedelec_sz_face_values.cc
+++ b/tests/fe/fe_nedelec_sz_face_values.cc
@@ -19,6 +19,7 @@
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_nedelec_sz.h>
+#include <deal.II/fe/fe_values.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>


### PR DESCRIPTION
These are the `#include` statements the Include-what-you-use tool flagged can be removed from header files. 

I will have to separately think about the source files. The tool was quite eager to remove our `.inst` file inclusions, at which point it realized that pretty much every other include is also unnecessary. That's clearly not the case, and so requires more manual work than the scripted solution here.