### PR TITLE
Use latest version of lukka@get-cmake, but specify cmake version.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,7 +356,9 @@ jobs:
         # deleting 15GB
         rm -rf /usr/share/dotnet/
         df -h
-    - uses: lukka/get-cmake@v3.27.9
+    - uses: lukka/get-cmake@v4.3.2
+      with:
+        cmakeVersion: 3.27.9
     - name: info
       run: |
         mpicc -v
@@ -449,7 +451,9 @@ jobs:
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    - uses: lukka/get-cmake@v3.27.9
+    - uses: lukka/get-cmake@v4.3.2
+      with:
+        cmakeVersion: 3.27.9
     - name: info
       run: |
         mpicc -v


### PR DESCRIPTION
Better alternative for #19609.

This way, we use the up-to-date version of the action, and specify the cmake version we want to use.

See also: https://github.com/lukka/get-cmake#if-you-want-to-pin-the-workflow-to-specific-range-of-versions-of-cmake-and-ninja