### PR TITLE
Do not export std::printf and std::snprintf.

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -412,12 +412,10 @@ export
     using std::isalnum;
     using std::isdigit;
     using std::match_results;
-    using std::printf;
     using std::regex;
     using std::regex_match;
     using std::regex_replace;
     using std::regex_search;
-    using std::snprintf;
     using std::sscanf;
     using std::stod;
     using std::stoi;


### PR DESCRIPTION
We have a failure with exporting `std::printf` and `std::snprintf` from modules with certain compilers. Let's just not export them, which we can get away with if we don't use them -- see #19760.