### PR TITLE
Use unpreconditioned residual norm in PETScWrappers::SolverCG

### DIFF
--- a/source/lac/petsc_solver.cc
+++ b/source/lac/petsc_solver.cc
@@ -107,13 +107,6 @@ namespace PETScWrappers
          * this can be overridden by command line.
          */
         AssertPETSc(KSPSetReusePreconditioner(ksp, PETSC_TRUE));
-
-        // By default, we use the unpreconditioned norm to check for
-        // convergence. This is consistent with the behavior of deal.II's own
-        // solvers, and is also more efficient to compute. However, users can
-        // override this default behavior with command-line options if they wish
-        // to use a different norm for convergence testing.
-        AssertPETSc(KSPSetNormType(ksp, KSP_NORM_UNPRECONDITIONED));
       }
 
     // setting the preconditioner overwrites the used matrices.
@@ -343,6 +336,11 @@ namespace PETScWrappers
     // honor the initial guess in the
     // solution vector. do so here as well:
     AssertPETSc(KSPSetInitialGuessNonzero(ksp, PETSC_TRUE));
+
+    // Use the unpreconditioned residual norm for the convergence check, to
+    // match the behavior of deal.II's own SolverCG. Users can still override
+    // this via the -ksp_norm_type command-line option.
+    AssertPETSc(KSPSetNormType(ksp, KSP_NORM_UNPRECONDITIONED));
   }
 
 

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -61,6 +61,6 @@ main(int argc, char **argv)
     check_solver_within_range(solver.solve(A, u, f, preconditioner),
                               control.last_step(),
                               40,
-                              42);
+                              45);
   }
 }

--- a/tests/petsc/solver_03.output
+++ b/tests/petsc/solver_03.output
@@ -1,4 +1,4 @@
 
 DEAL::Size 32 Unknowns 961
 DEAL::Solver type: N6dealii13PETScWrappers8SolverCGE
-DEAL::Solver stopped within 40 - 42 iterations
+DEAL::Solver stopped within 40 - 45 iterations


### PR DESCRIPTION
Set `KSP_NORM_UNPRECONDITIONED` as the convergence-test norm for
`PETScWrappers::SolverCG`, so its behavior matches deal.II's native
`SolverCG` (which checks the unpreconditioned residual). The call lives
in `SolverCG::set_solver_type()` only — other KSP types (Chebyshev,
Richardson, etc.) are intentionally left at PETSc's defaults, since
some of them do not support `KSP_NORM_UNPRECONDITIONED`. Users can
still override via `-ksp_norm_type` on the command line.