### PR TITLE
MappingQ etc.: avoid allocating support points.

### DIFF
--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -71,7 +71,8 @@ protected:
   virtual void
   add_line_support_points(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    std::vector<Point<spacedim>> &a) const override;
+    boost::container::small_vector<Point<spacedim>, 200>       &points)
+    const override;
 
   /**
    * For <tt>dim=3</tt>. Append the support points of all shape functions
@@ -85,7 +86,8 @@ protected:
   virtual void
   add_quad_support_points(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    std::vector<Point<spacedim>> &a) const override;
+    boost::container::small_vector<Point<spacedim>, 200>       &points)
+    const override;
 };
 
 /** @} */
@@ -96,22 +98,25 @@ protected:
 
 template <>
 void
-MappingC1<1>::add_line_support_points(const Triangulation<1>::cell_iterator &,
-                                      std::vector<Point<1>> &) const;
+MappingC1<1>::add_line_support_points(
+  const Triangulation<1>::cell_iterator &,
+  boost::container::small_vector<Point<1>, 200> &) const;
 template <>
 void
 MappingC1<2>::add_line_support_points(
   const Triangulation<2>::cell_iterator &cell,
-  std::vector<Point<2>>                 &a) const;
+  boost::container::small_vector<Point<2>, 200> &) const;
 
 template <>
 void
-MappingC1<1>::add_quad_support_points(const Triangulation<1>::cell_iterator &,
-                                      std::vector<Point<1>> &) const;
+MappingC1<1>::add_quad_support_points(
+  const Triangulation<1>::cell_iterator &,
+  boost::container::small_vector<Point<1>, 200> &) const;
 template <>
 void
-MappingC1<2>::add_quad_support_points(const Triangulation<2>::cell_iterator &,
-                                      std::vector<Point<2>> &) const;
+MappingC1<2>::add_quad_support_points(
+  const Triangulation<2>::cell_iterator &,
+  boost::container::small_vector<Point<2>, 200> &) const;
 
 
 #endif // DOXYGEN

--- a/include/deal.II/fe/mapping_c1.h
+++ b/include/deal.II/fe/mapping_c1.h
@@ -58,6 +58,7 @@ public:
   virtual std::unique_ptr<Mapping<dim, spacedim>>
   clone() const override;
 
+protected:
   /**
    * For <tt>dim=2,3</tt>. Append the support points of all shape functions
    * located on bounding lines to the vector @p a. Points located on the

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -606,9 +606,10 @@ protected:
    * interpolation, or if dim<spacedim, it asks the underlying manifold for
    * the locations of interior points.
    */
-  virtual std::vector<Point<spacedim>>
+  virtual void
   compute_mapping_support_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell) const;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    boost::container::small_vector<Point<spacedim>, 200>       &points) const;
 
   /**
    * Transform the point @p p on the real cell to the corresponding point on
@@ -636,7 +637,7 @@ protected:
   virtual void
   add_line_support_points(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    std::vector<Point<spacedim>>                               &a) const;
+    boost::container::small_vector<Point<spacedim>, 200>       &points) const;
 
   /**
    * Append the support points of all shape functions located on bounding
@@ -655,7 +656,7 @@ protected:
   virtual void
   add_quad_support_points(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    std::vector<Point<spacedim>>                               &a) const;
+    boost::container::small_vector<Point<spacedim>, 200>       &points) const;
 
   // Make MappingQCache a friend since it needs to call the
   // compute_mapping_support_points() function.

--- a/include/deal.II/fe/mapping_q1_eulerian.h
+++ b/include/deal.II/fe/mapping_q1_eulerian.h
@@ -173,9 +173,10 @@ protected:
    * documentation of MappingQ::compute_mapping_support_points() for
    * more information.
    */
-  virtual std::vector<Point<spacedim>>
+  virtual void
   compute_mapping_support_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell)
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    boost::container::small_vector<Point<spacedim>, 200>       &points)
     const override;
 
   /**

--- a/include/deal.II/fe/mapping_q_cache.h
+++ b/include/deal.II/fe/mapping_q_cache.h
@@ -215,10 +215,10 @@ protected:
   /**
    * This is the main function overridden from the base class MappingQ.
    */
-  virtual std::vector<Point<spacedim>>
+  virtual void
   compute_mapping_support_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell)
-    const override;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    boost::container::small_vector<Point<spacedim>, 200> &a) const override;
 
 private:
   /**

--- a/include/deal.II/fe/mapping_q_eulerian.h
+++ b/include/deal.II/fe/mapping_q_eulerian.h
@@ -147,10 +147,10 @@ public:
   preserves_vertex_locations() const override;
 
   // for documentation, see the Mapping base class
-  virtual std::vector<Point<spacedim>>
+  virtual void
   compute_mapping_support_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell)
-    const override;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    boost::container::small_vector<Point<spacedim>, 200> &a) const override;
 
   /**
    * Exception which is thrown when the mapping is being evaluated at

--- a/source/fe/mapping_c1.cc
+++ b/source/fe/mapping_c1.cc
@@ -36,8 +36,9 @@ MappingC1<dim, spacedim>::MappingC1()
 
 template <>
 void
-MappingC1<1>::add_line_support_points(const Triangulation<1>::cell_iterator &,
-                                      std::vector<Point<1>> &) const
+MappingC1<1>::add_line_support_points(
+  const Triangulation<1>::cell_iterator &,
+  boost::container::small_vector<Point<1>, 200> &) const
 {
   const unsigned int dim = 1;
   (void)dim;
@@ -49,8 +50,8 @@ MappingC1<1>::add_line_support_points(const Triangulation<1>::cell_iterator &,
 template <>
 void
 MappingC1<2>::add_line_support_points(
-  const Triangulation<2>::cell_iterator &cell,
-  std::vector<Point<2>>                 &a) const
+  const Triangulation<2>::cell_iterator         &cell,
+  boost::container::small_vector<Point<2>, 200> &a) const
 {
   const unsigned int          dim = 2;
   const std::array<double, 2> interior_gl_points{
@@ -156,7 +157,7 @@ template <int dim, int spacedim>
 void
 MappingC1<dim, spacedim>::add_line_support_points(
   const typename Triangulation<dim, spacedim>::cell_iterator &,
-  std::vector<Point<spacedim>> &) const
+  boost::container::small_vector<Point<spacedim>, 200> &) const
 {
   DEAL_II_NOT_IMPLEMENTED();
 }
@@ -165,8 +166,9 @@ MappingC1<dim, spacedim>::add_line_support_points(
 
 template <>
 void
-MappingC1<1>::add_quad_support_points(const Triangulation<1>::cell_iterator &,
-                                      std::vector<Point<1>> &) const
+MappingC1<1>::add_quad_support_points(
+  const Triangulation<1>::cell_iterator &,
+  boost::container::small_vector<Point<1>, 200> &) const
 {
   const unsigned int dim = 1;
   (void)dim;
@@ -177,8 +179,9 @@ MappingC1<1>::add_quad_support_points(const Triangulation<1>::cell_iterator &,
 
 template <>
 void
-MappingC1<2>::add_quad_support_points(const Triangulation<2>::cell_iterator &,
-                                      std::vector<Point<2>> &) const
+MappingC1<2>::add_quad_support_points(
+  const Triangulation<2>::cell_iterator &,
+  boost::container::small_vector<Point<2>, 200> &) const
 {
   const unsigned int dim = 2;
   (void)dim;
@@ -191,7 +194,7 @@ template <int dim, int spacedim>
 void
 MappingC1<dim, spacedim>::add_quad_support_points(
   const typename Triangulation<dim, spacedim>::cell_iterator &,
-  std::vector<Point<spacedim>> &) const
+  boost::container::small_vector<Point<spacedim>, 200> &) const
 {
   DEAL_II_NOT_IMPLEMENTED();
 }

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -1581,7 +1581,6 @@ MappingQ<dim, spacedim>::add_line_support_points(
     // otherwise call the more complicated functions and ask for inner points
     // from the manifold description
     {
-      std::vector<Point<spacedim>> tmp_points;
       for (unsigned int line_no = 0;
            line_no < GeometryInfo<dim>::lines_per_cell;
            ++line_no)
@@ -1624,9 +1623,6 @@ MappingQ<3, 3>::add_quad_support_points(
   boost::container::small_vector<Point<3>, 200> &a) const
 {
   const unsigned int faces_per_cell = GeometryInfo<3>::faces_per_cell;
-
-  // used if face quad at boundary or entirely in the interior of the domain
-  std::vector<Point<3>> tmp_points;
 
   // loop over all faces and collect points on them
   for (unsigned int face_no = 0; face_no < faces_per_cell; ++face_no)

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -284,12 +284,16 @@ MappingQ<dim, spacedim>::transform_unit_to_real_cell(
         internal::evaluate_tensor_product_value_linear(vertices.data(), p));
     }
   else
-    return Point<spacedim>(internal::evaluate_tensor_product_value(
-      polynomials_1d,
-      make_const_array_view(this->compute_mapping_support_points(cell)),
-      p,
-      polynomials_1d.size() == 2,
-      renumber_lexicographic_to_hierarchic));
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      return Point<spacedim>(internal::evaluate_tensor_product_value(
+        polynomials_1d,
+        ArrayView<const Point<spacedim>>(points.data(), points.size()),
+        p,
+        polynomials_1d.size() == 2,
+        renumber_lexicographic_to_hierarchic));
+    }
 }
 
 
@@ -333,8 +337,6 @@ MappingQ<1, 1>::transform_real_to_unit_cell_internal(
   const Point<1>                           &p,
   const Point<1>                           &initial_p_unit) const
 {
-  // dispatch to the various specializations for spacedim=dim,
-  // spacedim=dim+1, etc
   if (polynomial_degree == 1)
     {
       const auto vertices = this->get_vertices(cell);
@@ -342,18 +344,22 @@ MappingQ<1, 1>::transform_real_to_unit_cell_internal(
         do_transform_real_to_unit_cell_internal<1>(
           p,
           initial_p_unit,
-          ArrayView<const Point<1>>(vertices.data(), vertices.size()),
+          ArrayView<const Point<1>>(vertices),
           polynomials_1d,
           renumber_lexicographic_to_hierarchic);
     }
   else
-    return internal::MappingQImplementation::
-      do_transform_real_to_unit_cell_internal<1>(
-        p,
-        initial_p_unit,
-        make_const_array_view(this->compute_mapping_support_points(cell)),
-        polynomials_1d,
-        renumber_lexicographic_to_hierarchic);
+    {
+      boost::container::small_vector<Point<1>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      return internal::MappingQImplementation::
+        do_transform_real_to_unit_cell_internal<1>(
+          p,
+          initial_p_unit,
+          ArrayView<const Point<1>>(points),
+          polynomials_1d,
+          renumber_lexicographic_to_hierarchic);
+    }
 }
 
 
@@ -372,18 +378,22 @@ MappingQ<2, 2>::transform_real_to_unit_cell_internal(
         do_transform_real_to_unit_cell_internal<2>(
           p,
           initial_p_unit,
-          ArrayView<const Point<2>>(vertices.data(), vertices.size()),
+          ArrayView<const Point<2>>(vertices),
           polynomials_1d,
           renumber_lexicographic_to_hierarchic);
     }
   else
-    return internal::MappingQImplementation::
-      do_transform_real_to_unit_cell_internal<2>(
-        p,
-        initial_p_unit,
-        make_const_array_view(this->compute_mapping_support_points(cell)),
-        polynomials_1d,
-        renumber_lexicographic_to_hierarchic);
+    {
+      boost::container::small_vector<Point<2>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      return internal::MappingQImplementation::
+        do_transform_real_to_unit_cell_internal<2>(
+          p,
+          initial_p_unit,
+          ArrayView<const Point<2>>(points),
+          polynomials_1d,
+          renumber_lexicographic_to_hierarchic);
+    }
 }
 
 
@@ -407,13 +417,17 @@ MappingQ<3, 3>::transform_real_to_unit_cell_internal(
           renumber_lexicographic_to_hierarchic);
     }
   else
-    return internal::MappingQImplementation::
-      do_transform_real_to_unit_cell_internal<3>(
-        p,
-        initial_p_unit,
-        make_const_array_view(this->compute_mapping_support_points(cell)),
-        polynomials_1d,
-        renumber_lexicographic_to_hierarchic);
+    {
+      boost::container::small_vector<Point<3>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      return internal::MappingQImplementation::
+        do_transform_real_to_unit_cell_internal<3>(
+          p,
+          initial_p_unit,
+          ArrayView<const Point<3>>(points.data(), points.size()),
+          polynomials_1d,
+          renumber_lexicographic_to_hierarchic);
+    }
 }
 
 
@@ -436,7 +450,9 @@ MappingQ<1, 2>::transform_real_to_unit_cell_internal(
   auto mdata = Utilities::dynamic_unique_cast<InternalData>(
     get_data(update_flags, point_quadrature));
 
-  mdata->mapping_support_points = this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<2>, 200> points;
+  this->compute_mapping_support_points(cell, points);
+  mdata->mapping_support_points.assign(points.begin(), points.end());
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
@@ -469,7 +485,9 @@ MappingQ<2, 3>::transform_real_to_unit_cell_internal(
   auto mdata = Utilities::dynamic_unique_cast<InternalData>(
     get_data(update_flags, point_quadrature));
 
-  mdata->mapping_support_points = this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> points;
+  this->compute_mapping_support_points(cell, points);
+  mdata->mapping_support_points.assign(points.begin(), points.end());
 
   // dispatch to the various specializations for spacedim=dim,
   // spacedim=dim+1, etc
@@ -636,7 +654,8 @@ MappingQ<dim, spacedim>::transform_points_real_to_unit_cell(
     }
 
   AssertDimension(real_points.size(), unit_points.size());
-  std::vector<Point<spacedim>> support_points_higher_order;
+  boost::container::small_vector<Point<spacedim>, 200>
+    support_points_higher_order;
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
                                  ReferenceCells::max_n_vertices<dim>()
@@ -648,7 +667,7 @@ MappingQ<dim, spacedim>::transform_points_real_to_unit_cell(
   if (polynomial_degree == 1)
     vertices = this->get_vertices(cell);
   else
-    support_points_higher_order = this->compute_mapping_support_points(cell);
+    this->compute_mapping_support_points(cell, support_points_higher_order);
   const ArrayView<const Point<spacedim>> support_points(
     polynomial_degree == 1 ? vertices.data() :
                              support_points_higher_order.data(),
@@ -860,7 +879,11 @@ MappingQ<dim, spacedim>::fill_fe_values(
         data.mapping_support_points[i] = vertices[i];
     }
   else
-    data.mapping_support_points = this->compute_mapping_support_points(cell);
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      data.mapping_support_points.assign(points.begin(), points.end());
+    }
 
   // if the order of the mapping is greater than 1, then do not reuse any cell
   // similarity information. This is necessary because the cell similarity
@@ -1077,7 +1100,11 @@ MappingQ<dim, spacedim>::fill_fe_face_values(
         data.mapping_support_points[i] = vertices[i];
     }
   else
-    data.mapping_support_points = this->compute_mapping_support_points(cell);
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      data.mapping_support_points.assign(points.begin(), points.end());
+    }
 
   internal::MappingQImplementation::do_fill_fe_face_values(
     *this,
@@ -1124,7 +1151,11 @@ MappingQ<dim, spacedim>::fill_fe_subface_values(
         data.mapping_support_points[i] = vertices[i];
     }
   else
-    data.mapping_support_points = this->compute_mapping_support_points(cell);
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      data.mapping_support_points.assign(points.begin(), points.end());
+    }
 
   internal::MappingQImplementation::do_fill_fe_face_values(
     *this,
@@ -1174,7 +1205,12 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
         data.mapping_support_points[i] = vertices[i];
     }
   else
-    data.mapping_support_points = this->compute_mapping_support_points(cell);
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      data.mapping_support_points.assign(points.begin(), points.end());
+    }
+
 
   internal::MappingQImplementation::maybe_update_q_points_Jacobians_generic(
     CellSimilarity::none,
@@ -1318,7 +1354,11 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
         data.mapping_support_points[i] = vertices[i];
     }
   else
-    data.mapping_support_points = this->compute_mapping_support_points(cell);
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      data.mapping_support_points.assign(points.begin(), points.end());
+    }
 
   internal::MappingQImplementation::maybe_update_q_points_Jacobians_generic(
     CellSimilarity::none,
@@ -1359,7 +1399,12 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_face_quadrature(
         data.mapping_support_points[i] = vertices[i];
     }
   else
-    data.mapping_support_points = this->compute_mapping_support_points(cell);
+    {
+      boost::container::small_vector<Point<spacedim>, 200> points;
+      this->compute_mapping_support_points(cell, points);
+      data.mapping_support_points.assign(points.begin(), points.end());
+    }
+
   data.output_data = &output_data;
 
   internal::MappingQImplementation::do_fill_fe_face_values(
@@ -1509,7 +1554,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::add_line_support_points(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-  std::vector<Point<spacedim>>                               &a) const
+  boost::container::small_vector<Point<spacedim>, 200>       &a) const
 {
   // if we only need the midpoint, then ask for it.
   if (this->polynomial_degree == 2)
@@ -1575,8 +1620,8 @@ MappingQ<dim, spacedim>::add_line_support_points(
 template <>
 void
 MappingQ<3, 3>::add_quad_support_points(
-  const Triangulation<3, 3>::cell_iterator &cell,
-  std::vector<Point<3>>                    &a) const
+  const Triangulation<3, 3>::cell_iterator      &cell,
+  boost::container::small_vector<Point<3>, 200> &a) const
 {
   const unsigned int faces_per_cell = GeometryInfo<3>::faces_per_cell;
 
@@ -1646,8 +1691,8 @@ MappingQ<3, 3>::add_quad_support_points(
 template <>
 void
 MappingQ<2, 3>::add_quad_support_points(
-  const Triangulation<2, 3>::cell_iterator &cell,
-  std::vector<Point<3>>                    &a) const
+  const Triangulation<2, 3>::cell_iterator      &cell,
+  boost::container::small_vector<Point<3>, 200> &a) const
 {
   std::array<Point<3>, GeometryInfo<2>::vertices_per_cell> vertices;
   for (const unsigned int i : GeometryInfo<2>::vertex_indices())
@@ -1677,7 +1722,7 @@ template <int dim, int spacedim>
 void
 MappingQ<dim, spacedim>::add_quad_support_points(
   const typename Triangulation<dim, spacedim>::cell_iterator &,
-  std::vector<Point<spacedim>> &) const
+  boost::container::small_vector<Point<spacedim>, 200> &) const
 {
   DEAL_II_ASSERT_UNREACHABLE();
 }
@@ -1685,15 +1730,16 @@ MappingQ<dim, spacedim>::add_quad_support_points(
 
 
 template <int dim, int spacedim>
-std::vector<Point<spacedim>>
+void
 MappingQ<dim, spacedim>::compute_mapping_support_points(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  boost::container::small_vector<Point<spacedim>, 200>       &a) const
 {
-  // get the vertices first
-  std::vector<Point<spacedim>> a;
-  a.reserve(Utilities::fixed_power<dim>(polynomial_degree + 1));
+  // Get the vertices first. Don't use push_back() to get around an arcane GCC
+  // error about buffer overflows
+  a.resize(cell->n_vertices());
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-    a.push_back(cell->vertex(i));
+    a[i] = cell->vertex(i);
 
   if (this->polynomial_degree > 1)
     {
@@ -1777,8 +1823,6 @@ MappingQ<dim, spacedim>::compute_mapping_support_points(
               break;
           }
     }
-
-  return a;
 }
 
 
@@ -1788,7 +1832,9 @@ BoundingBox<spacedim>
 MappingQ<dim, spacedim>::get_bounding_box(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
-  return BoundingBox<spacedim>(this->compute_mapping_support_points(cell));
+  boost::container::small_vector<Point<spacedim>, 200> points;
+  this->compute_mapping_support_points(cell, points);
+  return BoundingBox<spacedim>(points);
 }
 
 

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -113,17 +113,13 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
 
 
 template <int dim, typename VectorType, int spacedim>
-std::vector<Point<spacedim>>
+void
 MappingQ1Eulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  boost::container::small_vector<Point<spacedim>, 200>       &points) const
 {
   const auto vertices = this->get_vertices(cell);
-
-  std::vector<Point<spacedim>> a(GeometryInfo<dim>::vertices_per_cell);
-  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-    a[i] = vertices[i];
-
-  return a;
+  points.assign(vertices.begin(), vertices.end());
 }
 
 

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -99,7 +99,9 @@ MappingQCache<dim, spacedim>::initialize(
         dynamic_cast<const MappingQ<dim, spacedim> *>(&mapping);
       if (mapping_q != nullptr && this->get_degree() == mapping_q->get_degree())
         {
-          return mapping_q->compute_mapping_support_points(cell);
+          boost::container::small_vector<Point<spacedim>, 200> points;
+          mapping_q->compute_mapping_support_points(cell, points);
+          return std::vector<Point<spacedim>>(points.begin(), points.end());
         }
       else
         {
@@ -155,8 +157,9 @@ MappingQCache<dim, spacedim>::initialize(
     [&](const typename Triangulation<dim, spacedim>::cell_iterator &cell,
         void *,
         void *) {
-      (*support_point_cache)[cell->level()][cell->index()] =
-        compute_points_on_cell(cell);
+      const auto result = compute_points_on_cell(cell);
+      (*support_point_cache)[cell->level()][cell->index()].assign(
+        result.begin(), result.end());
       // Do not use `this` in Assert because nvcc when using C++20 assumes that
       // `this` is an integer and we get the following error: invalid type
       // argument of unary '*' (have 'int')
@@ -194,14 +197,14 @@ MappingQCache<dim, spacedim>::initialize(
   this->initialize(
     tria,
     [&](const typename Triangulation<dim, spacedim>::cell_iterator &cell) {
-      std::vector<Point<spacedim>> points;
+      boost::container::small_vector<Point<spacedim>, 200> points;
 
       const auto mapping_q =
         dynamic_cast<const MappingQ<dim, spacedim> *>(&mapping);
 
       if (mapping_q != nullptr && this->get_degree() == mapping_q->get_degree())
         {
-          points = mapping_q->compute_mapping_support_points(cell);
+          mapping_q->compute_mapping_support_points(cell, points);
         }
       else
         {
@@ -226,7 +229,8 @@ MappingQCache<dim, spacedim>::initialize(
             }
 
           fe_values->reinit(cell);
-          points = fe_values->get_quadrature_points();
+          const auto &quadrature_points = fe_values->get_quadrature_points();
+          points.assign(quadrature_points.begin(), quadrature_points.end());
         }
 
       for (auto &p : points)
@@ -235,7 +239,7 @@ MappingQCache<dim, spacedim>::initialize(
         else
           p = transformation_function(cell, p);
 
-      return points;
+      return std::vector<Point<spacedim>>(points.begin(), points.end());
     });
 
   uses_level_info = true;
@@ -393,7 +397,7 @@ MappingQCache<dim, spacedim>::initialize(
             fe_values->reinit(cell_tria);
         }
 
-      std::vector<Point<spacedim>> result;
+      boost::container::small_vector<Point<spacedim>, 200> points;
 
       // Step 2b) read of quadrature points in the relative displacement case
       // note: we also take this path for non-active or artificial cells so that
@@ -403,19 +407,25 @@ MappingQCache<dim, spacedim>::initialize(
         {
           if (mapping_q != nullptr &&
               this->get_degree() == mapping_q->get_degree())
-            result = mapping_q->compute_mapping_support_points(cell_tria);
+            {
+              mapping_q->compute_mapping_support_points(cell_tria, points);
+            }
           else
-            result = fe_values_all.get()->get_quadrature_points();
+            {
+              const auto &quadrature_points =
+                fe_values_all.get()->get_quadrature_points();
+              points.assign(quadrature_points.begin(), quadrature_points.end());
+            }
 
           // for non-active or artificial cells we are done here and return
           // the absolute positions, since the provided vector cannot contain
           // any useful information for these cells
           if (is_active_non_artificial_cell == false)
-            return result;
+            return std::vector<Point<spacedim>>(points.begin(), points.end());
         }
       else
         {
-          result.resize(
+          points.resize(
             Utilities::pow<unsigned int>(this->get_degree() + 1, dim));
         }
 
@@ -436,20 +446,20 @@ MappingQCache<dim, spacedim>::initialize(
                 {
                   // case 1a: FE_Q
                   if (vector_describes_relative_displacement)
-                    result[id.second][id.first] +=
+                    points[id.second][id.first] +=
                       vector_ghosted(dof_indices[i]);
                   else
-                    result[id.second][id.first] =
+                    points[id.second][id.first] =
                       vector_ghosted(dof_indices[i]);
                 }
               else
                 {
                   // case 1b: FE_DGQ
                   if (vector_describes_relative_displacement)
-                    result[lexicographic_to_hierarchic_numbering[id.second]]
+                    points[lexicographic_to_hierarchic_numbering[id.second]]
                           [id.first] += vector_ghosted(dof_indices[i]);
                   else
-                    result[lexicographic_to_hierarchic_numbering[id.second]]
+                    points[lexicographic_to_hierarchic_numbering[id.second]]
                           [id.first] = vector_ghosted(dof_indices[i]);
                 }
             }
@@ -471,12 +481,12 @@ MappingQCache<dim, spacedim>::initialize(
           for (unsigned int q = 0; q < fe_values->n_quadrature_points; ++q)
             for (unsigned int c = 0; c < spacedim; ++c)
               if (vector_describes_relative_displacement)
-                result[q][c] += values[q][c];
+                points[q][c] += values[q][c];
               else
-                result[q][c] = values[q][c];
+                points[q][c] = values[q][c];
         }
 
-      return result;
+      return std::vector<Point<spacedim>>(points.begin(), points.end());
     });
 
   uses_level_info = false;
@@ -597,7 +607,7 @@ MappingQCache<dim, spacedim>::initialize(
             fe_values->reinit(cell_tria);
         }
 
-      std::vector<Point<spacedim>> result;
+      boost::container::small_vector<Point<spacedim>, 200> points;
 
       // Step 2b) read of quadrature points in the relative displacement case
       // note: we also take this path for non-active or artificial cells so that
@@ -607,19 +617,25 @@ MappingQCache<dim, spacedim>::initialize(
         {
           if (mapping_q != nullptr &&
               this->get_degree() == mapping_q->get_degree())
-            result = mapping_q->compute_mapping_support_points(cell_tria);
+            {
+              mapping_q->compute_mapping_support_points(cell_tria, points);
+            }
           else
-            result = fe_values_all.get()->get_quadrature_points();
+            {
+              const auto &quadrature_points =
+                fe_values_all.get()->get_quadrature_points();
+              points.assign(quadrature_points.begin(), quadrature_points.end());
+            }
 
           // for non-active or artificial cells we are done here and return
           // the absolute positions, since the provided vector cannot contain
           // any useful information for these cells
           if (is_non_artificial_cell == false)
-            return result;
+            return std::vector<Point<spacedim>>(points.begin(), points.end());
         }
       else
         {
-          result.resize(
+          points.resize(
             Utilities::pow<unsigned int>(this->get_degree() + 1, dim));
         }
 
@@ -640,21 +656,21 @@ MappingQCache<dim, spacedim>::initialize(
                 {
                   // case 1a: FE_Q
                   if (vector_describes_relative_displacement)
-                    result[id.second][id.first] +=
+                    points[id.second][id.first] +=
                       vectors_ghosted[cell_tria->level()](dof_indices[i]);
                   else
-                    result[id.second][id.first] =
+                    points[id.second][id.first] =
                       vectors_ghosted[cell_tria->level()](dof_indices[i]);
                 }
               else
                 {
                   // case 1b: FE_DGQ
                   if (vector_describes_relative_displacement)
-                    result[lexicographic_to_hierarchic_numbering[id.second]]
+                    points[lexicographic_to_hierarchic_numbering[id.second]]
                           [id.first] +=
                       vectors_ghosted[cell_tria->level()](dof_indices[i]);
                   else
-                    result[lexicographic_to_hierarchic_numbering[id.second]]
+                    points[lexicographic_to_hierarchic_numbering[id.second]]
                           [id.first] =
                             vectors_ghosted[cell_tria->level()](dof_indices[i]);
                 }
@@ -682,14 +698,14 @@ MappingQCache<dim, spacedim>::initialize(
             for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
               for (unsigned int q = 0; q < fe_values->n_quadrature_points; ++q)
                 if (vector_describes_relative_displacement == false && i == 0)
-                  result[q][c] =
+                  points[q][c] =
                     dof_values[i] * fe_values->shape_value_component(i, q, c);
                 else
-                  result[q][c] +=
+                  points[q][c] +=
                     dof_values[i] * fe_values->shape_value_component(i, q, c);
         }
 
-      return result;
+      return std::vector<Point<spacedim>>(points.begin(), points.end());
     });
 
   uses_level_info = true;
@@ -711,9 +727,10 @@ MappingQCache<dim, spacedim>::memory_consumption() const
 
 
 template <int dim, int spacedim>
-std::vector<Point<spacedim>>
+void
 MappingQCache<dim, spacedim>::compute_mapping_support_points(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  boost::container::small_vector<Point<spacedim>, 200>       &points) const
 {
   Assert(support_point_cache.get() != nullptr,
          ExcMessage("Must call MappingQCache::initialize() before "
@@ -723,7 +740,9 @@ MappingQCache<dim, spacedim>::compute_mapping_support_points(
 
   AssertIndexRange(cell->level(), support_point_cache->size());
   AssertIndexRange(cell->index(), (*support_point_cache)[cell->level()].size());
-  return (*support_point_cache)[cell->level()][cell->index()];
+  const auto &cached_points =
+    (*support_point_cache)[cell->level()][cell->index()];
+  points.assign(cached_points.begin(), cached_points.end());
 }
 
 

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -104,8 +104,8 @@ boost::container::small_vector<Point<spacedim>,
 MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
-  // get the vertices as the first 2^dim mapping support points
-  const std::vector<Point<spacedim>> a = compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> points;
+  compute_mapping_support_points(cell, points);
 
   boost::container::small_vector<Point<spacedim>,
 #ifndef _MSC_VER
@@ -114,7 +114,7 @@ MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
                                  GeometryInfo<dim>::vertices_per_cell
 #endif
                                  >
-    vertex_locations(a.begin(), a.begin() + cell->n_vertices());
+    vertex_locations(points.begin(), points.begin() + cell->n_vertices());
 
   return vertex_locations;
 }
@@ -122,9 +122,10 @@ MappingQEulerian<dim, VectorType, spacedim>::get_vertices(
 
 
 template <int dim, typename VectorType, int spacedim>
-std::vector<Point<spacedim>>
+void
 MappingQEulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  boost::container::small_vector<Point<spacedim>, 200>       &points) const
 {
   const bool mg_vector = level != numbers::invalid_unsigned_int;
 
@@ -177,15 +178,13 @@ MappingQEulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
 
   // and finally compute the positions of the support points in the deformed
   // configuration.
-  std::vector<Point<spacedim>> a(n_support_pts);
+  points.resize(n_support_pts);
   for (unsigned int q = 0; q < n_support_pts; ++q)
     {
-      a[q] = fe_values.quadrature_point(q);
+      points[q] = fe_values.quadrature_point(q);
       for (unsigned int d = 0; d < spacedim; ++d)
-        a[q][d] += shift_vector[q][d];
+        points[q][d] += shift_vector[q][d];
     }
-
-  return a;
 }
 
 


### PR DESCRIPTION
This prevents allocations when computing support points for most common cases (degree 4 or less). Since these functions are all protected this is a purely internal change, with the exception of some public members of `MappingC1` which should have been protected (they are protected in the base class).

Since all of these classes inherit from `MappingQ` we have to change all of them at once. I'll post an equivalent changes for the other `Mapping` classes later.

This lowers the number of allocations in step-32 by about 12%.