### PR TITLE
Remove taskflow includes from SparseVanka.

### DIFF
--- a/source/lac/sparse_vanka.cc
+++ b/source/lac/sparse_vanka.cc
@@ -17,10 +17,6 @@
 #include <deal.II/lac/sparse_vanka.h>
 #include <deal.II/lac/sparse_vanka.templates.h>
 
-#include <taskflow/core/async.hpp>
-#include <taskflow/core/graph.hpp>
-#include <taskflow/utility/traits.hpp>
-
 #include <ostream>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Follow-up to #19523.

Our docker configuration complains about these taskflow includes as we only configure deal.II with TBB and not with taskflow yet.

I do not see how `SparseVanka` requires these includes, so instead of guarding them I suggest to remove them.