### PR TITLE
[ARKODE] Rename `ARKStepper::mass_times_setup` `ARKStepper::mass_times_vector_setup` and fix user data in `ARKStepSetMassTimes`

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -527,7 +527,7 @@ namespace SUNDIALS
      * to ARKode as a stepper. If this requirement is violated, an exception is
      * triggered upon access to this field.
      *
-     * @deprecated Specify @p ARKStepper::mass_times_setup instead.
+     * @deprecated Specify @p ARKStepper::mass_times_vector_setup instead.
      */
     FunctionProxy<void(const double t)> mass_times_setup;
 

--- a/include/deal.II/sundials/arkode.templates.h
+++ b/include/deal.II/sundials/arkode.templates.h
@@ -70,7 +70,7 @@ namespace SUNDIALS
     explicit_function     = &ark_stepper_storage->explicit_function;
     implicit_function     = &ark_stepper_storage->implicit_function;
     mass_times_vector     = &ark_stepper_storage->mass_times_vector;
-    mass_times_setup      = &ark_stepper_storage->mass_times_setup;
+    mass_times_setup      = &ark_stepper_storage->mass_times_vector_setup;
     jacobian_times_vector = &ark_stepper_storage->jacobian_times_vector;
     jacobian_times_setup  = &ark_stepper_storage->jacobian_times_vector_setup;
 

--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -308,7 +308,7 @@ namespace SUNDIALS
    *
    * If the @ref GlossMassMatrix "mass matrix" is different from the identity, the user should supply
    *  - mass_times_vector() and, optionally,
-   *  - mass_times_setup()
+   *  - mass_times_vector_setup()
    *
    * If the use of a Newton method is desired, then the user should also supply
    * jacobian_times_vector(). jacobian_times_vector_setup() is optional.
@@ -539,8 +539,9 @@ namespace SUNDIALS
      * A function object that users may supply and that is intended to compute
      * the product of the @ref GlossMassMatrix "mass matrix" with a given vector `v`.
      * This function will be called by ARKode (possibly several times) after
-     * mass_times_setup() has been called at least once. ARKode tries to do its
-     * best to call mass_times_setup() the minimum amount of times.
+     * mass_times_vector_setup() has been called at least once. ARKode tries to
+     * do its best to call mass_times_vector_setup() the minimum amount of
+     * times.
      *
      * A call to this function should store in `Mv` the result of $M$
      * applied to `v`.
@@ -567,8 +568,8 @@ namespace SUNDIALS
      * not the case where the mass matrix depends on the solution itself.
      *
      * If the user does not provide a mass_times_vector() function, then the
-     * identity is used. If the mass_times_setup() function is not provided,
-     * then mass_times_vector() should do all the work by itself.
+     * identity is used. If the mass_times_vector_setup() function is not
+     * provided, then mass_times_vector() should do all the work by itself.
      *
      * If the user uses a matrix-based computation of the mass matrix, then
      * this is the right place where an assembly routine should be called to
@@ -578,7 +579,7 @@ namespace SUNDIALS
      *
      * @note No assumption is made by this interface on what the user
      *   should do in this function. ARKode only assumes that after a call to
-     *   mass_times_setup() it is possible to call mass_times_vector().
+     *   mass_times_vector_setup() it is possible to call mass_times_vector().
      *
      * @param t The current evaluation time
      *
@@ -589,7 +590,7 @@ namespace SUNDIALS
      * with "recoverable" errors in some circumstances, so callbacks
      * can throw exceptions of type RecoverableUserCallbackError.
      */
-    std::function<void(const double t)> mass_times_setup;
+    std::function<void(const double t)> mass_times_vector_setup;
 
     /**
      * A function object that users may supply and that is intended to compute

--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -432,7 +432,7 @@ namespace SUNDIALS
           auto &callback_ctx = *static_cast<CallbackContext *>(mtimes_data);
 
           return Utilities::call_and_possibly_capture_exception(
-            callback_ctx.stepper->mass_times_setup,
+            callback_ctx.stepper->mass_times_vector_setup,
             *callback_ctx.pending_exception,
             t);
         };
@@ -456,7 +456,7 @@ namespace SUNDIALS
         };
 
         status = ARKStepSetMassTimes(arkode_mem,
-                                     mass_times_setup ?
+                                     mass_times_vector_setup ?
                                        mass_matrix_times_vector_setup_callback :
                                        ARKLsMassTimesSetupFn(nullptr),
                                      mass_matrix_times_vector_callback,

--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -460,7 +460,7 @@ namespace SUNDIALS
                                        mass_matrix_times_vector_setup_callback :
                                        ARKLsMassTimesSetupFn(nullptr),
                                      mass_matrix_times_vector_callback,
-                                     this);
+                                     &callback_ctx);
         AssertARKode(status);
 
         if (mass_preconditioner_solve)


### PR DESCRIPTION
As proposed in #19282 by @bangerth, the callback `jacobian_times_setup` was renamed to `jacobian_times_vector_setup`. At that time we missed `mass_times_setup` - I think it has to be also renamed to `mass_times_vector_setup` for consistency.

I also detected a minor bug in using `mass_times_vector_setup` providing the wrong user data - this is also fixed in this PR. The bug was not detected by tests, since a test working with this callback is missing. I will add it later, when refactoring tests in the upcoming PRs.