### PR TITLE
Deal with OpenCASCADE module shenanigans.

### DIFF
--- a/contrib/utilities/convert_to_module_units_common.py
+++ b/contrib/utilities/convert_to_module_units_common.py
@@ -48,6 +48,7 @@ opencascade_includes = [
     "Adaptor3d_Curve.hxx",
     "Adaptor3d_HCurve.hxx",
     "BRep.*.hxx",
+    "GCPnts_AbscissaPoint.hxx",
     "Geom.*.hxx",
     "Handle.*.hxx",
     "IGESControl.*.hxx",

--- a/module/interface_module_partitions/opencascade.ccm
+++ b/module/interface_module_partitions/opencascade.ccm
@@ -155,6 +155,7 @@ export
   using ::BRepAdaptor_Curve;
   using ::BRepAdaptor_HCompCurve;
   using ::BRepAdaptor_HCurve;
+  using ::GCPnts_AbscissaPoint;
   using ::Handle_Adaptor3d_HCurve;
   using ::Handle_BRepAdaptor_HCompCurve;
   using ::Handle_BRepAdaptor_HCurve;
@@ -172,8 +173,12 @@ export
   using ::IGESControl_Writer;
   using ::IntCurvesFace_ShapeIntersector;
   using ::Poly_Triangulation;
+  using ::RealLast;
   using ::ShapeAnalysis_Curve;
   using ::ShapeAnalysis_Surface;
+  using ::Standard_Boolean;
+  using ::Standard_Integer;
+  using ::Standard_Real;
   using ::STEPControl_AsIs;
   using ::STEPControl_Controller;
   using ::STEPControl_Reader;
@@ -204,5 +209,27 @@ export
   using ::TopoDS_Vertex;
   using ::TopoDS_Wire;
 }
+
+// Deal with non-exportable entities like for all
+// of the other external libraries:
+#  define CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(sym)        \
+    namespace dealii                                        \
+    {                                                       \
+      namespace OpenCASCADE_Macros                          \
+      {                                                     \
+        [[maybe_unused]] const auto exportable_##sym = sym; \
+      }                                                     \
+    } // namespace dealii
+
+#  define EXPORT_PREPROCESSOR_SYMBOL(sym)                                    \
+    namespace dealii                                                         \
+    {                                                                        \
+      export const auto &sym = dealii::OpenCASCADE_Macros::exportable_##sym; \
+    }
+
+
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(Standard_False)
+#  undef Standard_False
+EXPORT_PREPROCESSOR_SYMBOL(Standard_False)
 
 #endif

--- a/source/opencascade/manifold_lib.cc
+++ b/source/opencascade/manifold_lib.cc
@@ -34,7 +34,21 @@
 #    include <Handle_Adaptor3d_HCurve.hxx>
 #  endif
 
-
+// OpenCASCADE defines a macro that creates class names. When building
+// modules, we don't #include any of the OpenCASCADE header files, and
+// we can't export macros, so the macro is not available. Re-declare
+// it here if it is not defined. (And if it is defined, we have a
+// problem: Apparently some header #include above is left in the file
+// by accident. Error out in that case so we get alerted to the
+// problem.)
+#  ifdef DEAL_II_BUILDING_CXX20_MODULE
+#    ifndef HANDLE
+#      define Handle(ClassName) Handle_##ClassName
+#    else
+#      error \
+        "Some OpenCASCADE header file is apparently included even when building modules!"
+#    endif
+#  endif
 
 #endif
 

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -82,7 +82,21 @@
 #  include <algorithm>
 #  include <vector>
 
-
+// OpenCASCADE defines a macro that creates class names. When building
+// modules, we don't #include any of the OpenCASCADE header files, and
+// we can't export macros, so the macro is not available. Re-declare
+// it here if it is not defined. (And if it is defined, we have a
+// problem: Apparently some header #include above is left in the file
+// by accident. Error out in that case so we get alerted to the
+// problem.)
+#  ifdef DEAL_II_BUILDING_CXX20_MODULE
+#    ifndef HANDLE
+#      define Handle(ClassName) Handle_##ClassName
+#    else
+#      error \
+        "Some OpenCASCADE header file is apparently included even when building modules!"
+#    endif
+#  endif
 
 #endif
 


### PR DESCRIPTION
I had missed an OpenCASCADE `#include` from the list of header files we want to exclude, which was therefore executed even in module compilations, and that meant that we imported a macro (`Handle`) that shouldn't have been available in module compilations. Finding that of course meant that (i) we have to add several more exports, (ii) we now have to deal with the macro ourselves.

Related to #18071.