### PR TITLE
Introduce ReferenceCells::n_vertices_to_reference_cell().

### DIFF
--- a/doc/news/changes/minor/20260512Bangerth2
+++ b/doc/news/changes/minor/20260512Bangerth2
@@ -1,0 +1,4 @@
+Moved: The function ReferenceCell::n_vertices_to_type() has been deprecated.
+Its replacement is ReferenceCells::n_vertices_to_reference_cell().
+<br>
+(Wolfgang Bangerth, 2026/05/12)

--- a/include/deal.II/cgal/utilities.h
+++ b/include/deal.II/cgal/utilities.h
@@ -621,7 +621,7 @@ namespace CGALWrappers
 
     if constexpr (spacedim == 2)
       if ((structdim == 2) &&
-          (ReferenceCell<2>::n_vertices_to_type(structdim, vertices.size()) ==
+          (ReferenceCells::n_vertices_to_reference_cell<2>(vertices.size()) ==
            ReferenceCells::Quadrilateral))
         std::swap(vertices[2], vertices[3]);
   }

--- a/include/deal.II/grid/cell_data.h
+++ b/include/deal.II/grid/cell_data.h
@@ -77,8 +77,8 @@ struct CellData
    * `vertices` member variable after construction.
    *
    * The kind of cell described by the current object is then determined by
-   * calling ReferenceCell::n_vertices_to_type() on the number of vertices
-   * described by this array.
+   * calling ReferenceCells::n_vertices_to_reference_cell() on the number of
+   * vertices described by this array.
    */
   std::vector<unsigned int> vertices;
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -134,7 +134,11 @@ public:
    * `n_vertices==4`, this function will return ReferenceCells::Quadrilateral.
    * But if `dim==3` and `n_vertices==4`, it will return
    * ReferenceCells::Tetrahedron.
+   *
+   * @deprecated Use ReferenceCells::n_vertices_to_reference_cell() instead.
    */
+  DEAL_II_DEPRECATED_EARLY_WITH_COMMENT(
+    "Use ReferenceCells::n_vertices_to_reference_cell() instead")
   static ReferenceCell
   n_vertices_to_type(const int dim_, const unsigned int n_vertices);
 
@@ -1423,6 +1427,23 @@ namespace ReferenceCells
   template <int dim>
   constexpr const ReferenceCell<dim> &
   get_hypercube();
+
+  /**
+   * Given the number of vertices a reference cell has (provided as
+   * a function argument), and the dimension the reference cell lives in
+   * (provided as a template argument), return the ReferenceCell object
+   * that corresponds to this input. For example, if you call
+   * `ReferenceCells::n_vertices_to_reference_cell<2>(4)`, you will get
+   * ReferenceCells::Quadrilateral because the only 2d reference cell
+   * with four vertices is a quadrilateral. On the other hand, if you call
+   * `ReferenceCells::n_vertices_to_reference_cell<3>(4)`, you will get
+   * ReferenceCells::Tetrahedron because the only 3d reference cell
+   * with four vertices is a tetrahedron.
+   */
+  template <int dim>
+  ReferenceCell<dim>
+  n_vertices_to_reference_cell(const unsigned int n_vertices);
+
 
   /**
    * Return the maximum number of vertices an object of dimension `structdim`
@@ -3425,6 +3446,49 @@ namespace ReferenceCells
 
 
 
+  template <int dim>
+  inline ReferenceCell<dim>
+  n_vertices_to_reference_cell(const unsigned int n_vertices)
+  {
+    if constexpr (dim == 0)
+      if (n_vertices == 1)
+        return ReferenceCells::Vertex;
+
+    if constexpr (dim == 1)
+      {
+        if (n_vertices == 2)
+          return ReferenceCells::Line;
+      }
+
+    if constexpr (dim == 2)
+      {
+        if (n_vertices == 3)
+          return ReferenceCells::Triangle;
+        else if (n_vertices == 4)
+          return ReferenceCells::Quadrilateral;
+      }
+
+    if constexpr (dim == 3)
+      {
+        if (n_vertices == 4)
+          return ReferenceCells::Tetrahedron;
+        else if (n_vertices == 5)
+          return ReferenceCells::Pyramid;
+        if (n_vertices == 6)
+          return ReferenceCells::Wedge;
+        else if (n_vertices == 8)
+          return ReferenceCells::Hexahedron;
+      }
+
+    Assert(false,
+           ExcMessage("The combination of dim = " + std::to_string(dim) +
+                      " and n_vertices = " + std::to_string(n_vertices) +
+                      " does not correspond to a known reference cell type."));
+    return ReferenceCells::Invalid<dim>;
+  }
+
+
+
   template <int structdim>
   inline constexpr unsigned int
   max_n_vertices()
@@ -3468,42 +3532,7 @@ ReferenceCell<dim>::n_vertices_to_type(const int          dim_,
                                        const unsigned int n_vertices)
 {
   AssertDimension(dim, dim_);
-
-  if constexpr (dim == 0)
-    if (n_vertices == 1)
-      return ReferenceCells::Vertex;
-
-  if constexpr (dim == 1)
-    {
-      if (n_vertices == 2)
-        return ReferenceCells::Line;
-    }
-
-  if constexpr (dim == 2)
-    {
-      if (n_vertices == 3)
-        return ReferenceCells::Triangle;
-      else if (n_vertices == 4)
-        return ReferenceCells::Quadrilateral;
-    }
-
-  if constexpr (dim == 3)
-    {
-      if (n_vertices == 4)
-        return ReferenceCells::Tetrahedron;
-      else if (n_vertices == 5)
-        return ReferenceCells::Pyramid;
-      if (n_vertices == 6)
-        return ReferenceCells::Wedge;
-      else if (n_vertices == 8)
-        return ReferenceCells::Hexahedron;
-    }
-
-  Assert(false,
-         ExcMessage("The combination of dim = " + std::to_string(dim) +
-                    " and n_vertices = " + std::to_string(n_vertices) +
-                    " does not correspond to a known reference cell type."));
-  return ReferenceCells::Invalid<dim>;
+  return ReferenceCells::n_vertices_to_reference_cell<dim>(n_vertices);
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4387,7 +4387,7 @@ namespace internal
         vertices)
     {
       const ReferenceCell<dim> reference_cell =
-        ReferenceCell<dim>::n_vertices_to_type(dim, vertices.size());
+        ReferenceCells::n_vertices_to_reference_cell<dim>(vertices.size());
 
       if (reference_cell == ReferenceCells::Line)
         // Return the distance between the two vertices

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3416,7 +3416,8 @@ GridIn<dim, spacedim>::read_partitioned_msh(const std::string &file_prefix,
                     {
                       // Determine reference cell type from number of vertices
                       const ReferenceCell<dim> ref_cell =
-                        ReferenceCell<dim>::n_vertices_to_type(dim, n_vertices);
+                        ReferenceCells::n_vertices_to_reference_cell<dim>(
+                          n_vertices);
 
                       // Number of faces for this reference cell
                       const unsigned int n_faces = ref_cell.n_faces();
@@ -4566,7 +4567,8 @@ namespace
             const CellData<dim> &cell =
               cells[face_id / ReferenceCells::max_n_faces<dim>()];
             const auto reference_cell =
-              ReferenceCell<dim>::n_vertices_to_type(dim, cell.vertices.size());
+              ReferenceCells::n_vertices_to_reference_cell<dim>(
+                cell.vertices.size());
             const unsigned int deal_face_n =
               reference_cell.exodusii_face_to_deal_face(local_face_n);
             const auto face_reference_cell =

--- a/source/grid/grid_tools_topology.cc
+++ b/source/grid/grid_tools_topology.cc
@@ -532,7 +532,8 @@ namespace GridTools
           {
             ++n_negative_cells;
             const auto reference_cell =
-              ReferenceCell<dim>::n_vertices_to_type(dim, vertices.size());
+              ReferenceCells::n_vertices_to_reference_cell<dim>(
+                vertices.size());
 
             if (reference_cell.is_hyper_cube())
               {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3063,7 +3063,8 @@ namespace internal
             }
 
           cell_types.push_back(
-            ReferenceCell<dim>::n_vertices_to_type(dim, cell.vertices.size()));
+            ReferenceCells::n_vertices_to_reference_cell<dim>(
+              cell.vertices.size()));
           all_reference_cells.insert(cell_types.back());
 
           // create CRS of vertices (to remove template argument dim)


### PR DESCRIPTION
As mentioned in #19391, all of the functions that *create* `ReferenceCell` objects are located in namespace `ReferenceCells`, except `ReferenceCell::n_vertices_to_type()`. This function moves the function to namespace `ReferenceCells::n_vertices_to_reference_cell()`. The second commit converts all uses of that function in our source files.

Fixes #19391.