### PR TITLE
Arkode: add option to pick the integrator Butcher tables (explicit and implicit)

### DIFF
--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -410,8 +410,9 @@ namespace SUNDIALS
        *
        * @param order Desired order of accuracy for the time integration.
        *   If set to 0 the default order for the chosen method is used. This
-       *   parameter is mutually exclusive with @p implicit_butcher_table and
-       *   @p explicit_butcher_table.
+       *   parameter can't be set to a nonzero value if either of the
+       *   parameters @p implicit_butcher_table or @p explicit_butcher_table
+       *   is set to a non-empty string.
        * @param maximum_non_linear_iterations Maximum number of nonlinear
        *   iterations
        * @param implicit_function_is_linear Specifies that the implicit portion
@@ -423,13 +424,31 @@ namespace SUNDIALS
        * @param anderson_acceleration_subspace The number of vectors to use for
        *   Anderson acceleration within the packaged SUNDIALS solver.
        * @param implicit_butcher_table Name of the implicit (DIRK) Butcher
-       *   table. An empty string means no implicit table is selected, which
-       *   is equivalent to passing `"ARKODE_DIRK_NONE"` to SUNDIALS. This
-       *   parameter is mutually exclusive with @p order.
+       *   table. The default is an empty string.
+       *   If both @p implicit_butcher_table and @p explicit_butcher_table are
+       *   left as empty strings, then ARKStep will default to the method
+       *   corresponding to the specified order (or the default order if
+       *   @p order is set to 0).
+       *   If @p implicit_butcher_table is left empty but
+       *   @p explicit_butcher_table is set to a non-empty string, that means
+       *   no implicit table is selected, which is equivalent to passing
+       *   `"ARKODE_DIRK_NONE"` to SUNDIALS.
+       *   If @p implicit_butcher_table is set to a non-empty string, then
+       *   the method corresponding to the specified table will be used.
+       *   This option is supported if SUNDIALS version 6.4.0 or later is used.
        * @param explicit_butcher_table Name of the explicit (ERK) Butcher
-       *   table. An empty string means no explicit table is selected, which
-       *   is equivalent to passing `"ARKODE_ERK_NONE"` to SUNDIALS. This
-       *   parameter is mutually exclusive with @p order.
+       *   table. The default is an empty string.
+       *   If both @p implicit_butcher_table and @p explicit_butcher_table are
+       *   left as empty strings, then ARKStep will default to the method
+       *   corresponding to the specified order (or the default order if
+       *   @p order is set to 0).
+       *   If @p explicit_butcher_table is left empty but
+       *   @p implicit_butcher_table is set to a non-empty string, that means
+       *   no explicit table is selected, which is equivalent to passing
+       *   `"ARKODE_ERK_NONE"` to SUNDIALS.
+       *   If @p explicit_butcher_table is set to a non-empty string, then
+       *   the method corresponding to the specified table will be used.
+       *   This option is supported if SUNDIALS version 6.4.0 or later is used.
        */
       explicit AdditionalData(
         const unsigned int order                                 = 0,
@@ -463,8 +482,8 @@ namespace SUNDIALS
        * the default order for the chosen method is used.
        *
        * This option is mutually exclusive with implicit_butcher_table and
-       * explicit_butcher_table: either the order is specified, or specific
-       * Butcher tables are chosen, but not both.
+       * explicit_butcher_table: either the order is specified as a nonzero
+       * value, or specific Butcher tables are chosen, but not both.
        */
       unsigned int order;
 
@@ -911,13 +930,12 @@ namespace SUNDIALS
      * custom settings on the supplied @p arkode_mem object. Refer to the
      * SUNDIALS documentation for valid options.
      *
-     * For instance, the following code indicates to use specific built-in
-     * Butcher tables for the ERK, DIRK or ARK method of the ARKStep module:
+     * For instance, the following code specifies the fraction of the estimated
+     * explicitly stable step to use as 0.25 instead of the default value 0.5:
      *
      * @code
      *      stepper.custom_setup = [&](void *arkode_mem) {
-     *        const int status = ARKStepSetTableName(
-     *          arkode_mem, implicit_method_name, explicit_method_name);
+     *        const int status = ARKStepSetCFLFraction(arkode_mem, 0.25);
      *
      *        AssertARKode(status);
      *      };

--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -52,6 +52,7 @@
 
 #  include <exception>
 #  include <memory>
+#  include <string>
 
 #endif // DEAL_II_WITH_SUNDIALS
 
@@ -408,7 +409,9 @@ namespace SUNDIALS
        * Initialization parameters for ARKStepper.
        *
        * @param order Desired order of accuracy for the time integration.
-       *   If set to 0 the default order for the chosen method is used.
+       *   If set to 0 the default order for the chosen method is used. This
+       *   parameter is mutually exclusive with @p implicit_butcher_table and
+       *   @p explicit_butcher_table.
        * @param maximum_non_linear_iterations Maximum number of nonlinear
        *   iterations
        * @param implicit_function_is_linear Specifies that the implicit portion
@@ -419,6 +422,14 @@ namespace SUNDIALS
        *   independent of time
        * @param anderson_acceleration_subspace The number of vectors to use for
        *   Anderson acceleration within the packaged SUNDIALS solver.
+       * @param implicit_butcher_table Name of the implicit (DIRK) Butcher
+       *   table. An empty string means no implicit table is selected, which
+       *   is equivalent to passing `"ARKODE_DIRK_NONE"` to SUNDIALS. This
+       *   parameter is mutually exclusive with @p order.
+       * @param explicit_butcher_table Name of the explicit (ERK) Butcher
+       *   table. An empty string means no explicit table is selected, which
+       *   is equivalent to passing `"ARKODE_ERK_NONE"` to SUNDIALS. This
+       *   parameter is mutually exclusive with @p order.
        */
       explicit AdditionalData(
         const unsigned int order                                 = 0,
@@ -426,7 +437,9 @@ namespace SUNDIALS
         const bool         implicit_function_is_linear           = false,
         const bool         implicit_function_is_time_independent = false,
         const bool         mass_is_time_independent              = false,
-        const int          anderson_acceleration_subspace        = 3);
+        const int          anderson_acceleration_subspace        = 3,
+        const std::string &implicit_butcher_table                = "",
+        const std::string &explicit_butcher_table                = "");
 
       /**
        * Add all AdditionalData() parameters to the given ParameterHandler
@@ -448,6 +461,10 @@ namespace SUNDIALS
       /**
        * Desired order of accuracy for the time integration. If set to 0
        * the default order for the chosen method is used.
+       *
+       * This option is mutually exclusive with implicit_butcher_table and
+       * explicit_butcher_table: either the order is specified, or specific
+       * Butcher tables are chosen, but not both.
        */
       unsigned int order;
 
@@ -479,6 +496,28 @@ namespace SUNDIALS
        * meaningful if the packaged SUNDIALS fixed-point solver is used.
        */
       int anderson_acceleration_subspace;
+
+      /**
+       * Name of the implicit (DIRK) Butcher table to use. An empty string
+       * leaves the implicit table unset, equivalent to passing
+       * `"ARKODE_DIRK_NONE"` to SUNDIALS (i.e., no implicit component).
+       *
+       * Must be a name recognised by ARKStep (e.g.,
+       * `"ARKODE_SDIRK_2_1_2"`, `"ARKODE_ARK324L2SA_DIRK_4_2_3"`). This
+       * option is mutually exclusive with order.
+       */
+      std::string implicit_butcher_table;
+
+      /**
+       * Name of the explicit (ERK) Butcher table to use. An empty string
+       * leaves the explicit table unset, equivalent to passing
+       * `"ARKODE_ERK_NONE"` to SUNDIALS (i.e., no explicit component).
+       *
+       * Must be a name recognised by ARKStep (e.g.,
+       * `"ARKODE_BOGACKI_SHAMPINE_4_2_3"`, `"ARKODE_FEHLBERG_13_7_8"`). This
+       * option is mutually exclusive with order.
+       */
+      std::string explicit_butcher_table;
     };
 
     /**
@@ -968,7 +1007,9 @@ namespace SUNDIALS
     const bool         implicit_function_is_linear,
     const bool         implicit_function_is_time_independent,
     const bool         mass_is_time_independent,
-    const int          anderson_acceleration_subspace)
+    const int          anderson_acceleration_subspace,
+    const std::string &implicit_butcher_table,
+    const std::string &explicit_butcher_table)
     : order(order)
     , maximum_non_linear_iterations(maximum_non_linear_iterations)
     , implicit_function_is_linear(implicit_function_is_linear)
@@ -976,6 +1017,8 @@ namespace SUNDIALS
         implicit_function_is_time_independent)
     , mass_is_time_independent(mass_is_time_independent)
     , anderson_acceleration_subspace(anderson_acceleration_subspace)
+    , implicit_butcher_table(implicit_butcher_table)
+    , explicit_butcher_table(explicit_butcher_table)
   {}
 
 
@@ -994,6 +1037,8 @@ namespace SUNDIALS
     prm.add_parameter("Mass is time independent", mass_is_time_independent);
     prm.add_parameter("Anderson-acceleration subspace",
                       anderson_acceleration_subspace);
+    prm.add_parameter("Implicit Butcher table", implicit_butcher_table);
+    prm.add_parameter("Explicit Butcher table", explicit_butcher_table);
   }
 
 } // namespace SUNDIALS

--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -146,6 +146,13 @@ namespace SUNDIALS
 
     setup_mass_solver(y0, inv_ctx);
 
+    AssertThrow(
+      data.order == 0 || (data.implicit_butcher_table.empty() &&
+                          data.explicit_butcher_table.empty()),
+      ExcMessage(
+        "Either the order of accuracy or the Butcher table names may be "
+        "specified, but not both."));
+
     if (data.order != 0)
       {
 #  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
@@ -153,6 +160,19 @@ namespace SUNDIALS
 #  else
         status = ARKStepSetOrder(arkode_mem, data.order);
 #  endif
+        AssertARKode(status);
+      }
+    else if (!data.implicit_butcher_table.empty() ||
+             !data.explicit_butcher_table.empty())
+      {
+        const std::string itable = data.implicit_butcher_table.empty() ?
+                                     "ARKODE_DIRK_NONE" :
+                                     data.implicit_butcher_table;
+        const std::string etable = data.explicit_butcher_table.empty() ?
+                                     "ARKODE_ERK_NONE" :
+                                     data.explicit_butcher_table;
+        status =
+          ARKStepSetTableName(arkode_mem, itable.c_str(), etable.c_str());
         AssertARKode(status);
       }
 

--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -48,7 +48,25 @@ namespace SUNDIALS
   ARKStepper<VectorType>::ARKStepper(const AdditionalData &data)
     : arkode_mem(nullptr)
     , data(data)
-  {}
+  {
+#  if DEAL_II_SUNDIALS_VERSION_LT(6, 4, 0)
+    AssertThrow(
+      data.implicit_butcher_table.empty() &&
+        data.explicit_butcher_table.empty(),
+      ExcMessage(
+        "Setting ARK Butcher tables by name requires SUNDIALS version 6.4.0 "
+        "or later. Set the order of accuracy instead or use custom_setup "
+        "callback to set the Butcher tables manually using "
+        "function ARKStepSetTableNum()."));
+#  endif
+
+    AssertThrow(
+      data.order == 0 || (data.implicit_butcher_table.empty() &&
+                          data.explicit_butcher_table.empty()),
+      ExcMessage(
+        "Either the order of accuracy or the Butcher table names may be "
+        "specified, but not both."));
+  }
 
 
 
@@ -146,13 +164,6 @@ namespace SUNDIALS
 
     setup_mass_solver(y0, inv_ctx);
 
-    AssertThrow(
-      data.order == 0 || (data.implicit_butcher_table.empty() &&
-                          data.explicit_butcher_table.empty()),
-      ExcMessage(
-        "Either the order of accuracy or the Butcher table names may be "
-        "specified, but not both."));
-
     if (data.order != 0)
       {
 #  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
@@ -165,6 +176,7 @@ namespace SUNDIALS
     else if (!data.implicit_butcher_table.empty() ||
              !data.explicit_butcher_table.empty())
       {
+#  if DEAL_II_SUNDIALS_VERSION_GTE(6, 4, 0)
         const std::string itable = data.implicit_butcher_table.empty() ?
                                      "ARKODE_DIRK_NONE" :
                                      data.implicit_butcher_table;
@@ -174,6 +186,7 @@ namespace SUNDIALS
         status =
           ARKStepSetTableName(arkode_mem, itable.c_str(), etable.c_str());
         AssertARKode(status);
+#  endif
       }
 
     if (custom_setup)

--- a/tests/sundials/arkode_arkstep_order_butcher.cc
+++ b/tests/sundials/arkode_arkstep_order_butcher.cc
@@ -1,0 +1,223 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/sundials/arkode.h>
+#include <deal.II/sundials/arkode_stepper.h>
+
+#include <arkode/arkode_arkstep.h>
+
+#include <array>
+
+#include "../tests.h"
+
+
+// Test ARKStepper::AdditionalData parameters for controlling the accuracy
+// order and Butcher tables of ARKStep.
+//
+// Based on the Brusselator benchmark (arkode_03). Two sub-tests are run with
+// different stepper configurations:
+//   1. Explicitly set order of accuracy = 3 via AdditionalData::order.
+//   2. Select order-2 paired Butcher tables (ARKODE_ARK2_DIRK_3_1_2 /
+//      ARKODE_ARK2_ERK_3_1_2) via AdditionalData::implicit_butcher_table and
+//      AdditionalData::explicit_butcher_table.
+//
+// Both runs solve the same stiff Brusselator IVP. We compare final states and
+// solver work statistics to make method differences visible.
+
+using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+struct RunResult
+{
+  std::array<double, 3> final_state;
+
+  long int n_steps                    = -1;
+  long int n_step_attempts            = -1;
+  long int n_error_test_failures      = -1;
+  long int n_explicit_rhs_evaluations = -1;
+  long int n_implicit_rhs_evaluations = -1;
+  long int n_nonlinear_iterations     = -1;
+  long int n_nonlinear_conv_failures  = -1;
+};
+
+
+static void
+print_work_stats(const RunResult &result)
+{
+  deallog << "work stats:" << std::endl;
+  deallog << "  steps = " << result.n_steps << std::endl;
+  deallog << "  step attempts = " << result.n_step_attempts << std::endl;
+  deallog << "  error test failures = " << result.n_error_test_failures
+          << std::endl;
+  deallog << "  explicit rhs evals = " << result.n_explicit_rhs_evaluations
+          << std::endl;
+  deallog << "  implicit rhs evals = " << result.n_implicit_rhs_evaluations
+          << std::endl;
+  deallog << "  nonlinear iterations = " << result.n_nonlinear_iterations
+          << std::endl;
+  deallog << "  nonlinear convergence failures = "
+          << result.n_nonlinear_conv_failures << std::endl;
+
+  if (result.n_step_attempts > 0 && result.n_steps >= 0)
+    {
+      const double rejection_rate =
+        static_cast<double>(result.n_step_attempts - result.n_steps) /
+        static_cast<double>(result.n_step_attempts);
+      deallog << "  rejection rate = " << std::setprecision(6) << rejection_rate
+              << std::endl;
+    }
+}
+
+// Set up ARKode AdditionalData for the Brusselator benchmark.
+static SUNDIALS::ARKode<VectorType>::AdditionalData
+make_arkode_data(const double absolute_tolerance,
+                 const double relative_tolerance)
+{
+  return {0.0 /*initial_time*/,
+          3.0 /*final_time*/,
+          1e-6 /*initial_step_size*/,
+          0.1 /*output_period*/,
+          1e-7 /*minimum_step_size*/,
+          absolute_tolerance,
+          relative_tolerance};
+}
+
+
+// Run the Brusselator benchmark with the given stepper.
+static RunResult
+run(const SUNDIALS::ARKStepper<VectorType>::AdditionalData &stepper_data,
+    const double                                            absolute_tolerance,
+    const double                                            relative_tolerance)
+{
+  RunResult result;
+
+  SUNDIALS::ARKStepper<VectorType> stepper(stepper_data);
+
+  const double u0 = 3.9, v0 = 1.1, w0 = 2.8;
+  const double a = 1.2, b = 2.5, eps = 1e-5;
+
+  stepper.implicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = 0;
+      ydot[1] = 0;
+      ydot[2] = -y[2] / eps;
+    };
+
+  stepper.explicit_function =
+    [&](double, const VectorType &y, VectorType &ydot) {
+      ydot[0] = a - (y[2] + 1) * y[0] + y[1] * y[0] * y[0];
+      ydot[1] = y[2] * y[0] - y[1] * y[0] * y[0];
+      ydot[2] = b / eps - y[2] * y[0];
+    };
+
+  const auto arkode_data =
+    make_arkode_data(absolute_tolerance, relative_tolerance);
+  SUNDIALS::ARKode<VectorType> ode(stepper, arkode_data);
+
+  void *arkode_mem = nullptr;
+
+  ode.custom_setup = [&](void *arkode_mem_ptr) {
+    arkode_mem = arkode_mem_ptr;
+
+    int ierr = ARKStepSetMaxNumSteps(arkode_mem_ptr, 20000);
+    AssertThrow(ierr == 0, ExcInternalError());
+  };
+
+  VectorType y(3);
+  y[0] = u0;
+  y[1] = v0;
+  y[2] = w0;
+
+  ode.solve_ode(y);
+
+  AssertThrow(arkode_mem != nullptr, ExcInternalError());
+
+  result.final_state = {{y[0], y[1], y[2]}};
+
+  int ierr = ARKStepGetNumSteps(arkode_mem, &result.n_steps);
+  AssertThrow(ierr == 0, ExcInternalError());
+
+#if DEAL_II_SUNDIALS_VERSION_GTE(5, 2, 0)
+  ierr = ARKStepGetNumStepAttempts(arkode_mem, &result.n_step_attempts);
+  AssertThrow(ierr == 0, ExcInternalError());
+
+  ierr = ARKStepGetNumErrTestFails(arkode_mem, &result.n_error_test_failures);
+  AssertThrow(ierr == 0, ExcInternalError());
+
+  ierr = ARKStepGetNumRhsEvals(arkode_mem,
+                               &result.n_explicit_rhs_evaluations,
+                               &result.n_implicit_rhs_evaluations);
+  AssertThrow(ierr == 0, ExcInternalError());
+
+  ierr =
+    ARKStepGetNumNonlinSolvIters(arkode_mem, &result.n_nonlinear_iterations);
+  AssertThrow(ierr == 0, ExcInternalError());
+
+  ierr = ARKStepGetNumNonlinSolvConvFails(arkode_mem,
+                                          &result.n_nonlinear_conv_failures);
+  AssertThrow(ierr == 0, ExcInternalError());
+#endif
+
+  return result;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  auto make_stepper_data = []() {
+    SUNDIALS::ARKStepper<VectorType>::AdditionalData stepper_data;
+    stepper_data.implicit_function_is_linear           = true;
+    stepper_data.implicit_function_is_time_independent = true;
+    stepper_data.maximum_non_linear_iterations         = 50;
+    stepper_data.anderson_acceleration_subspace        = 10;
+    return stepper_data;
+  };
+
+  // Sub-test 1: set the overall order of accuracy to 3.
+  {
+    deallog << "=== Order 3 ===" << std::endl;
+
+    auto stepper_data  = make_stepper_data();
+    stepper_data.order = 3;
+
+    const auto order_3_result = run(stepper_data, 1e-4, 1e-4);
+    deallog << std::fixed << std::setprecision(6)
+            << "final = " << order_3_result.final_state[0] << ' '
+            << order_3_result.final_state[1] << ' '
+            << order_3_result.final_state[2] << std::endl;
+    print_work_stats(order_3_result);
+  }
+
+  // Sub-test 2: select order-2 paired ARK Butcher tables explicitly.
+  // ARKODE_ARK2_DIRK_3_1_2 (implicit) and ARKODE_ARK2_ERK_3_1_2 (explicit)
+  // form a second-order additive Runge-Kutta pair.
+  {
+    deallog << "=== Butcher tables order 2 ===" << std::endl;
+
+    auto stepper_data                   = make_stepper_data();
+    stepper_data.implicit_butcher_table = "ARKODE_ARK2_DIRK_3_1_2";
+    stepper_data.explicit_butcher_table = "ARKODE_ARK2_ERK_3_1_2";
+
+    const auto butcher_2_result = run(stepper_data, 1e-4, 1e-4);
+    deallog << std::fixed << std::setprecision(6)
+            << "final = " << butcher_2_result.final_state[0] << ' '
+            << butcher_2_result.final_state[1] << ' '
+            << butcher_2_result.final_state[2] << std::endl;
+    print_work_stats(butcher_2_result);
+  }
+}

--- a/tests/sundials/arkode_arkstep_order_butcher.output
+++ b/tests/sundials/arkode_arkstep_order_butcher.output
@@ -1,0 +1,23 @@
+
+DEAL::=== Order 3 ===
+DEAL::final = 0.789523 2.326694 2.500137
+DEAL::work stats:
+DEAL::  steps = 41
+DEAL::  step attempts = 41
+DEAL::  error test failures = 0
+DEAL::  explicit rhs evals = 164
+DEAL::  implicit rhs evals = 540
+DEAL::  nonlinear iterations = 376
+DEAL::  nonlinear convergence failures = 0
+DEAL::  rejection rate = 0.000000
+DEAL::=== Butcher tables order 2 ===
+DEAL::final = 0.789602 2.326738 2.499895
+DEAL::work stats:
+DEAL::  steps = 99
+DEAL::  step attempts = 99
+DEAL::  error test failures = 0
+DEAL::  explicit rhs evals = 297
+DEAL::  implicit rhs evals = 897
+DEAL::  nonlinear iterations = 600
+DEAL::  nonlinear convergence failures = 0
+DEAL::  rejection rate = 0.000000


### PR DESCRIPTION
Sometimes, it is quite handy to specify not only the order, but also particular Butcher tables to use for integration, especially when performance of different integrators is investigated. For this reason, I decided to add two additional parameters to `ARKStepper::AdditionalData`. These two options, when provided, are mutually exclusive with the integration order and for this reason I decided to add them here: let this aspect to be properly handled by the wrapper rather than individually by a user when working via the `custom_setup` callback.