### PR TITLE
ARKode: do not deprecate AdditionalData()

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -175,12 +175,12 @@ namespace SUNDIALS
         "with the ARKStepper relevant parameters instead.")
       AdditionalData(
         // Initial parameters
-        const double initial_time      = 0.0,
-        const double final_time        = 1.0,
-        const double initial_step_size = 1e-2,
-        const double output_period     = 1e-1,
+        const double initial_time,
+        const double final_time,
+        const double initial_step_size,
+        const double output_period,
         // Running parameters
-        const double       minimum_step_size                     = 1e-6,
+        const double       minimum_step_size,
         const unsigned int maximum_order                         = 5,
         const unsigned int maximum_non_linear_iterations         = 10,
         const bool         implicit_function_is_linear           = false,
@@ -212,15 +212,15 @@ namespace SUNDIALS
        */
       AdditionalData(
         // Initial parameters
-        const double initial_time,
-        const double final_time,
-        const double initial_step_size,
-        const double output_period,
+        const double initial_time      = 0.0,
+        const double final_time        = 1.0,
+        const double initial_step_size = 1e-2,
+        const double output_period     = 1e-1,
         // Running parameters
-        const double minimum_step_size,
+        const double minimum_step_size = 1e-6,
         // Error parameters
-        const double absolute_tolerance,
-        const double relative_tolerance);
+        const double absolute_tolerance = 1e-6,
+        const double relative_tolerance = 1e-5);
 
       /**
        * Add all AdditionalData() parameters to the given ParameterHandler
@@ -837,6 +837,7 @@ namespace SUNDIALS
   };
 
 
+
   template <typename VectorType>
   ARKode<VectorType>::AdditionalData::AdditionalData(
     // Initial parameters
@@ -871,6 +872,8 @@ namespace SUNDIALS
     , anderson_acceleration_subspace(anderson_acceleration_subspace)
   {}
 
+
+
   template <typename VectorType>
   ARKode<VectorType>::AdditionalData::AdditionalData(
     // Initial parameters
@@ -897,6 +900,8 @@ namespace SUNDIALS
     , mass_is_time_independent(false)
     , anderson_acceleration_subspace(3)
   {}
+
+
 
   template <typename VectorType>
   void


### PR DESCRIPTION
We use the default constructor in ASPECT and set parameters manually but get a deprecation warning now. Fix this.