### PR TITLE
Do not use A.residual() in SolverFIRE.

### DIFF
--- a/doc/news/changes/minor/20260521Bangerth
+++ b/doc/news/changes/minor/20260521Bangerth
@@ -1,0 +1,7 @@
+Fixed: The SolverFIRE class assumed that the matrix object has a
+`residual()` function, but this function is not part of the required
+interface for all matrix types that can be passed to linear
+solvers. This is now fixed by instead relying on `vmult()`
+functionality.
+<br>
+(Wolfgang Bangerth, 2026/05/21)

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -363,12 +363,10 @@ void SolverFIRE<VectorType>::solve(const MatrixType         &A,
 {
   std::function<double(VectorType &, const VectorType &)> compute_func =
     [&](VectorType &g, const VectorType &x) -> double {
-    // Residual of the quadratic form $ \frac{1}{2} xAx - xb $.
-    // G = b - Ax
-    A.residual(g, x, b);
-
-    // Gradient G = Ax -b.
-    g *= -1.;
+    // The residual of the quadratic form $ \frac{1}{2} xAx - xb $ is
+    // g = b - Ax, but at the end of the day we need g = Ax -b:
+    A.vmult(g, x);
+    g -= b;
 
     // The quadratic form $\frac{1}{2} xAx - xb $.
     return 0.5 * A.matrix_norm_square(x) - x * b;


### PR DESCRIPTION
`residual()` is not part of the required interface of operators, and so `SolverFIRE` will not work for all matrix types. Fix this.

Fixes #19345.