### PR TITLE
Exploit constexpr in GMRES implementation.

### DIFF
--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -2281,7 +2281,7 @@ void SolverMPGMRES<VectorType>::solve_internal(
 
   const auto preconditioner_vmult = [&](auto &dst, const auto &src) {
     // We have no preconditioner that we could apply
-    if (n_preconditioners == 0)
+    if constexpr (n_preconditioners == 0)
       dst = src;
     else
       {
@@ -2294,28 +2294,30 @@ void SolverMPGMRES<VectorType>::solve_internal(
   // Krylov space sequence according to the chosen indexing strategy
 
   const auto previous_vector_index =
-    [n_preconditioners, indexing_strategy](unsigned int i) -> unsigned int {
+    [indexing_strategy](unsigned int i) -> unsigned int {
     // In the special case of no preconditioners we simply fall back to the
     // FGMRES indexing strategy.
-    if (n_preconditioners == 0)
+    if constexpr (n_preconditioners == 0)
+      return i;
+    else
       {
-        return i;
-      }
-
-    switch (indexing_strategy)
-      {
-        case IndexingStrategy::fgmres:
-          // 0, 1, 2, 3, ...
-          return i;
-        case IndexingStrategy::full_mpgmres:
-          // 0, 0, ..., 1, 1, ..., 2, 2, ..., 3, 3, ...
-          return i / n_preconditioners;
-        case IndexingStrategy::truncated_mpgmres:
-          // 0, 0, ..., 1, 2, 3, ...
-          return (1 + i >= n_preconditioners) ? (1 + i - n_preconditioners) : 0;
-        default:
-          DEAL_II_ASSERT_UNREACHABLE();
-          return 0;
+        switch (indexing_strategy)
+          {
+            case IndexingStrategy::fgmres:
+              // 0, 1, 2, 3, ...
+              return i;
+            case IndexingStrategy::full_mpgmres:
+              // 0, 0, ..., 1, 1, ..., 2, 2, ..., 3, 3, ...
+              return i / n_preconditioners;
+            case IndexingStrategy::truncated_mpgmres:
+              // 0, 0, ..., 1, 2, 3, ...
+              return (1 + i >= n_preconditioners) ?
+                       (1 + i - n_preconditioners) :
+                       0;
+            default:
+              DEAL_II_ASSERT_UNREACHABLE();
+              return 0;
+          }
       }
   };
 


### PR DESCRIPTION
In playing with Clang-23, I get a warning that in a lambda capture in the GMRES implementation
```
  const auto previous_vector_index =
    [n_preconditioners, indexing_strategy](unsigned int i) -> unsigned int {
```
the variable `n_preconditioners` is *implicitly* already captured because it is a `constexpr` variable and those are automatically captured from the environment by lambdas. This patch removes the variable from the capture list, and while I'm there I'm also letting the compiler throw away some code by changing `if` to `if constexpr`.

I have a dim memory of making this change before and that some other compiler was unhappy with it. Let's see what happens this time.