### PR TITLE
No longer mention 'unfinished' tutorials in the tut graph.

### DIFF
--- a/doc/doxygen/scripts/steps.pl
+++ b/doc/doxygen/scripts/steps.pl
@@ -32,7 +32,6 @@ my %colors = (
  "fluids"         => 'yellow2',
  "solids"         => 'coral',
  "time dependent" => 'darkolivegreen1',
- "unfinished"     => 'white',
  "code-gallery"   => 'white',
     );
 
@@ -42,7 +41,6 @@ my %style = (
  "fluids"         => ',height=.25,width=.25',
  "solids"         => ',height=.25,width=.25',
  "time dependent" => ',height=.25,width=.25',
- "unfinished"     => ',height=.25,width=.25,style="dashed"',
  "code-gallery"   => ',height=.08,width=.125,shape="circle"',
     );
 
@@ -319,7 +317,6 @@ my %kind_descriptions = (
  "fluids"         => 'Fluid dynamics',
  "solids"         => 'Solid mechanics',
  "time dependent" => 'Time dependent problems',
- "unfinished"     => 'Unfinished codes',
  "code-gallery"   => 'Code gallery',
     );
 
@@ -341,13 +338,12 @@ print "  basic -- techniques [style=invis];\n";
 print "  techniques -- fluids [style=invis];\n";
 print "  fluids -- solids [style=invis];\n";
 print "  solids -- time_dependent [style=invis];\n";
-print "  time_dependent -- unfinished [style=invis];\n";
-print "  unfinished -- code_gallery [style=invis];\n";
+print "  time_dependent -- code_gallery [style=invis];\n";
 
 # we need to tell 'dot' that all of these are at the same
 # rank to ensure they appear next to (as opposed to atop)
 # each other
-print "  {rank=same; basic, techniques, fluids, solids, time_dependent, unfinished, code_gallery}";
+print "  {rank=same; basic, techniques, fluids, solids, time_dependent, code_gallery}";
 
 # end the graph
 print "}\n";


### PR DESCRIPTION
The tutorial graph (and specifically its legend below the graph, see https://dealii.org/developer/doxygen/deal.II/Tutorial.html) has a category for 'unfinished' programs. That was relevant back when we developed tutorial programs in the main repo over time, but these days we do that in branches that get merged when the program is finished. So there should no longer be any unfinished programs to begin with.

This patch just removes the whole category.