### PR TITLE
Fix Tpetra sparse matrix wont compress if one rank doesnt own entries

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -1531,11 +1531,15 @@ namespace LinearAlgebra
     void
     SparseMatrix<Number, MemorySpace>::compress(VectorOperation::values)
     {
-      // We can't use fillComplete multiple times in a row, so we need to know
-      // if any process has changed matrix entries
-      if (!dealii::Utilities::MPI::logical_or(compressed,
-                                              this->get_mpi_communicator()))
+      // fillComplete() has to be called by all processes if at least one
+      // process needs to compress. However, it cannot be called if there are
+      // processes which have not called resumeFill() first. So first check if
+      // any process has changed matrix entries, if so, first call resumeFill(),
+      // then fillComplete() on all processes.
+      if (!dealii::Utilities::MPI::logical_and(compressed,
+                                               this->get_mpi_communicator()))
         {
+          matrix->resumeFill();
           matrix->fillComplete(column_space_map, matrix->getRowMap());
           compressed = true;
         }

--- a/tests/trilinos_tpetra/sparse_matrix_05.cc
+++ b/tests/trilinos_tpetra/sparse_matrix_05.cc
@@ -62,5 +62,6 @@ main(int argc, char **argv)
     Assert(matrix.is_compressed() == true, ExcInternalError());
 
   matrix.compress(VectorOperation::insert);
+  Assert(matrix.is_compressed() == true, ExcInternalError());
   deallog << "OK" << std::endl;
 }


### PR DESCRIPTION
This fixes a curious little bug that I encountered in `TpetraWrappers::SparseMatrix` when one MPI process does not own any DoFs.

If not all processes agree on whether the matrix is compressed or not, currently the `compress()` function will not work (it will skip compressing). This is because as the comment in the code points out, Tpetra only allows to call `fillComplete()` if all processs call it, and if all agree that the matrix is not already fill complete. However this is not the case if some ranks have not modified the matrix entries (either because they dont own any, or because they didnt have to modify their entries).

But we need to be able to support this case, so the correct workaround is to first check if any processes need to compress. If there are any, all processes have to mark the matrix as fill active, because only then all can call `fillComplete()`. I am not entirely sure if this is intended by Tpetra or if just no one thought about this case, but it is at least easy to work around.

We even had a test case for this particular case, but it was focused on the `reinit()` and `set()` functions, and didnt assert that `compress()` would actually lead to `is_compressed() == true`. The modified test fails on master, but passes on this branch.