### PR TITLE
Ensure index>=0 in AssertIndexRange.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -898,13 +898,20 @@
  *
  * @ingroup Exceptions
  */
-#define AssertIndexRange(index, range)                                         \
-  Assert(::dealii::deal_II_exceptions::internals::compare_less_than(index,     \
-                                                                    range),    \
-         ::dealii::ExcIndexRangeType<::dealii::internal::argument_type_t<void( \
-           std::common_type_t<decltype(index), decltype(range)>)>>((index),    \
-                                                                   0,          \
-                                                                   (range)))
+#define AssertIndexRange(index, range)                                    \
+  Assert(                                                                 \
+    ::dealii::deal_II_exceptions::internals::compare_less_than(index,     \
+                                                               range) &&  \
+      [](const auto ind) {                                                \
+        if constexpr (std::is_unsigned_v<decltype(ind)>)                  \
+          return true;                                                    \
+        else                                                              \
+          return (ind >= decltype(ind)(0));                               \
+      }(index),                                                           \
+    ::dealii::ExcIndexRangeType<::dealii::internal::argument_type_t<void( \
+      std::common_type_t<decltype(index), decltype(range)>)>>((index),    \
+                                                              0,          \
+                                                              (range)))
 
 /**
  * An assertion that checks whether a number is finite or not. We explicitly


### PR DESCRIPTION
The discussion in #19618 highlighted that in `AssertIndexRange(index, size)`, we compare `index<size`, but not `index>=0`. We should really be checking both. Of course, in almost all cases, `index` will be an unsigned variable, and so the latter comparison is implicitly true. But in #19618, the index is a signed integer, and there we should check.

This patch checks the lower bound as well. It took a few iterations to get this to work so that we don't get warnings about tautological comparisons -- in essence, I need to avoid the comparison altogether when we have an unsigned variable, and the only way to do that is to hide it behind an `if constexpr` statement which requires me to put the comparison into a lambda function that I execute right where it is declared. It isn't pretty, but it does the job.