### PR TITLE
Avoid unnecessary exceptions in TableHandler class

### DIFF
--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -39,41 +39,24 @@ namespace internal
     // the value if this happens to be a number
     //
     // first try with int
-    try
-      {
-        return std::get<int>(value);
-      }
-    catch (...)
-      {}
-
+    if (const auto *stored_value = std::get_if<int>(&value))
+      return *stored_value;
 
     // ... then with unsigned int...
-    try
-      {
-        return std::get<unsigned int>(value);
-      }
-    catch (...)
-      {}
+    if (const auto *stored_value = std::get_if<unsigned int>(&value))
+      return *stored_value;
 
     // ... then with std::uint64_t...
-    try
-      {
-        return std::get<std::uint64_t>(value);
-      }
-    catch (...)
-      {}
+    if (const auto *stored_value = std::get_if<std::uint64_t>(&value))
+      return *stored_value;
 
     // ...and finally with double precision:
-    try
-      {
-        return std::get<double>(value);
-      }
-    catch (...)
-      {
-        Assert(false,
-               ExcMessage("The number stored by this element of the "
-                          "table is not a number."));
-      }
+    if (const auto *stored_value = std::get_if<double>(&value))
+      return *stored_value;
+
+    Assert(false,
+           ExcMessage("The entry stored by this element of the "
+                      "table is not a number."));
 
     return 0;
   }


### PR DESCRIPTION
In this function we want to return a value from an std::variant, but dont quite know the type. So we try different types inside try-catch statements, until we find the correct one. This works, but throws exceptions for every test that doesnt succeed. This is annoying when debugging programs with gdb and `catch throw` (because the execution is interrupted every time this function is hit). Exceptions are for exceptional situations, and we do not need them for checking the type of a variant.

The workaround uses `get_if` to convert a pointer to the variant to the correct type. The pointer will only be different from `nullptr` (and hence returned) if the variant is indeed of the requested type.

I have verified that this works for my application and gets rid of the exceptions thrown.