### PR TITLE
Use correct condition within for loop when iterating over children.

### DIFF
--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -249,9 +249,7 @@ namespace parallel
                       if (cell->has_children())
                         {
                           bool keep_cell = false;
-                          for (unsigned int c = 0;
-                               c < GeometryInfo<dim>::max_children_per_cell;
-                               ++c)
+                          for (unsigned int c = 0; c < cell->n_children(); ++c)
                             if (cell->child(c)->level_subdomain_id() ==
                                 this->my_subdomain)
                               {


### PR DESCRIPTION
Iterate over the number of children that are actually present, and don't assume it's just the maximum possible number of children.

> Required for https://github.com/dealii/dealii/pull/19626