### PR TITLE
Arkode: add additional Butcher test output for SUNDIALS < 7.3

### DIFF
--- a/tests/sundials/arkode_arkstep_order_butcher.output.sundials73
+++ b/tests/sundials/arkode_arkstep_order_butcher.output.sundials73
@@ -2,12 +2,12 @@
 DEAL::=== Order 3 ===
 DEAL::final = -0.958924 0.283662
 DEAL::work stats:
-DEAL::  steps = 3469
-DEAL::  step attempts = 3469
+DEAL::  steps = 2635
+DEAL::  step attempts = 2635
 DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 13877
-DEAL::  implicit rhs evals = 34691
-DEAL::  nonlinear iterations = 20814
+DEAL::  explicit rhs evals = 10540
+DEAL::  implicit rhs evals = 26350
+DEAL::  nonlinear iterations = 15810
 DEAL::  nonlinear convergence failures = 0
 DEAL::  rejection rate = 0.000000
 DEAL::=== Butcher tables order 5 ===


### PR DESCRIPTION
The Butcher tables test for `ARKStepper` crashes (https://cdash.dealii.org/tests/9229882) since the default methods were changed in SUNDIALS 7.3: https://github.com/llnl/sundials/releases/tag/v7.3.0. See #19741 for the report. It makes sense then to add a second output file. Note that the second sub-test works fine since the tables are explicitly specified, so the behavior remains consistent between multiple SUNDIALS versions.