### PR TITLE
Fix Tpetra vector swap and assignment.

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -39,6 +39,7 @@
 
 #  include <memory>
 #  include <optional>
+#  include <utility>
 
 #endif
 
@@ -1163,11 +1164,22 @@ namespace LinearAlgebra
       return compressed;
     }
 
+
+
     template <typename Number, typename MemorySpace>
     inline void
     Vector<Number, MemorySpace>::swap(Vector<Number, MemorySpace> &v) noexcept
     {
+      std::swap(compressed, v.compressed);
+      std::swap(has_ghost, v.has_ghost);
+      std::swap(last_action, v.last_action);
       vector.swap(v.vector);
+      nonlocal_vector.swap(v.nonlocal_vector);
+      std::swap(source_stored_elements, v.source_stored_elements);
+      std::swap(local_entries, v.local_entries);
+      std::swap(nonlocal_cached_indices, v.nonlocal_cached_indices);
+      std::swap(nonlocal_cached_values, v.nonlocal_cached_values);
+      tpetra_comm_pattern.swap(v.tpetra_comm_pattern);
     }
 
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -104,9 +104,11 @@ namespace LinearAlgebra
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.nonlocal_vector,
                                                           Teuchos::Copy);
         }
+      source_stored_elements  = V.source_stored_elements;
       local_entries           = V.local_entries;
       nonlocal_cached_indices = V.nonlocal_cached_indices;
       nonlocal_cached_values  = V.nonlocal_cached_values;
+      tpetra_comm_pattern     = V.tpetra_comm_pattern;
     }
 
 
@@ -118,7 +120,15 @@ namespace LinearAlgebra
       , has_ghost(V->getMap()->isOneToOne() == false)
       , last_action(VectorOperation::unknown)
       , vector(V)
-    {}
+    {
+      // If there are ghost entries, we do not know which process owns which
+      // entries. Assume no one owns any entries, which will allow read access,
+      // but no write access.
+      if (has_ghost)
+        local_entries = IndexSet(vector->getGlobalLength());
+      else
+        local_entries = IndexSet(vector->getMap());
+    }
 
 
 
@@ -203,8 +213,12 @@ namespace LinearAlgebra
       compressed  = true;
       last_action = VectorOperation::unknown;
       nonlocal_vector.reset();
+      source_stored_elements.clear();
+      local_entries.clear();
+      local_entries.set_size(0);
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
+      tpetra_comm_pattern = Teuchos::null;
     }
 
 
@@ -217,8 +231,10 @@ namespace LinearAlgebra
     {
       vector.reset();
       nonlocal_vector.reset();
+      source_stored_elements.clear();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
+      tpetra_comm_pattern = Teuchos::null;
 
       compressed  = true;
       has_ghost   = false;
@@ -242,8 +258,10 @@ namespace LinearAlgebra
     {
       // release memory before reallocation
       nonlocal_vector.reset();
+      source_stored_elements.clear();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
+      tpetra_comm_pattern = Teuchos::null;
 
       local_entries = locally_owned_entries;
 
@@ -473,17 +491,31 @@ namespace LinearAlgebra
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                           Teuchos::Copy);
 
+          nonlocal_vector.reset();
+          if (!V.nonlocal_vector.is_null())
+            {
+              nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
+                TpetraTypes::VectorType<Number, MemorySpace>>(
+                *V.nonlocal_vector, Teuchos::Copy);
+            }
+
           compressed             = V.compressed;
           has_ghost              = V.has_ghost;
           source_stored_elements = V.source_stored_elements;
           tpetra_comm_pattern    = V.tpetra_comm_pattern;
+          local_entries          = V.local_entries;
         }
 
       // Because V is compressed and has no pending changes
       // clear our local cache as well.
+      if (!nonlocal_vector.is_null())
+        nonlocal_vector->putScalar(Number(0));
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
-      last_action = VectorOperation::unknown;
+      source_stored_elements.clear();
+      tpetra_comm_pattern = Teuchos::null;
+      compressed          = true;
+      last_action         = VectorOperation::unknown;
 
       return *this;
     }
@@ -507,9 +539,13 @@ namespace LinearAlgebra
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(),
         vector_data);
 
-      has_ghost   = false;
-      compressed  = true;
-      last_action = VectorOperation::unknown;
+      local_entries = V.locally_owned_elements();
+
+      source_stored_elements.clear();
+      tpetra_comm_pattern = Teuchos::null;
+      has_ghost           = false;
+      compressed          = true;
+      last_action         = VectorOperation::unknown;
 
       return *this;
     }

--- a/tests/trilinos_tpetra/tpetra_vector_06.cc
+++ b/tests/trilinos_tpetra/tpetra_vector_06.cc
@@ -1,0 +1,145 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2018 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Check that various LinearAlgebra::TpetraWrappers::Vector initialization
+// and assignment routines correctly set state variables.
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/trilinos_tpetra_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+template <typename VectorType>
+void
+test_for_equality(VectorType a, VectorType b)
+{
+  Assert(a.has_ghost_elements() == b.has_ghost_elements(),
+         ExcMessage("Difference in ghosted state."));
+  Assert(a.is_compressed() == b.is_compressed(),
+         ExcMessage("Difference in compressed state."));
+  Assert(a.size() == b.size(), ExcMessage("Difference in global size."));
+  Assert(a.locally_owned_size() == b.locally_owned_size(),
+         ExcMessage("Difference in locally owned size."));
+  Assert(a.locally_owned_elements() == b.locally_owned_elements(),
+         ExcMessage("Difference in owned elements."));
+
+  const unsigned int my_rank =
+    dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  for (const auto i : a.locally_owned_elements())
+    Assert(a(i) == b(i),
+           ExcMessage("Difference on rank " + std::to_string(my_rank) +
+                      " in vector element index <" + std::to_string(i) +
+                      ">. Values: <" + std::to_string(a(i)) + "> and <" +
+                      std::to_string(b(i)) + ">."));
+}
+
+template <typename VectorType>
+void
+test_vector_operations(VectorType a)
+{
+  // Check copy constructor
+  VectorType b(a);
+
+  test_for_equality(a, b);
+
+  // Check clear()
+  VectorType c;
+  b.clear();
+  test_for_equality(b, c);
+
+  // Check assignment
+  b = a;
+  test_for_equality(a, b);
+
+  // Check swap function
+  VectorType d;
+  b.swap(c);
+
+  test_for_equality(a, c);
+  test_for_equality(b, d);
+}
+
+template <typename VectorType>
+void
+test()
+{
+  IndexSet     parallel_partitioner_owned(5);
+  IndexSet     parallel_partitioner_relevant(5);
+  unsigned int rank = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  if (rank == 0)
+    {
+      parallel_partitioner_owned.add_range(0, 2);
+      parallel_partitioner_relevant.add_range(0, 3);
+    }
+  else
+    {
+      parallel_partitioner_owned.add_range(2, 5);
+      parallel_partitioner_relevant.add_range(1, 5);
+    }
+
+  parallel_partitioner_owned.compress();
+  parallel_partitioner_relevant.compress();
+
+  VectorType a(parallel_partitioner_owned, MPI_COMM_WORLD);
+
+  // test on fully-distributd empty vector
+  test_vector_operations(a);
+
+  for (const auto i : a.locally_owned_elements())
+    a(i) = i;
+
+  // test on fully-distributed filled vector
+  test_vector_operations(a);
+
+  if (rank == 0)
+    {
+      a(2) += 2;
+    }
+  else
+    {
+      a(1) += 1;
+    }
+
+  // test on fully-distributd vector after compressing
+  a.compress(VectorOperation::add);
+  test_vector_operations(a);
+
+  // test on ghosted vector
+  VectorType b(parallel_partitioner_owned,
+               parallel_partitioner_relevant,
+               MPI_COMM_WORLD);
+  b = a;
+  test_vector_operations(b);
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
+
+  MPILogInitAll log;
+
+  test<typename LinearAlgebra::TpetraWrappers::Vector<double,
+                                                      MemorySpace::Host>>();
+
+  deallog << "OK" << std::endl;
+
+  return 0;
+}

--- a/tests/trilinos_tpetra/tpetra_vector_06.mpirun=2.with_trilinos_with_tpetra=on.output
+++ b/tests/trilinos_tpetra/tpetra_vector_06.mpirun=2.with_trilinos_with_tpetra=on.output
@@ -1,0 +1,5 @@
+
+DEAL:0::OK
+
+DEAL:1::OK
+


### PR DESCRIPTION
TpetraWrappers::Vector has acquired quite a number of state variables, but not all of them were properly kept up-to-date by the various functions of the class. This PR fixes all the cases I could find and adds a test that ensures that all state variables that can be tracked from the outside are properly tracked.
Many of the changes are just resetting variables properly (potentially preventing issues if they were not properly reinitialized later). But two consequential bug fixes are:
- `std::swap` would not properly swap all necessary variables
- `operator=` would loose track of the locally owned entries, setting the assigned to vector in a partially wrong state

This now all works, and I can now use TpetraWrappers::Vector as a full-replacement for TrilinosWrappers::Vector for all the operations we use in https://github.com/geodynamics/aspect.

However, the class is still a bit inconsistent in its handling of the `compressed` state. E.g. we do not allow assignment from an uncompressed vector, but we do allow copy construction. Also we do not check for all other global operations whether the vector is compressed or not, leading to potentially wrong results (e.g. assigning to non local entries, then globally scaling the vector, then compressing the vector would overwrite the scaled entry with the cached non local entry). I could fix that later, but I was not sure what useful policy is here. Do we just not allow any global operations on a vector that is not compressed (i.e. as long as `is_compressed` is `false`, the only valid operation on a vector is to call `compress`?).