### PR TITLE
Unify function overloads via 'if constexpr'.

### DIFF
--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -1458,28 +1458,12 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
      * initialized with the same IndexSet that was used for the column indices
      * of the matrix.
      *
-     * This function will be called when the underlying number type for the
-     * matrix object and the one for the vector object are the same.
-     * Despite looking complicated, the return type is just `void`.
-     *
      * In case of a serial vector, this function will only work when
      * running on one processor, since the matrix object is inherently
      * distributed. Otherwise, an exception will be thrown.
      */
     template <typename VectorType>
-    std::enable_if_t<
-      std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
-    vmult(VectorType &dst, const VectorType &src) const;
-
-    /**
-     * Same as the function above for the case that the underlying number type
-     * for the matrix object and the one for the vector object do not coincide.
-     * This case is not implemented. Calling it will result in a runtime error.
-     * Despite looking complicated, the return type is just `void`.
-     */
-    template <typename VectorType>
-    std::enable_if_t<
-      !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
+    void
     vmult(VectorType &dst, const VectorType &src) const;
 
     /**
@@ -1491,25 +1475,9 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
      *
      * This function can be called with several types of vector objects,
      * see the discussion about @p VectorType in vmult().
-     *
-     * This function will be called when the underlying number type for the
-     * matrix object and the one for the vector object are the same.
-     * Despite looking complicated, the return type is just `void`.
      */
     template <typename VectorType>
-    std::enable_if_t<
-      std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
-    Tvmult(VectorType &dst, const VectorType &src) const;
-
-    /**
-     * Same as the function above for the case that the underlying number type
-     * for the matrix object and the one for the vector object do not coincide.
-     * This case is not implemented. Calling it will result in a runtime error.
-     * Despite looking complicated, the return type is just `void`.
-     */
-    template <typename VectorType>
-    std::enable_if_t<
-      !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
+    void
     Tvmult(VectorType &dst, const VectorType &src) const;
 
     /**

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1986,82 +1986,80 @@ namespace TrilinosWrappers
 
 
   template <typename VectorType>
-  std::enable_if_t<
-    std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
+  void
   SparseMatrix::vmult(VectorType &dst, const VectorType &src) const
   {
-    Assert(&src != &dst, ExcSourceEqualsDestination());
-    Assert(matrix->Filled(), ExcMatrixNotCompressed());
+    if constexpr (std::is_same_v<typename VectorType::value_type,
+                                 TrilinosScalar>)
+      {
+        Assert(&src != &dst, ExcSourceEqualsDestination());
+        Assert(matrix->Filled(), ExcMatrixNotCompressed());
 
-    internal::SparseMatrixImplementation::check_vector_map_equality(*matrix,
-                                                                    src,
-                                                                    dst);
-    const size_type dst_local_size = internal::end(dst) - internal::begin(dst);
-    AssertDimension(dst_local_size, matrix->RangeMap().NumMyPoints());
-    const size_type src_local_size = internal::end(src) - internal::begin(src);
-    AssertDimension(src_local_size, matrix->DomainMap().NumMyPoints());
+        internal::SparseMatrixImplementation::check_vector_map_equality(*matrix,
+                                                                        src,
+                                                                        dst);
+        const size_type dst_local_size =
+          internal::end(dst) - internal::begin(dst);
+        AssertDimension(dst_local_size, matrix->RangeMap().NumMyPoints());
+        const size_type src_local_size =
+          internal::end(src) - internal::begin(src);
+        AssertDimension(src_local_size, matrix->DomainMap().NumMyPoints());
 
-    Epetra_MultiVector tril_dst(
-      View, matrix->RangeMap(), internal::begin(dst), dst_local_size, 1);
-    Epetra_MultiVector tril_src(View,
-                                matrix->DomainMap(),
-                                const_cast<TrilinosScalar *>(
-                                  internal::begin(src)),
-                                src_local_size,
-                                1);
+        Epetra_MultiVector tril_dst(
+          View, matrix->RangeMap(), internal::begin(dst), dst_local_size, 1);
+        Epetra_MultiVector tril_src(View,
+                                    matrix->DomainMap(),
+                                    const_cast<TrilinosScalar *>(
+                                      internal::begin(src)),
+                                    src_local_size,
+                                    1);
 
-    const int ierr = matrix->Multiply(false, tril_src, tril_dst);
-    Assert(ierr == 0, ExcTrilinosError(ierr));
+        const int ierr = matrix->Multiply(false, tril_src, tril_dst);
+        Assert(ierr == 0, ExcTrilinosError(ierr));
+      }
+    else
+      {
+        AssertThrow(false, ExcNotImplemented());
+      }
   }
 
 
 
   template <typename VectorType>
-  std::enable_if_t<
-    !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
-  SparseMatrix::vmult(VectorType & /*dst*/, const VectorType & /*src*/) const
-  {
-    AssertThrow(false, ExcNotImplemented());
-  }
-
-
-
-  template <typename VectorType>
-  std::enable_if_t<
-    std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
+  void
   SparseMatrix::Tvmult(VectorType &dst, const VectorType &src) const
   {
-    Assert(&src != &dst, ExcSourceEqualsDestination());
-    Assert(matrix->Filled(), ExcMatrixNotCompressed());
+    if constexpr (std::is_same_v<typename VectorType::value_type,
+                                 TrilinosScalar>)
+      {
+        Assert(&src != &dst, ExcSourceEqualsDestination());
+        Assert(matrix->Filled(), ExcMatrixNotCompressed());
 
-    internal::SparseMatrixImplementation::check_vector_map_equality(*matrix,
-                                                                    dst,
-                                                                    src);
-    const size_type dst_local_size = internal::end(dst) - internal::begin(dst);
-    AssertDimension(dst_local_size, matrix->DomainMap().NumMyPoints());
-    const size_type src_local_size = internal::end(src) - internal::begin(src);
-    AssertDimension(src_local_size, matrix->RangeMap().NumMyPoints());
+        internal::SparseMatrixImplementation::check_vector_map_equality(*matrix,
+                                                                        dst,
+                                                                        src);
+        const size_type dst_local_size =
+          internal::end(dst) - internal::begin(dst);
+        AssertDimension(dst_local_size, matrix->DomainMap().NumMyPoints());
+        const size_type src_local_size =
+          internal::end(src) - internal::begin(src);
+        AssertDimension(src_local_size, matrix->RangeMap().NumMyPoints());
 
-    Epetra_MultiVector tril_dst(
-      View, matrix->DomainMap(), internal::begin(dst), dst_local_size, 1);
-    Epetra_MultiVector tril_src(View,
-                                matrix->RangeMap(),
-                                const_cast<double *>(internal::begin(src)),
-                                src_local_size,
-                                1);
+        Epetra_MultiVector tril_dst(
+          View, matrix->DomainMap(), internal::begin(dst), dst_local_size, 1);
+        Epetra_MultiVector tril_src(View,
+                                    matrix->RangeMap(),
+                                    const_cast<double *>(internal::begin(src)),
+                                    src_local_size,
+                                    1);
 
-    const int ierr = matrix->Multiply(true, tril_src, tril_dst);
-    Assert(ierr == 0, ExcTrilinosError(ierr));
-  }
-
-
-
-  template <typename VectorType>
-  std::enable_if_t<
-    !std::is_same_v<typename VectorType::value_type, TrilinosScalar>>
-  SparseMatrix::Tvmult(VectorType & /*dst*/, const VectorType & /*src*/) const
-  {
-    AssertThrow(false, ExcNotImplemented());
+        const int ierr = matrix->Multiply(true, tril_src, tril_dst);
+        Assert(ierr == 0, ExcTrilinosError(ierr));
+      }
+    else
+      {
+        AssertThrow(false, ExcNotImplemented());
+      }
   }
 
 


### PR DESCRIPTION
I'm running into something that's likely a module-related compiler bug in Clang. This patch works around that by merging separate function overloads that only differ in `enable_if` variations by just throwing everything into the same function and making the distinction via `if constexpr`. This leads to shorter code and also makes sure that we don't have to deal with the issue in user documentation, so I count that as a win on almost every front :-)

Related to #18071.