### PR TITLE
Only export Trilinos symbols we actually need.

### DIFF
--- a/module/interface_module_partitions/trilinos.ccm
+++ b/module/interface_module_partitions/trilinos.ccm
@@ -121,11 +121,13 @@ module;
 #    include <Tpetra_Vector_fwd.hpp>
 #    include <Tpetra_Version.hpp>
 
-#    ifdef DEAL_II_TRILINOS_WITH_AMESOS2
+#    if defined(DEAL_II_TRILINOS_WITH_AMESOS2) && \
+      defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #      include <Amesos2.hpp>
 #    endif
 
-#    ifdef DEAL_II_TRILINOS_WITH_IFPACK2
+#    if defined(DEAL_II_TRILINOS_WITH_IFPACK2) && \
+      defined(DEAL_II_TRILINOS_WITH_TPETRA)
 #      include <Ifpack2_Factory.hpp>
 #      include <Ifpack2_IdentitySolver.hpp>
 #      include <Ifpack2_IdentitySolver_decl.hpp>
@@ -182,7 +184,8 @@ export
   using ::operator<<;
 
 #  if defined(DEAL_II_TRILINOS_WITH_AMESOS2) && \
-    DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
+    DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0) &&   \
+    defined(DEAL_II_TRILINOS_WITH_TPETRA)
   namespace Amesos2
   {
     using ::Amesos2::create;
@@ -208,7 +211,8 @@ export
   {
     using ::EpetraExt::MatrixMatrix;
   }
-#  ifdef DEAL_II_TRILINOS_WITH_IFPACK2
+#  if defined(DEAL_II_TRILINOS_WITH_IFPACK2) && \
+    defined(DEAL_II_TRILINOS_WITH_TPETRA)
   namespace Ifpack2
   {
     using ::Ifpack2::Factory;


### PR DESCRIPTION
@masterleinad points out some Trilinos export errors in https://github.com/masterleinad/dealii/actions/runs/25887075925/job/76081349053 (see https://github.com/dealii/dealii/pull/19692#issuecomment-4454995317). These are for symbols in Ifpack2 and Amesos2. I must admit that I don't know why we can't export these symbols, but we also don't have to right now: These are only used in code guarded by `DEAL_II_TRILINOS_WITH_TPETRA`. We should only export these symbols if that preprocessor variable is set.

Part of #18071.