### PR TITLE
Introduce base class for orthogonal basis evaluation

### DIFF
--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -17,7 +17,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/point.h>
-#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/scalar_polynomials_vandermonde_base.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/lac/full_matrix.h>
@@ -34,7 +34,8 @@ DEAL_II_NAMESPACE_OPEN
  * multiplied with the modal basis vector evaluated at the evaluation point.
  */
 template <int dim>
-class ScalarLagrangePolynomialPyramid : public ScalarPolynomialsBase<dim>
+class ScalarLagrangePolynomialPyramid
+  : public ScalarPolynomialsVandermondeBase<dim>
 {
 public:
   /**
@@ -57,76 +58,6 @@ public:
     const unsigned int             n_dofs,
     const std::vector<Point<dim>> &support_points);
 
-  /**
-   * @copydoc ScalarPolynomialsBase::evaluate()
-   *
-   * @note Currently, only the vectors @p values and @p grads are filled.
-   */
-  void
-  evaluate(const Point<dim>            &unit_point,
-           std::vector<double>         &values,
-           std::vector<Tensor<1, dim>> &grads,
-           std::vector<Tensor<2, dim>> &grad_grads,
-           std::vector<Tensor<3, dim>> &third_derivatives,
-           std::vector<Tensor<4, dim>> &fourth_derivatives) const override;
-
-  /**
-   * @copydoc ScalarPolynomialsBase::compute_value()
-   */
-  double
-  compute_value(const unsigned int i, const Point<dim> &p) const override;
-
-  /**
-   * @copydoc ScalarPolynomialsBase::compute_derivative()
-   *
-   * @note Currently, only implemented for first derivative.
-   */
-  template <int order>
-  Tensor<order, dim>
-  compute_derivative(const unsigned int i, const Point<dim> &p) const;
-
-  Tensor<1, dim>
-  compute_1st_derivative(const unsigned int i,
-                         const Point<dim>  &p) const override;
-
-  Tensor<2, dim>
-  compute_2nd_derivative(const unsigned int i,
-                         const Point<dim>  &p) const override;
-
-  /**
-   * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
-   *
-   * @note Not implemented yet.
-   */
-  Tensor<3, dim>
-  compute_3rd_derivative(const unsigned int i,
-                         const Point<dim>  &p) const override;
-
-  /**
-   * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
-   *
-   * @note Not implemented yet.
-   */
-  Tensor<4, dim>
-  compute_4th_derivative(const unsigned int i,
-                         const Point<dim>  &p) const override;
-
-  /**
-   * @copydoc ScalarPolynomialsBase::compute_grad()
-   *
-   * @note Not implemented yet.
-   */
-  Tensor<1, dim>
-  compute_grad(const unsigned int i, const Point<dim> &p) const override;
-
-  /**
-   * @copydoc ScalarPolynomialsBase::compute_grad_grad()
-   *
-   * @note Not implemented yet.
-   */
-  Tensor<2, dim>
-  compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
-
   std::string
   name() const override;
 
@@ -135,23 +66,16 @@ public:
 
 private:
   /**
-   * The Vandermonde matrix evaluates each modal basis function at the chosen
-   * nodal points.
-   * Applying the inverse of the Vandermonde matrix transforms from the modal
-   * basis to the nodal basis.
-   */
-  FullMatrix<double> vandermonde_matrix_inverse;
-
-  /**
    * Evaluate the orthogonal basis at point @p p. The indices @p i, @p j
-   * and @p k corresponde to the polynomial degrees of the Jacobi polynomials,
+   * and @p k correspond to the polynomial degrees of the Jacobi polynomials,
    * see @cite Bergot2010 proposition 1.10.
    */
   double
-  evaluate_orthogonal_basis_function_by_degree(const unsigned int i,
-                                               const unsigned int j,
-                                               const unsigned int k,
-                                               const Point<dim>  &p) const;
+  evaluate_orthogonal_basis_function_by_degree(
+    const unsigned int i,
+    const unsigned int j,
+    const unsigned int k,
+    const Point<dim>  &p) const override;
 
   /**
    * Evaluate the orthogonal basis function @p i at point @p p.
@@ -160,18 +84,19 @@ private:
    */
   double
   evaluate_orthogonal_basis_function(const unsigned int i,
-                                     const Point<dim>  &p) const;
+                                     const Point<dim>  &p) const override;
 
   /**
    * Evaluate the derivative of the orthogonal basis at point @p p.
-   * The indices @p i, @p j and @p k corresponde to the polynomial degrees of
+   * The indices @p i, @p j and @p k correspond to the polynomial degrees of
    * the Jacobi polynomials, see @cite Bergot2010 proposition 1.10.
    */
   Tensor<1, dim>
-  evaluate_orthogonal_basis_derivative_by_degree(const unsigned int i,
-                                                 const unsigned int j,
-                                                 const unsigned int k,
-                                                 const Point<dim>  &p) const;
+  evaluate_orthogonal_basis_derivative_by_degree(
+    const unsigned int i,
+    const unsigned int j,
+    const unsigned int k,
+    const Point<dim>  &p) const override;
 
   /**
    * Evaluate the derivative of the orthogonal basis function @p i at point
@@ -180,28 +105,9 @@ private:
    */
   Tensor<1, dim>
   evaluate_orthogonal_basis_derivative(const unsigned int i,
-                                       const Point<dim>  &p) const;
+                                       const Point<dim>  &p) const override;
 };
 
-
-
-template <int dim>
-template <int order>
-Tensor<order, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_derivative(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  Tensor<order, dim> der;
-
-  Assert(order == 1, ExcNotImplemented());
-  const auto grad = compute_grad(i, p);
-
-  for (unsigned int i = 0; i < dim; ++i)
-    der[i] = grad[i];
-
-  return der;
-}
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/base/scalar_polynomials_vandermonde_base.h
+++ b/include/deal.II/base/scalar_polynomials_vandermonde_base.h
@@ -1,0 +1,211 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2020 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef dealii_scalar_polynomials_vandermonde_base_h
+#define dealii_scalar_polynomials_vandermonde_base_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/lac/full_matrix.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * This class provides a framework for finite elements using a nodal polynomial
+ * basis, where the polynomial basis is constructed by evaluating the values of
+ * a modal basis first that then gets transformed to the actual nodal polynomial
+ * values via a Vandermonde matrix. This is a common approach for high-order
+ * bases on general point distributions.
+ *
+ * Any derived class must provide the most basic properties for the modal basis
+ * like evaluate_orthogonal_basis_function_by_degree(),
+ * evaluate_orthogonal_basis_function(),
+ * evaluate_orthogonal_basis_derivative_by_degree() and
+ * evaluate_orthogonal_basis_derivative().
+ */
+template <int dim>
+class ScalarPolynomialsVandermondeBase : public ScalarPolynomialsBase<dim>
+{
+public:
+  /**
+   * Constructor. This takes the degree @p degree of the space and the number
+   * of polynomials @p n.
+   */
+  ScalarPolynomialsVandermondeBase(const unsigned int degree,
+                                   const unsigned int n_dofs);
+
+  /*
+   * Virtual destructor. Makes sure that pointers to this class are deleted
+   * properly.
+   */
+  virtual ~ScalarPolynomialsVandermondeBase() = default;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::evaluate()
+   *
+   * @note Currently, only the vectors @p values and @p grads are filled.
+   */
+  void
+  evaluate(const Point<dim>            &unit_point,
+           std::vector<double>         &values,
+           std::vector<Tensor<1, dim>> &grads,
+           std::vector<Tensor<2, dim>> &grad_grads,
+           std::vector<Tensor<3, dim>> &third_derivatives,
+           std::vector<Tensor<4, dim>> &fourth_derivatives) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_value()
+   */
+  double
+  compute_value(const unsigned int i, const Point<dim> &p) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_derivative()
+   *
+   * @note Currently, only implemented for first derivative.
+   */
+  template <int order>
+  Tensor<order, dim>
+  compute_derivative(const unsigned int i, const Point<dim> &p) const;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   */
+  Tensor<1, dim>
+  compute_1st_derivative(const unsigned int i,
+                         const Point<dim>  &p) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   *
+   * @note Not implemented yet.
+   */
+  Tensor<2, dim>
+  compute_2nd_derivative(const unsigned int i,
+                         const Point<dim>  &p) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   *
+   * @note Not implemented yet.
+   */
+  Tensor<3, dim>
+  compute_3rd_derivative(const unsigned int i,
+                         const Point<dim>  &p) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   *
+   * @note Not implemented yet.
+   */
+  Tensor<4, dim>
+  compute_4th_derivative(const unsigned int i,
+                         const Point<dim>  &p) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_grad()
+   */
+  Tensor<1, dim>
+  compute_grad(const unsigned int i, const Point<dim> &p) const override;
+
+  /**
+   * @copydoc ScalarPolynomialsBase::compute_grad_grad()
+   *
+   * @note Not implemented yet.
+   */
+  Tensor<2, dim>
+  compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
+
+protected:
+  /**
+   * The Vandermonde matrix evaluates each modal basis function at the chosen
+   * nodal points.
+   * Applying the inverse of the Vandermonde matrix transforms from the modal
+   * basis to the nodal basis.
+   */
+  FullMatrix<double> vandermonde_matrix_inverse;
+
+  /*
+   * Evaluate the modal basis at all support points @p support_points to construct
+   * the Vandermonde matrix and invert it.
+   */
+  void
+  reinit(const std::vector<Point<dim>> &support_points);
+
+  /**
+   * Evaluate the orthogonal basis at point @p p. The indices @p i, @p j
+   * and @p k correspond to the polynomial degrees of the Jacobi polynomials.
+   */
+  virtual double
+  evaluate_orthogonal_basis_function_by_degree(const unsigned int i,
+                                               const unsigned int j,
+                                               const unsigned int k,
+                                               const Point<dim>  &p) const = 0;
+
+  /**
+   * Evaluate the orthogonal basis function @p i at point @p p.
+   * This function determines the corresponding indices for the Jacobi
+   * polynomials and calls the function taking all indices as arguments.
+   */
+  virtual double
+  evaluate_orthogonal_basis_function(const unsigned int i,
+                                     const Point<dim>  &p) const = 0;
+
+  /**
+   * Evaluate the derivative of the orthogonal basis at point @p p.
+   * The indices @p i, @p j and @p k correspond to the polynomial degrees of
+   * the Jacobi polynomials.
+   */
+  virtual Tensor<1, dim>
+  evaluate_orthogonal_basis_derivative_by_degree(const unsigned int i,
+                                                 const unsigned int j,
+                                                 const unsigned int k,
+                                                 const Point<dim> &p) const = 0;
+
+  /**
+   * Evaluate the derivative of the orthogonal basis function @p i at point
+   * @p p. This function determines the corresponding indices for the Jacobi
+   * polynomials and calls the function taking all indices as arguments.
+   */
+  virtual Tensor<1, dim>
+  evaluate_orthogonal_basis_derivative(const unsigned int i,
+                                       const Point<dim>  &p) const = 0;
+};
+
+
+
+template <int dim>
+template <int order>
+Tensor<order, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_derivative(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  Tensor<order, dim> der;
+
+  Assert(order == 1, ExcNotImplemented());
+  const auto grad = compute_grad(i, p);
+
+  for (unsigned int i = 0; i < dim; ++i)
+    der[i] = grad[i];
+
+  return der;
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/source/base/CMakeLists.txt
+++ b/source/base/CMakeLists.txt
@@ -83,6 +83,7 @@ set(_unity_include_src
   quadrature_lib.cc
   quadrature_selector.cc
   scalar_polynomials_base.cc
+  scalar_polynomials_vandermonde_base.cc
   symbolic_function.cc
   table_handler.cc
   tensor.cc

--- a/source/base/polynomials_pyramid.cc
+++ b/source/base/polynomials_pyramid.cc
@@ -21,16 +21,12 @@
 #include <deal.II/base/polynomial.h>
 #include <deal.II/base/polynomials_barycentric.h>
 #include <deal.II/base/polynomials_pyramid.h>
-#include <deal.II/base/scalar_polynomials_base.h>
+#include <deal.II/base/scalar_polynomials_vandermonde_base.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/reference_cell.h>
-
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/householder.h>
-#include <deal.II/lac/vector.h>
 
 #include <Kokkos_Macros.hpp>
 
@@ -87,56 +83,12 @@ ScalarLagrangePolynomialPyramid<dim>::ScalarLagrangePolynomialPyramid(
   const unsigned int             degree,
   const unsigned int             n_dofs,
   const std::vector<Point<dim>> &support_points)
-  : ScalarPolynomialsBase<dim>(degree, n_dofs)
+  : ScalarPolynomialsVandermondeBase<dim>(degree, n_dofs)
 {
-  (void)n_dofs;
-
   AssertThrow(dim == 3,
               ExcNotImplemented("Pyramid elements only make sense in 3D."));
 
-  AssertThrow(
-    support_points.size() == n_dofs,
-    ExcNotImplemented(
-      "The number of DoF must be equal to the number of support points."));
-
-  // fill VDM Matrix
-  const unsigned int n = support_points.size();
-  FullMatrix<double> VDM(n);
-
-  for (unsigned i = 0; i < n; ++i)
-    for (unsigned j = 0; j < n; ++j)
-      VDM[i][j] =
-        this->evaluate_orthogonal_basis_function(i, support_points[j]);
-
-  // get the inverse matrix
-  Householder<double> householder(VDM);
-  Vector<double>      e(n);
-  Vector<double>      x(n);
-
-  // assume e_j are unit vectors
-  // compute (VDM^-1)_ij by using (VDM^-1)_ij = e_i (VDM^-1) e_j
-  // loop over all vectors e_j
-  for (unsigned int j = 0; j < n; ++j)
-    {
-      e    = 0.;
-      e[j] = 1.;
-
-      x = 0.;
-      // get x = (VDM^-1) e_j
-      householder.least_squares(x, e);
-
-      for (unsigned int i = 0; i < n; ++i)
-        // (VDM^-1)_ij = e_i (VDM^-1) e_j
-        VDM(i, j) = x[i];
-    }
-
-  vandermonde_matrix_inverse = VDM;
-
-  // clean up small values
-  for (unsigned int i = 0; i < n; ++i)
-    for (unsigned int j = 0; j < n; ++j)
-      if (std::abs(vandermonde_matrix_inverse[i][j]) < 1e-14)
-        vandermonde_matrix_inverse[i][j] = 0.;
+  this->reinit(support_points);
 }
 
 
@@ -354,152 +306,6 @@ ScalarLagrangePolynomialPyramid<dim>::evaluate_orthogonal_basis_derivative(
   DEAL_II_ASSERT_UNREACHABLE();
   return Tensor<1, dim>();
 }
-
-
-
-template <int dim>
-double
-ScalarLagrangePolynomialPyramid<dim>::compute_value(const unsigned int i,
-                                                    const Point<dim>  &p) const
-{
-  AssertDimension(dim, 3);
-  AssertIndexRange(i, vandermonde_matrix_inverse.m());
-
-  double result = 0.;
-  for (unsigned int j = 0; j < vandermonde_matrix_inverse.n(); ++j)
-    result += vandermonde_matrix_inverse[i][j] *
-              this->evaluate_orthogonal_basis_function(j, p);
-
-  if (std::fabs(result) < 1e-14)
-    result = 0.0;
-
-  return result;
-}
-
-
-
-template <int dim>
-Tensor<1, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_grad(const unsigned int i,
-                                                   const Point<dim>  &p) const
-{
-  AssertDimension(dim, 3);
-  AssertIndexRange(i, vandermonde_matrix_inverse.m());
-
-  Tensor<1, dim> grad;
-
-  grad = 0.;
-  for (unsigned int j = 0; j < vandermonde_matrix_inverse.n(); ++j)
-    grad += vandermonde_matrix_inverse[i][j] *
-            this->evaluate_orthogonal_basis_derivative(j, p);
-
-  for (unsigned int d = 0; d < dim; ++d)
-    if (std::fabs(grad[d]) < 1e-14)
-      grad[d] = 0.0;
-
-  return grad;
-}
-
-
-
-template <int dim>
-Tensor<2, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_grad_grad(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  (void)i;
-  (void)p;
-
-  DEAL_II_NOT_IMPLEMENTED();
-  return Tensor<2, dim>();
-}
-
-
-
-template <int dim>
-void
-ScalarLagrangePolynomialPyramid<dim>::evaluate(
-  const Point<dim>            &unit_point,
-  std::vector<double>         &values,
-  std::vector<Tensor<1, dim>> &grads,
-  std::vector<Tensor<2, dim>> &grad_grads,
-  std::vector<Tensor<3, dim>> &third_derivatives,
-  std::vector<Tensor<4, dim>> &fourth_derivatives) const
-{
-  (void)grads;
-  (void)grad_grads;
-  (void)third_derivatives;
-  (void)fourth_derivatives;
-
-  if (values.size() == this->n())
-    for (unsigned int i = 0; i < this->n(); ++i)
-      values[i] = compute_value(i, unit_point);
-
-  if (grads.size() == this->n())
-    for (unsigned int i = 0; i < this->n(); ++i)
-      grads[i] = compute_grad(i, unit_point);
-}
-
-
-
-template <int dim>
-Tensor<1, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_1st_derivative(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  return compute_grad(i, p);
-}
-
-
-
-template <int dim>
-Tensor<2, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_2nd_derivative(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  (void)i;
-  (void)p;
-
-  DEAL_II_NOT_IMPLEMENTED();
-
-  return {};
-}
-
-
-
-template <int dim>
-Tensor<3, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_3rd_derivative(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  (void)i;
-  (void)p;
-
-  DEAL_II_NOT_IMPLEMENTED();
-
-  return {};
-}
-
-
-
-template <int dim>
-Tensor<4, dim>
-ScalarLagrangePolynomialPyramid<dim>::compute_4th_derivative(
-  const unsigned int i,
-  const Point<dim>  &p) const
-{
-  (void)i;
-  (void)p;
-
-  DEAL_II_NOT_IMPLEMENTED();
-
-  return {};
-}
-
 
 
 template <int dim>

--- a/source/base/scalar_polynomials_vandermonde_base.cc
+++ b/source/base/scalar_polynomials_vandermonde_base.cc
@@ -1,0 +1,235 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2020 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/numbers.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/scalar_polynomials_vandermonde_base.h>
+
+#include <deal.II/lac/householder.h>
+#include <deal.II/lac/vector.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+template <int dim>
+ScalarPolynomialsVandermondeBase<dim>::ScalarPolynomialsVandermondeBase(
+  const unsigned int degree,
+  const unsigned int n_dofs)
+  : ScalarPolynomialsBase<dim>(degree, n_dofs)
+{}
+
+
+
+template <int dim>
+void
+ScalarPolynomialsVandermondeBase<dim>::reinit(
+  const std::vector<Point<dim>> &support_points)
+{
+  AssertThrow(
+    support_points.size() == this->n(),
+    ExcNotImplemented(
+      "The number of DoFs must be equal to the number of support points."));
+
+  // fill VDM Matrix
+  const unsigned int n = support_points.size();
+  FullMatrix<double> VDM(n);
+
+  for (unsigned i = 0; i < n; ++i)
+    for (unsigned j = 0; j < n; ++j)
+      VDM[i][j] = evaluate_orthogonal_basis_function(i, support_points[j]);
+
+  // get the inverse matrix
+  Householder<double> householder(VDM);
+  Vector<double>      e(n);
+  Vector<double>      x(n);
+
+  // assume e_j are unit vectors
+  // compute (VDM^-1)_ij by using (VDM^-1)_ij = e_i (VDM^-1) e_j
+  // loop over all vectors e_j
+  for (unsigned int j = 0; j < n; ++j)
+    {
+      e    = 0.;
+      e[j] = 1.;
+
+      x = 0.;
+      // get x = (VDM^-1) e_j
+      householder.least_squares(x, e);
+
+      for (unsigned int i = 0; i < n; ++i)
+        // (VDM^-1)_ij = e_i (VDM^-1) e_j
+        VDM(i, j) = x[i];
+    }
+
+  vandermonde_matrix_inverse = VDM;
+
+  // clean up small values
+  for (unsigned int i = 0; i < n; ++i)
+    for (unsigned int j = 0; j < n; ++j)
+      if (std::abs(vandermonde_matrix_inverse[i][j]) < 1e-14)
+        vandermonde_matrix_inverse[i][j] = 0.;
+}
+
+
+
+template <int dim>
+double
+ScalarPolynomialsVandermondeBase<dim>::compute_value(const unsigned int i,
+                                                     const Point<dim>  &p) const
+{
+  AssertIndexRange(i, vandermonde_matrix_inverse.m());
+
+  double result = 0.;
+  for (unsigned int j = 0; j < vandermonde_matrix_inverse.n(); ++j)
+    result += vandermonde_matrix_inverse[i][j] *
+              evaluate_orthogonal_basis_function(j, p);
+
+  if (std::fabs(result) < 1e-14)
+    result = 0.0;
+
+  return result;
+}
+
+
+
+template <int dim>
+Tensor<1, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_grad(const unsigned int i,
+                                                    const Point<dim>  &p) const
+{
+  AssertIndexRange(i, vandermonde_matrix_inverse.m());
+
+  Tensor<1, dim> grad;
+
+  grad = 0.;
+  for (unsigned int j = 0; j < vandermonde_matrix_inverse.n(); ++j)
+    grad += vandermonde_matrix_inverse[i][j] *
+            evaluate_orthogonal_basis_derivative(j, p);
+
+  for (unsigned int d = 0; d < dim; ++d)
+    if (std::fabs(grad[d]) < 1e-14)
+      grad[d] = 0.0;
+
+  return grad;
+}
+
+
+
+template <int dim>
+Tensor<2, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_grad_grad(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  (void)i;
+  (void)p;
+
+  DEAL_II_NOT_IMPLEMENTED();
+  return Tensor<2, dim>();
+}
+
+
+
+template <int dim>
+void
+ScalarPolynomialsVandermondeBase<dim>::evaluate(
+  const Point<dim>            &unit_point,
+  std::vector<double>         &values,
+  std::vector<Tensor<1, dim>> &grads,
+  std::vector<Tensor<2, dim>> &grad_grads,
+  std::vector<Tensor<3, dim>> &third_derivatives,
+  std::vector<Tensor<4, dim>> &fourth_derivatives) const
+{
+  (void)grad_grads;
+  (void)third_derivatives;
+  (void)fourth_derivatives;
+
+  if (values.size() == this->n())
+    for (unsigned int i = 0; i < this->n(); ++i)
+      values[i] = compute_value(i, unit_point);
+
+  if (grads.size() == this->n())
+    for (unsigned int i = 0; i < this->n(); ++i)
+      grads[i] = compute_grad(i, unit_point);
+}
+
+
+
+template <int dim>
+Tensor<1, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_1st_derivative(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  return compute_grad(i, p);
+}
+
+
+
+template <int dim>
+Tensor<2, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_2nd_derivative(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  (void)i;
+  (void)p;
+
+  DEAL_II_NOT_IMPLEMENTED();
+
+  return {};
+}
+
+
+
+template <int dim>
+Tensor<3, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_3rd_derivative(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  (void)i;
+  (void)p;
+
+  DEAL_II_NOT_IMPLEMENTED();
+
+  return {};
+}
+
+
+
+template <int dim>
+Tensor<4, dim>
+ScalarPolynomialsVandermondeBase<dim>::compute_4th_derivative(
+  const unsigned int i,
+  const Point<dim>  &p) const
+{
+  (void)i;
+  (void)p;
+
+  DEAL_II_NOT_IMPLEMENTED();
+
+  return {};
+}
+
+
+
+template class ScalarPolynomialsVandermondeBase<0>;
+template class ScalarPolynomialsVandermondeBase<1>;
+template class ScalarPolynomialsVandermondeBase<2>;
+template class ScalarPolynomialsVandermondeBase<3>;
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
This PR introduces a base class for nodal bases by construction a modal basis first and then transfroming the bases with the help of the Vandermonde matrix to a nodal basis. The procedure is already used for pyramids and can also be applied to wedges and tetrahedrons. 