### PR TITLE
Create copies of arguments in exception-related functions.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1242,10 +1242,19 @@ namespace deal_II_exceptions
      * A function that compares two values for equality, after converting to a
      * common type to avoid compiler warnings when comparing objects of
      * different types (e.g., unsigned and signed variables).
+     *
+     * This function takes its arguments by value, rather than reference,
+     * because this ensures that we can also compare variables that may
+     * not live in a memory space accessible at the place where the
+     * comparison occurs -- say, comparing `static constexpr` member
+     * variables (which are variables that live in global memory) on
+     * a device that has a separate memory space. The copy this implies
+     * is generally not problematic because we apply this function to
+     * scalar values with integer types.
      */
     template <typename T, typename U>
     inline DEAL_II_HOST_DEVICE constexpr bool
-    compare_for_equality(const T &t, const U &u)
+    compare_for_equality(const T t, const U u)
     {
       using common_type = std::common_type_t<T, U>;
       return static_cast<common_type>(t) == static_cast<common_type>(u);
@@ -1256,10 +1265,19 @@ namespace deal_II_exceptions
      * A function that compares two values with `operator<`, after converting to
      * a common type to avoid compiler warnings when comparing objects of
      * different types (e.g., unsigned and signed variables).
+     *
+     * This function takes its arguments by value, rather than reference,
+     * because this ensures that we can also compare variables that may
+     * not live in a memory space accessible at the place where the
+     * comparison occurs -- say, comparing `static constexpr` member
+     * variables (which are variables that live in global memory) on
+     * a device that has a separate memory space. The copy this implies
+     * is generally not problematic because we apply this function to
+     * scalar values with integer types.
      */
     template <typename T, typename U>
     inline DEAL_II_HOST_DEVICE constexpr bool
-    compare_less_than(const T &t, const U &u)
+    compare_less_than(const T t, const U u)
     {
       using common_type = std::common_type_t<T, U>;
       return (static_cast<common_type>(t) < static_cast<common_type>(u));


### PR DESCRIPTION
The discussion in #19618 and the link to https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#const-variables provided by @masterleinad shows that we can't take references to `static constexpr` variables when in device code. That also prevented us from using the current implementation of `AssertIndexRange`. 

This patch fixes the issue by making sure we're not taking references in the assert machinery.