### PR TITLE
FEValues: improve exception message

### DIFF
--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1526,7 +1526,17 @@ public:
   DeclExceptionMsg(
     ExcFEDontMatch,
     "The FiniteElement you provided to FEValues and the FiniteElement that belongs "
-    "to the DoFHandler that provided the cell iterator do not match.");
+    "to the DoFHandler that provided the cell iterator do not match. "
+    "In most cases, this is a bug: You're calling FEValues::reinit() with a cell "
+    "from the wrong DoFHandler.\n"
+    "\n"
+    "On the other hand, there are cases where you want to only use an FEValues "
+    "object with the geometric information of a cell, without the information "
+    "about degrees of freedom associated with this cell. In those cases, you "
+    "may want to cast the cell iterator to one that only has the "
+    "geometric information of the triangulation, and initialize with that instead:\n"
+    "\tfe_values.reinit(\n"
+    "\t\tstatic_cast<Triangulation<dim, spacedim>::cell_iterator>(cell));");
   /**
    * A given shape function is not primitive, but it needs to be.
    *


### PR DESCRIPTION
The message looks like this:
```
An error occurred in line <304> of file </homes/numerik/muench/store/sw-index/dealii-reference/source/fe/fe_values.cc> in function
    void dealii::FEValues<dim, spacedim>::reinit(const dealii::TriaIterator<dealii::DoFCellAccessor<dim, spacedim, level_dof_access> >&) [with bool level_dof_access = false; int dim = 1; int spacedim = 1]
The violated condition was: 
    static_cast<const FiniteElementData<dim> &>(*this->fe) == static_cast<const FiniteElementData<dim> &>(cell->get_fe())
Additional information: 
    The FiniteElement you provided to FEValues and the FiniteElement that
    belongs to the DoFHandler that provided the cell iterator do not
    match. You might want to write
    	fe_values.reinit(
    		static_cast<Triangulation<dim, spacedim>::cell_iterator>(cell))
    if you do not need information about degrees of freedom.
```

FYI @joshishivangi