### PR TITLE
Arkode: include sundials_context.h into invocation_context.h

### DIFF
--- a/include/deal.II/sundials/invocation_context.h
+++ b/include/deal.II/sundials/invocation_context.h
@@ -21,7 +21,10 @@
 
 #ifdef DEAL_II_WITH_SUNDIALS
 
-#  include <sundials/sundials_types.h>
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 0, 0)
+#    include <sundials/sundials_context.h>
+#    include <sundials/sundials_types.h>
+#  endif
 
 #  include <exception>
 


### PR DESCRIPTION
Fixes the `SUNContext` issue identified in #19635, should fix #19610.