### PR TITLE
Add a lot of potentially missing complex includes.

### DIFF
--- a/source/base/function.cc
+++ b/source/base/function.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/base/function.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 // explicit instantiations

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -18,6 +18,7 @@
 
 #include <deal.II/lac/vector.h>
 
+#include <complex>
 #include <map>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/base/function_time.cc
+++ b/source/base/function_time.cc
@@ -14,6 +14,7 @@
 #include <deal.II/base/function_time.h>
 #include <deal.II/base/function_time.templates.h>
 
+#include <complex>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/incremental_function.cc
+++ b/source/base/incremental_function.cc
@@ -15,6 +15,8 @@
 
 #include <deal.II/lac/vector.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace Functions

--- a/source/base/mu_parser_internal.cc
+++ b/source/base/mu_parser_internal.cc
@@ -15,6 +15,7 @@
 #include <deal.II/base/utilities.h>
 
 #include <cmath>
+#include <complex>
 #include <ctime>
 #include <limits>
 #include <map>

--- a/source/base/symbolic_function.cc
+++ b/source/base/symbolic_function.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/base/symbolic_function.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 #ifdef DEAL_II_WITH_SYMENGINE
 namespace Functions

--- a/source/base/symmetric_tensor.cc
+++ b/source/base/symmetric_tensor.cc
@@ -24,6 +24,8 @@
 #  include <adolc/adtl.h>
 #endif
 
+#include <complex>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/base/tensor_function.cc
+++ b/source/base/tensor_function.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/base/tensor_function.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 // explicit instantiations

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -31,6 +31,7 @@
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
+#include <complex>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -44,6 +44,7 @@
 #include <deal.II/numerics/vector_tools_interpolate.h>
 
 #include <algorithm>
+#include <complex>
 #include <numeric>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <array>
+#include <complex>
 #include <memory>
 #include <numeric>
 

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -41,6 +41,7 @@
 #include <deal.II/lac/vector.h>
 
 #include <algorithm>
+#include <complex>
 #include <numeric>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -13,6 +13,8 @@
 
 #include <deal.II/fe/fe_tools.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -33,6 +33,7 @@
 
 #include <boost/container/small_vector.hpp>
 
+#include <complex>
 #include <iomanip>
 #include <memory>
 #include <type_traits>

--- a/source/fe/fe_values_views.cc
+++ b/source/fe/fe_values_views.cc
@@ -27,6 +27,8 @@
 #  include <adolc/adtl.h>
 #endif
 
+#include <complex>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -13,6 +13,7 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/affine_constraints.templates.h>
 
+#include <complex>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/lac/block_sparse_matrix.cc
+++ b/source/lac/block_sparse_matrix.cc
@@ -13,6 +13,8 @@
 
 #include <deal.II/lac/block_sparse_matrix.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #include "lac/block_sparse_matrix.inst"

--- a/source/lac/block_vector.cc
+++ b/source/lac/block_vector.cc
@@ -13,6 +13,8 @@
 
 #include <deal.II/lac/block_vector.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #include "lac/block_vector.inst"

--- a/source/lac/chunk_sparse_matrix.cc
+++ b/source/lac/chunk_sparse_matrix.cc
@@ -13,6 +13,8 @@
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/chunk_sparse_matrix.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 #include "lac/chunk_sparse_matrix.inst"
 DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/la_parallel_block_vector.cc
+++ b/source/lac/la_parallel_block_vector.cc
@@ -15,6 +15,8 @@
 #include <deal.II/lac/la_parallel_block_vector.templates.h>
 #include <deal.II/lac/lapack_full_matrix.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #include "lac/la_parallel_block_vector.inst"

--- a/source/lac/la_parallel_vector.cc
+++ b/source/lac/la_parallel_vector.cc
@@ -13,6 +13,8 @@
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/la_parallel_vector.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #include "lac/la_parallel_vector.inst"

--- a/source/lac/read_write_vector.cc
+++ b/source/lac/read_write_vector.cc
@@ -13,6 +13,8 @@
 #include <deal.II/lac/read_write_vector.h>
 #include <deal.II/lac/read_write_vector.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #include "lac/read_write_vector.inst"

--- a/source/lac/sparse_matrix_inst1.cc
+++ b/source/lac/sparse_matrix_inst1.cc
@@ -14,6 +14,8 @@
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/sparse_matrix.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #define SPLIT_INSTANTIATIONS_COUNT 2

--- a/source/lac/sparse_matrix_inst2.cc
+++ b/source/lac/sparse_matrix_inst2.cc
@@ -15,6 +15,8 @@
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/sparse_matrix.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #define SPLIT_INSTANTIATIONS_COUNT 2

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/lac/vector.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #ifndef DOXYGEN

--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -34,6 +34,7 @@
 
 #include <deal.II/non_matching/coupling.h>
 
+#include <complex>
 #include <limits>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 #include <functional>
 #include <numeric>
 #include <vector>

--- a/source/numerics/error_estimator_inst1.cc
+++ b/source/numerics/error_estimator_inst1.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/numerics/error_estimator.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #define SPLIT_INSTANTIATIONS_COUNT 2

--- a/source/numerics/error_estimator_inst2.cc
+++ b/source/numerics/error_estimator_inst2.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/numerics/error_estimator.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 #define SPLIT_INSTANTIATIONS_COUNT 2

--- a/source/numerics/matrix_creator_inst1.cc
+++ b/source/numerics/matrix_creator_inst1.cc
@@ -12,6 +12,7 @@
 
 #include <deal.II/numerics/matrix_creator.templates.h>
 
+#include <complex>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/numerics/matrix_creator_inst2.cc
+++ b/source/numerics/matrix_creator_inst2.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/numerics/matrix_creator.templates.h>
 
+#include <complex>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/numerics/matrix_creator_inst3.cc
+++ b/source/numerics/matrix_creator_inst3.cc
@@ -12,6 +12,8 @@
 
 #include <deal.II/numerics/matrix_creator.templates.h>
 
+#include <complex>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/source/numerics/matrix_tools.cc
+++ b/source/numerics/matrix_tools.cc
@@ -47,6 +47,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
 
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/numerics/vector_tools_boundary.cc
+++ b/source/numerics/vector_tools_boundary.cc
@@ -13,6 +13,8 @@
 
 #include <deal.II/numerics/vector_tools_boundary.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 // ---------------------------- explicit instantiations --------------------

--- a/source/numerics/vector_tools_integrate_difference.cc
+++ b/source/numerics/vector_tools_integrate_difference.cc
@@ -13,6 +13,8 @@
 
 #include <deal.II/numerics/vector_tools_integrate_difference.templates.h>
 
+#include <complex>
+
 DEAL_II_NAMESPACE_OPEN
 
 // ---------------------------- explicit instantiations --------------------

--- a/source/numerics/vector_tools_mean_value.cc
+++ b/source/numerics/vector_tools_mean_value.cc
@@ -13,6 +13,7 @@
 
 #include <deal.II/numerics/vector_tools_mean_value.templates.h>
 
+#include <complex>
 #include <vector>
 
 


### PR DESCRIPTION
If we need to instantiate for a complex type then we should include `<complex>`.

Should fix #19739. I think this only shows up if we compile with complex numbers.