### PR TITLE
Add a constant for the maximum number of levels.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -413,6 +413,14 @@ namespace numbers
    */
   constexpr types::subdomain_id artificial_subdomain_id =
     static_cast<types::subdomain_id>(-2);
+
+  /**
+   * Maximum number of levels, including the coarsest level.
+   *
+   * @note This is the same limit imposed by p4est, which bounds the maximum
+   * level index by 30 via `P4EST_MAX_LEVEL` and `P8EST_MAX_LEVEL`.
+   */
+  constexpr std::uint8_t max_n_levels = 31;
 } // namespace numbers
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/cell_id.h
+++ b/include/deal.II/grid/cell_id.h
@@ -23,10 +23,6 @@
 #include <iostream>
 #include <vector>
 
-#ifdef DEAL_II_WITH_P4EST
-#  include <deal.II/distributed/p4est_wrappers.h>
-#endif
-
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
@@ -216,20 +212,17 @@ private:
   unsigned int n_child_indices;
 
   /**
-   * An array of integers that denotes which child to pick from one
-   * refinement level to the next, starting with the coarse cell,
-   * until we get to the cell represented by the current object.
-   * Only the first n_child_indices entries are used, but we use a statically
-   * allocated array instead of a vector of size n_child_indices to speed up
-   * creation of this object. If the given dimensions ever become a limitation
-   * the array can be extended.
+   * An array of integers that denotes which child to pick from one refinement
+   * level to the next, starting with the coarse cell, until we get to the cell
+   * represented by the current object. Only the first n_child_indices entries
+   * are used, but we use a statically allocated array instead of a vector of
+   * size n_child_indices to speed up creation of this object. If the given
+   * dimensions ever become a limitation the array can be extended.
+   *
+   * @note Since this array stores child indices, it does not need to store a
+   * child index on the finest level, so its size is decremented by 1.
    */
-#ifdef DEAL_II_WITH_P4EST
-  std::array<std::uint8_t, internal::p4est::functions<2>::max_level>
-    child_indices;
-#else
-  std::array<std::uint8_t, 30> child_indices;
-#endif
+  std::array<std::uint8_t, numbers::max_n_levels - 1> child_indices;
 
   friend std::istream &
   operator>>(std::istream &is, CellId &cid);

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3990,6 +3990,11 @@ public:
    *
    * @ingroup Exceptions
    */
+  DeclExceptionMsg(ExcTooManyLevels,
+                   "The provided refinement pattern requires creating a level "
+                   "in the Triangulation. However, the maximum number of "
+                   "levels has already been reached, so that is not allowed.");
+
   DeclException2(ExcInvalidLevel,
                  int,
                  int,
@@ -4710,6 +4715,7 @@ void Triangulation<dim, spacedim>::save(Archive &ar, const unsigned int) const
 
   unsigned int n_levels = levels.size();
   ar          &n_levels;
+  Assert(n_levels <= numbers::max_n_levels, ExcInternalError());
   for (const auto &level : levels)
     ar &level;
 
@@ -4752,9 +4758,10 @@ void Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
 
   ar &reference_cells;
 
-  unsigned int size;
-  ar          &size;
-  levels.resize(size);
+  unsigned int n_levels;
+  ar          &n_levels;
+  Assert(n_levels <= numbers::max_n_levels, ExcInternalError());
+  levels.resize(n_levels);
   for (auto &level_ : levels)
     {
       std::unique_ptr<

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -6356,6 +6356,9 @@ namespace internal
                triangulation.levels.size() - 1))
           if (cell->refine_flag_set())
             {
+              AssertThrow(
+                triangulation.levels.size() < numbers::max_n_levels,
+                (typename Triangulation<3, spacedim>::ExcTooManyLevels()));
               triangulation.levels.push_back(
                 std::make_unique<internal::TriangulationImplementation::
                                    TriaLevel<dim, spacedim>>(
@@ -7927,6 +7930,9 @@ namespace internal
                triangulation.levels.size() - 1))
           if (cell->refine_flag_set())
             {
+              AssertThrow(
+                triangulation.levels.size() < numbers::max_n_levels,
+                (typename Triangulation<3, spacedim>::ExcTooManyLevels()));
               triangulation.levels.push_back(
                 std::make_unique<internal::TriangulationImplementation::
                                    TriaLevel<dim, spacedim>>(
@@ -13207,6 +13213,7 @@ void Triangulation<dim, spacedim>::copy_triangulation(
     set_manifold(p.first, *p.second);
 
 
+  Assert(other_tria.levels.size() <= numbers::max_n_levels, ExcInternalError());
   levels.reserve(other_tria.levels.size());
   for (const auto &level : other_tria.levels)
     levels.push_back(


### PR DESCRIPTION
This will let us un-hardcode some constants (like the use of `30` in `CellId`).