### PR TITLE
Fix extract_boundary_mesh for 3D simplex meshes

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -10,8 +10,6 @@
 //
 // -----------------------------------------------------------------------------
 
-#include "deal.II/base/exception_macros.h"
-#include "deal.II/base/exceptions.h"
 #include <deal.II/base/ndarray.h>
 #include <deal.II/base/parameter_handler.h>
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -9429,7 +9429,7 @@ namespace GridGenerator
     //    also, that it will not reorder the vertices.
 
     // dimension of the boundary mesh
-    const unsigned int boundary_dim = dim - 1;
+    static constexpr unsigned int boundary_dim = dim - 1;
 
     // temporary map for level==0
     // iterator to face is stored along with face number
@@ -9460,27 +9460,54 @@ namespace GridGenerator
     // is considered and vertices 1 and 2 of the corresponding boundary cell
     // are swapped to get proper normal orientation, swap_matrix[3]=( 0, 2, 1,
     // 3 )
-    Table<2, unsigned int> swap_matrix(
-      GeometryInfo<spacedim>::faces_per_cell,
-      GeometryInfo<dim - 1>::vertices_per_cell);
-    for (unsigned int i1 = 0; i1 < GeometryInfo<spacedim>::faces_per_cell; ++i1)
+    //
+    // Permutation depends on the volume cell's reference cell. Currently only
+    // hypercube and simplex meshes are supported
+    const ReferenceCell<dim> reference_cell =
+      volume_mesh.begin(0)->reference_cell();
+
+    // Size the table to the maximum number of vertices that can occur on any
+    // face of the cell (4 for hypercubes, 3 for simplices). Unused entries
+    // are left at the identity.
+    const unsigned int max_n_face_vertices =
+      reference_cell.is_hyper_cube() ?
+        GeometryInfo<dim - 1>::vertices_per_cell :
+        (dim - 1 == 1 ? 2 : 3);
+
+    Table<2, unsigned int> swap_matrix(reference_cell.n_faces(),
+                                       max_n_face_vertices);
+    for (unsigned int f = 0; f < reference_cell.n_faces(); ++f)
+      for (unsigned int j = 0; j < max_n_face_vertices; ++j)
+        swap_matrix[f][j] = j;
+
+    if (reference_cell.is_hyper_cube())
       {
-        for (unsigned int i2 = 0; i2 < GeometryInfo<dim - 1>::vertices_per_cell;
-             i2++)
-          swap_matrix[i1][i2] = i2;
+        // Hard-coded permutations for hypercube cells
+        if (dim == 3)
+          {
+            std::swap(swap_matrix[0][1], swap_matrix[0][2]);
+            std::swap(swap_matrix[2][1], swap_matrix[2][2]);
+            std::swap(swap_matrix[4][1], swap_matrix[4][2]);
+          }
+        else if (dim == 2)
+          {
+            std::swap(swap_matrix[1][0], swap_matrix[1][1]);
+            std::swap(swap_matrix[2][0], swap_matrix[2][1]);
+          }
       }
-    // vertex swapping such that normals on the surface mesh point out of the
-    // underlying volume
-    if (dim == 3)
+    else if (reference_cell == ReferenceCells::get_simplex<dim>())
       {
-        std::swap(swap_matrix[0][1], swap_matrix[0][2]);
-        std::swap(swap_matrix[2][1], swap_matrix[2][2]);
-        std::swap(swap_matrix[4][1], swap_matrix[4][2]);
+        // Hard-coded permutations for simplex cells.
+        // For both triangles (3 faces) and tetrahedra (4 faces) we swap the
+        // first two face vertices so that the resulting boundary cell's normal
+        // points outward.
+        for (unsigned int f = 0; f < reference_cell.n_faces(); ++f)
+          std::swap(swap_matrix[f][0], swap_matrix[f][1]);
       }
-    else if (dim == 2)
+    else
       {
-        std::swap(swap_matrix[1][0], swap_matrix[1][1]);
-        std::swap(swap_matrix[2][0], swap_matrix[2][1]);
+        // Wedges, pyramids, and mixed meshes are not currently supported.
+        DEAL_II_NOT_IMPLEMENTED();
       }
 
     // Create boundary mesh and mapping
@@ -9498,10 +9525,9 @@ namespace GridGenerator
               (boundary_ids.empty() ||
                (boundary_ids.find(face->boundary_id()) != boundary_ids.end())))
             {
-              CellData<boundary_dim> c_data;
+              CellData<boundary_dim> c_data(face->n_vertices());
 
-              for (const unsigned int j :
-                   GeometryInfo<boundary_dim>::vertex_indices())
+              for (const unsigned int j : face->vertex_indices())
                 {
                   const unsigned int v_index = face->vertex_index(j);
 
@@ -9526,7 +9552,7 @@ namespace GridGenerator
               // we set default boundary ids for boundary lines
               // and numbers::internal_face_boundary_id for internal lines
               if (dim == 3)
-                for (unsigned int e = 0; e < 4; ++e)
+                for (unsigned int e = 0; e < face->n_lines(); ++e)
                   {
                     // see if we already saw this edge from a
                     // neighboring face, either in this or the reverse

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -10,6 +10,8 @@
 //
 // -----------------------------------------------------------------------------
 
+#include "deal.II/base/exception_macros.h"
+#include "deal.II/base/exceptions.h"
 #include <deal.II/base/ndarray.h>
 #include <deal.II/base/parameter_handler.h>
 
@@ -9429,7 +9431,7 @@ namespace GridGenerator
     //    also, that it will not reorder the vertices.
 
     // dimension of the boundary mesh
-    static constexpr unsigned int boundary_dim = dim - 1;
+    constexpr unsigned int boundary_dim = dim - 1;
 
     // temporary map for level==0
     // iterator to face is stored along with face number
@@ -9462,7 +9464,11 @@ namespace GridGenerator
     // 3 )
     //
     // Permutation depends on the volume cell's reference cell. Currently only
-    // hypercube and simplex meshes are supported
+    // hypercube and simplex meshes are supported.
+    AssertThrow(
+      (volume_mesh.get_triangulation().is_mixed_mesh() == false),
+      ExcNotImplemented(
+        "Boundary extraction for mixed meshes is currently not supported."));
     const ReferenceCell<dim> reference_cell =
       volume_mesh.begin(0)->reference_cell();
 
@@ -9470,9 +9476,7 @@ namespace GridGenerator
     // face of the cell (4 for hypercubes, 3 for simplices). Unused entries
     // are left at the identity.
     const unsigned int max_n_face_vertices =
-      reference_cell.is_hyper_cube() ?
-        GeometryInfo<dim - 1>::vertices_per_cell :
-        (dim - 1 == 1 ? 2 : 3);
+      reference_cell.face_reference_cell(0).n_vertices();
 
     Table<2, unsigned int> swap_matrix(reference_cell.n_faces(),
                                        max_n_face_vertices);

--- a/tests/codim_one/extract_boundary_mesh_16.cc
+++ b/tests/codim_one/extract_boundary_mesh_16.cc
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2015 - 2023 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// test extract_boundary_mesh on a 3D simplex mesh
+
+#include "deal.II/grid/grid_tools_geometry.h"
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  deallog << "dim = " << dim << std::endl;
+
+  Triangulation<dim> hex_tria, triangulation;
+  GridGenerator::hyper_cube(hex_tria);
+  hex_tria.refine_global(3);
+  GridGenerator::convert_hypercube_to_simplex_mesh(hex_tria, triangulation);
+
+  // now extract the surface mesh
+  Triangulation<dim - 1, dim> triangulation_surface;
+
+  GridGenerator::extract_boundary_mesh(triangulation, triangulation_surface);
+  double measure_boundary_mesh = GridTools::volume(triangulation_surface);
+  if constexpr (dim == 2)
+    AssertThrow(
+      std::fabs(measure_boundary_mesh - 4.0) < 1e-12,
+      ExcMessage(
+        "The measure of the boundary of the unit square should be 4, but is " +
+        std::to_string(measure_boundary_mesh)));
+  else if constexpr (dim == 3)
+    AssertThrow(
+      std::fabs(measure_boundary_mesh - 6.0) < 1e-12,
+      ExcMessage(
+        "The measure of the boundary of the unit cube should be 6, but is " +
+        std::to_string(measure_boundary_mesh)));
+  deallog << "Ok" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  test<2>(); // we know this already works...
+  test<3>();
+}

--- a/tests/codim_one/extract_boundary_mesh_16.output
+++ b/tests/codim_one/extract_boundary_mesh_16.output
@@ -1,0 +1,5 @@
+
+DEAL::dim = 2
+DEAL::Ok
+DEAL::dim = 3
+DEAL::Ok

--- a/tests/codim_one/extract_boundary_mesh_17.cc
+++ b/tests/codim_one/extract_boundary_mesh_17.cc
@@ -1,0 +1,91 @@
+#include "deal.II/base/exception_macros.h"
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+// Check the orientation is correct by using the divergence theorem
+
+// int_{d Omega}  x \cdot n dS = dim * |Omega| = dim * 1 = dim
+
+using namespace dealii;
+
+template <int dim, bool simplex>
+void
+run(const std::string &label)
+{
+  Triangulation<dim> hex_tria, vol_tria;
+  GridGenerator::hyper_cube(hex_tria);
+  hex_tria.refine_global(2);
+  if constexpr (simplex)
+    GridGenerator::convert_hypercube_to_simplex_mesh(hex_tria, vol_tria);
+  else
+    vol_tria.copy_triangulation(hex_tria);
+
+  Triangulation<dim - 1, dim> surf;
+  GridGenerator::extract_boundary_mesh(vol_tria, surf);
+
+
+  std::unique_ptr<FiniteElement<dim - 1, dim>> fe;
+  std::unique_ptr<Quadrature<dim - 1>>         quad;
+  if (simplex)
+    {
+      if constexpr (dim == 2)
+        fe = std::make_unique<FE_Q<dim - 1, dim>>(1);
+      else
+        fe = std::make_unique<FE_SimplexP<dim - 1, dim>>(1);
+      if constexpr (dim == 2)
+        quad = std::make_unique<QGauss<dim - 1>>(2);
+      else
+        quad = std::make_unique<QGaussSimplex<dim - 1>>(2);
+    }
+  else
+    {
+      fe   = std::make_unique<FE_Q<dim - 1, dim>>(1);
+      quad = std::make_unique<QGauss<dim - 1>>(2);
+    }
+  MappingFE<dim - 1, dim> mapping(*fe);
+  FEValues<dim - 1, dim>  fev(mapping,
+                             *fe,
+                             *quad,
+                             update_quadrature_points | update_normal_vectors |
+                               update_JxW_values);
+
+  double integral = 0.0;
+  for (const auto &cell : surf.active_cell_iterators())
+    {
+      fev.reinit(cell);
+      for (unsigned int q = 0; q < fev.n_quadrature_points; ++q)
+        integral +=
+          (fev.quadrature_point(q) * fev.normal_vector(q)) * fev.JxW(q);
+    }
+
+  AssertThrow(std::fabs(integral - dim) < 1e-14, ExcInternalError());
+  deallog << "Divergence theorem for " << label << ": ok " << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  run<2, false>("2D hex   ");
+  run<2, true>("2D simplex");
+  run<3, false>("3D hex   ");
+  run<3, true>("3D simplex");
+}

--- a/tests/codim_one/extract_boundary_mesh_17.output
+++ b/tests/codim_one/extract_boundary_mesh_17.output
@@ -1,0 +1,5 @@
+
+DEAL::Divergence theorem for 2D hex   : ok 
+DEAL::Divergence theorem for 2D simplex: ok 
+DEAL::Divergence theorem for 3D hex   : ok 
+DEAL::Divergence theorem for 3D simplex: ok 


### PR DESCRIPTION
I have a project where I need to use `extract_boundary_mesh` for 3D simplex meshes, but I realized that it is not supporting the 3D simplex case. 

The permutation of vertices to guarantee a consistently oriented surface has been hard-coded (see also https://github.com/dealii/dealii/issues/18068#issuecomment-2629163376). One test has been added, which fails without this patch.

Closes #18066 