### PR TITLE
Improve checking for errors.

### DIFF
--- a/doc/news/changes/minor/20260512Bangerth
+++ b/doc/news/changes/minor/20260512Bangerth
@@ -1,0 +1,6 @@
+Fixed: The default mapping provided to FEFieldFunction only worked for
+hypercube meshes. This is now fixed by introducing a second
+constructor that determines what the appropriate linear mapping for a
+given mesh is, and then using this mapping.
+<br>
+(Wolfgang Bangerth, Sam Scheuerman, David Wells, 2026/05/12)

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -188,7 +188,8 @@ namespace Functions
      * lifetime of this object. The number of components of this functions is
      * equal to the number of components of the finite element object. If a
      * mapping is specified, that is what is used to find out where the points
-     * lay. Otherwise the standard Q1 mapping is used.
+     * lay. Otherwise the standard $Q_1$ mapping is used, which is appropriate
+     * for quad and hex meshes, but not for simplex or mixed meshes.
      */
     FEFieldFunction(
       const DoFHandler<dim, spacedim> &dh,

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -183,18 +183,32 @@ namespace Functions
   {
   public:
     /**
-     * Construct a vector function. A smart pointers is stored to the dof
-     * handler, so you have to make sure that it make sense for the entire
-     * lifetime of this object. The number of components of this functions is
-     * equal to the number of components of the finite element object. If a
-     * mapping is specified, that is what is used to find out where the points
-     * lay. Otherwise the standard $Q_1$ mapping is used, which is appropriate
-     * for quad and hex meshes, but not for simplex or mixed meshes.
+     * Construct a vector function. The number of components of this functions
+     * is equal to the number of components of the finite element object. The
+     * mapping provided is used to find out where the points at which the
+     * function is evaluated are located in reference space.
+     *
+     * This class stores pointers to the arguments
+     * provided, so you have to make sure that they remain alive for the entire
+     * lifetime of this object.
      */
-    FEFieldFunction(
-      const DoFHandler<dim, spacedim> &dh,
-      const VectorType                &data_vector,
-      const Mapping<dim>              &mapping = StaticMappingQ1<dim>::mapping);
+    FEFieldFunction(const DoFHandler<dim, spacedim> &dh,
+                    const VectorType                &data_vector,
+                    const Mapping<dim>              &mapping);
+
+    /**
+     * Construct a vector function. The number of components of this functions
+     * is equal to the number of components of the finite element object. In
+     * contrast to the previous constructor, this constructor uses a linear
+     * mapping appropriate for the reference cell type used by the triangulation
+     * that underlies the `dh` object.
+     *
+     * This class stores pointers to the arguments
+     * provided, so you have to make sure that they remain alive for the entire
+     * lifetime of this object.
+     */
+    FEFieldFunction(const DoFHandler<dim, spacedim> &dh,
+                    const VectorType                &data_vector);
 
     /**
      * Set the current cell. If you know in advance where your points lie, you

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -49,7 +49,18 @@ namespace Functions
     , mapping(mymapping)
     , cache(dh->get_triangulation(), mymapping)
     , cell_hint(dh->end())
-  {}
+  {
+    // Make sure the mapping is compatible with the cell type of the
+    // mesh. Since we only accept a single mapping, the mesh must also
+    // use only one kind of cell.
+    Assert(mydh.get_triangulation().is_mixed_mesh() == false,
+           ExcNotImplemented());
+    Assert(mapping.is_compatible_with(
+             mydh.get_triangulation().get_reference_cells()[0]),
+           ExcMessage("The mapping you provided (or that was chosen via the "
+                      "constructor's default argument) is not compatible "
+                      "with the cell type of the mesh you are using."));
+  }
 
 
 

--- a/include/deal.II/numerics/fe_field_function.templates.h
+++ b/include/deal.II/numerics/fe_field_function.templates.h
@@ -65,6 +65,22 @@ namespace Functions
 
 
   template <int dim, typename VectorType, int spacedim>
+  FEFieldFunction<dim, VectorType, spacedim>::FEFieldFunction(
+    const DoFHandler<dim, spacedim> &mydh,
+    const VectorType                &myv)
+    : // Defer to the other constructor, but with a mapping that
+      // is appropriate for the cell type used
+    FEFieldFunction<dim, VectorType, spacedim>(
+      mydh,
+      myv,
+      mydh.get_triangulation()
+        .get_reference_cells()[0]
+        .template get_default_linear_mapping<spacedim>())
+  {}
+
+
+
+  template <int dim, typename VectorType, int spacedim>
   void
   FEFieldFunction<dim, VectorType, spacedim>::set_active_cell(
     const typename DoFHandler<dim, spacedim>::active_cell_iterator &newcell)

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -1828,6 +1828,12 @@ BoundingBox<spacedim>
 MappingQ<dim, spacedim>::get_bounding_box(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
+  Assert(is_compatible_with(cell->reference_cell()),
+         ExcMessage(
+           "You are trying to call a MappingQ function with a cell of type " +
+           cell->reference_cell().to_string() +
+           " but MappingQ only works for hypercube cells."));
+
   boost::container::small_vector<Point<spacedim>, 200> points;
   this->compute_mapping_support_points(cell, points);
   return BoundingBox<spacedim>(points);


### PR DESCRIPTION
My student @sam0h51 gave me a piece of code that threw an error about accessing the fifth vertex of a cell that has only four (it's a tet). The error was not at all useful: The ultimate issue is that the code was using `MappingQ1` with a simplex mesh. We can improve the error we get.