### PR TITLE
Improve polynomial allocations

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -576,19 +576,15 @@ TensorProductPolynomials<dim, PolynomialType>::compute_derivative(
   std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
-  ndarray<double, dim, 5> v;
-  {
-    std::vector<double> tmp(5);
-    for (unsigned int d = 0; d < dim; ++d)
-      {
-        polynomials[indices[d]].value(p[d], tmp);
-        v[d][0] = tmp[0];
-        v[d][1] = tmp[1];
-        v[d][2] = tmp[2];
-        v[d][3] = tmp[3];
-        v[d][4] = tmp[4];
-      }
-  }
+  ndarray<double, dim, order + 1> v;
+  if constexpr (running_in_debug_mode())
+    for (auto &array : v)
+      array.fill(std::numeric_limits<double>::signaling_NaN());
+
+  for (unsigned int d = 0; d < dim; ++d)
+    {
+      polynomials[indices[d]].value(p[d], order, v[d].data());
+    }
 
   if constexpr (order == 1)
     {
@@ -755,9 +751,14 @@ AnisotropicPolynomials<dim>::compute_derivative(const unsigned int i,
   std::array<unsigned int, dim> indices;
   compute_index(i, indices);
 
-  std::vector<std::vector<double>> v(dim, std::vector<double>(order + 1));
+  ndarray<double, dim, order + 1> v;
+  if constexpr (running_in_debug_mode())
+    for (auto &array : v)
+      array.fill(std::numeric_limits<double>::signaling_NaN());
   for (unsigned int d = 0; d < dim; ++d)
-    polynomials[d][indices[d]].value(p[d], v[d]);
+    {
+      polynomials[d][indices[d]].value(p[d], order, v[d].data());
+    }
 
   if constexpr (order == 1)
     {

--- a/source/base/polynomial_space.cc
+++ b/source/base/polynomial_space.cc
@@ -25,6 +25,8 @@
 #include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>
 
+#include <boost/container/small_vector.hpp>
+
 #include <Kokkos_Macros.hpp>
 
 #include <array>
@@ -270,13 +272,23 @@ PolynomialSpace<dim>::evaluate(
   //  d: coordinate direction
   //  n: number of 1d polynomial
   //  o: order of derivative
-  Table<2, std::vector<double>> v(dim, n_1d);
-  for (unsigned int d = 0; d < v.size()[0]; ++d)
-    for (unsigned int i = 0; i < v.size()[1]; ++i)
-      {
-        v(d, i).resize(v_size, 0.);
-        polynomials[i].value(p[d], v(d, i));
-      }
+  //
+  // Our rule-of-thumb for stack arrays is 200 elements in a small_vector. Here,
+  // we have (in 3d) 3 * 14 * 5 = 210 elements, in which 5 is the maximum number
+  // derivatives (4) plus one value.
+  std::array<boost::container::small_vector<std::array<double, 5>, 14>, dim> v;
+  for (unsigned int d = 0; d < dim; ++d)
+    {
+      v[d].resize(n_1d);
+      for (unsigned int i = 0; i < n_1d; ++i)
+        {
+          Assert(v_size > 0, ExcInternalError());
+          Assert(v_size <= v[d][i].size(), ExcInternalError());
+          if constexpr (running_in_debug_mode())
+            v[d][i].fill(std::numeric_limits<double>::signaling_NaN());
+          polynomials[i].value(p[d], v_size - 1, v[d][i].data());
+        }
+    }
 
   if (update_values)
     {
@@ -351,7 +363,7 @@ PolynomialSpace<dim>::evaluate(
                       // Derivative
                       // order for each
                       // direction
-                      std::vector<unsigned int> deriv_order(dim, 0);
+                      std::array<unsigned int, dim> deriv_order{};
                       for (unsigned int x = 0; x < dim; ++x)
                         {
                           if (d1 == x)
@@ -387,7 +399,7 @@ PolynomialSpace<dim>::evaluate(
                         // Derivative
                         // order for each
                         // direction
-                        std::vector<unsigned int> deriv_order(dim, 0);
+                        std::array<unsigned int, dim> deriv_order{};
                         for (unsigned int x = 0; x < dim; ++x)
                           {
                             if (d1 == x)


### PR DESCRIPTION
This also slightly improves performance: the current version of `compute_derivative()` computed all derivatives, even though we usually just need first derivatives.

Like the others, I found this with heaptrack: these allocations are about 2% of total allocations and about 40% of temporary allocations of step-32.