### PR TITLE
Make files play well with modules.

### DIFF
--- a/source/lac/slepc_solver.cc
+++ b/source/lac/slepc_solver.cc
@@ -13,7 +13,6 @@
 #include <deal.II/lac/slepc_solver.h>
 
 #ifdef DEAL_II_WITH_SLEPC
-
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/petsc_vector_base.h>
 #  include <deal.II/lac/slepc_spectral_transformation.h>
@@ -24,8 +23,12 @@
 
 #  include <cmath>
 #  include <vector>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
+
+
+#ifdef DEAL_II_WITH_SLEPC
 
 namespace SLEPcWrappers
 {
@@ -492,6 +495,6 @@ namespace SLEPcWrappers
   }
 } // namespace SLEPcWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SLEPC
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/slepc_spectral_transformation.cc
+++ b/source/lac/slepc_spectral_transformation.cc
@@ -13,7 +13,6 @@
 #include <deal.II/lac/slepc_spectral_transformation.h>
 
 #ifdef DEAL_II_WITH_SLEPC
-
 #  include <deal.II/lac/petsc_matrix_base.h>
 #  include <deal.II/lac/slepc_solver.h>
 
@@ -21,8 +20,11 @@
 
 #  include <cmath>
 #  include <vector>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_SLEPC
 
 namespace SLEPcWrappers
 {
@@ -120,6 +122,6 @@ namespace SLEPcWrappers
 
 } // namespace SLEPcWrappers
 
-DEAL_II_NAMESPACE_CLOSE
-
 #endif // DEAL_II_WITH_SLEPC
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Two more files where we need to move the namespace declarations out of `#ifdef` blocks. Part of #18071.