### PR TITLE
Portable::MatrixFree: add missing fence() instructions

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -731,10 +731,14 @@ namespace Portable
     const unsigned int size = internal::VectorLocalSize<VectorType>::get(dst);
     const Number      *src_ptr = src.get_values();
     Number            *dst_ptr = dst.get_values();
+
+    MemorySpace::Default::kokkos_space::execution_space exec;
+
     Kokkos::parallel_for(
       "dealii::copy_constrained_values",
-      Kokkos::RangePolicy<MemorySpace::Default::kokkos_space::execution_space>(
-        0, dof_handler_data[dof_handler_index].n_constrained_dofs),
+      Kokkos::RangePolicy<
+        typename MemorySpace::Default::kokkos_space::execution_space>(
+        exec, 0, dof_handler_data[dof_handler_index].n_constrained_dofs),
       KOKKOS_LAMBDA(int dof) {
         // When working with distributed vectors, the constrained dofs are
         // computed for ghosted vectors but we want to copy the values of the
@@ -743,6 +747,7 @@ namespace Portable
         if (constrained_dof < size)
           dst_ptr[constrained_dof] = src_ptr[constrained_dof];
       });
+    exec.fence();
   }
 
 
@@ -797,14 +802,18 @@ namespace Portable
                                 dst.locally_owned_size() :
                                 dst.size();
 
+    MemorySpace::Default::kokkos_space::execution_space exec;
+
     Kokkos::parallel_for(
       "dealii::set_constrained_values",
-      Kokkos::RangePolicy<MemorySpace::Default::kokkos_space::execution_space>(
-        0, dof_handler_data[dof_handler_index].n_constrained_dofs),
+      Kokkos::RangePolicy<
+        typename MemorySpace::Default::kokkos_space::execution_space>(
+        exec, 0, dof_handler_data[dof_handler_index].n_constrained_dofs),
       KOKKOS_LAMBDA(int dof) {
         if (constr_dofs[dof] < size)
           dst_ptr[constr_dofs[dof]] = value;
       });
+    exec.fence();
   }
 
 
@@ -915,6 +924,7 @@ namespace Portable
                   func(&data, cell_index, q_point);
                 });
             });
+          exec.fence();
         }
   }
 


### PR DESCRIPTION
Add missing fence() instructions in:
- ``copy_constrained_values``
- ``set_constrained_values``
- ``evaluate_coefficients``