### PR TITLE
Arkode: ensure arkode_mem is deleted before SUNLinearSolver's in ARKStepper

### DIFF
--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -1005,17 +1005,30 @@ namespace SUNDIALS
                       internal::InvocationContext inv_ctx);
 
     /**
-     * ARKode memory object.
-     */
-    ARKodeMemoryPtr arkode_mem;
-
-    /**
      * ARKStepper configuration data.
      */
     AdditionalData data;
 
+    /**
+     * Linear solver for applying the Jacobian of the implicit function in the
+     * nonlinear solver. This is used if the user provides both
+     * jacobian_times_vector() and solve_linearized_system().
+     */
     std::unique_ptr<internal::LinearSolverWrapper<VectorType>> linear_solver;
+
+    /**
+     * Linear solver for applying the mass matrix. This is used if the user
+     * provides both mass_times_vector() and solve_mass().
+     */
     std::unique_ptr<internal::LinearSolverWrapper<VectorType>> mass_solver;
+
+    /**
+     * ARKODE memory object. Declared after linear_solver and mass_solver so
+     * that it is destroyed first (C++ destroys members in reverse declaration
+     * order), ensuring ARKStepFree is called before the solver wrappers free
+     * their SUNLinearSolver objects.
+     */
+    ARKodeMemoryPtr arkode_mem;
 
     /**
      * ARKStepper callback context.

--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -46,12 +46,11 @@ namespace SUNDIALS
 {
   template <typename VectorType>
   ARKStepper<VectorType>::ARKStepper(const AdditionalData &data)
-    : arkode_mem(nullptr,
-                 [](void *mem) {
-                   if (mem)
-                     ARKStepFree(&mem);
-                 })
-    , data(data)
+    : data(data)
+    , arkode_mem(nullptr, [](void *mem) {
+      if (mem)
+        ARKStepFree(&mem);
+    })
   {
 #  if DEAL_II_SUNDIALS_VERSION_LT(6, 4, 0)
     AssertThrow(


### PR DESCRIPTION
There was an issue identified by #19712 and related to the order how the Arkode memory objects should be cleaned up. This PR fixes that.

The remaining crashing test should get fixed after merging #19707.