### PR TITLE
Fix support contained within without constraints

### DIFF
--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1331,8 +1331,9 @@ namespace DoFTools
    *
    * In case of parallel::distributed::Triangulation @p predicate will be called
    * only for locally owned and ghost cells. The resulting index set may contain
-   * DoFs that are associated with the locally owned or ghost cells, but are not
-   * owned by the current MPI process.
+   * DoFs associated with locally owned cells, as well as DoFs by which a
+   * locally active DoF is constrained but which may not themselves be locally
+   * active.
    */
   template <int dim, int spacedim, typename number = double>
   IndexSet

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -10,10 +10,14 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/base/types.h>
 
 #include <deal.II/distributed/shared_tria.h>
 #include <deal.II/distributed/tria.h>
@@ -840,83 +844,121 @@ namespace DoFTools
     local_dof_indices.reserve(
       dof_handler.get_fe_collection().max_dofs_per_cell());
 
-    // Get all the dofs that live on the subdomain:
-    std::set<types::global_dof_index> predicate_dofs;
+    // Get all the DoFs that live on the locally owned subdomain part
+    std::set<types::global_dof_index> predicate_dofs_owned_cells;
 
-    for (const auto &cell : dof_handler.active_cell_iterators())
-      if (!cell->is_artificial() && predicate(cell))
-        {
-          local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
-          cell->get_dof_indices(local_dof_indices);
-          predicate_dofs.insert(local_dof_indices.begin(),
-                                local_dof_indices.end());
-        }
+    for (const auto &cell :
+         dof_handler.active_cell_iterators() | predicate_local)
+      {
+        local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
+        cell->get_dof_indices(local_dof_indices);
+        predicate_dofs_owned_cells.insert(local_dof_indices.begin(),
+                                          local_dof_indices.end());
+      }
 
-    // Get halo layer and accumulate its DoFs
-    std::set<types::global_dof_index> dofs_with_support_on_halo_cells;
+    IndexSet predicate_owned_set(dof_handler.n_dofs());
+    predicate_owned_set.add_indices(predicate_dofs_owned_cells.begin(),
+                                    predicate_dofs_owned_cells.end());
+    predicate_owned_set.compress();
+
+    // Build halo layer around locally owned part of subdomain.
+    // The halo layer consists of:
+    // - locally owned cells not fulfilling the predicate -> add to
+    // non_predicate_halo_set
+    // - ghost cells fulfilling the predicate -> add to predicate_ghost_set
+    // - ghost cells not fulfilling the predicate -> add to non_predicate_halo
+    // set
+    std::set<types::global_dof_index> non_predicate_dofs_halo_cells;
+    std::set<types::global_dof_index> predicate_dofs_ghosts;
 
     const std::vector<typename DoFHandler<dim, spacedim>::active_cell_iterator>
       halo_cells =
         GridTools::compute_active_cell_halo_layer(dof_handler, predicate_local);
-    for (typename std::vector<typename DoFHandler<dim, spacedim>::
-                                active_cell_iterator>::const_iterator it =
-           halo_cells.begin();
-         it != halo_cells.end();
-         ++it)
+
+    for (const auto &cell : halo_cells)
       {
-        // skip halo cells that satisfy the given predicate and thereby
-        // shall be a part of the index set on another MPI core.
-        // Those could only be ghost cells with p::d::Tria.
-        if (predicate(*it))
+        const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
+        local_dof_indices.resize(dofs_per_cell);
+        cell->get_dof_indices(local_dof_indices);
+        if (predicate(cell))
           {
-            Assert((*it)->is_ghost(), ExcInternalError());
+            Assert(cell->is_ghost(), ExcInternalError());
+            predicate_dofs_ghosts.insert(local_dof_indices.begin(),
+                                         local_dof_indices.end());
             continue;
           }
 
-        const unsigned int dofs_per_cell = (*it)->get_fe().n_dofs_per_cell();
-        local_dof_indices.resize(dofs_per_cell);
-        (*it)->get_dof_indices(local_dof_indices);
-        dofs_with_support_on_halo_cells.insert(local_dof_indices.begin(),
-                                               local_dof_indices.end());
+        non_predicate_dofs_halo_cells.insert(local_dof_indices.begin(),
+                                             local_dof_indices.end());
       }
 
-    // A complication coming from the fact that DoFs living on locally
-    // owned cells which satisfy predicate may participate in constraints for
-    // DoFs outside of this region.
+    IndexSet non_predicate_halo_set(dof_handler.n_dofs());
+    non_predicate_halo_set.add_indices(non_predicate_dofs_halo_cells.begin(),
+                                       non_predicate_dofs_halo_cells.end());
+    non_predicate_halo_set.compress();
+
+    IndexSet predicate_ghost_set(dof_handler.n_dofs());
+    predicate_ghost_set.add_indices(predicate_dofs_ghosts.begin(),
+                                    predicate_dofs_ghosts.end());
+    predicate_ghost_set.compress();
+
+    // Get DoFs contained in the predicate_ghost_set that constrain a DoF in the
+    // predicate_owned_set. We need to add the constraining entries to the
+    // support_set as locally active DoFs will contribute to these constraining
+    // DoFs.
+    IndexSet constraining_predicate_ghost_set(dof_handler.n_dofs());
+    if (cm.n_constraints() > 0 && predicate_ghost_set.n_elements() > 0)
+      {
+        std::set<types::global_dof_index> constraining_ghost_dofs;
+        for (const auto dof : predicate_owned_set)
+          {
+            if (const auto *line_ptr = cm.get_constraint_entries(dof))
+              {
+                const unsigned int line_size = line_ptr->size();
+                for (unsigned int j = 0; j < line_size; ++j)
+                  {
+                    constraining_ghost_dofs.insert((*line_ptr)[j].first);
+                  }
+              }
+          }
+        constraining_predicate_ghost_set.add_indices(
+          constraining_ghost_dofs.begin(), constraining_ghost_dofs.end());
+      }
+
+    // Now we collected all DoFs that we need to add to the support_set
+    IndexSet support_set(dof_handler.n_dofs());
+    support_set.add_indices(predicate_owned_set);
+    support_set.add_indices(constraining_predicate_ghost_set);
+
+
+    // Remove the following from the support_set:
+    // - The non_predicate_halo_set
+    // - DoFs constraining the non_predicate_halo_set DoFs:
+    // A DoF living on locally owned predicate cells that constrains non
+    // predicate halo DoFs must be removed to not extend the support outside the
+    // predicate domain.
+    support_set.subtract_set(non_predicate_halo_set);
+
     if (cm.n_constraints() > 0)
       {
-        // Remove DoFs that are part of constraints for DoFs outside
-        // of predicate. Since we will subtract halo_dofs from predicate_dofs,
-        // achieve this by extending halo_dofs with DoFs to which
-        // halo_dofs are constrained.
-        std::set<types::global_dof_index> extra_halo;
-        for (const auto dof : dofs_with_support_on_halo_cells)
-          // if halo DoF is constrained, add all DoFs to which it's constrained
-          // because after resolving constraints, the support of the DoFs that
-          // constrain the current DoF will extend to the halo cells.
-          if (const auto *line_ptr = cm.get_constraint_entries(dof))
-            {
-              const unsigned int line_size = line_ptr->size();
-              for (unsigned int j = 0; j < line_size; ++j)
-                extra_halo.insert((*line_ptr)[j].first);
-            }
+        std::set<types::global_dof_index> dofs_constraining_halo;
+        for (const auto dof : non_predicate_halo_set)
+          {
+            if (const auto *line_ptr = cm.get_constraint_entries(dof))
+              {
+                const unsigned int line_size = line_ptr->size();
+                for (unsigned int j = 0; j < line_size; ++j)
+                  dofs_constraining_halo.insert((*line_ptr)[j].first);
+              }
+          }
 
-        dofs_with_support_on_halo_cells.insert(extra_halo.begin(),
-                                               extra_halo.end());
+        IndexSet dofs_constraining_halo_set(dof_handler.n_dofs());
+        dofs_constraining_halo_set.add_indices(dofs_constraining_halo.begin(),
+                                               dofs_constraining_halo.end());
+        support_set.subtract_set(dofs_constraining_halo_set);
       }
 
-    // Rework our std::set's into IndexSet and subtract halo DoFs from the
-    // predicate_dofs:
-    IndexSet support_set(dof_handler.n_dofs());
-    support_set.add_indices(predicate_dofs.begin(), predicate_dofs.end());
     support_set.compress();
-
-    IndexSet halo_set(dof_handler.n_dofs());
-    halo_set.add_indices(dofs_with_support_on_halo_cells.begin(),
-                         dofs_with_support_on_halo_cells.end());
-    halo_set.compress();
-
-    support_set.subtract_set(halo_set);
 
     // we intentionally do not want to limit the output to locally owned DoFs.
     return support_set;

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.cc
@@ -13,7 +13,12 @@
 
 // test DoFTools::extract_dofs_with_support_contained_within() for the
 // p::d::Tria. As an MPI test, make sure that the total number of shape
-// functions that are non-zero within the domain is the same.
+// functions that are non-zero within the predicate domain is the same
+// regardless of how many MPI processes are used.
+// Note: the function DoFTools::extract_dofs_with_support_contained_within()
+// does not return the total number of shape functions contained within the
+// predicate domain, but only a local subset that contains locally active DoFs,
+// as well as DoFs by which a locally active DoF is constrained.
 
 #include <deal.II/base/point.h>
 
@@ -33,10 +38,6 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include <deal.II/numerics/data_out.h>
-
-#include <list>
-#include <set>
-#include <sstream>
 
 #include "../tests.h"
 
@@ -76,9 +77,7 @@ test(const unsigned int flag)
   DoFHandler<dim> dh(triangulation);
 
   // Extra refinement to generate hanging nodes
-  for (typename DoFHandler<dim>::active_cell_iterator cell = dh.begin_active();
-       cell != dh.end();
-       ++cell)
+  for (const auto &cell : dh.active_cell_iterators())
     if (cell->is_locally_owned() &&
         ((flag == 1 && pred_d<dim>(cell)) || (flag == 2 && !pred_d<dim>(cell))))
       cell->set_refine_flag();
@@ -94,20 +93,23 @@ test(const unsigned int flag)
 
   const IndexSet locally_relevant_set =
     DoFTools::extract_locally_relevant_dofs(dh);
+  const IndexSet locally_active_set = DoFTools::extract_locally_active_dofs(dh);
 
   AffineConstraints<double> cm;
   cm.reinit(dh.locally_owned_dofs(), locally_relevant_set);
   DoFTools::make_hanging_node_constraints(dh, cm);
   cm.close();
 
-  const IndexSet support = DoFTools::extract_dofs_with_support_contained_within(
-    dh,
-    std::function<bool(const typename DoFHandler<dim>::active_cell_iterator &)>(
-      &pred_d<dim>),
-    cm);
+  const IndexSet support =
+    DoFTools::extract_dofs_with_support_contained_within(dh, &pred_d<dim>, cm);
   const IndexSet support_local = support & dh.locally_owned_dofs();
 
-  deallog << support.n_elements() << std::endl;
+  deallog << "Number of locally active dofs: "
+          << locally_active_set.n_elements() << std::endl;
+  deallog << "Number of dofs with contained support: " << support.n_elements()
+          << std::endl;
+  deallog << "Number of owned dofs with contained support: "
+          << support_local.n_elements() << std::endl;
 
   // now accumulate the number of indices and make sure it's the same for
   // various runs with different number of MPI cores
@@ -115,8 +117,8 @@ test(const unsigned int flag)
     Utilities::MPI::sum(support_local.n_elements(), MPI_COMM_WORLD);
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {
-      deallog << "accumulated: " << std::endl;
-      deallog << dofs_support << std::endl;
+      deallog << "Total number of dofs with contained support: " << dofs_support
+              << std::endl;
     }
 
   // print grid and DoFs for visual inspection
@@ -160,9 +162,10 @@ test(const unsigned int flag)
       if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
         {
           std::vector<std::string> filenames;
-          for (unsigned int i = 0;
-               i < Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
-               ++i)
+          const unsigned           n_ranks =
+            Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+          filenames.reserve(n_ranks);
+          for (unsigned int i = 0; i < n_ranks; ++i)
             filenames.push_back(output_name(flag, i));
 
           const std::string pvtu_filename =

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.with_p4est=true.mpirun=1.output
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.with_p4est=true.mpirun=1.output
@@ -1,10 +1,13 @@
 
-DEAL:0:0::16
-DEAL:0:0::accumulated: 
-DEAL:0:0::16
-DEAL:0:0::76
-DEAL:0:0::accumulated: 
-DEAL:0:0::76
-DEAL:0:0::16
-DEAL:0:0::accumulated: 
-DEAL:0:0::16
+DEAL:0:0::Number of locally active dofs: 81
+DEAL:0:0::Number of dofs with contained support: 16
+DEAL:0:0::Number of owned dofs with contained support: 16
+DEAL:0:0::Total number of dofs with contained support: 16
+DEAL:0:0::Number of locally active dofs: 141
+DEAL:0:0::Number of dofs with contained support: 76
+DEAL:0:0::Number of owned dofs with contained support: 76
+DEAL:0:0::Total number of dofs with contained support: 76
+DEAL:0:0::Number of locally active dofs: 245
+DEAL:0:0::Number of dofs with contained support: 16
+DEAL:0:0::Number of owned dofs with contained support: 16
+DEAL:0:0::Total number of dofs with contained support: 16

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.with_p4est=true.mpirun=3.output
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.with_p4est=true.mpirun=3.output
@@ -1,20 +1,35 @@
 
-DEAL:0:0::16
-DEAL:0:0::accumulated: 
-DEAL:0:0::16
-DEAL:0:0::61
-DEAL:0:0::accumulated: 
-DEAL:0:0::76
-DEAL:0:0::16
-DEAL:0:0::accumulated: 
-DEAL:0:0::16
+DEAL:0:0::Number of locally active dofs: 25
+DEAL:0:0::Number of dofs with contained support: 16
+DEAL:0:0::Number of owned dofs with contained support: 16
+DEAL:0:0::Total number of dofs with contained support: 16
+DEAL:0:0::Number of locally active dofs: 45
+DEAL:0:0::Number of dofs with contained support: 43
+DEAL:0:0::Number of owned dofs with contained support: 43
+DEAL:0:0::Total number of dofs with contained support: 76
+DEAL:0:0::Number of locally active dofs: 87
+DEAL:0:0::Number of dofs with contained support: 16
+DEAL:0:0::Number of owned dofs with contained support: 16
+DEAL:0:0::Total number of dofs with contained support: 16
 
-DEAL:1:1::21
-DEAL:1:1::64
-DEAL:1:1::15
+DEAL:1:1::Number of locally active dofs: 49
+DEAL:1:1::Number of dofs with contained support: 0
+DEAL:1:1::Number of owned dofs with contained support: 0
+DEAL:1:1::Number of locally active dofs: 68
+DEAL:1:1::Number of dofs with contained support: 41
+DEAL:1:1::Number of owned dofs with contained support: 33
+DEAL:1:1::Number of locally active dofs: 106
+DEAL:1:1::Number of dofs with contained support: 0
+DEAL:1:1::Number of owned dofs with contained support: 0
 
 
-DEAL:2:2::9
-DEAL:2:2::27
-DEAL:2:2::9
+DEAL:2:2::Number of locally active dofs: 25
+DEAL:2:2::Number of dofs with contained support: 0
+DEAL:2:2::Number of owned dofs with contained support: 0
+DEAL:2:2::Number of locally active dofs: 45
+DEAL:2:2::Number of dofs with contained support: 0
+DEAL:2:2::Number of owned dofs with contained support: 0
+DEAL:2:2::Number of locally active dofs: 81
+DEAL:2:2::Number of dofs with contained support: 0
+DEAL:2:2::Number of owned dofs with contained support: 0
 

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.with_p4est=true.mpirun=5.output
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_02.with_p4est=true.mpirun=5.output
@@ -1,30 +1,57 @@
 
-DEAL:0:0::16
-DEAL:0:0::accumulated: 
-DEAL:0:0::16
-DEAL:0:0::49
-DEAL:0:0::accumulated: 
-DEAL:0:0::76
-DEAL:0:0::16
-DEAL:0:0::accumulated: 
-DEAL:0:0::16
+DEAL:0:0::Number of locally active dofs: 25
+DEAL:0:0::Number of dofs with contained support: 16
+DEAL:0:0::Number of owned dofs with contained support: 16
+DEAL:0:0::Total number of dofs with contained support: 16
+DEAL:0:0::Number of locally active dofs: 25
+DEAL:0:0::Number of dofs with contained support: 25
+DEAL:0:0::Number of owned dofs with contained support: 25
+DEAL:0:0::Total number of dofs with contained support: 76
+DEAL:0:0::Number of locally active dofs: 68
+DEAL:0:0::Number of dofs with contained support: 16
+DEAL:0:0::Number of owned dofs with contained support: 16
+DEAL:0:0::Total number of dofs with contained support: 16
 
-DEAL:1:1::15
-DEAL:1:1::69
-DEAL:1:1::15
+DEAL:1:1::Number of locally active dofs: 25
+DEAL:1:1::Number of dofs with contained support: 0
+DEAL:1:1::Number of owned dofs with contained support: 0
+DEAL:1:1::Number of locally active dofs: 49
+DEAL:1:1::Number of dofs with contained support: 45
+DEAL:1:1::Number of owned dofs with contained support: 36
+DEAL:1:1::Number of locally active dofs: 45
+DEAL:1:1::Number of dofs with contained support: 0
+DEAL:1:1::Number of owned dofs with contained support: 0
 
 
-DEAL:2:2::0
-DEAL:2:2::46
-DEAL:2:2::15
+DEAL:2:2::Number of locally active dofs: 0
+DEAL:2:2::Number of dofs with contained support: 0
+DEAL:2:2::Number of owned dofs with contained support: 0
+DEAL:2:2::Number of locally active dofs: 25
+DEAL:2:2::Number of dofs with contained support: 22
+DEAL:2:2::Number of owned dofs with contained support: 15
+DEAL:2:2::Number of locally active dofs: 65
+DEAL:2:2::Number of dofs with contained support: 0
+DEAL:2:2::Number of owned dofs with contained support: 0
 
 
-DEAL:3:3::15
-DEAL:3:3::45
-DEAL:3:3::9
+DEAL:3:3::Number of locally active dofs: 25
+DEAL:3:3::Number of dofs with contained support: 0
+DEAL:3:3::Number of owned dofs with contained support: 0
+DEAL:3:3::Number of locally active dofs: 49
+DEAL:3:3::Number of dofs with contained support: 0
+DEAL:3:3::Number of owned dofs with contained support: 0
+DEAL:3:3::Number of locally active dofs: 49
+DEAL:3:3::Number of dofs with contained support: 0
+DEAL:3:3::Number of owned dofs with contained support: 0
 
 
-DEAL:4:4::9
-DEAL:4:4::9
-DEAL:4:4::0
+DEAL:4:4::Number of locally active dofs: 25
+DEAL:4:4::Number of dofs with contained support: 0
+DEAL:4:4::Number of owned dofs with contained support: 0
+DEAL:4:4::Number of locally active dofs: 25
+DEAL:4:4::Number of dofs with contained support: 0
+DEAL:4:4::Number of owned dofs with contained support: 0
+DEAL:4:4::Number of locally active dofs: 65
+DEAL:4:4::Number of dofs with contained support: 0
+DEAL:4:4::Number of owned dofs with contained support: 0
 

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_05.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_05.cc
@@ -1,0 +1,261 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+//
+
+// test DoFTools::extract_dofs_with_support_contained_within() for the
+// p::d::Tria. As an MPI test, make sure that the total number of shape
+// functions that are non-zero within the predicate domain is the same
+// regardless of how many MPI processes are used.
+// Note: the function DoFTools::extract_dofs_with_support_contained_within()
+// does not return the total number of shape functions contained within the
+// predicate domain, but only a local subset that contains locally active DoFs,
+// as well as DoFs by which a locally active DoF is constrained.
+
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/data_out.h>
+
+#include "../tests.h"
+
+bool
+predicate_left(const typename Triangulation<2, 2>::active_cell_iterator &cell)
+{
+  return (cell->center()[0] < 1.00);
+}
+
+bool
+predicate_right(const typename Triangulation<2, 2>::active_cell_iterator &cell)
+{
+  return (cell->center()[0] > 1.00);
+}
+
+enum class Refine
+{
+  None,
+  RightCell,
+  LeftCell
+};
+
+std::string
+to_string(Refine cell_to_refine)
+{
+  switch (cell_to_refine)
+    {
+      case Refine::None:
+        return "none";
+      case Refine::RightCell:
+        return "right_cell";
+      case Refine::LeftCell:
+        return "left_cell";
+    }
+  DEAL_II_ASSERT_UNREACHABLE();
+};
+
+
+void
+test(Refine cell_to_refine)
+{
+  constexpr unsigned                        dim = 2;
+  parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+
+  GridGenerator::subdivided_hyper_rectangle(triangulation,
+                                            {2, 1},
+                                            Point<dim>(0, 0),
+                                            Point<dim>(2, 1));
+  switch (cell_to_refine)
+    {
+      case Refine::None:
+        break;
+      case Refine::RightCell:
+        for (const auto &cell : triangulation.active_cell_iterators())
+          {
+            if (cell->is_locally_owned() && predicate_right(cell))
+              {
+                cell->set_refine_flag();
+              }
+          }
+        triangulation.signals.weight.connect(
+          [](const typename Triangulation<dim>::cell_iterator &cell,
+             const CellStatus                                  status) {
+            // Give left unrefined cell a larger weight such that the mesh
+            // partitions right down the middle. Consequently, process 0 owns
+            // the unrefined cell on the left and process 1 the four refined
+            // cells on the right.
+            if (predicate_left(cell))
+              return 4u;
+
+            return 1u;
+          });
+        break;
+      case Refine::LeftCell:
+        for (const auto &cell : triangulation.active_cell_iterators())
+          {
+            if (cell->is_locally_owned() && predicate_left(cell))
+              {
+                cell->set_refine_flag();
+              }
+          }
+
+        triangulation.signals.weight.connect(
+          [](const typename Triangulation<dim>::cell_iterator &cell,
+             const CellStatus                                  status) {
+            // Give right unrefined cell a larger weight such that the mesh
+            // partitions right down the middle. Consequently, process 0 owns
+            // the four refined cells on the left and process 1 the one
+            // unrefined cell on the right.
+            if (predicate_right(cell))
+              return 4u;
+
+            return 1u;
+          });
+        break;
+    }
+
+  triangulation.prepare_coarsening_and_refinement();
+  triangulation.execute_coarsening_and_refinement();
+
+  DoFHandler<dim> dh(triangulation);
+
+  FE_Q<dim> fe(1);
+  dh.distribute_dofs(fe);
+
+  const IndexSet &locally_owned_set = dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_set =
+    DoFTools::extract_locally_relevant_dofs(dh);
+
+  AffineConstraints<double> cm;
+  cm.reinit(locally_owned_set, locally_relevant_set);
+  DoFTools::make_hanging_node_constraints(dh, cm);
+  cm.close();
+
+  const IndexSet locally_active = DoFTools::extract_locally_active_dofs(dh);
+
+  deallog << "Refined cell: " << to_string(cell_to_refine) << std::endl;
+  deallog << "Number of locally active dofs: " << locally_active.n_elements()
+          << std::endl;
+
+  const IndexSet support =
+    DoFTools::extract_dofs_with_support_contained_within(dh,
+                                                         &predicate_right,
+                                                         cm);
+
+  const IndexSet support_locally_owned = support & dh.locally_owned_dofs();
+
+  deallog << "Number of dofs with contained support: " << support.n_elements()
+          << std::endl;
+  deallog << "Number of owned dofs with contained support: "
+          << support_locally_owned.n_elements() << std::endl;
+
+  const unsigned int dofs_support =
+    Utilities::MPI::sum(support_locally_owned.n_elements(), MPI_COMM_WORLD);
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      deallog << "Total number of dofs with contained support: " << dofs_support
+              << std::endl;
+    }
+  deallog << std::endl;
+
+  // print grid and DoFs for visual inspection
+  if (false)
+    {
+      DataOut<dim> data_out;
+      data_out.attach_dof_handler(dh);
+
+      std::vector<LinearAlgebra::distributed::Vector<double>> shape_functions(
+        dh.n_dofs());
+      for (unsigned int i = 0; i < dh.n_dofs(); ++i)
+        {
+          LinearAlgebra::distributed::Vector<double> &s = shape_functions[i];
+          s.reinit(dh.locally_owned_dofs(),
+                   locally_relevant_set,
+                   MPI_COMM_WORLD);
+          s = 0.;
+          if (dh.locally_owned_dofs().is_element(i))
+            s[i] = 1.0;
+          s.compress(VectorOperation::insert);
+          cm.distribute(s);
+          s.update_ghost_values();
+
+          data_out.add_data_vector(s,
+                                   std::string("N_") +
+                                     Utilities::int_to_string(i));
+        }
+
+      Vector<float> subdomain(triangulation.n_active_cells());
+      for (unsigned int i = 0; i < subdomain.size(); ++i)
+        subdomain(i) = triangulation.locally_owned_subdomain();
+      data_out.add_data_vector(subdomain, "subdomain");
+      data_out.build_patches();
+
+      const std::string file_base_name =
+        "output_refine_" + to_string(cell_to_refine);
+
+      const std::string filename =
+        file_base_name + "_subdomain_" +
+        std::to_string(triangulation.locally_owned_subdomain()) + ".vtu";
+
+      std::ofstream output(filename);
+      data_out.write_vtu(output);
+
+      const unsigned rank    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+      const unsigned n_ranks = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+      if (rank == 0)
+        {
+          std::vector<std::string> filenames;
+          filenames.reserve(n_ranks);
+          for (unsigned int rank = 0; rank < n_ranks; ++rank)
+            filenames.push_back(file_base_name + "_subdomain_" +
+                                std::to_string(rank) + ".vtu");
+
+          const std::string pvtu_filename = file_base_name + ".pvtu";
+          std::ofstream     pvtu_output(pvtu_filename);
+          data_out.write_pvtu_record(pvtu_output, filenames);
+        }
+    }
+
+  dh.clear();
+}
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  MPILogInitAll log;
+
+  deallog.push(Utilities::int_to_string(myid));
+
+  test(Refine::None);
+  test(Refine::LeftCell);
+  test(Refine::RightCell);
+
+  deallog.pop();
+}

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_05.with_p4est=true.mpirun=1.output
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_05.with_p4est=true.mpirun=1.output
@@ -1,0 +1,19 @@
+
+DEAL:0:0::Refined cell: none
+DEAL:0:0::Number of locally active dofs: 6
+DEAL:0:0::Number of dofs with contained support: 2
+DEAL:0:0::Number of owned dofs with contained support: 2
+DEAL:0:0::Total number of dofs with contained support: 2
+DEAL:0:0::
+DEAL:0:0::Refined cell: left_cell
+DEAL:0:0::Number of locally active dofs: 11
+DEAL:0:0::Number of dofs with contained support: 2
+DEAL:0:0::Number of owned dofs with contained support: 2
+DEAL:0:0::Total number of dofs with contained support: 2
+DEAL:0:0::
+DEAL:0:0::Refined cell: right_cell
+DEAL:0:0::Number of locally active dofs: 11
+DEAL:0:0::Number of dofs with contained support: 7
+DEAL:0:0::Number of owned dofs with contained support: 7
+DEAL:0:0::Total number of dofs with contained support: 7
+DEAL:0:0::

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_05.with_p4est=true.mpirun=2.output
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_05.with_p4est=true.mpirun=2.output
@@ -1,0 +1,36 @@
+
+DEAL:0:0::Refined cell: none
+DEAL:0:0::Number of locally active dofs: 4
+DEAL:0:0::Number of dofs with contained support: 0
+DEAL:0:0::Number of owned dofs with contained support: 0
+DEAL:0:0::Total number of dofs with contained support: 2
+DEAL:0:0::
+DEAL:0:0::Refined cell: left_cell
+DEAL:0:0::Number of locally active dofs: 9
+DEAL:0:0::Number of dofs with contained support: 0
+DEAL:0:0::Number of owned dofs with contained support: 0
+DEAL:0:0::Total number of dofs with contained support: 2
+DEAL:0:0::
+DEAL:0:0::Refined cell: right_cell
+DEAL:0:0::Number of locally active dofs: 4
+DEAL:0:0::Number of dofs with contained support: 0
+DEAL:0:0::Number of owned dofs with contained support: 0
+DEAL:0:0::Total number of dofs with contained support: 7
+DEAL:0:0::
+
+DEAL:1:1::Refined cell: none
+DEAL:1:1::Number of locally active dofs: 4
+DEAL:1:1::Number of dofs with contained support: 2
+DEAL:1:1::Number of owned dofs with contained support: 2
+DEAL:1:1::
+DEAL:1:1::Refined cell: left_cell
+DEAL:1:1::Number of locally active dofs: 4
+DEAL:1:1::Number of dofs with contained support: 2
+DEAL:1:1::Number of owned dofs with contained support: 2
+DEAL:1:1::
+DEAL:1:1::Refined cell: right_cell
+DEAL:1:1::Number of locally active dofs: 9
+DEAL:1:1::Number of dofs with contained support: 7
+DEAL:1:1::Number of owned dofs with contained support: 7
+DEAL:1:1::
+


### PR DESCRIPTION
This PR fixes the following problems for the parallel implementation of `extract_dofs_with_support_contained_within()`:
- Fixes reporting an index as contained with support on a ghost cell fulfilling the predicate that is not actually contained. (Main reason for updated numbers in the output)
- Fixes reporting a larger number of contained indices on a rank than actually being contained as reported in https://github.com/dealii/dealii/issues/19696 when the processor boundary and a predicate boundary coincide.

Note: The current implementation might still fail if there is a constraint which involves only dofs that are supported on ghost cells that fulfill the predicate, like shown in the figure:
<img width="400" height="410" alt="grid_n_ranks_2_rank_0" src="https://github.com/user-attachments/assets/23c2b01a-d9db-4f26-bbe8-92d01deff0d4" />
Note: the previous implementation has the same problem.

I hope someone can provide some useful tips to solve this problem.