### PR TITLE
DataOutBase: write base64 output directly to the stream instead of a temporary `std::string`.

### DIFF
--- a/doc/news/changes/minor/20260503Wells
+++ b/doc/news/changes/minor/20260503Wells
@@ -1,0 +1,4 @@
+Improved: VTU output is now about 5\% faster on large meshes
+and no longer allocates memory for every processed cell.
+<br>
+(David Wells, 2026/05/03)

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -160,7 +160,6 @@ namespace
                             reinterpret_cast<const Bytef *>(data.data()),
                             uncompressed_size,
                             get_zlib_compression_level(compression_level));
-        (void)err;
         Assert(err == Z_OK, ExcInternalError());
 
         // Discard the unnecessary bytes

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5452,8 +5452,11 @@ namespace DataOutBase
 
       unsigned int first_vertex_of_patch = 0;
 
+      std::vector<unsigned int> local_vertex_order;
       for (const auto &patch : patches)
         {
+          local_vertex_order.clear();
+
           // First treat a slight oddball case: For triangles and tetrahedra,
           // the case with n_subdivisions==2 is treated as if the cell was
           // output as a single, quadratic, cell rather than as one would
@@ -5518,9 +5521,6 @@ namespace DataOutBase
             {
               const unsigned int n_subdivisions         = patch.n_subdivisions;
               const unsigned int n_points_per_direction = n_subdivisions + 1;
-
-              std::vector<unsigned> local_vertex_order;
-
               // Output the current state of the local_vertex_order array,
               // then clear it:
               const auto flush_current_cell = [&flags,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2595,6 +2595,16 @@ namespace DataOutBase
     static const std::array<unsigned int, 5> table = {{0, 1, 3, 2, 4}};
 
     std::vector<Point<spacedim>> node_positions;
+    std::size_t                  n_nodes = 0;
+    for (const auto &patch : patches)
+      {
+        if (patch.reference_cell != ReferenceCells::get_hypercube<dim>())
+          n_nodes += patch.data.n_cols();
+        else
+          n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
+      }
+    node_positions.reserve(n_nodes);
+
     for (const auto &patch : patches)
       {
         // special treatment of non-hypercube cells

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -45,6 +45,8 @@
 #  include <hdf5.h>
 #endif
 
+#include <boost/archive/iterators/base64_from_binary.hpp>
+#include <boost/archive/iterators/transform_width.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
@@ -125,13 +127,14 @@ namespace
 #  endif
 
   /**
-   * Do a zlib compression followed by a base64 encoding of the given data. The
-   * result is then returned as a string object.
+   * Do a zlib compression followed by a base64 encoding of the given data, and
+   * save the result to the provided output stream.
    */
   template <typename T>
-  std::string
+  void
   compress_array(const std::vector<T>               &data,
-                 const DataOutBase::CompressionLevel compression_level)
+                 const DataOutBase::CompressionLevel compression_level,
+                 std::ostringstream                 &output)
   {
 #  ifdef DEAL_II_WITH_ZLIB
     if (data.size() != 0)
@@ -174,22 +177,57 @@ namespace
           static_cast<std::uint32_t>(
             compressed_data_length)}; /* list of compressed sizes of blocks */
 
-        const auto *const header_start =
-          reinterpret_cast<const unsigned char *>(&compression_header[0]);
+        // Both the header and the data need padding
+        const std::array<std::string, 3> paddings{{"", "==", "="}};
 
-        return (Utilities::encode_base64(
-                  {header_start, header_start + 4 * sizeof(std::uint32_t)}) +
-                Utilities::encode_base64(compressed_data));
+        // Rather than use Utilities::encode_base64(), avoid creating large
+        // temporary buffers by either writing directly to the output stream.
+        static_assert(sizeof(compressed_data[0]) == 1);
+        using namespace boost::archive::iterators;
+        using iterator =
+          base64_from_binary<transform_width<const unsigned char *, 6, 8>>;
+        {
+          auto char_begin = reinterpret_cast<const unsigned char *>(
+                 std::begin(compression_header)),
+               char_end = reinterpret_cast<const unsigned char *>(
+                 std::end(compression_header));
+          auto begin = iterator(char_begin), end = iterator(char_end);
+          for (auto it = begin; it != end; ++it)
+            output << *it;
+
+          output << paddings[(char_end - char_begin) % 3];
+        }
+
+        {
+          // Similarly, avoid the overhead of calling std::ostream::operator<<
+          // (which is virtual) on every character by writing to a small buffer
+          // first.
+          auto it  = iterator(compressed_data.data()),
+               end = iterator(compressed_data.data() + compressed_data.size());
+          std::array<char, 128> buffer;
+          while (it != end)
+            {
+              std::streamsize count = 0;
+              for (; count < static_cast<std::streamsize>(buffer.size());
+                   ++count)
+                {
+                  if (it == end)
+                    break;
+                  buffer[count] = *it;
+                  ++it;
+                }
+              output.write(buffer.data(), count);
+            }
+
+          output << paddings[compressed_data.size() % 3];
+        }
       }
-    else
-      return {};
 #  else
     (void)data;
     (void)compression_level;
     Assert(false,
            ExcMessage("This function can only be called if cmake found "
                       "a working libz installation."));
-    return {};
 #  endif
   }
 
@@ -204,24 +242,24 @@ namespace
    * element.
    */
   template <typename T>
-  std::string
+  void
   vtu_stringize_array(const std::vector<T>               &data,
                       const DataOutBase::CompressionLevel compression_level,
-                      const int                           precision)
+                      const int                           precision,
+                      std::ostringstream                 &output)
   {
     if (deal_ii_with_zlib &&
         (compression_level != DataOutBase::CompressionLevel::plain_text))
       {
         // compress the data we have in memory
-        return compress_array(data, compression_level);
+        compress_array(data, compression_level, output);
       }
     else
       {
-        std::ostringstream stream;
-        stream.precision(precision);
+        const auto old_precision = output.precision(precision);
         for (const T &el : data)
-          stream << el << ' ';
-        return stream.str();
+          output << el << ' ';
+        output.precision(old_precision);
       }
   }
 
@@ -5422,10 +5460,11 @@ namespace DataOutBase
             else
               node_coordinates_3d.emplace_back(0.0f);
         }
-      o << vtu_stringize_array(node_coordinates_3d,
-                               flags.compression_level,
-                               output_precision)
-        << '\n';
+      vtu_stringize_array(node_coordinates_3d,
+                          flags.compression_level,
+                          output_precision,
+                          o);
+      o << '\n';
       o << "    </DataArray>\n";
       o << "  </Points>\n\n";
 
@@ -5723,10 +5762,11 @@ namespace DataOutBase
       if (deal_ii_with_zlib && (flags.compression_level !=
                                 DataOutBase::CompressionLevel::plain_text))
         {
-          o << vtu_stringize_array(cells,
-                                   flags.compression_level,
-                                   output_precision)
-            << '\n';
+          vtu_stringize_array(cells,
+                              flags.compression_level,
+                              output_precision,
+                              o);
+          o << '\n';
         }
       o << "    </DataArray>\n";
 
@@ -5782,9 +5822,10 @@ namespace DataOutBase
               }
           }
 
-        o << vtu_stringize_array(offsets,
-                                 flags.compression_level,
-                                 output_precision);
+        vtu_stringize_array(offsets,
+                            flags.compression_level,
+                            output_precision,
+                            o);
         o << '\n';
         o << "    </DataArray>\n";
 
@@ -5798,15 +5839,17 @@ namespace DataOutBase
             for (unsigned int i = 0; i < cell_types.size(); ++i)
               cell_types_uint8_t[i] = static_cast<std::uint8_t>(cell_types[i]);
 
-            o << vtu_stringize_array(cell_types_uint8_t,
-                                     flags.compression_level,
-                                     output_precision);
+            vtu_stringize_array(cell_types_uint8_t,
+                                flags.compression_level,
+                                output_precision,
+                                o);
           }
         else
           {
-            o << vtu_stringize_array(cell_types,
-                                     flags.compression_level,
-                                     output_precision);
+            vtu_stringize_array(cell_types,
+                                flags.compression_level,
+                                output_precision,
+                                o);
           }
 
         o << '\n';
@@ -5968,9 +6011,7 @@ namespace DataOutBase
               }
           } // loop over nodes
 
-        o << vtu_stringize_array(data,
-                                 flags.compression_level,
-                                 output_precision);
+        vtu_stringize_array(data, flags.compression_level, output_precision, o);
         o << '\n';
         o << "    </DataArray>\n";
 
@@ -5997,9 +6038,7 @@ namespace DataOutBase
 
         const std::vector<float> data(data_vectors[data_set].begin(),
                                       data_vectors[data_set].end());
-        o << vtu_stringize_array(data,
-                                 flags.compression_level,
-                                 output_precision);
+        vtu_stringize_array(data, flags.compression_level, output_precision, o);
         o << '\n';
         o << "    </DataArray>\n";
 


### PR DESCRIPTION
This saves us from doing some huge temporary allocations (since we immediately write the base64 output to the stream) at the cost of setting up the base64 calls ourselves. It may also be possible to combine compression and base64 via iterator chaining (similar to our own "deal.II intermediate" format) in the future.