### PR TITLE
TriaObjects: rename cells to bounding_objects and add getters/setters.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5232,9 +5232,7 @@ TriaAccessor<structdim, dim, spacedim>::vertex_index(
       // This branch needs to be first (and not combined with the structdim ==
       // dim branch) so that we can get line vertex indices when setting up the
       // cell vertex index cache
-      const auto &objects = this->objects();
-      return objects
-        .cells[this->present_index * objects.faces_per_object + corner];
+      return this->objects().get_bounding_object(this->present_index, corner);
     }
   else if constexpr (structdim == dim)
     {
@@ -5304,8 +5302,7 @@ TriaAccessor<structdim, dim, spacedim>::line_index(const unsigned int i) const
 
   if constexpr (structdim == 2)
     {
-      const auto &objects = this->objects();
-      return objects.cells[this->present_index * objects.faces_per_object + i];
+      return this->objects().get_bounding_object(this->present_index, i);
     }
   else if constexpr (structdim == 3)
     {
@@ -5338,21 +5335,18 @@ inline typename dealii::internal::TriangulationImplementation::
 
 template <int structdim, int dim, int spacedim>
 inline unsigned int
-TriaAccessor<structdim, dim, spacedim>::quad_index(const unsigned int i) const
+TriaAccessor<structdim, dim, spacedim>::quad_index(
+  const unsigned int face_no) const
 {
   Assert(structdim == 3,
          ExcMessage("You can't ask for the index of a quad bounding "
                     "a one- or two-dimensional cell because it is not "
                     "bounded by quads."));
-  // work around a bogus GCC-9 warning which considers i unused except in 3d
-  (void)i;
+  // work around a bogus GCC-9 warning which considers face_no unused except in
+  // 3d
+  (void)face_no;
   if constexpr (structdim == 3)
-    {
-      AssertIndexRange(i, n_faces());
-      return this->tria->levels[this->level()]
-        ->cells
-        .cells[this->present_index * ReferenceCells::max_n_faces<3>() + i];
-    }
+    return this->objects().get_bounding_object(this->present_index, face_no);
   else
     return numbers::invalid_unsigned_int;
 }

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -116,20 +116,25 @@ namespace internal
       unsigned int faces_per_object;
 
       /**
-       * Vector of the objects bounding each cell in this level. This is
-       * typically accessed via get_bounding_object_indices().
-       *
-       * @note In this context, "cells" means "geometric entities bounded by
-       * other geometric entities": for example, TriaFaces::quads stores quads
-       * (structdim 2 objects) which are bounded by lines.
-       */
-      std::vector<int> cells;
-
-      /**
        * Return number of geometric objects stored by this class.
        */
       std::size_t
       n_objects() const;
+
+      /**
+       * Return the index of the bounding object of @p index on face @p face_no.
+       */
+      int
+      get_bounding_object(const int index, const unsigned int face_no) const;
+
+      /**
+       * Set the index of the bounding object of @p index on face @p face_no to
+       * @p neighbor_index.
+       */
+      void
+      set_bounding_object(const int          index,
+                          const unsigned int face_no,
+                          const int          neighbor_index);
 
       /**
        * Return a view on the indices of the objects that bound the @p
@@ -420,6 +425,17 @@ namespace internal
        * access will not be allowed to change the type of data accessed.
        */
       mutable UserDataType user_data_type;
+
+    private:
+      /**
+       * Vector of the objects bounding each cell in this level. This is
+       * typically accessed via get_bounding_object_indices().
+       *
+       * @note In this context, "bounding_objects" means "geometric entities bounded by
+       * other geometric entities": for example, TriaFaces::quads stores quads
+       * (structdim 2 objects) which are bounded by lines.
+       */
+      std::vector<int> bounding_objects;
     };
 
 
@@ -430,8 +446,39 @@ namespace internal
     {
       // ensure that sizes are consistent, and then return one that
       // corresponds to the number of objects
-      AssertDimension(cells.size(), manifold_id.size() * faces_per_object);
+      AssertDimension(bounding_objects.size(),
+                      manifold_id.size() * faces_per_object);
       return manifold_id.size();
+    }
+
+
+
+    inline int
+    TriaObjects::get_bounding_object(const int          index,
+                                     const unsigned int face_no) const
+    {
+      // Accessors with an index of -1 shouldn't get here
+      Assert(index != -1, ExcInternalError());
+      AssertIndexRange(face_no, faces_per_object);
+      const auto i = index * faces_per_object + face_no;
+      AssertIndexRange(i, bounding_objects.size());
+      return bounding_objects[i];
+    }
+
+
+
+    inline void
+    TriaObjects::set_bounding_object(const int          index,
+                                     const unsigned int face_no,
+                                     const int          neighbor_index)
+    {
+      // Accessors with an index of -1 shouldn't get here
+      Assert(index != -1, ExcInternalError());
+      Assert(neighbor_index >= -1, ExcInternalError());
+      AssertIndexRange(face_no, faces_per_object);
+      const auto i = index * faces_per_object + face_no;
+      AssertIndexRange(i, bounding_objects.size());
+      bounding_objects[i] = neighbor_index;
     }
 
 
@@ -440,7 +487,7 @@ namespace internal
     TriaObjects::get_bounding_object_indices(const unsigned int index)
     {
       // each cell has the same number of subcell objects
-      return ArrayView<int>(cells.data() + index * faces_per_object,
+      return ArrayView<int>(bounding_objects.data() + index * faces_per_object,
                             faces_per_object);
     }
 
@@ -594,7 +641,7 @@ namespace internal
       ar                                   &structdim;
       ar                                   &children_per_object;
       ar                                   &faces_per_object;
-      ar &cells                            &children;
+      ar &bounding_objects                 &children;
       ar                                   &refinement_cases;
       ar                                   &used;
       ar                                   &user_flags;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3728,9 +3728,7 @@ namespace internal
               {
                 const auto vertices = lines_to_vertices[line];
                 for (unsigned int v = 0; v < vertices.size(); ++v)
-                  faces.lines
-                    .cells[line * faces.lines.children_per_object + v] =
-                    vertices[v]; // set vertex indices
+                  faces.lines.set_bounding_object(line, v, vertices[v]);
               }
           }
 
@@ -3754,8 +3752,7 @@ namespace internal
                   {
                     AssertIndexRange(l, face_reference_cell.n_lines());
                     // set line index
-                    faces.quads.cells[q * faces.quads.children_per_object + l] =
-                      lines[l];
+                    faces.quads.set_bounding_object(q, l, lines[l]);
 
                     // set line orientations
                     const auto combined_orientation =
@@ -3833,7 +3830,7 @@ namespace internal
                     level.set_neighbor(cell, f, 0, neighbors[f]);
 
                   // set face indices
-                  cells_0.cells[cell * level.faces_per_object + f] = faces[f];
+                  cells_0.set_bounding_object(cell, f, faces[f]);
 
                   // set face orientation if needed
                   if (orientation_needed)

--- a/source/grid/tria_objects.cc
+++ b/source/grid/tria_objects.cc
@@ -77,7 +77,7 @@ namespace internal
       Assert(children_per_object % 2 == 0, ExcNotImplemented());
       children.assign(children_per_object / 2 * n_objects, -1);
 
-      cells.assign(n_objects * faces_per_object, -1);
+      bounding_objects.assign(n_objects * faces_per_object, -1);
 
       if (structdim <= 2)
         {
@@ -152,10 +152,11 @@ namespace internal
           // only allocate space if necessary
           if (new_size > this->n_objects())
             {
-              cells.reserve(new_size * faces_per_object);
-              cells.insert(cells.end(),
-                           (new_size - this->n_objects()) * faces_per_object,
-                           -1);
+              bounding_objects.reserve(new_size * faces_per_object);
+              bounding_objects.insert(bounding_objects.end(),
+                                      (new_size - this->n_objects()) *
+                                        faces_per_object,
+                                      -1);
 
               used.reserve(new_size);
               used.insert(used.end(), new_size - used.size(), false);
@@ -209,10 +210,11 @@ namespace internal
           // see above...
           if (new_size > this->n_objects())
             {
-              cells.reserve(new_size * faces_per_object);
-              cells.insert(cells.end(),
-                           (new_size - this->n_objects()) * faces_per_object,
-                           -1);
+              bounding_objects.reserve(new_size * faces_per_object);
+              bounding_objects.insert(bounding_objects.end(),
+                                      (new_size - this->n_objects()) *
+                                        faces_per_object,
+                                      -1);
 
               used.reserve(new_size);
               used.insert(used.end(), new_size - used.size(), false);
@@ -257,7 +259,7 @@ namespace internal
     std::size_t
     TriaObjects::memory_consumption() const
     {
-      return (MemoryConsumption::memory_consumption(cells) +
+      return (MemoryConsumption::memory_consumption(bounding_objects) +
               MemoryConsumption::memory_consumption(children) +
               MemoryConsumption::memory_consumption(used) +
               MemoryConsumption::memory_consumption(user_flags) +


### PR DESCRIPTION
At some point in this process we discussed how `TriaObjects::cells` was not a great name since it doesn't actually store 'cells' (or faces, or lines) but instead stores objects which bound some higher-dimensional object. Hence I renamed it `bounding_objects` and, like #19551, I added getters and setters so that the caller doesn't have to mess around with array strides.

I think the only remaining user-computed stride is now the cell vertex index cache.