### PR TITLE
Fix typos.

### DIFF
--- a/doc/news/8.4.2-vs-8.5.0.h
+++ b/doc/news/8.4.2-vs-8.5.0.h
@@ -526,7 +526,7 @@ inconvenience this causes.
 
  <li>
   Refactored: The contrib/ directory has been cleaned up and the
-  Parameter GUI has be reloacted into its own repository:
+  Parameter GUI has be relocated into its own repository:
   https://github.com/dealii/parameter_gui
   <br>
   (Matthias Maier, Timo Heister, 2016/07/06)

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -676,7 +676,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &row_parallel_partitioning,
            const IndexSet &col_parallel_partitioning,
-           const IndexSet &writeable_rows,
+           const IndexSet &writable_rows,
            const MPI_Comm  communicator,
            const size_type n_entries_per_row);
 
@@ -685,7 +685,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &row_parallel_partitioning,
            const IndexSet &col_parallel_partitioning,
-           const IndexSet &writeable_rows,
+           const IndexSet &writable_rows,
            const MPI_Comm  communicator);
 
     DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
@@ -693,7 +693,7 @@ namespace TrilinosWrappers
     void
     reinit(const IndexSet &row_parallel_partitioning,
            const IndexSet &col_parallel_partitioning,
-           const IndexSet &writeable_rows);
+           const IndexSet &writable_rows);
 
     /**
      * Same as before, but now using a vector <tt>n_entries_per_row</tt> for

--- a/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparsity_pattern.h
@@ -599,7 +599,7 @@ namespace LinearAlgebra
       void
       reinit(const IndexSet &row_parallel_partitioning,
              const IndexSet &col_parallel_partitioning,
-             const IndexSet &writeable_rows,
+             const IndexSet &writable_rows,
              const MPI_Comm  communicator,
              const size_type n_entries_per_row);
 


### PR DESCRIPTION
This fixes the typos pointed out by the CI check in https://github.com/dealii/dealii/pull/19648.

@marcfehling You may want to rebase #19648 on top of this patch.