### PR TITLE
See if we can do 'import std'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ if(POLICY CMP0177)
   cmake_policy(SET CMP0177 NEW)
 endif()
 
+# Allow CMake to support C++23-style 'import std' statements by
+# querying the compiler whether it has support for this:
+set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "0e5672d5-25f0-410a-b320-b4618e00155b")
+
+
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 
 #
@@ -95,6 +101,7 @@ endif()
 # do it at this point:
 #
 verbose_include(${CMAKE_SOURCE_DIR}/cmake/setup_cached_variables.cmake)
+
 
 #
 # Now, set the project and set up the rest:

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -168,7 +168,6 @@ if(DEAL_II_WITH_CXX20_MODULE)
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/petsc.ccm"
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/psblas.ccm"
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/slepc.ccm"
-    "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/std.ccm"
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/sundials.ccm"
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/taskflow.ccm"
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/tbb.ccm"
@@ -177,6 +176,26 @@ if(DEAL_II_WITH_CXX20_MODULE)
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/vtk.ccm"
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/zlib.ccm"
     )
+
+  #
+  # If CMake is new enough, and if we are building in C++23 or later
+  # mode, then we can use 'import std;' with a compiler-provided
+  # module that wraps everything in namespace std, assuming the
+  # compiler supports it. For compatibility with the situation where
+  # we can't support that, we want everything in namespace std to be
+  # in a module partition dealii.external.std, which we do in the file
+  # std_cxx23.ccm.
+  #
+  if ((CMAKE_VERSION VERSION_GREATER_EQUAL 3.30) AND
+        (${CMAKE_CXX_STANDARD} GREATER_EQUAL 23) AND
+        ("23" IN_LIST CMAKE_CXX_COMPILER_IMPORT_STD))
+    list(APPEND _external_interface_module_partition_units_public
+      "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/std_cxx23.ccm")
+  else()
+    list(APPEND _external_interface_module_partition_units_public
+      "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/std.ccm")
+  endif()
+
 
   set(_external_interface_module_partition_units_private
     "${CMAKE_CURRENT_SOURCE_DIR}/interface_module_partitions/metis.ccm"
@@ -372,6 +391,20 @@ if(DEAL_II_WITH_CXX20_MODULE)
     target_compile_features(${DEAL_II_TARGET_NAME}_module_${build_lowercase}
       INTERFACE cxx_std_${CMAKE_CXX_STANDARD}
       )
+
+    #
+    # If CMake is new enough, and if we are building in C++23 or later
+    # mode, then we can use 'import std;' with a compiler-provided
+    # module that wraps everything in namespace std, assuming the
+    # compiler supports it. Set the appropriate property on the
+    # library to enable this behavior.
+    #
+    if ((CMAKE_VERSION VERSION_GREATER_EQUAL 3.30) AND
+        (${CMAKE_CXX_STANDARD} GREATER_EQUAL 23) AND
+        ("23" IN_LIST CMAKE_CXX_COMPILER_IMPORT_STD))
+      set_target_properties(${DEAL_II_TARGET_NAME}_module_${build_lowercase}
+        PROPERTIES CXX_MODULE_STD ON)
+    endif()
 
     set_target_properties(${DEAL_II_TARGET_NAME}_module_${build_lowercase}
       PROPERTIES

--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -11,6 +11,10 @@
 // -----------------------------------------------------------------------------
 
 
+// This file is used in C++20 mode where compilers did not support
+// 'import std;'. As a consequence, we have to wrap everything in
+// namespace std ourselves.
+
 // It is very inefficient in the module system to have repeated
 // #includes in many module partition files because when you 'import'
 // those partitions, you also have to load everything they

--- a/module/interface_module_partitions/std_cxx23.ccm
+++ b/module/interface_module_partitions/std_cxx23.ccm
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// This file is used in C++23 mode and later where compilers do support
+// 'import std;'. As a consequence, we do not have to to wrap everything in
+// namespace std ourselves.
+
+module;
+
+#include <deal.II/macros.h>
+
+#ifndef DEAL_II_HAVE_CXX23
+#  error "This file should not be compiled in pre-C++23 mode"
+#endif
+
+
+
+export module dealii.external.std;
+
+// Instead of wrapping everything ourselves, simply take what compiler writers
+// wrapped and re-export it under the module name dealii.external.std where we
+// would otherwise have our own wrappers.
+export import std;


### PR DESCRIPTION
Since we now have a CI check that has C++23 and modules both enabled, I thought I'd try to see if we can support `import std` instead of having to export everything ourselves. It turns out that CMake says that's not supported on my system (perhaps because the base GCC compiler/its libstdc++ is too old) and so I can't actually test this patch, but at least *in principle*, this should work.

Part of #18071.