### PR TITLE
Arkode: add tests for the backwards compatibility interface

### DIFF
--- a/tests/sundials/arkode_compat_interface_explicit_function.cc
+++ b/tests/sundials/arkode_compat_interface_explicit_function.cc
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::explicit_function.
+//
+// When ARKode is constructed without an explicit ARKodeStepper argument, it
+// internally creates an ARKStepper and wraps its callbacks via FunctionProxy.
+// Assigning to ode.explicit_function must route to the underlying ARKStepper.
+// This test verifies the proxy fires correctly for a pure-explicit ODE solve.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  // Integrate  y' = -y,  y(0)=1,  explicit RK.  Exact: y(t)=exp(-t).
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool explicit_callback_called = false;
+
+  // Assign via the backwards-compat proxy (explicit-only path).
+  ode.explicit_function =
+    [&](const double /*t*/, const VectorType &y, VectorType &f) {
+      f[0]                     = -y[0];
+      explicit_callback_called = true;
+    };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "explicit_callback_called: " << explicit_callback_called
+          << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_explicit_function.cc
+++ b/tests/sundials/arkode_compat_interface_explicit_function.cc
@@ -41,11 +41,7 @@ main()
   // Integrate  y' = -y,  y(0)=1,  explicit RK.  Exact: y(t)=exp(-t).
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_explicit_function.output
+++ b/tests/sundials/arkode_compat_interface_explicit_function.output
@@ -1,0 +1,3 @@
+
+DEAL::explicit_callback_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_implicit_function.cc
+++ b/tests/sundials/arkode_compat_interface_implicit_function.cc
@@ -41,11 +41,7 @@ main()
   // Integrate  y' = -y,  y(0)=1,  implicit DIRK.  Exact: y(t)=exp(-t).
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_implicit_function.cc
+++ b/tests/sundials/arkode_compat_interface_implicit_function.cc
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::implicit_function.
+//
+// When ARKode is constructed without an explicit ARKodeStepper argument, it
+// internally creates an ARKStepper and wraps its callbacks via FunctionProxy.
+// Assigning to ode.implicit_function must route to the underlying ARKStepper.
+// This test verifies the proxy fires correctly for a pure-implicit ODE solve.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  // Integrate  y' = -y,  y(0)=1,  implicit DIRK.  Exact: y(t)=exp(-t).
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool implicit_callback_called = false;
+
+  // Assign via the backwards-compat proxy (implicit-only path).
+  ode.implicit_function =
+    [&](const double /*t*/, const VectorType &y, VectorType &f) {
+      f[0]                     = -y[0];
+      implicit_callback_called = true;
+    };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "implicit_callback_called: " << implicit_callback_called
+          << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_implicit_function.output
+++ b/tests/sundials/arkode_compat_interface_implicit_function.output
@@ -1,0 +1,3 @@
+
+DEAL::implicit_callback_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_jacobian_preconditioner_setup.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_preconditioner_setup.cc
@@ -1,0 +1,108 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::jacobian_preconditioner_setup.
+//
+// The setup callback is called by ARKStep before jacobian_preconditioner_solve
+// whenever it deems the Jacobian data stale.  This test verifies the setup
+// proxy routes correctly.
+//
+// Problem: y' = -y (implicit), y(0)=1.  J = -I.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool jpu_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType       &Jv,
+                                  const double /*t*/,
+                                  const VectorType & /*y*/,
+                                  const VectorType & /*fy*/) { Jv[0] = -v[0]; };
+
+  ode.solve_linearized_system =
+    [&](SUNDIALS::SundialsOperator<VectorType>       &op,
+        SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+        VectorType                                   &x,
+        const VectorType                             &b,
+        double /*tol*/) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, prec);
+    };
+
+  // Assign via the backwards-compat proxy: store gamma for use in solve.
+  ode.jacobian_preconditioner_setup = [&](const double /*t*/,
+                                          const VectorType & /*y*/,
+                                          const VectorType & /*fy*/,
+                                          const int /*jok*/,
+                                          int         &jcur,
+                                          const double gamma) {
+    jcur       = 1;
+    jpu_called = true;
+  };
+
+  ode.jacobian_preconditioner_solve = [&](const double /*t*/,
+                                          const VectorType & /*y*/,
+                                          const VectorType & /*fy*/,
+                                          const VectorType &r,
+                                          VectorType       &z,
+                                          const double      gamma,
+                                          const double /*tol*/,
+                                          const int /*lr*/) {
+    z[0] = r[0] / (1.0 + gamma);
+  };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "jacobian_preconditioner_setup_called: " << jpu_called
+          << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_jacobian_preconditioner_setup.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_preconditioner_setup.cc
@@ -44,11 +44,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_jacobian_preconditioner_setup.output
+++ b/tests/sundials/arkode_compat_interface_jacobian_preconditioner_setup.output
@@ -1,0 +1,3 @@
+
+DEAL::jacobian_preconditioner_setup_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_jacobian_preconditioner_solve.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_preconditioner_solve.cc
@@ -45,11 +45,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_jacobian_preconditioner_solve.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_preconditioner_solve.cc
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::jacobian_preconditioner_solve.
+//
+// ARKode is constructed without an explicit ARKodeStepper (proxy mode).
+// A custom solve_linearized_system uses CG+prec; the prec wrapper routes
+// prec.vmult() to the jacobian_preconditioner_solve proxy callback.
+//
+// Problem: y' = -y (implicit), y(0)=1.  J = -I.
+// Linear system:  (1+gamma)*x = b.  Preconditioner: z = r/(1+gamma).
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool jps_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType       &Jv,
+                                  const double /*t*/,
+                                  const VectorType & /*y*/,
+                                  const VectorType & /*fy*/) { Jv[0] = -v[0]; };
+
+  ode.solve_linearized_system =
+    [&](SUNDIALS::SundialsOperator<VectorType>       &op,
+        SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+        VectorType                                   &x,
+        const VectorType                             &b,
+        double /*tol*/) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, prec);
+    };
+
+  // Assign via the backwards-compat proxy.
+  // op represents (I - gamma*J) = (1+gamma)*I, so P^{-1}*r = r/(1+gamma).
+  ode.jacobian_preconditioner_solve = [&](const double /*t*/,
+                                          const VectorType & /*y*/,
+                                          const VectorType & /*fy*/,
+                                          const VectorType &r,
+                                          VectorType       &z,
+                                          const double      gamma,
+                                          const double /*tol*/,
+                                          const int /*lr*/) {
+    z[0]       = r[0] / (1.0 + gamma);
+    jps_called = true;
+  };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "jacobian_preconditioner_solve_called: " << jps_called
+          << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_jacobian_preconditioner_solve.output
+++ b/tests/sundials/arkode_compat_interface_jacobian_preconditioner_solve.output
@@ -1,0 +1,3 @@
+
+DEAL::jacobian_preconditioner_solve_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_jacobian_times_setup.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_times_setup.cc
@@ -1,0 +1,78 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::jacobian_times_setup.
+//
+// ARKode is constructed without an explicit ARKodeStepper (proxy mode).
+// Assigning to ode.jacobian_times_setup must route to the underlying
+// ARKStepper, which calls the setup callback before jacobian_times_vector.
+//
+// Problem: y' = -y (implicit), y(0)=1.  J = -I.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool jts_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType       &Jv,
+                                  const double /*t*/,
+                                  const VectorType & /*y*/,
+                                  const VectorType & /*fy*/) { Jv[0] = -v[0]; };
+
+  // Assign via the backwards-compat proxy.
+  ode.jacobian_times_setup = [&](const double /*t*/,
+                                 const VectorType & /*y*/,
+                                 const VectorType & /*fy*/) {
+    jts_called = true;
+  };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "jacobian_times_setup_called: " << jts_called << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_jacobian_times_setup.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_times_setup.cc
@@ -41,11 +41,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_jacobian_times_setup.output
+++ b/tests/sundials/arkode_compat_interface_jacobian_times_setup.output
@@ -1,0 +1,3 @@
+
+DEAL::jacobian_times_setup_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_jacobian_times_vector.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_times_vector.cc
@@ -41,11 +41,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_jacobian_times_vector.cc
+++ b/tests/sundials/arkode_compat_interface_jacobian_times_vector.cc
@@ -1,0 +1,75 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::jacobian_times_vector.
+//
+// ARKode is constructed without an explicit ARKodeStepper (proxy mode).
+// Assigning to ode.jacobian_times_vector must route to the underlying
+// ARKStepper, so that GMRES can use J*v during the Newton linear solve.
+//
+// Problem: y' = -y (implicit), y(0)=1.  J = -I, so J*v = -v.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool jtv_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  // Assign via the backwards-compat proxy.
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType       &Jv,
+                                  const double /*t*/,
+                                  const VectorType & /*y*/,
+                                  const VectorType & /*fy*/) {
+    Jv[0]      = -v[0];
+    jtv_called = true;
+  };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "jacobian_times_vector_called: " << jtv_called << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_jacobian_times_vector.output
+++ b/tests/sundials/arkode_compat_interface_jacobian_times_vector.output
@@ -1,0 +1,3 @@
+
+DEAL::jacobian_times_vector_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_mass_preconditioner_setup.cc
+++ b/tests/sundials/arkode_compat_interface_mass_preconditioner_setup.cc
@@ -1,0 +1,87 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::mass_preconditioner_setup.
+//
+// Trivial ODE:  M y' = -y,  y(0)=1,  M=I  (identity mass matrix).
+// mass_preconditioner_setup requires mass_preconditioner_solve to be set.
+// We provide a solve_mass that delegates to prec.vmult() so that SUNDIALS
+// actually invokes the preconditioner (and its setup).
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool callback_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  // Identity mass: Mv = v.
+  ode.mass_times_vector =
+    [&](const double /*t*/, const VectorType &v, VectorType &Mv) { Mv = v; };
+
+  // Solve Mx=b by delegating to the preconditioner.
+  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &,
+                       SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+                       VectorType                                   &x,
+                       const VectorType                             &b,
+                       double) { prec.vmult(x, b); };
+
+  // Identity preconditioner: z = r.
+  ode.mass_preconditioner_solve =
+    [&](const double /*t*/, const VectorType &r, VectorType &z, double, int) {
+      z = r;
+    };
+
+  // Assign via the backwards-compat proxy.
+  ode.mass_preconditioner_setup = [&](const double /*t*/) {
+    callback_called = true;
+  };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "mass_preconditioner_setup_called: " << callback_called
+          << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_mass_preconditioner_setup.cc
+++ b/tests/sundials/arkode_compat_interface_mass_preconditioner_setup.cc
@@ -40,11 +40,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_mass_preconditioner_setup.output
+++ b/tests/sundials/arkode_compat_interface_mass_preconditioner_setup.output
@@ -1,0 +1,3 @@
+
+DEAL::mass_preconditioner_setup_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_mass_preconditioner_solve.cc
+++ b/tests/sundials/arkode_compat_interface_mass_preconditioner_solve.cc
@@ -1,0 +1,84 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::mass_preconditioner_solve.
+//
+// Trivial ODE:  M y' = -y,  y(0)=1,  M=I  (identity mass matrix).
+// mass_preconditioner_solve requires mass_times_vector to be set.
+// We provide a solve_mass that delegates to prec.vmult() so that SUNDIALS
+// actually invokes the preconditioner.  For M=I both are identity ops.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool callback_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  // Identity mass: Mv = v.
+  ode.mass_times_vector =
+    [&](const double /*t*/, const VectorType &v, VectorType &Mv) { Mv = v; };
+
+  // Solve Mx=b by delegating to the preconditioner.
+  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &,
+                       SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+                       VectorType                                   &x,
+                       const VectorType                             &b,
+                       double) { prec.vmult(x, b); };
+
+  // Assign via the backwards-compat proxy.
+  // Identity preconditioner: z = r.
+  ode.mass_preconditioner_solve =
+    [&](const double /*t*/, const VectorType &r, VectorType &z, double, int) {
+      z               = r;
+      callback_called = true;
+    };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "mass_preconditioner_solve_called: " << callback_called
+          << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_mass_preconditioner_solve.cc
+++ b/tests/sundials/arkode_compat_interface_mass_preconditioner_solve.cc
@@ -40,11 +40,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_mass_preconditioner_solve.output
+++ b/tests/sundials/arkode_compat_interface_mass_preconditioner_solve.output
@@ -1,0 +1,3 @@
+
+DEAL::mass_preconditioner_solve_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_mass_times_setup.cc
+++ b/tests/sundials/arkode_compat_interface_mass_times_setup.cc
@@ -40,11 +40,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_mass_times_setup.cc
+++ b/tests/sundials/arkode_compat_interface_mass_times_setup.cc
@@ -1,0 +1,71 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::mass_times_setup.
+//
+// Trivial ODE:  M y' = -y,  y(0)=1,  M=I  (identity mass matrix).
+// mass_times_setup cannot be used without mass_times_vector because the
+// entire mass solver setup is gated by `if (mass_times_vector)`.  We set
+// mass_times_vector to the identity and flag mass_times_setup.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool mts_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  // Identity mass: Mv = v.
+  ode.mass_times_vector =
+    [&](const double /*t*/, const VectorType &v, VectorType &Mv) { Mv = v; };
+
+  // Assign via the backwards-compat proxy.
+  ode.mass_times_setup = [&](const double /*t*/) { mts_called = true; };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "mass_times_setup_called: " << mts_called << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_mass_times_setup.output
+++ b/tests/sundials/arkode_compat_interface_mass_times_setup.output
@@ -1,0 +1,3 @@
+
+DEAL::mass_times_setup_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_mass_times_vector.cc
+++ b/tests/sundials/arkode_compat_interface_mass_times_vector.cc
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::mass_times_vector.
+//
+// Trivial ODE:  M y' = -y,  y(0)=1,  M=I  (identity mass matrix).
+// The mass matrix is the identity so SUNDIALS' built-in unpreconditioned
+// SPGMR solver handles M x = b without needing solve_mass or any mass
+// preconditioner callbacks.  This isolates mass_times_vector alone.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool mtv_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  // Assign via the backwards-compat proxy.
+  // Identity mass: Mv = v.
+  ode.mass_times_vector =
+    [&](const double /*t*/, const VectorType &v, VectorType &Mv) {
+      Mv         = v;
+      mtv_called = true;
+    };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "mass_times_vector_called: " << mtv_called << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_mass_times_vector.cc
+++ b/tests/sundials/arkode_compat_interface_mass_times_vector.cc
@@ -40,11 +40,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_mass_times_vector.output
+++ b/tests/sundials/arkode_compat_interface_mass_times_vector.output
@@ -1,0 +1,3 @@
+
+DEAL::mass_times_vector_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_solve_linearized_system.cc
+++ b/tests/sundials/arkode_compat_interface_solve_linearized_system.cc
@@ -46,11 +46,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 

--- a/tests/sundials/arkode_compat_interface_solve_linearized_system.cc
+++ b/tests/sundials/arkode_compat_interface_solve_linearized_system.cc
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::solve_linearized_system.
+//
+// ARKode is constructed without an explicit ARKodeStepper (proxy mode).
+// Assigning to ode.solve_linearized_system must route to the underlying
+// ARKStepper so that the custom CG solver is called during Newton iterations.
+//
+// Problem: y' = -y (implicit), y(0)=1.  J = -I.
+// Linear system:  (I - gamma*(-I))*x = b  =>  (1+gamma)*x = b.
+// Solved via CG applied to the op wrapper.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool sls_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  ode.jacobian_times_vector = [&](const VectorType &v,
+                                  VectorType       &Jv,
+                                  const double /*t*/,
+                                  const VectorType & /*y*/,
+                                  const VectorType & /*fy*/) { Jv[0] = -v[0]; };
+
+  // Assign via the backwards-compat proxy.
+  ode.solve_linearized_system =
+    [&](SUNDIALS::SundialsOperator<VectorType>       &op,
+        SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+        VectorType                                   &x,
+        const VectorType                             &b,
+        double /*tol*/) {
+      ReductionControl     control;
+      SolverCG<VectorType> solver_cg(control);
+      solver_cg.solve(op, x, b, prec);
+      sls_called = true;
+    };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "solve_linearized_system_called: " << sls_called << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_solve_linearized_system.output
+++ b/tests/sundials/arkode_compat_interface_solve_linearized_system.output
@@ -1,0 +1,3 @@
+
+DEAL::solve_linearized_system_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true

--- a/tests/sundials/arkode_compat_interface_solve_mass.cc
+++ b/tests/sundials/arkode_compat_interface_solve_mass.cc
@@ -39,11 +39,7 @@ main()
 
   SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
                                                     1.0 /*tf*/,
-                                                    0.01 /*dt*/,
-                                                    0.5 /*output_period*/,
-                                                    1e-8 /*min dt*/,
-                                                    1e-8 /*abstol*/,
-                                                    1e-6 /*reltol*/);
+                                                    0.01 /*dt*/);
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
@@ -59,15 +55,14 @@ main()
 
   // Assign via the backwards-compat proxy.
   // For M=I, solving Mx=b is simply x=b.
-  ode.solve_mass =
-    [&](SUNDIALS::SundialsOperator<VectorType> &,
-        SUNDIALS::SundialsPreconditioner<VectorType> &,
-        VectorType                                   &x,
-        const VectorType                             &b,
-        double) {
-      x               = b;
-      callback_called = true;
-    };
+  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &,
+                       SUNDIALS::SundialsPreconditioner<VectorType> &,
+                       VectorType       &x,
+                       const VectorType &b,
+                       double) {
+    x               = b;
+    callback_called = true;
+  };
 
   VectorType y(1);
   y[0] = 1.0;

--- a/tests/sundials/arkode_compat_interface_solve_mass.cc
+++ b/tests/sundials/arkode_compat_interface_solve_mass.cc
@@ -1,0 +1,79 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include "../tests.h"
+
+// Test the backwards-compatibility proxy for
+// SUNDIALS::ARKode::solve_mass.
+//
+// Trivial ODE:  M y' = -y,  y(0)=1,  M=I  (identity mass matrix).
+// solve_mass requires mass_times_vector to be set (the entire mass solver
+// setup is gated by it).  For M=I the mass solve is just x = b.
+
+using VectorType = Vector<double>;
+
+int
+main()
+{
+  initlog();
+  deallog.precision(3);
+  deallog << std::boolalpha;
+
+  SUNDIALS::ARKode<VectorType>::AdditionalData data(0.0 /*t0*/,
+                                                    1.0 /*tf*/,
+                                                    0.01 /*dt*/,
+                                                    0.5 /*output_period*/,
+                                                    1e-8 /*min dt*/,
+                                                    1e-8 /*abstol*/,
+                                                    1e-6 /*reltol*/);
+
+  SUNDIALS::ARKode<VectorType> ode(data);
+
+  bool callback_called = false;
+
+  ode.implicit_function = [&](const double /*t*/,
+                              const VectorType &y,
+                              VectorType       &f) { f[0] = -y[0]; };
+
+  // Identity mass: Mv = v.
+  ode.mass_times_vector =
+    [&](const double /*t*/, const VectorType &v, VectorType &Mv) { Mv = v; };
+
+  // Assign via the backwards-compat proxy.
+  // For M=I, solving Mx=b is simply x=b.
+  ode.solve_mass =
+    [&](SUNDIALS::SundialsOperator<VectorType> &,
+        SUNDIALS::SundialsPreconditioner<VectorType> &,
+        VectorType                                   &x,
+        const VectorType                             &b,
+        double) {
+      x               = b;
+      callback_called = true;
+    };
+
+  VectorType y(1);
+  y[0] = 1.0;
+  ode.solve_ode(y);
+
+  deallog << "solve_mass_called: " << callback_called << std::endl;
+  deallog << "Final |y - exp(-1)| < 1e-4: "
+          << (std::abs(y[0] - std::exp(-1.0)) < 1e-4) << std::endl;
+}

--- a/tests/sundials/arkode_compat_interface_solve_mass.output
+++ b/tests/sundials/arkode_compat_interface_solve_mass.output
@@ -1,0 +1,3 @@
+
+DEAL::solve_mass_called: true
+DEAL::Final |y - exp(-1)| < 1e-4: true


### PR DESCRIPTION
As planned in #19282, this PR adds various unit tests to check the backwards compatibility interface.

Instead of duplicating the existing `ARKode` tests, I decided to create a set of much simpler tests checking whether a particular callback has been called after integrating a very simple problem.

The existing `ARKode` tests will be refactored to work with the new interface and `ARKStepper` in an follow-up PR.