### PR TITLE
Add guard for old SUNDIALS to the Butcher tables test

### DIFF
--- a/tests/sundials/arkode_arkstep_order_butcher.cc
+++ b/tests/sundials/arkode_arkstep_order_butcher.cc
@@ -203,6 +203,7 @@ main()
     print_work_stats(order_3_result);
   }
 
+#if DEAL_II_SUNDIALS_VERSION_GTE(6, 4, 0)
   // Sub-test 2: select order-2 paired ARK Butcher tables explicitly.
   // ARKODE_ARK2_DIRK_3_1_2 (implicit) and ARKODE_ARK2_ERK_3_1_2 (explicit)
   // form a second-order additive Runge-Kutta pair.
@@ -220,4 +221,5 @@ main()
             << butcher_2_result.final_state[2] << std::endl;
     print_work_stats(butcher_2_result);
   }
+#endif
 }

--- a/tests/sundials/arkode_arkstep_order_butcher.output
+++ b/tests/sundials/arkode_arkstep_order_butcher.output
@@ -10,14 +10,3 @@ DEAL::  implicit rhs evals = 540
 DEAL::  nonlinear iterations = 376
 DEAL::  nonlinear convergence failures = 0
 DEAL::  rejection rate = 0.000000
-DEAL::=== Butcher tables order 2 ===
-DEAL::final = 0.789602 2.326738 2.499895
-DEAL::work stats:
-DEAL::  steps = 99
-DEAL::  step attempts = 99
-DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 297
-DEAL::  implicit rhs evals = 897
-DEAL::  nonlinear iterations = 600
-DEAL::  nonlinear convergence failures = 0
-DEAL::  rejection rate = 0.000000

--- a/tests/sundials/arkode_arkstep_order_butcher.output.sundials64
+++ b/tests/sundials/arkode_arkstep_order_butcher.output.sundials64
@@ -1,0 +1,23 @@
+
+DEAL::=== Order 3 ===
+DEAL::final = 0.789523 2.326694 2.500137
+DEAL::work stats:
+DEAL::  steps = 41
+DEAL::  step attempts = 41
+DEAL::  error test failures = 0
+DEAL::  explicit rhs evals = 164
+DEAL::  implicit rhs evals = 540
+DEAL::  nonlinear iterations = 376
+DEAL::  nonlinear convergence failures = 0
+DEAL::  rejection rate = 0.000000
+DEAL::=== Butcher tables order 2 ===
+DEAL::final = 0.789602 2.326738 2.499895
+DEAL::work stats:
+DEAL::  steps = 99
+DEAL::  step attempts = 99
+DEAL::  error test failures = 0
+DEAL::  explicit rhs evals = 297
+DEAL::  implicit rhs evals = 897
+DEAL::  nonlinear iterations = 600
+DEAL::  nonlinear convergence failures = 0
+DEAL::  rejection rate = 0.000000


### PR DESCRIPTION
The test introduced in #19661 should crash in older versions of SUNDIALS. I assume the regression tester might catch it.