### PR TITLE
Update lukka/get-cmake requires updating Kokkos.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,7 +356,7 @@ jobs:
         # deleting 15GB
         rm -rf /usr/share/dotnet/
         df -h
-    - uses: lukka/get-cmake@v3.27.9
+    - uses: lukka/get-cmake@v4.3.2
     - name: info
       run: |
         mpicc -v
@@ -449,7 +449,7 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    - uses: lukka/get-cmake@v3.27.9
+    - uses: lukka/get-cmake@v4.3.2
     - name: info
       run: |
         mpicc -v
@@ -531,7 +531,7 @@ jobs:
         echo "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-20 main" | tee -a /etc/apt/sources.list.d/llvm.list
         apt-get update && apt-get install -yq --no-install-recommends \
              libc++-20-dev clang-tools-20 clang-20
-    - uses: lukka/get-cmake@v3.28.3
+    - uses: lukka/get-cmake@v4.3.2
     - uses: actions/checkout@v6
       with:
         repository: kokkos/kokkos


### PR DESCRIPTION
github actions reports the following:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: lukka/get-cmake@v3.28.3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I have updated lukka/get-cmake to the most recent version, from 3.27.9 to 4.3.2, which itself uses node 24.