### PR TITLE
Add a missing header file.

### DIFF
--- a/include/deal.II/sundials/arkode_stepper.templates.h
+++ b/include/deal.II/sundials/arkode_stepper.templates.h
@@ -31,6 +31,9 @@
 #  include <deal.II/sundials/utilities.h>
 
 #  include <arkode/arkode_arkstep.h>
+#  if DEAL_II_SUNDIALS_VERSION_GTE(7, 0, 0)
+#    include <arkode/arkode.h>
+#  endif
 #  include <sunlinsol/sunlinsol_spgmr.h>
 #  include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
 


### PR DESCRIPTION
`ARKodeSetOrder` is declared in `arkode/arkode.h` on my system, but in `sundials/arkode_stepper.templates.h` we only `#include <arkode/arkode_arkstep.h>`. I believe this is what causes #19729.

Fixes #19729. 