### PR TITLE
Improve performance of FEInterfaceValues::reinit

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -2714,9 +2714,12 @@ FEInterfaceValues<dim, spacedim>::reinit(
         interface_dof_indices.begin() + v.size();
       for (unsigned int i = 0; i < v2.size(); ++i)
         {
-          auto it = std::find(interface_dof_indices.begin(),
-                              interface_dof_indices_end_after_v,
-                              v2[i]);
+          // Find out whether v2[i] is a DoF that also exists on the first side
+          // of the interface. If it does, we need to record 'i' in the second
+          // slot of the map. If it doesn't, record an {invalid,i} entry.
+          const auto it = std::find(interface_dof_indices.begin(),
+                                    interface_dof_indices_end_after_v,
+                                    v2[i]);
           if (it != interface_dof_indices_end_after_v)
             {
               dofmap[it - interface_dof_indices.begin()][1] = i;

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -2700,37 +2700,36 @@ FEInterfaceValues<dim, spacedim>::reinit(
         fe_face_values_neighbor->get_fe().n_dofs_per_cell());
       cell_neighbor->get_active_or_mg_dof_indices(v2);
 
-      // Fill a map from the global dof index to the left and right
-      // local index.
-      std::map<types::global_dof_index, std::pair<unsigned int, unsigned int>>
-                                            tempmap;
-      std::pair<unsigned int, unsigned int> invalid_entry(
-        numbers::invalid_unsigned_int, numbers::invalid_unsigned_int);
+      dofmap.resize(v.size() + v2.size());
+      interface_dof_indices.resize(v.size() + v2.size());
 
       for (unsigned int i = 0; i < v.size(); ++i)
         {
-          // If not already existing, add an invalid entry:
-          auto result = tempmap.insert(std::make_pair(v[i], invalid_entry));
-          result.first->second.first = i;
+          interface_dof_indices[i] = v[i];
+          dofmap[i]                = {{i, numbers::invalid_unsigned_int}};
         }
 
+      unsigned int idx = v.size();
+      auto         interface_dof_indices_end_after_v =
+        interface_dof_indices.begin() + v.size();
       for (unsigned int i = 0; i < v2.size(); ++i)
         {
-          // If not already existing, add an invalid entry:
-          auto result = tempmap.insert(std::make_pair(v2[i], invalid_entry));
-          result.first->second.second = i;
+          auto it = std::find(interface_dof_indices.begin(),
+                              interface_dof_indices_end_after_v,
+                              v2[i]);
+          if (it != interface_dof_indices_end_after_v)
+            {
+              dofmap[it - interface_dof_indices.begin()][1] = i;
+            }
+          else
+            {
+              interface_dof_indices[idx] = v2[i];
+              dofmap[idx]                = {{numbers::invalid_unsigned_int, i}};
+              ++idx;
+            }
         }
-
-      // Transfer from the map to the sorted std::vectors.
-      dofmap.resize(tempmap.size());
-      interface_dof_indices.resize(tempmap.size());
-      unsigned int idx = 0;
-      for (auto &x : tempmap)
-        {
-          interface_dof_indices[idx] = x.first;
-          dofmap[idx]                = {{x.second.first, x.second.second}};
-          ++idx;
-        }
+      dofmap.resize(idx);
+      interface_dof_indices.resize(idx);
     }
   else
     {

--- a/tests/feinterface/fe_interface_values_03.output
+++ b/tests/feinterface/fe_interface_values_03.output
@@ -1,57 +1,57 @@
 
 DEAL::FE_DGQ<2>(0)
 DEAL::qpoint 0: 1.00000 0.250000
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 2 dof indices: 0 | -1
-DEAL::shape_value(true): 0.00000 0.500000
-DEAL::shape_value(false): 0.500000 0.00000
-DEAL::jump_in_shape_values(): -0.500000 0.500000
+DEAL::  idx: 0 global: 2 dof indices: 0 | -1
+DEAL::  idx: 1 global: 0 dof indices: -1 | 0
+DEAL::shape_value(true): 0.500000 0.00000
+DEAL::shape_value(false): 0.00000 0.500000
+DEAL::jump_in_shape_values(): 0.500000 -0.500000
 DEAL::average_of_shape_values(): 0.250000 0.250000
 DEAL::FE_DGQ<2>(1)
 DEAL::qpoint 0: 1.00000 0.105662
 DEAL::qpoint 1: 1.00000 0.394338
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 1 dof indices: -1 | 1
-DEAL::  idx: 2 global: 2 dof indices: -1 | 2
-DEAL::  idx: 3 global: 3 dof indices: -1 | 3
-DEAL::  idx: 4 global: 8 dof indices: 0 | -1
-DEAL::  idx: 5 global: 9 dof indices: 1 | -1
-DEAL::  idx: 6 global: 10 dof indices: 2 | -1
-DEAL::  idx: 7 global: 11 dof indices: 3 | -1
-DEAL::shape_value(true): 0.00000 0.00000 0.00000 0.00000 0.00000 0.250000 0.00000 0.250000
-DEAL::shape_value(false): 0.375000 0.00000 0.125000 0.00000 0.00000 0.00000 0.00000 0.00000
-DEAL::jump_in_shape_values(): -0.375000 0.00000 -0.125000 0.00000 0.00000 0.250000 0.00000 0.250000
-DEAL::average_of_shape_values(): 0.187500 0.00000 0.0625000 0.00000 0.00000 0.125000 0.00000 0.125000
+DEAL::  idx: 0 global: 8 dof indices: 0 | -1
+DEAL::  idx: 1 global: 9 dof indices: 1 | -1
+DEAL::  idx: 2 global: 10 dof indices: 2 | -1
+DEAL::  idx: 3 global: 11 dof indices: 3 | -1
+DEAL::  idx: 4 global: 0 dof indices: -1 | 0
+DEAL::  idx: 5 global: 1 dof indices: -1 | 1
+DEAL::  idx: 6 global: 2 dof indices: -1 | 2
+DEAL::  idx: 7 global: 3 dof indices: -1 | 3
+DEAL::shape_value(true): 0.00000 0.250000 0.00000 0.250000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.00000 0.00000 0.00000 0.375000 0.00000 0.125000 0.00000
+DEAL::jump_in_shape_values(): 0.00000 0.250000 0.00000 0.250000 -0.375000 0.00000 -0.125000 0.00000
+DEAL::average_of_shape_values(): 0.00000 0.125000 0.00000 0.125000 0.187500 0.00000 0.0625000 0.00000
 DEAL::FE_DGQ<3>(0)
 DEAL::qpoint 0: 1.00000 0.250000 0.250000
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 2 dof indices: 0 | -1
-DEAL::shape_value(true): 0.00000 0.250000
-DEAL::shape_value(false): 0.250000 0.00000
-DEAL::jump_in_shape_values(): -0.250000 0.250000
+DEAL::  idx: 0 global: 2 dof indices: 0 | -1
+DEAL::  idx: 1 global: 0 dof indices: -1 | 0
+DEAL::shape_value(true): 0.250000 0.00000
+DEAL::shape_value(false): 0.00000 0.250000
+DEAL::jump_in_shape_values(): 0.250000 -0.250000
 DEAL::average_of_shape_values(): 0.125000 0.125000
 DEAL::FE_DGQ<3>(1)
 DEAL::qpoint 0: 1.00000 0.105662 0.105662
 DEAL::qpoint 1: 1.00000 0.394338 0.105662
 DEAL::qpoint 2: 1.00000 0.105662 0.394338
 DEAL::qpoint 3: 1.00000 0.394338 0.394338
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 1 dof indices: -1 | 1
-DEAL::  idx: 2 global: 2 dof indices: -1 | 2
-DEAL::  idx: 3 global: 3 dof indices: -1 | 3
-DEAL::  idx: 4 global: 4 dof indices: -1 | 4
-DEAL::  idx: 5 global: 5 dof indices: -1 | 5
-DEAL::  idx: 6 global: 6 dof indices: -1 | 6
-DEAL::  idx: 7 global: 7 dof indices: -1 | 7
-DEAL::  idx: 8 global: 16 dof indices: 0 | -1
-DEAL::  idx: 9 global: 17 dof indices: 1 | -1
-DEAL::  idx: 10 global: 18 dof indices: 2 | -1
-DEAL::  idx: 11 global: 19 dof indices: 3 | -1
-DEAL::  idx: 12 global: 20 dof indices: 4 | -1
-DEAL::  idx: 13 global: 21 dof indices: 5 | -1
-DEAL::  idx: 14 global: 22 dof indices: 6 | -1
-DEAL::  idx: 15 global: 23 dof indices: 7 | -1
-DEAL::shape_value(true): 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000
-DEAL::shape_value(false): 0.140625 0.00000 0.0468750 0.00000 0.0468750 0.00000 0.0156250 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
-DEAL::jump_in_shape_values(): -0.140625 0.00000 -0.0468750 0.00000 -0.0468750 0.00000 -0.0156250 0.00000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000
-DEAL::average_of_shape_values(): 0.0703125 0.00000 0.0234375 0.00000 0.0234375 0.00000 0.00781250 0.00000 0.00000 0.0312500 0.00000 0.0312500 0.00000 0.0312500 0.00000 0.0312500
+DEAL::  idx: 0 global: 16 dof indices: 0 | -1
+DEAL::  idx: 1 global: 17 dof indices: 1 | -1
+DEAL::  idx: 2 global: 18 dof indices: 2 | -1
+DEAL::  idx: 3 global: 19 dof indices: 3 | -1
+DEAL::  idx: 4 global: 20 dof indices: 4 | -1
+DEAL::  idx: 5 global: 21 dof indices: 5 | -1
+DEAL::  idx: 6 global: 22 dof indices: 6 | -1
+DEAL::  idx: 7 global: 23 dof indices: 7 | -1
+DEAL::  idx: 8 global: 0 dof indices: -1 | 0
+DEAL::  idx: 9 global: 1 dof indices: -1 | 1
+DEAL::  idx: 10 global: 2 dof indices: -1 | 2
+DEAL::  idx: 11 global: 3 dof indices: -1 | 3
+DEAL::  idx: 12 global: 4 dof indices: -1 | 4
+DEAL::  idx: 13 global: 5 dof indices: -1 | 5
+DEAL::  idx: 14 global: 6 dof indices: -1 | 6
+DEAL::  idx: 15 global: 7 dof indices: -1 | 7
+DEAL::shape_value(true): 1.15648e-18 0.0625000 4.31605e-18 0.0625000 3.09879e-19 0.0625000 1.15648e-18 0.0625000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.140625 0.00000 0.0468750 0.00000 0.0468750 0.00000 0.0156250 0.00000
+DEAL::jump_in_shape_values(): 1.15648e-18 0.0625000 4.31605e-18 0.0625000 3.09879e-19 0.0625000 1.15648e-18 0.0625000 -0.140625 0.00000 -0.0468750 0.00000 -0.0468750 0.00000 -0.0156250 0.00000
+DEAL::average_of_shape_values(): 5.78241e-19 0.0312500 2.15803e-18 0.0312500 1.54939e-19 0.0312500 5.78241e-19 0.0312500 0.0703125 0.00000 0.0234375 0.00000 0.0234375 0.00000 0.00781250 0.00000

--- a/tests/feinterface/fe_interface_values_06.output
+++ b/tests/feinterface/fe_interface_values_06.output
@@ -2,38 +2,38 @@
 DEAL::FE_Q<2>(1)
 DEAL::qpoint 0: 1.00000 0.105662
 DEAL::qpoint 1: 1.00000 0.394338
-DEAL::  idx: 0 global: 0 dof indices: 1 | 0
-DEAL::  idx: 1 global: 1 dof indices: -1 | 1
-DEAL::  idx: 2 global: 2 dof indices: -1 | 2
-DEAL::  idx: 3 global: 3 dof indices: -1 | 3
-DEAL::  idx: 4 global: 5 dof indices: 0 | -1
-DEAL::  idx: 5 global: 7 dof indices: 2 | -1
-DEAL::  idx: 6 global: 8 dof indices: 3 | -1
-DEAL::shape_value(true): 0.250000 0.00000 0.00000 0.00000 0.00000 0.00000 0.250000
-DEAL::shape_value(false): 0.375000 0.00000 0.125000 0.00000 0.00000 0.00000 0.00000
-DEAL::jump_in_shape_values(): -0.125000 0.00000 -0.125000 0.00000 0.00000 0.00000 0.250000
-DEAL::average_of_shape_values(): 0.312500 0.00000 0.0625000 0.00000 0.00000 0.00000 0.125000
+DEAL::  idx: 0 global: 5 dof indices: 0 | -1
+DEAL::  idx: 1 global: 0 dof indices: 1 | 0
+DEAL::  idx: 2 global: 7 dof indices: 2 | -1
+DEAL::  idx: 3 global: 8 dof indices: 3 | -1
+DEAL::  idx: 4 global: 1 dof indices: -1 | 1
+DEAL::  idx: 5 global: 2 dof indices: -1 | 2
+DEAL::  idx: 6 global: 3 dof indices: -1 | 3
+DEAL::shape_value(true): 0.00000 0.250000 0.00000 0.250000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.375000 0.00000 0.00000 0.00000 0.125000 0.00000
+DEAL::jump_in_shape_values(): 0.00000 -0.125000 0.00000 0.250000 0.00000 -0.125000 0.00000
+DEAL::average_of_shape_values(): 0.00000 0.312500 0.00000 0.125000 0.00000 0.0625000 0.00000
 DEAL::FE_Q<3>(1)
 DEAL::qpoint 0: 1.00000 0.105662 0.105662
 DEAL::qpoint 1: 1.00000 0.394338 0.105662
 DEAL::qpoint 2: 1.00000 0.105662 0.394338
 DEAL::qpoint 3: 1.00000 0.394338 0.394338
-DEAL::  idx: 0 global: 0 dof indices: 1 | 0
-DEAL::  idx: 1 global: 1 dof indices: -1 | 1
-DEAL::  idx: 2 global: 2 dof indices: -1 | 2
-DEAL::  idx: 3 global: 3 dof indices: -1 | 3
-DEAL::  idx: 4 global: 4 dof indices: -1 | 4
-DEAL::  idx: 5 global: 5 dof indices: -1 | 5
-DEAL::  idx: 6 global: 6 dof indices: -1 | 6
-DEAL::  idx: 7 global: 7 dof indices: -1 | 7
-DEAL::  idx: 8 global: 9 dof indices: 0 | -1
-DEAL::  idx: 9 global: 11 dof indices: 2 | -1
-DEAL::  idx: 10 global: 13 dof indices: 4 | -1
-DEAL::  idx: 11 global: 15 dof indices: 6 | -1
-DEAL::  idx: 12 global: 16 dof indices: 3 | -1
-DEAL::  idx: 13 global: 17 dof indices: 5 | -1
-DEAL::  idx: 14 global: 18 dof indices: 7 | -1
-DEAL::shape_value(true): 0.0625000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.0625000 0.0625000 0.0625000
-DEAL::shape_value(false): 0.140625 0.00000 0.0468750 0.00000 0.0468750 0.00000 0.0156250 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
-DEAL::jump_in_shape_values(): -0.0781250 0.00000 -0.0468750 0.00000 -0.0468750 0.00000 -0.0156250 0.00000 0.00000 0.00000 0.00000 0.00000 0.0625000 0.0625000 0.0625000
-DEAL::average_of_shape_values(): 0.101562 0.00000 0.0234375 0.00000 0.0234375 0.00000 0.00781250 0.00000 0.00000 0.00000 0.00000 0.00000 0.0312500 0.0312500 0.0312500
+DEAL::  idx: 0 global: 9 dof indices: 0 | -1
+DEAL::  idx: 1 global: 0 dof indices: 1 | 0
+DEAL::  idx: 2 global: 11 dof indices: 2 | -1
+DEAL::  idx: 3 global: 16 dof indices: 3 | -1
+DEAL::  idx: 4 global: 13 dof indices: 4 | -1
+DEAL::  idx: 5 global: 17 dof indices: 5 | -1
+DEAL::  idx: 6 global: 15 dof indices: 6 | -1
+DEAL::  idx: 7 global: 18 dof indices: 7 | -1
+DEAL::  idx: 8 global: 1 dof indices: -1 | 1
+DEAL::  idx: 9 global: 2 dof indices: -1 | 2
+DEAL::  idx: 10 global: 3 dof indices: -1 | 3
+DEAL::  idx: 11 global: 4 dof indices: -1 | 4
+DEAL::  idx: 12 global: 5 dof indices: -1 | 5
+DEAL::  idx: 13 global: 6 dof indices: -1 | 6
+DEAL::  idx: 14 global: 7 dof indices: -1 | 7
+DEAL::shape_value(true): 1.15648e-18 0.0625000 4.31605e-18 0.0625000 3.09879e-19 0.0625000 1.15648e-18 0.0625000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.140625 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.0468750 0.00000 0.0468750 0.00000 0.0156250 0.00000
+DEAL::jump_in_shape_values(): 1.15648e-18 -0.0781250 4.31605e-18 0.0625000 3.09879e-19 0.0625000 1.15648e-18 0.0625000 0.00000 -0.0468750 0.00000 -0.0468750 0.00000 -0.0156250 0.00000
+DEAL::average_of_shape_values(): 5.78241e-19 0.101562 2.15803e-18 0.0312500 1.54939e-19 0.0312500 5.78241e-19 0.0312500 0.00000 0.0234375 0.00000 0.0234375 0.00000 0.00781250 0.00000

--- a/tests/feinterface/fe_interface_values_12.output
+++ b/tests/feinterface/fe_interface_values_12.output
@@ -1,57 +1,57 @@
 
 DEAL::FE_DGQ<2>(0)-FE_DGQ<2>(0)
 DEAL::qpoint 0: 1.00000 0.250000
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 2 dof indices: 0 | -1
-DEAL::shape_value(true): 0.00000 0.500000
-DEAL::shape_value(false): 0.500000 0.00000
-DEAL::jump_in_shape_values(): -0.500000 0.500000
+DEAL::  idx: 0 global: 2 dof indices: 0 | -1
+DEAL::  idx: 1 global: 0 dof indices: -1 | 0
+DEAL::shape_value(true): 0.500000 0.00000
+DEAL::shape_value(false): 0.00000 0.500000
+DEAL::jump_in_shape_values(): 0.500000 -0.500000
 DEAL::average_of_shape_values(): 0.250000 0.250000
 DEAL::FE_DGQ<2>(1)-FE_DGQ<2>(2)
 DEAL::qpoint 0: 1.00000 0.105662
 DEAL::qpoint 1: 1.00000 0.394338
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 1 dof indices: -1 | 1
-DEAL::  idx: 2 global: 2 dof indices: -1 | 2
-DEAL::  idx: 3 global: 3 dof indices: -1 | 3
-DEAL::  idx: 4 global: 8 dof indices: 0 | -1
-DEAL::  idx: 5 global: 9 dof indices: 1 | -1
-DEAL::  idx: 6 global: 10 dof indices: 2 | -1
-DEAL::  idx: 7 global: 11 dof indices: 3 | -1
-DEAL::shape_value(true): 0.00000 0.00000 0.00000 0.00000 0.00000 0.250000 0.00000 0.250000
-DEAL::shape_value(false): 0.375000 0.00000 0.125000 0.00000 0.00000 0.00000 0.00000 0.00000
-DEAL::jump_in_shape_values(): -0.375000 0.00000 -0.125000 0.00000 0.00000 0.250000 0.00000 0.250000
-DEAL::average_of_shape_values(): 0.187500 0.00000 0.0625000 0.00000 0.00000 0.125000 0.00000 0.125000
+DEAL::  idx: 0 global: 8 dof indices: 0 | -1
+DEAL::  idx: 1 global: 9 dof indices: 1 | -1
+DEAL::  idx: 2 global: 10 dof indices: 2 | -1
+DEAL::  idx: 3 global: 11 dof indices: 3 | -1
+DEAL::  idx: 4 global: 0 dof indices: -1 | 0
+DEAL::  idx: 5 global: 1 dof indices: -1 | 1
+DEAL::  idx: 6 global: 2 dof indices: -1 | 2
+DEAL::  idx: 7 global: 3 dof indices: -1 | 3
+DEAL::shape_value(true): 0.00000 0.250000 0.00000 0.250000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.00000 0.00000 0.00000 0.375000 0.00000 0.125000 0.00000
+DEAL::jump_in_shape_values(): 0.00000 0.250000 0.00000 0.250000 -0.375000 0.00000 -0.125000 0.00000
+DEAL::average_of_shape_values(): 0.00000 0.125000 0.00000 0.125000 0.187500 0.00000 0.0625000 0.00000
 DEAL::FE_DGQ<3>(0)-FE_DGQ<3>(0)
 DEAL::qpoint 0: 1.00000 0.250000 0.250000
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 2 dof indices: 0 | -1
-DEAL::shape_value(true): 0.00000 0.250000
-DEAL::shape_value(false): 0.250000 0.00000
-DEAL::jump_in_shape_values(): -0.250000 0.250000
+DEAL::  idx: 0 global: 2 dof indices: 0 | -1
+DEAL::  idx: 1 global: 0 dof indices: -1 | 0
+DEAL::shape_value(true): 0.250000 0.00000
+DEAL::shape_value(false): 0.00000 0.250000
+DEAL::jump_in_shape_values(): 0.250000 -0.250000
 DEAL::average_of_shape_values(): 0.125000 0.125000
 DEAL::FE_DGQ<3>(1)-FE_DGQ<3>(2)
 DEAL::qpoint 0: 1.00000 0.105662 0.105662
 DEAL::qpoint 1: 1.00000 0.394338 0.105662
 DEAL::qpoint 2: 1.00000 0.105662 0.394338
 DEAL::qpoint 3: 1.00000 0.394338 0.394338
-DEAL::  idx: 0 global: 0 dof indices: -1 | 0
-DEAL::  idx: 1 global: 1 dof indices: -1 | 1
-DEAL::  idx: 2 global: 2 dof indices: -1 | 2
-DEAL::  idx: 3 global: 3 dof indices: -1 | 3
-DEAL::  idx: 4 global: 4 dof indices: -1 | 4
-DEAL::  idx: 5 global: 5 dof indices: -1 | 5
-DEAL::  idx: 6 global: 6 dof indices: -1 | 6
-DEAL::  idx: 7 global: 7 dof indices: -1 | 7
-DEAL::  idx: 8 global: 16 dof indices: 0 | -1
-DEAL::  idx: 9 global: 17 dof indices: 1 | -1
-DEAL::  idx: 10 global: 18 dof indices: 2 | -1
-DEAL::  idx: 11 global: 19 dof indices: 3 | -1
-DEAL::  idx: 12 global: 20 dof indices: 4 | -1
-DEAL::  idx: 13 global: 21 dof indices: 5 | -1
-DEAL::  idx: 14 global: 22 dof indices: 6 | -1
-DEAL::  idx: 15 global: 23 dof indices: 7 | -1
-DEAL::shape_value(true): 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000
-DEAL::shape_value(false): 0.140625 0.00000 0.0468750 0.00000 0.0468750 0.00000 0.0156250 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
-DEAL::jump_in_shape_values(): -0.140625 0.00000 -0.0468750 0.00000 -0.0468750 0.00000 -0.0156250 0.00000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000 0.00000 0.0625000
-DEAL::average_of_shape_values(): 0.0703125 0.00000 0.0234375 0.00000 0.0234375 0.00000 0.00781250 0.00000 0.00000 0.0312500 0.00000 0.0312500 0.00000 0.0312500 0.00000 0.0312500
+DEAL::  idx: 0 global: 16 dof indices: 0 | -1
+DEAL::  idx: 1 global: 17 dof indices: 1 | -1
+DEAL::  idx: 2 global: 18 dof indices: 2 | -1
+DEAL::  idx: 3 global: 19 dof indices: 3 | -1
+DEAL::  idx: 4 global: 20 dof indices: 4 | -1
+DEAL::  idx: 5 global: 21 dof indices: 5 | -1
+DEAL::  idx: 6 global: 22 dof indices: 6 | -1
+DEAL::  idx: 7 global: 23 dof indices: 7 | -1
+DEAL::  idx: 8 global: 0 dof indices: -1 | 0
+DEAL::  idx: 9 global: 1 dof indices: -1 | 1
+DEAL::  idx: 10 global: 2 dof indices: -1 | 2
+DEAL::  idx: 11 global: 3 dof indices: -1 | 3
+DEAL::  idx: 12 global: 4 dof indices: -1 | 4
+DEAL::  idx: 13 global: 5 dof indices: -1 | 5
+DEAL::  idx: 14 global: 6 dof indices: -1 | 6
+DEAL::  idx: 15 global: 7 dof indices: -1 | 7
+DEAL::shape_value(true): 1.15648e-18 0.0625000 4.31605e-18 0.0625000 3.09879e-19 0.0625000 1.15648e-18 0.0625000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000
+DEAL::shape_value(false): 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.140625 0.00000 0.0468750 0.00000 0.0468750 0.00000 0.0156250 0.00000
+DEAL::jump_in_shape_values(): 1.15648e-18 0.0625000 4.31605e-18 0.0625000 3.09879e-19 0.0625000 1.15648e-18 0.0625000 -0.140625 0.00000 -0.0468750 0.00000 -0.0468750 0.00000 -0.0156250 0.00000
+DEAL::average_of_shape_values(): 5.78241e-19 0.0312500 2.15803e-18 0.0312500 1.54939e-19 0.0312500 5.78241e-19 0.0312500 0.0703125 0.00000 0.0234375 0.00000 0.0234375 0.00000 0.00781250 0.00000


### PR DESCRIPTION
Related to https://github.com/dealii/dealii/issues/19686. Just inserting information from the first cell directly into the final data structures and then updating with information from the second cell, seems to be quite a bit faster than using an `std::map` or `std::unordered_map` first.