### PR TITLE
Fix assert for Trilinos pre 14

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -849,7 +849,6 @@ namespace LinearAlgebra
 #  else
       Assert(local_index != Teuchos::OrdinalTraits<int>::invalid(),
              ExcAccessToNonLocalElement(index,
-                                        vector->getMap()->getLocalNumElements(),
                                         vector->getMap()->getNodeNumElements(),
                                         vector->getMap()->getMinLocalIndex(),
                                         vector->getMap()->getMaxLocalIndex()));


### PR DESCRIPTION
This fixes a copy-paste bug I introduced in #19542 (https://github.com/dealii/dealii/pull/19542/changes#diff-ae46d36763e11b67ec562c145fd5f61cd193f3a633ce944baf621f0e95a72599R852).

`getNodeNumElements` in Trilinos prior to version 14 is now called `getLocalNumElements`.

