### PR TITLE
Let dependabot also check for updates in pre-commit ecosystem.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Set update schedule for GitHub Actions
+# Set update schedule for GitHub Actions and pre-commit
 
 version: 2
 updates:
@@ -6,5 +6,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "https://github.com/pre-commit/mirrors-clang-format"


### PR DESCRIPTION
[Only recently](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/), github's dependabot is able to check for updates in the pre-commit ecosystem.

This patch enables checks for our pre-commit hooks, ignoring updates for `clang-format` since we require a specific version.

@jpthiele -- FYI