### PR TITLE
modules: fix compilation of petsc_parallel_full_matrix.

### DIFF
--- a/module/interface_module_partitions/petsc.ccm
+++ b/module/interface_module_partitions/petsc.ccm
@@ -96,6 +96,7 @@ export
   using ::MatConvert;
   using ::MatCopy;
   using ::MatCreate;
+  using ::MatCreateDense;
   using ::MatCreateIS;
   using ::MatCreateNest;
   using ::MatCreateSeqAIJ;

--- a/source/lac/petsc_parallel_full_matrix.cc
+++ b/source/lac/petsc_parallel_full_matrix.cc
@@ -20,7 +20,12 @@
 #  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_vector.h>
 
+
+#endif // DEAL_II_WITH_PETSC
+
 DEAL_II_NAMESPACE_OPEN
+
+#ifdef DEAL_II_WITH_PETSC
 
 namespace PETScWrappers
 {
@@ -112,6 +117,6 @@ namespace PETScWrappers
   } // namespace MPI
 
 } // namespace PETScWrappers
-DEAL_II_NAMESPACE_CLOSE
 
 #endif // DEAL_II_WITH_PETSC
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Newer implementations of modules don't permit mixing module declarations (which we generate here via script at DEAL_II_NAMESPACE_OPEN) and preprocessor commands.

I can't test this locally - let's see if it works!