### PR TITLE
TimeStepping::ExplicitRungeKutta: add HEUN_EULER

### DIFF
--- a/doc/news/changes/minor/20260505Munch
+++ b/doc/news/changes/minor/20260505Munch
@@ -1,0 +1,4 @@
+Improved: TimeStepping::ExplicitRungeKutta now also supports
+TimeStepping::HEUN_EULER.
+<br>
+(Peter Munch, 2026/05/05)

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -33,6 +33,7 @@ namespace TimeStepping
    * The following Runge-Kutta methods are available:
    * - Explicit methods (see ExplicitRungeKutta::initialize):
    *   - FORWARD_EULER (first order)
+   *   - HEUN_EULER (second order)
    *   - RK_THIRD_ORDER (third order Runge-Kutta)
    *   - SSP_THIRD_ORDER (third order SSP Runge-Kutta)
    *   - RK_CLASSIC_FOURTH_ORDER (classical fourth order Runge-Kutta)

--- a/include/deal.II/base/time_stepping.templates.h
+++ b/include/deal.II/base/time_stepping.templates.h
@@ -90,6 +90,22 @@ namespace TimeStepping
 
             break;
           }
+        case (HEUN_EULER):
+          {
+            this->n_stages = 2;
+            this->b.push_back(1.0 / 2.0);
+            this->b.push_back(1.0 / 2.0);
+            this->c.push_back(0.0);
+            this->c.push_back(1.0);
+
+            std::vector<double> tmp;
+            this->a.push_back(tmp);
+            tmp.resize(1);
+            tmp[0] = 1.0;
+            this->a.push_back(tmp);
+
+            break;
+          }
         case (RK_THIRD_ORDER):
           {
             this->n_stages = 3;

--- a/tests/base/time_stepping_01.cc
+++ b/tests/base/time_stepping_01.cc
@@ -295,6 +295,11 @@ main()
       TimeStepping::FORWARD_EULER);
     test(fe, f1, id_minus_tau_J_inv1, my1);
 
+    deallog << "Runge-Kutta third order (Heun-Euler)" << std::endl;
+    TimeStepping::ExplicitRungeKutta<Vector<double>> rk2(
+      TimeStepping::HEUN_EULER);
+    test(rk2, f2, id_minus_tau_J_inv2, my2);
+
     deallog << "Runge-Kutta third order" << std::endl;
     TimeStepping::ExplicitRungeKutta<Vector<double>> rk3(
       TimeStepping::RK_THIRD_ORDER);
@@ -406,6 +411,14 @@ main()
     test_convergence(rk1,
                      my_rhs_function,
                      id_minus_tau_J_inv1,
+                     my_exact_solution);
+
+    deallog << "Runge-Kutta second order (Heun-Euler)" << std::endl;
+    TimeStepping::ExplicitRungeKutta<Vector<double>> rk2(
+      TimeStepping::HEUN_EULER);
+    test_convergence(rk2,
+                     my_rhs_function,
+                     id_minus_tau_J_inv2,
                      my_exact_solution);
 
     deallog << "Runge-Kutta third order" << std::endl;

--- a/tests/base/time_stepping_01.output
+++ b/tests/base/time_stepping_01.output
@@ -1,6 +1,8 @@
 
 DEAL::Forward Euler
 DEAL::0
+DEAL::Runge-Kutta third order (Heun-Euler)
+DEAL::0
 DEAL::Runge-Kutta third order
 DEAL::0
 DEAL::Strong Stability Preserving Runge-Kutta third order
@@ -49,6 +51,14 @@ DEAL::dt 0.06250    error 0.02543    rate 0.8621
 DEAL::dt 0.03125    error 0.01339    rate 0.9248    
 DEAL::dt 0.01562    error 0.006882   rate 0.9606    
 DEAL::dt 0.007812   error 0.003490   rate 0.9798    
+DEAL::Runge-Kutta second order (Heun-Euler)
+DEAL::convergence rate
+DEAL::dt 0.2500     error 0.005740   rate 1.927
+DEAL::dt 0.1250     error 0.001443   rate 1.992
+DEAL::dt 0.06250    error 0.0003588  rate 2.008
+DEAL::dt 0.03125    error 8.920e-05  rate 2.008
+DEAL::dt 0.01562    error 2.222e-05  rate 2.005
+DEAL::dt 0.007812   error 5.543e-06  rate 2.003
 DEAL::Runge-Kutta third order
 DEAL::convergence rate
 DEAL::dt 0.2500     error 3.856e-05  rate 0.05239   


### PR DESCRIPTION
so that one can also run second-order scheme with `TimeStepping::ExplicitRungeKutta`