### PR TITLE
ExcNumberNotFinite: make it a template.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -914,10 +914,7 @@
                                                               (range)))
 
 /**
- * An assertion that checks whether a number is finite or not. We explicitly
- * cast the number to std::complex to match the signature of the exception
- * (see there for an explanation of why we use std::complex at all) and to
- * satisfy the fact that std::complex has no implicit conversions.
+ * An assertion that checks whether a number is finite or not.
  *
  * @note This and similar macro names are examples of preprocessor definitions
  * in the deal.II library that are not prefixed by a string that likely makes
@@ -932,9 +929,8 @@
  *
  * @ingroup Exceptions
  */
-#define AssertIsFinite(number)               \
-  Assert(dealii::numbers::is_finite(number), \
-         dealii::ExcNumberNotFinite(std::complex<double>(number)))
+#define AssertIsFinite(number) \
+  Assert(dealii::numbers::is_finite(number), dealii::ExcNumberNotFinite(number))
 
 /**
  * Assert that a geometric object is not used. This assertion is used when

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -31,7 +31,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <deal.II/base/exception_macros.h>
 
-#include <complex>
 #include <exception>
 #include <ostream>
 #include <string>
@@ -208,13 +207,11 @@ namespace StandardExceptions
    * This exception should be used to catch infinite or not a number results
    * of arithmetic operations that do not result from a division by zero (use
    * ExcDivideByZero for those).
-   *
-   * The exception uses std::complex as its argument to ensure that we can use
-   * it for all scalar arguments (real or complex-valued).
    */
+  template <typename Number>
   DeclException1(
     ExcNumberNotFinite,
-    std::complex<double>,
+    Number,
     << "In a significant number of places, deal.II checks that some intermediate "
     << "value is a finite number (as opposed to plus or minus infinity, or "
     << "NaN/Not a Number). In the current function, we encountered a number "

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <array>
+#include <complex>
 #include <deque>
 #include <limits>
 #include <list>

--- a/include/deal.II/fe/fe_series.h
+++ b/include/deal.II/fe/fe_series.h
@@ -31,6 +31,7 @@
 
 #include <deal.II/numerics/vector_tools_common.h>
 
+#include <complex>
 #include <memory>
 #include <string>
 #include <vector>

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -63,6 +63,7 @@
 #include <deal.II/lac/householder.h>
 
 #include <cctype>
+#include <complex>
 #include <iostream>
 #include <memory>
 #include <shared_mutex>

--- a/include/deal.II/lac/arpack_solver.h
+++ b/include/deal.II/lac/arpack_solver.h
@@ -22,6 +22,7 @@
 
 #include <deal.II/lac/solver_control.h>
 
+#include <complex>
 #include <cstring>
 
 

--- a/include/deal.II/lac/blas_extension_templates.h
+++ b/include/deal.II/lac/blas_extension_templates.h
@@ -18,10 +18,6 @@
 
 #include <deal.II/lac/lapack_support.h>
 
-#ifdef DEAL_II_HAVE_FP_EXCEPTIONS
-#  include <cfenv>
-#endif
-
 // Intel-MKL specific functions
 #ifdef DEAL_II_LAPACK_WITH_MKL
 // see
@@ -31,6 +27,11 @@
 #  include <mkl_trans.h>
 #endif
 
+#ifdef DEAL_II_HAVE_FP_EXCEPTIONS
+#  include <cfenv>
+#endif
+
+#include <complex>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -23,6 +23,7 @@
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/vector.h>
 
+#include <complex>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/lac/lapack_templates.h
+++ b/include/deal.II/lac/lapack_templates.h
@@ -24,6 +24,8 @@
 #  include <cfenv>
 #endif
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 DEAL_II_NAMESPACE_CLOSE // Do not convert for module purposes
 

--- a/include/deal.II/lac/parpack_solver.h
+++ b/include/deal.II/lac/parpack_solver.h
@@ -22,6 +22,7 @@
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/vector_operation.h>
 
+#include <complex>
 #include <cstring>
 
 

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -43,6 +43,8 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <boost/io/ios_state.hpp>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <limits>
 #include <memory>
 #include <utility>

--- a/include/deal.II/lac/sparse_direct.h
+++ b/include/deal.II/lac/sparse_direct.h
@@ -43,6 +43,8 @@
 #  include <deal.II/lac/petsc_vector.h>
 #endif
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace types

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -37,6 +37,7 @@
 #  include <Tpetra_Vector.hpp>
 #  include <Tpetra_Version.hpp>
 
+#  include <complex>
 #  include <memory>
 #  include <optional>
 #  include <utility>


### PR DESCRIPTION
This avoids including `<complex>` in this header, which is nearly 15k lines of extra code after running the preprocessor.

I noticed this while working on #19704: the fewer headers we transitively include the better.