### PR TITLE
Add getters and setters to TriaFaces.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5511,7 +5511,7 @@ TriaAccessor<structdim, dim, spacedim>::line_orientation(
   else
     {
       DEAL_II_ASSERT_UNREACHABLE();
-      return false;
+      return numbers::invalid_geometric_orientation;
     }
 }
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5488,16 +5488,7 @@ TriaAccessor<structdim, dim, spacedim>::line_orientation(
     }
   else if constexpr (structdim == 2 && dim == 3)
     {
-      // line orientations in 3d are stored in their own array as bools: here
-      // 'true' is the default orientation and 'false' is the reversed one
-      // (which matches set_line_orientation())
-      const auto index =
-        this->present_index * ReferenceCells::max_n_lines<2>() + line;
-      Assert(index < this->tria->faces->quads_line_orientations.size(),
-             ExcInternalError());
-      return this->tria->faces->quads_line_orientations[index] ?
-               numbers::default_geometric_orientation :
-               numbers::reverse_line_orientation;
+      return this->tria->faces->get_line_orientation(this->present_index, line);
     }
   else if constexpr (structdim == 3 && dim == 3)
     {
@@ -5551,12 +5542,7 @@ TriaAccessor<structdim, dim, spacedim>::set_line_orientation(
       // We set line orientations per face, not per cell, so this only works for
       // faces in 3d.
       Assert(structdim == 2, ExcNotImplemented());
-      const auto index =
-        this->present_index * ReferenceCells::max_n_lines<2>() + line;
-      Assert(index < this->tria->faces->quads_line_orientations.size(),
-             ExcInternalError());
-      this->tria->faces->quads_line_orientations[index] =
-        value == numbers::default_geometric_orientation;
+      this->tria->faces->set_line_orientation(this->present_index, line, value);
     }
 }
 

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -98,12 +98,23 @@ namespace internal
       TriaObjects quads;
 
       /**
-       * Orientation of each line of each quad. Like elsewhere, `true` refers to
-       * the standard orientation and `false` refers to the reverse orientation.
+       * Get the orientation of the @p line_no-th line of the index-th face.
        *
        * @note Used only for dim=3.
        */
-      std::vector<bool> quads_line_orientations;
+      types::geometric_orientation
+      get_line_orientation(const int index, const unsigned int line_no) const;
+
+      /**
+       * Set the orientation of the @p line_no-th line of the index-th face to
+       * @p line_orientation.
+       *
+       * @note Used only for dim=3.
+       */
+      void
+      set_line_orientation(const int                    index,
+                           const unsigned int           line_no,
+                           types::geometric_orientation line_orientation);
 
       /**
        * Helper accessor function for quad_is_quadrilateral
@@ -149,6 +160,14 @@ namespace internal
        * @note Used only for dim=3.
        */
       std::vector<bool> quad_is_quadrilateral;
+
+      /**
+       * Orientation of each line of each quad. Like elsewhere, `true` refers to
+       * the standard orientation and `false` refers to the reverse orientation.
+       *
+       * @note Used only for dim=3.
+       */
+      std::vector<bool> quads_line_orientations;
     };
 
 
@@ -185,6 +204,51 @@ namespace internal
         quad_is_quadrilateral[index] = true;
       else
         quad_is_quadrilateral[index] = false;
+    }
+
+
+
+    template <int dim>
+    inline types::geometric_orientation
+    TriaFaces<dim>::get_line_orientation(const int          index,
+                                         const unsigned int line_no) const
+    {
+      Assert(index >= 0, ExcInternalError());
+      AssertIndexRange(line_no, lines_per_quad);
+      const std::size_t i = index * lines_per_quad + line_no;
+      AssertIndexRange(i, quads_line_orientations.size());
+      if constexpr (dim == 3)
+        return quads_line_orientations[i] ?
+                 numbers::default_geometric_orientation :
+                 numbers::reverse_line_orientation;
+      else
+        {
+          DEAL_II_ASSERT_UNREACHABLE();
+          return numbers::invalid_geometric_orientation;
+        }
+    }
+
+
+
+    template <int dim>
+    inline void
+    TriaFaces<dim>::set_line_orientation(
+      const int                          index,
+      const unsigned int                 line_no,
+      const types::geometric_orientation line_orientation)
+    {
+      Assert(index >= 0, ExcInternalError());
+      AssertIndexRange(line_no, lines_per_quad);
+      const std::size_t i = index * lines_per_quad + line_no;
+      AssertIndexRange(i, quads_line_orientations.size());
+      Assert(line_orientation == numbers::default_geometric_orientation ||
+               line_orientation == numbers::reverse_line_orientation,
+             ExcInternalError());
+      if constexpr (dim == 3)
+        quads_line_orientations[i] =
+          line_orientation == numbers::default_geometric_orientation;
+      else
+        DEAL_II_ASSERT_UNREACHABLE();
     }
 
 

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -118,14 +118,13 @@ namespace internal
        * Helper accessor function for quad_is_quadrilateral
        */
       ReferenceCell<dim - 1>
-      get_quad_type(const std::size_t index) const;
+      get_quad_type(const int index) const;
 
       /**
        * Helper accessor function for quad_is_quadrilateral
        */
       void
-      set_quad_type(const std::size_t            index,
-                    const ReferenceCell<dim - 1> face_type);
+      set_quad_type(const int index, const ReferenceCell<dim - 1> face_type);
 
       /**
        * The TriaObject containing the data of lines.
@@ -155,8 +154,9 @@ namespace internal
 
     template <int dim>
     inline ReferenceCell<dim - 1>
-    TriaFaces<dim>::get_quad_type(const std::size_t index) const
+    TriaFaces<dim>::get_quad_type(const int index) const
     {
+      Assert(index >= 0, ExcInternalError());
       AssertIndexRange(index, quad_is_quadrilateral.size());
       if constexpr (dim == 3)
         return quad_is_quadrilateral[index] ? ReferenceCells::Quadrilateral :
@@ -172,9 +172,10 @@ namespace internal
 
     template <int dim>
     inline void
-    TriaFaces<dim>::set_quad_type(const std::size_t            index,
+    TriaFaces<dim>::set_quad_type(const int                    index,
                                   const ReferenceCell<dim - 1> face_type)
     {
+      Assert(index >= 0, ExcInternalError());
       AssertIndexRange(index, quad_is_quadrilateral.size());
       Assert(face_type == ReferenceCells::Quadrilateral ||
                face_type == ReferenceCells::Triangle,

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -106,15 +106,6 @@ namespace internal
       std::vector<bool> quads_line_orientations;
 
       /**
-       * Whether or not each quad is a Quadrilateral. Since, if dim = 3, faces
-       * are either Triangles or Quadrilaterals, it suffices to store a
-       * boolean.
-       *
-       * @note Used only for dim=3.
-       */
-      std::vector<bool> quad_is_quadrilateral;
-
-      /**
        * Helper accessor function for quad_is_quadrilateral
        */
       ReferenceCell<dim - 1>
@@ -148,6 +139,16 @@ namespace internal
       template <class Archive>
       void
       serialize(Archive &ar, const unsigned int version);
+
+    private:
+      /**
+       * Whether or not each quad is a Quadrilateral. Since, if dim = 3, faces
+       * are either Triangles or Quadrilaterals, it suffices to store a
+       * boolean.
+       *
+       * @note Used only for dim=3.
+       */
+      std::vector<bool> quad_is_quadrilateral;
     };
 
 

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -85,10 +85,10 @@ namespace internal
                    const std::size_t new_quads_single);
 
       /**
-       * Maximum number of lines for each quad (i.e., face of a 3d cell).
-       * Only used for `dim == 3`.
+       * Number of lines for each quad (i.e., face of a 3d cell). Only used for
+       * `dim == 3`.
        */
-      unsigned int max_lines_per_quad;
+      unsigned int lines_per_quad;
 
       /**
        * The TriaObject containing the data of quads.
@@ -194,7 +194,7 @@ namespace internal
     void
     TriaFaces<dim>::serialize(Archive &ar, const unsigned int)
     {
-      ar &max_lines_per_quad &quads &lines &quads_line_orientations
+      ar &lines_per_quad &quads &lines &quads_line_orientations
         &quad_is_quadrilateral;
     }
   } // namespace TriangulationImplementation

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3715,8 +3715,14 @@ namespace internal
           dim > 1 ? connectivity.entity_to_entities(1, 0) : empty;
         const ArrayOfArrays &quads_to_lines =
           dim == 3 ? connectivity.entity_to_entities(2, 1) : empty;
-        const unsigned int n_lines = lines_to_vertices.size();
-        const unsigned int n_quads = quads_to_lines.size();
+        const auto n_lines = lines_to_vertices.size();
+        AssertThrow(
+          n_lines <= std::size_t(std::numeric_limits<int>::max()),
+          ExcMessage("The number of lines must be less than the largest int."));
+        const auto n_quads = quads_to_lines.size();
+        AssertThrow(
+          n_quads <= std::size_t(std::numeric_limits<int>::max()),
+          ExcMessage("The number of quads must be less than the largest int."));
 
         if (dim > 1)
           tria.faces->allocate(n_lines, n_quads);
@@ -3726,7 +3732,7 @@ namespace internal
           {
             auto &faces = *tria.faces;
             // loop over lines
-            for (unsigned int line = 0; line < n_lines; ++line)
+            for (int line = 0; line < int(n_lines); ++line)
               {
                 const auto vertices = lines_to_vertices[line];
                 for (unsigned int v = 0; v < vertices.size(); ++v)
@@ -3741,7 +3747,7 @@ namespace internal
             // get connectivity between quads and lines
 
             // loop over all quads -> entity type, line indices/orientations
-            for (unsigned int q = 0, k = 0; q < n_quads; ++q)
+            for (int q = 0, k = 0; q < int(n_quads); ++q)
               {
                 // set entity type of quads
                 const auto face_reference_cell =

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3757,22 +3757,8 @@ namespace internal
                     faces.quads.set_bounding_object(q, l, lines[l]);
 
                     // set line orientations
-                    const auto combined_orientation =
-                      connectivity.entity_orientations(1)[k];
-                    // it doesn't make sense to set any flags except
-                    // orientation for a line
-                    Assert(combined_orientation ==
-                               numbers::default_geometric_orientation ||
-                             combined_orientation ==
-                               numbers::reverse_line_orientation,
-                           ExcInternalError());
-                    // Same convention as TriaAccessor::set_line_orientation():
-                    // store true for the default orientation and false for
-                    // reversed.
-                    faces.quads_line_orientations
-                      [q * faces.quads.children_per_object + l] =
-                      combined_orientation ==
-                      numbers::default_geometric_orientation;
+                    faces.set_line_orientation(
+                      q, l, connectivity.entity_orientations(1)[k]);
                   }
               }
           }

--- a/source/grid/tria_faces.cc
+++ b/source/grid/tria_faces.cc
@@ -34,8 +34,8 @@ namespace internal
     template <int dim>
     TriaFaces<dim>::TriaFaces(const unsigned int max_children_per_quad,
                               const unsigned int max_lines_per_quad)
-      : max_lines_per_quad(max_lines_per_quad)
-      , quads(2, max_children_per_quad, max_lines_per_quad)
+      : lines_per_quad(max_lines_per_quad)
+      , quads(2, max_children_per_quad, lines_per_quad)
       , lines(1,
               ReferenceCells::max_n_children<1>(),
               ReferenceCells::max_n_faces<1>())
@@ -57,7 +57,7 @@ namespace internal
         {
           quads.allocate(n_quads);
           quad_is_quadrilateral.assign(n_quads, true);
-          quads_line_orientations.assign(n_quads * max_lines_per_quad, true);
+          quads_line_orientations.assign(n_quads * lines_per_quad, true);
         }
     }
 


### PR DESCRIPTION
I think this is the last place where we were computing array indices inside `TriaAccessor` or `Triangulation` instead of one of `Triangulation`'s internal data objects.