### PR TITLE
Portable::MatrixFree: move AdditionalData check

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -224,19 +224,7 @@ namespace Portable
         , overlap_communication_computation(overlap_communication_computation)
         , mg_level(mg_level)
         , team_size(team_size)
-      {
-#ifndef DEAL_II_MPI_WITH_DEVICE_SUPPORT
-        AssertThrow(
-          overlap_communication_computation == false,
-          ExcMessage(
-            "Overlapping communication and computation requires device-aware MPI."));
-#endif
-
-        AssertThrow(
-          use_coloring == false || overlap_communication_computation == false,
-          ExcMessage(
-            "Overlapping communication and coloring are incompatible options. Only one of them can be enabled."));
-      }
+      {}
 
       /**
        * This flag is used to determine which quantities should be cached. This

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -550,6 +550,19 @@ namespace Portable
     const IteratorFiltersType                            &iterator_filter,
     const AdditionalData                                 &additional_data)
   {
+#ifndef DEAL_II_MPI_WITH_DEVICE_SUPPORT
+    AssertThrow(
+      additional_data.overlap_communication_computation == false,
+      ExcMessage(
+        "Overlapping communication and computation requires device-aware MPI."));
+#endif
+
+    AssertThrow(
+      additional_data.use_coloring == false ||
+        additional_data.overlap_communication_computation == false,
+      ExcMessage(
+        "Overlapping communication and coloring are incompatible options. Only one of them can be enabled."));
+
     const auto &triangulation = dof_handler[0]->get_triangulation();
 
     if (const auto parallel_triangulation =


### PR DESCRIPTION
Move consistency checks in AdditionalData from the constructor to where to options are actually used. Otherwise, the user can create a valid AdditionalData and later change ``.use_coloring = true.`` without the check failing.