### PR TITLE
Arkode: add additional output for sub-test 2 of the Butcher tables test for the old SUNDIALS versions

### DIFF
--- a/tests/sundials/arkode_arkstep_order_butcher.cc
+++ b/tests/sundials/arkode_arkstep_order_butcher.cc
@@ -55,6 +55,11 @@
 // each step is more expensive (more stages), the total number of function
 // evaluations is significantly lower, demonstrating the benefit of high-order
 // ImEx methods on smooth problems.
+//
+// The test behaves differently for SUNDIALS >=7.3.0 since the default method
+// pairs for most of the integration orders were changed (affects sub-test 1).
+// Additionally, the default time step adaptivity parameters were also changed
+// in SUNDIALS 7.3.0 - this modification affects both sub-tests.
 
 using VectorType = LinearAlgebra::distributed::Vector<double>;
 

--- a/tests/sundials/arkode_arkstep_order_butcher.output
+++ b/tests/sundials/arkode_arkstep_order_butcher.output
@@ -13,11 +13,11 @@ DEAL::  rejection rate = 0.000000
 DEAL::=== Butcher tables order 5 ===
 DEAL::final = -0.958924 0.283662
 DEAL::work stats:
-DEAL::  steps = 214
-DEAL::  step attempts = 214
+DEAL::  steps = 294
+DEAL::  step attempts = 294
 DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 1712
-DEAL::  implicit rhs evals = 4708
-DEAL::  nonlinear iterations = 2996
+DEAL::  explicit rhs evals = 2354
+DEAL::  implicit rhs evals = 6470
+DEAL::  nonlinear iterations = 4116
 DEAL::  nonlinear convergence failures = 0
 DEAL::  rejection rate = 0.000000


### PR DESCRIPTION
It seems the behavior of sub-test 2 also got influenced by the modifications in SUNDIALS 7.3.0 - https://cdash.dealii.org/tests/9553095. Here, additionally to #19745, I also provide an alternative output for sub-test 1. Not only the default pairs, but also the default time adaptivity settings were changed in SUNDIALS 7.3.0 (https://github.com/llnl/sundials/releases/tag/v7.3.0) and it has a serious impact on the resultant solver metrics. I tried to fallback to the old defaults as described in those release notes, and then I managed to reproduce the significantly worse behavior of the integrator but not the exact numbers from the alternative outputs we have now for this test. Probably, some other minor modifications were also made in the integrators and it is difficult to track them.

PS: after dealing with these issues, I actually tend to think that, probably, all of the ARKODE tests have to be restructured such that not to be dependent on the internal behavior of the solver, but to check our wrappers only instead and to verify that the options set via the wrappers produce the expected effect (e.g., for this test to check that the numbers for the higher order scheme are better than for the lower one). That could be a separate PR just for this. It looks like the maintenance of the current ARKODE tests is quite sophisticated and heavily dependent on the future modifications of SUNDIALS.