### PR TITLE
inplace_vector: add a missing header.

### DIFF
--- a/include/deal.II/base/std_cxx26/inplace_vector.h
+++ b/include/deal.II/base/std_cxx26/inplace_vector.h
@@ -28,6 +28,7 @@
 // half the preprocessed size of <iterator>) from <array>
 #  include <algorithm>
 #  include <array>
+#  include <cstdint>
 #  include <initializer_list>
 #  include <limits>
 #  include <type_traits>


### PR DESCRIPTION
Caught by the CI: see 

https://cdash.dealii.org/builds/1505/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D