### PR TITLE
Provide a module wrapper with the right include file.

### DIFF
--- a/module/interface_module_partitions/boost.ccm
+++ b/module/interface_module_partitions/boost.ccm
@@ -75,6 +75,7 @@ module;
 #include <boost/math/special_functions/legendre.hpp>
 #include <boost/math/special_functions/relative_difference.hpp>
 #include <boost/math/special_functions/sign.hpp>
+#include <boost/math/special_functions/spherical_harmonic.hpp>
 #include <boost/math/tools/roots.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>


### PR DESCRIPTION
Getting close to being done with #18071 again. This one was weird: We export `boost::math::spherical_harmonic()` from our `boost.ccm` wrapper, but we forgot to include the header file that declares it. I suspect that means that we pick up *some* declaration from some other transitive include, but it's only one of several overloads and the whole house of cards comes down. Either way, the patch here fixes it.