### PR TITLE
ARKode: refactor old tests to use ARKStepper

### DIFF
--- a/tests/sundials/arkode_01.cc
+++ b/tests/sundials/arkode_01.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2017 - 2024 by the deal.II authors
+// Copyright (C) 2017 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -57,6 +57,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   // Set to true to reset input file.
   if (false)
     {
@@ -68,17 +71,19 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_01_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   double kappa = 1.0;
 
   unsigned int n_rhs_evaluations = 0;
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = y[1];
-    ydot[1] = -kappa * kappa * y[0];
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = y[1];
+      ydot[1] = -kappa * kappa * y[0];
 
-    ++n_rhs_evaluations;
-  };
+      ++n_rhs_evaluations;
+    };
 
   ode.output_step =
     [&](const double t, const VectorType &sol, const unsigned int step_number) {

--- a/tests/sundials/arkode_01_in.prm
+++ b/tests/sundials/arkode_01_in.prm
@@ -2,14 +2,14 @@ set Final time                        = 6.28
 set Initial time                      = 0
 set Time interval between each output = 0.05
 
+set Integration accuracy order = 5
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end

--- a/tests/sundials/arkode_02.cc
+++ b/tests/sundials/arkode_02.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2017 - 2023 by the deal.II authors
+// Copyright (C) 2017 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -57,18 +57,23 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   // Use the same parameters of test 1.
   std::ifstream ifile(SOURCE_DIR "/arkode_01_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   double kappa = 1.0;
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = y[1];
-    ydot[1] = -kappa * kappa * y[0];
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = y[1];
+      ydot[1] = -kappa * kappa * y[0];
+    };
 
   ode.output_step =
     [&](const double t, const VectorType &sol, const unsigned int step_number) {

--- a/tests/sundials/arkode_03.cc
+++ b/tests/sundials/arkode_03.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2017 - 2024 by the deal.II authors
+// Copyright (C) 2017 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -56,6 +56,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_03_in.prm");
@@ -66,23 +69,26 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_03_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 0;
-    ydot[1] = 0;
-    ydot[2] = -y[2] / eps;
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 0;
+      ydot[1] = 0;
+      ydot[2] = -y[2] / eps;
+    };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
-    ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
-    ydot[2] = b / eps - y[2] * y[0];
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
+      ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
+      ydot[2] = b / eps - y[2] * y[0];
+    };
 
   ode.output_step =
     [&](const double t, const VectorType &sol, const unsigned int step_number) {

--- a/tests/sundials/arkode_03_in.prm
+++ b/tests/sundials/arkode_03_in.prm
@@ -2,6 +2,13 @@ set Final time                        = 10
 set Initial time                      = 0
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 50
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+# A larger subspace, combined with looser tolerances, are required by 5.4
+set Anderson-acceleration subspace         = 10
+
 subsection Error control
   # making this tolerance any lower prevents convergence in 5.4:
   # this is fixed in 6.2
@@ -10,12 +17,6 @@ subsection Error control
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 1e-6
-  set Maximum number of nonlinear iterations = 50
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 1e-7
-  # A larger subspace, combined with looser tolerances, are required by 5.4
-  set Anderson-acceleration subspace = 10
+  set Initial step size = 1e-6
+  set Minimum step size = 1e-7
 end

--- a/tests/sundials/arkode_04.cc
+++ b/tests/sundials/arkode_04.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2017 - 2024 by the deal.II authors
+// Copyright (C) 2017 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -54,6 +54,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_04_in.prm");
@@ -64,7 +67,8 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_04_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
@@ -72,24 +76,26 @@ main()
   FullMatrix<double> J(3, 3);
   J(2, 2) = -1.0 / eps;
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 0;
-    ydot[1] = 0;
-    ydot[2] = -y[2] / eps;
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 0;
+      ydot[1] = 0;
+      ydot[2] = -y[2] / eps;
+    };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
-    ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
-    ydot[2] = b / eps - y[2] * y[0];
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
+      ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
+      ydot[2] = b / eps - y[2] * y[0];
+    };
 
-  ode.jacobian_times_vector = [&](const VectorType &src,
-                                  VectorType       &dst,
-                                  double            t,
-                                  const VectorType & /*y*/,
-                                  const VectorType & /*fy*/) {
+  stepper.jacobian_times_vector = [&](const VectorType &src,
+                                      VectorType       &dst,
+                                      double            t,
+                                      const VectorType & /*y*/,
+                                      const VectorType & /*fy*/) {
     J.vmult(dst, src);
   };
 

--- a/tests/sundials/arkode_04_in.prm
+++ b/tests/sundials/arkode_04_in.prm
@@ -2,6 +2,12 @@ set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 50
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+set Anderson-acceleration subspace         = 5
+
 subsection Error control
   # This test is somewhat easier since we have a way to evaluate the Jacobian
   set Absolute error tolerance = 4e-9
@@ -9,11 +15,6 @@ subsection Error control
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 5e-7
-  set Maximum number of nonlinear iterations = 50
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 1e-8
-  set Anderson-acceleration subspace         = 5
+  set Initial step size = 5e-7
+  set Minimum step size = 1e-8
 end

--- a/tests/sundials/arkode_05_in.prm
+++ b/tests/sundials/arkode_05_in.prm
@@ -2,16 +2,17 @@ set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 10
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end

--- a/tests/sundials/arkode_06.cc
+++ b/tests/sundials/arkode_06.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2020 - 2024 by the deal.II authors
+// Copyright (C) 2020 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,6 +61,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_06_in.prm");
@@ -71,40 +74,43 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_06_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
   // Explicit jacobian.
   FullMatrix<double> J(3, 3);
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 0;
-    ydot[1] = 0;
-    ydot[2] = -y[2] / eps;
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 0;
+      ydot[1] = 0;
+      ydot[2] = -y[2] / eps;
+    };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
-    ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
-    ydot[2] = b / eps - y[2] * y[0];
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
+      ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
+      ydot[2] = b / eps - y[2] * y[0];
+    };
 
 
-  ode.jacobian_times_setup =
+  stepper.jacobian_times_vector_setup =
     [&](SUNDIALS::realtype t, const VectorType &y, const VectorType &fy) {
       J       = 0;
       J(2, 2) = -1.0 / eps;
     };
 
-  ode.jacobian_times_vector = [&](const VectorType &v,
-                                  VectorType       &Jv,
-                                  double            t,
-                                  const VectorType &y,
-                                  const VectorType &fy) { J.vmult(Jv, v); };
+  stepper.jacobian_times_vector = [&](const VectorType &v,
+                                      VectorType       &Jv,
+                                      double            t,
+                                      const VectorType &y,
+                                      const VectorType &fy) { J.vmult(Jv, v); };
 
-  ode.solve_linearized_system =
+  stepper.solve_linearized_system =
     [&](SUNDIALS::SundialsOperator<VectorType> &op,
         SUNDIALS::SundialsPreconditioner<VectorType> &,
         VectorType       &x,

--- a/tests/sundials/arkode_06_in.prm
+++ b/tests/sundials/arkode_06_in.prm
@@ -2,16 +2,17 @@ set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 10
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end

--- a/tests/sundials/arkode_07.cc
+++ b/tests/sundials/arkode_07.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2020 - 2025 by the deal.II authors
+// Copyright (C) 2020 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -61,6 +61,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_07_in.prm");
@@ -71,40 +74,43 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_07_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
   // Explicit jacobian.
   FullMatrix<double> J(3, 3);
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 0;
-    ydot[1] = 0;
-    ydot[2] = -y[2] / eps;
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 0;
+      ydot[1] = 0;
+      ydot[2] = -y[2] / eps;
+    };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
-    ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
-    ydot[2] = b / eps - y[2] * y[0];
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
+      ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
+      ydot[2] = b / eps - y[2] * y[0];
+    };
 
 
-  ode.jacobian_times_setup =
+  stepper.jacobian_times_vector_setup =
     [&](SUNDIALS::realtype t, const VectorType &y, const VectorType &fy) {
       J       = 0;
       J(2, 2) = -1.0 / eps;
     };
 
-  ode.jacobian_times_vector = [&](const VectorType &v,
-                                  VectorType       &Jv,
-                                  double            t,
-                                  const VectorType &y,
-                                  const VectorType &fy) { J.vmult(Jv, v); };
+  stepper.jacobian_times_vector = [&](const VectorType &v,
+                                      VectorType       &Jv,
+                                      double            t,
+                                      const VectorType &y,
+                                      const VectorType &fy) { J.vmult(Jv, v); };
 
-  ode.solve_linearized_system =
+  stepper.solve_linearized_system =
     [&](SUNDIALS::SundialsOperator<VectorType>       &op,
         SUNDIALS::SundialsPreconditioner<VectorType> &prec,
         VectorType                                   &x,
@@ -115,23 +121,23 @@ main()
       solver_cg.solve(op, x, b, prec);
     };
 
-  ode.jacobian_preconditioner_setup = [&](double            t,
-                                          const VectorType &y,
-                                          const VectorType &fy,
-                                          int               jok,
-                                          int              &jcur,
-                                          double            gamma) {
+  stepper.jacobian_preconditioner_setup = [&](double            t,
+                                              const VectorType &y,
+                                              const VectorType &fy,
+                                              int               jok,
+                                              int              &jcur,
+                                              double            gamma) {
     deallog << "jacobian_preconditioner_setup called\n";
   };
 
-  ode.jacobian_preconditioner_solve = [&](double            t,
-                                          const VectorType &y,
-                                          const VectorType &fy,
-                                          const VectorType &r,
-                                          VectorType       &z,
-                                          double            gamma,
-                                          double            delta,
-                                          int               lr) {
+  stepper.jacobian_preconditioner_solve = [&](double            t,
+                                              const VectorType &y,
+                                              const VectorType &fy,
+                                              const VectorType &r,
+                                              VectorType       &z,
+                                              double            gamma,
+                                              double            delta,
+                                              int               lr) {
     deallog << "jacobian_preconditioner_solve called\n";
     z = r;
   };

--- a/tests/sundials/arkode_07_in.prm
+++ b/tests/sundials/arkode_07_in.prm
@@ -2,16 +2,17 @@ set Final time                        = 10.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 10
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end

--- a/tests/sundials/arkode_08.cc
+++ b/tests/sundials/arkode_08.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2020 - 2024 by the deal.II authors
+// Copyright (C) 2020 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -54,6 +54,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_08_in.prm");
@@ -64,7 +67,8 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_08_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Explicit jacobian = stiffness matrix
   FullMatrix<double> K(2, 2);
@@ -76,21 +80,21 @@ main()
   M(0, 0) = M(1, 1) = 2.0 / 3;
   M(1, 0) = M(0, 1) = 1.0 / 3;
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    K.vmult(ydot, y);
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) { K.vmult(ydot, y); };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 1;
-    ydot[1] = 2;
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 1;
+      ydot[1] = 2;
+    };
 
-  ode.jacobian_times_vector = [&](const VectorType &v,
-                                  VectorType       &Jv,
-                                  double            t,
-                                  const VectorType &y,
-                                  const VectorType &fy) { K.vmult(Jv, v); };
+  stepper.jacobian_times_vector = [&](const VectorType &v,
+                                      VectorType       &Jv,
+                                      double            t,
+                                      const VectorType &y,
+                                      const VectorType &fy) { K.vmult(Jv, v); };
 
   const auto solve_function =
     [&](SUNDIALS::SundialsOperator<VectorType>       &op,
@@ -103,28 +107,28 @@ main()
       solver_cg.solve(op, x, b, prec);
     };
 
-  ode.solve_linearized_system = solve_function;
+  stepper.solve_linearized_system = solve_function;
 
-  ode.solve_mass = solve_function;
+  stepper.solve_mass = solve_function;
 
   FullMatrix<double> M_inv(2, 2);
 
-  ode.mass_preconditioner_solve =
+  stepper.mass_preconditioner_solve =
     [&](double t, const VectorType &r, VectorType &z, double gamma, int lr) {
       LogStream::Prefix prefix("mass_preconditioner_solve");
       deallog << "applied" << std::endl;
       M_inv.vmult(z, r);
     };
 
-  ode.mass_preconditioner_setup = [&](double t) {
+  stepper.mass_preconditioner_setup = [&](double t) {
     LogStream::Prefix prefix("mass_preconditioner_setup");
     deallog << "applied" << std::endl;
     M_inv.invert(M);
   };
 
-  ode.mass_times_vector = [&](const double      t,
-                              const VectorType &v,
-                              VectorType       &Mv) { M.vmult(Mv, v); };
+  stepper.mass_times_vector = [&](const double      t,
+                                  const VectorType &v,
+                                  VectorType       &Mv) { M.vmult(Mv, v); };
 
 
   ode.output_step =

--- a/tests/sundials/arkode_08_in.prm
+++ b/tests/sundials/arkode_08_in.prm
@@ -2,16 +2,17 @@ set Final time                        = 1.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 10
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end

--- a/tests/sundials/arkode_09.cc
+++ b/tests/sundials/arkode_09.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2023 - 2024 by the deal.II authors
+// Copyright (C) 2023 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -36,6 +36,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   // Set to true to reset input file.
   if (false)
     {
@@ -47,11 +50,12 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_09_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   double kappa = 1.0;
 
-  ode.explicit_function =
+  stepper.explicit_function =
     [&](const double t, const VectorType &y, VectorType &ydot) {
       deallog << "Evaluating right hand side at t=" << t << " with y=" << y[0]
               << std::endl;

--- a/tests/sundials/arkode_09_in.prm
+++ b/tests/sundials/arkode_09_in.prm
@@ -2,14 +2,14 @@ set Final time                        = 6
 set Initial time                      = 0
 set Time interval between each output = 2
 
+set Integration accuracy order = 5
+
 subsection Error control
   set Absolute error tolerance = 0.001
   set Relative error tolerance = 0.010
 end
 
 subsection Running parameters
-  set Initial step size                      = 3
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.01
+  set Initial step size = 3
+  set Minimum step size = 0.01
 end

--- a/tests/sundials/arkode_10.cc
+++ b/tests/sundials/arkode_10.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2020 - 2024 by the deal.II authors
+// Copyright (C) 2020 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -39,6 +39,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_10_in.prm");
@@ -49,7 +52,8 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_08_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Explicit jacobian = stiffness matrix
   FullMatrix<double> K(2, 2);
@@ -61,21 +65,21 @@ main()
   M(0, 0) = M(1, 1) = 2.0 / 3;
   M(1, 0) = M(0, 1) = 1.0 / 3;
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    K.vmult(ydot, y);
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) { K.vmult(ydot, y); };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 1;
-    ydot[1] = 2;
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 1;
+      ydot[1] = 2;
+    };
 
-  ode.jacobian_times_vector = [&](const VectorType &v,
-                                  VectorType       &Jv,
-                                  double            t,
-                                  const VectorType &y,
-                                  const VectorType &fy) { K.vmult(Jv, v); };
+  stepper.jacobian_times_vector = [&](const VectorType &v,
+                                      VectorType       &Jv,
+                                      double            t,
+                                      const VectorType &y,
+                                      const VectorType &fy) { K.vmult(Jv, v); };
 
   [&](SUNDIALS::SundialsOperator<VectorType> &,
       SUNDIALS::SundialsPreconditioner<VectorType> &,
@@ -86,7 +90,7 @@ main()
     throw RecoverableUserCallbackError();
   };
 
-  ode.solve_linearized_system =
+  stepper.solve_linearized_system =
     [&](SUNDIALS::SundialsOperator<VectorType> &,
         SUNDIALS::SundialsPreconditioner<VectorType> &,
         VectorType &,
@@ -98,11 +102,11 @@ main()
     };
 
 
-  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType>       &op,
-                       SUNDIALS::SundialsPreconditioner<VectorType> &prec,
-                       VectorType                                   &x,
-                       const VectorType                             &b,
-                       double                                        tol) {
+  stepper.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType>       &op,
+                           SUNDIALS::SundialsPreconditioner<VectorType> &prec,
+                           VectorType                                   &x,
+                           const VectorType                             &b,
+                           double                                        tol) {
     ReductionControl     control;
     SolverCG<VectorType> solver_cg(control);
     solver_cg.solve(op, x, b, prec);
@@ -110,22 +114,22 @@ main()
 
   FullMatrix<double> M_inv(2, 2);
 
-  ode.mass_preconditioner_solve =
+  stepper.mass_preconditioner_solve =
     [&](double t, const VectorType &r, VectorType &z, double gamma, int lr) {
       LogStream::Prefix prefix("mass_preconditioner_solve");
       deallog << "applied" << std::endl;
       M_inv.vmult(z, r);
     };
 
-  ode.mass_preconditioner_setup = [&](double t) {
+  stepper.mass_preconditioner_setup = [&](double t) {
     LogStream::Prefix prefix("mass_preconditioner_setup");
     deallog << "applied" << std::endl;
     M_inv.invert(M);
   };
 
-  ode.mass_times_vector = [&](const double      t,
-                              const VectorType &v,
-                              VectorType       &Mv) { M.vmult(Mv, v); };
+  stepper.mass_times_vector = [&](const double      t,
+                                  const VectorType &v,
+                                  VectorType       &Mv) { M.vmult(Mv, v); };
 
 
   ode.output_step =

--- a/tests/sundials/arkode_10_in.prm
+++ b/tests/sundials/arkode_10_in.prm
@@ -2,16 +2,17 @@ set Final time                        = 1.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 10
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end

--- a/tests/sundials/arkode_11.cc
+++ b/tests/sundials/arkode_11.cc
@@ -1,7 +1,7 @@
 // -----------------------------------------------------------------------------
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-// Copyright (C) 2020 - 2024 by the deal.II authors
+// Copyright (C) 2020 - 2026 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -39,6 +39,9 @@ main()
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
   data.add_parameters(prm);
 
+  SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+  stepper_data.add_parameters(prm);
+
   if (false)
     {
       std::ofstream ofile(SOURCE_DIR "/arkode_11_in.prm");
@@ -49,7 +52,8 @@ main()
   std::ifstream ifile(SOURCE_DIR "/arkode_08_in.prm");
   prm.parse_input(ifile);
 
-  SUNDIALS::ARKode<VectorType> ode(data);
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+  SUNDIALS::ARKode<VectorType>     ode(stepper, data);
 
   // Explicit jacobian = stiffness matrix
   FullMatrix<double> K(2, 2);
@@ -61,21 +65,21 @@ main()
   M(0, 0) = M(1, 1) = 2.0 / 3;
   M(1, 0) = M(0, 1) = 1.0 / 3;
 
-  ode.implicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    K.vmult(ydot, y);
-  };
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) { K.vmult(ydot, y); };
 
 
-  ode.explicit_function = [&](double, const VectorType &y, VectorType &ydot) {
-    ydot[0] = 1;
-    ydot[1] = 2;
-  };
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 1;
+      ydot[1] = 2;
+    };
 
-  ode.jacobian_times_vector = [&](const VectorType &v,
-                                  VectorType       &Jv,
-                                  double            t,
-                                  const VectorType &y,
-                                  const VectorType &fy) { K.vmult(Jv, v); };
+  stepper.jacobian_times_vector = [&](const VectorType &v,
+                                      VectorType       &Jv,
+                                      double            t,
+                                      const VectorType &y,
+                                      const VectorType &fy) { K.vmult(Jv, v); };
 
   [&](SUNDIALS::SundialsOperator<VectorType> &,
       SUNDIALS::SundialsPreconditioner<VectorType> &,
@@ -86,11 +90,11 @@ main()
     throw RecoverableUserCallbackError();
   };
 
-  ode.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &,
-                       SUNDIALS::SundialsPreconditioner<VectorType> &,
-                       VectorType &,
-                       const VectorType &,
-                       double) {
+  stepper.solve_mass = [&](SUNDIALS::SundialsOperator<VectorType> &,
+                           SUNDIALS::SundialsPreconditioner<VectorType> &,
+                           VectorType &,
+                           const VectorType &,
+                           double) {
     deallog
       << "Reporting recoverable failure when solving with the mass matrix."
       << std::endl;
@@ -98,7 +102,7 @@ main()
   };
 
 
-  ode.solve_linearized_system =
+  stepper.solve_linearized_system =
     [&](SUNDIALS::SundialsOperator<VectorType>       &op,
         SUNDIALS::SundialsPreconditioner<VectorType> &prec,
         VectorType                                   &x,
@@ -111,22 +115,22 @@ main()
 
   FullMatrix<double> M_inv(2, 2);
 
-  ode.mass_preconditioner_solve =
+  stepper.mass_preconditioner_solve =
     [&](double t, const VectorType &r, VectorType &z, double gamma, int lr) {
       LogStream::Prefix prefix("mass_preconditioner_solve");
       deallog << "applied" << std::endl;
       M_inv.vmult(z, r);
     };
 
-  ode.mass_preconditioner_setup = [&](double t) {
+  stepper.mass_preconditioner_setup = [&](double t) {
     LogStream::Prefix prefix("mass_preconditioner_setup");
     deallog << "applied" << std::endl;
     M_inv.invert(M);
   };
 
-  ode.mass_times_vector = [&](const double      t,
-                              const VectorType &v,
-                              VectorType       &Mv) { M.vmult(Mv, v); };
+  stepper.mass_times_vector = [&](const double      t,
+                                  const VectorType &v,
+                                  VectorType       &Mv) { M.vmult(Mv, v); };
 
 
   ode.output_step =

--- a/tests/sundials/arkode_11_in.prm
+++ b/tests/sundials/arkode_11_in.prm
@@ -2,16 +2,17 @@ set Final time                        = 1.
 set Initial time                      = 0.
 set Time interval between each output = 0.1
 
+set Integration accuracy order             = 5
+set Maximum number of nonlinear iterations = 10
+set Implicit function is linear            = true
+set Implicit function is time independent  = true
+
 subsection Error control
   set Absolute error tolerance = 0.000001
   set Relative error tolerance = 0.000010
 end
 
 subsection Running parameters
-  set Implicit function is linear            = true
-  set Implicit function is time independent  = true
-  set Initial step size                      = 0.010000
-  set Maximum number of nonlinear iterations = 10
-  set Maximum order of ARK                   = 5
-  set Minimum step size                      = 0.000001
+  set Initial step size = 0.010000
+  set Minimum step size = 0.000001
 end


### PR DESCRIPTION
As mentioned in #19615, the previously existing ARKode tests have been refactored to work with the new constructor explicitly receiving a stepper object.