### PR TITLE
Provide an container containing reference cells of a certain dimension

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1411,6 +1411,14 @@ namespace ReferenceCells
       std::numeric_limits<std::uint8_t>::max());
 
   /**
+   * Returns a vector containing all available reference cells of dimension
+   * `dim`.
+   */
+  template <int dim>
+  constexpr const std::vector<ReferenceCell<dim>>
+  get_reference_cells_in_dim();
+
+  /**
    * Return the correct simplex reference cell type for the given dimension
    * `dim`. Depending on the template argument `dim`, this function returns a
    * reference to either Vertex, Line, Triangle, or Tetrahedron.
@@ -1429,6 +1437,14 @@ namespace ReferenceCells
   get_hypercube();
 
   /**
+   * Return the number of different Reference Cells that are available for
+   * dimension `dim`.
+   */
+  template <int dim>
+  constexpr unsigned int
+  n_reference_cells_in_dim();
+
+  /**
    * Given the number of vertices a reference cell has (provided as
    * a function argument), and the dimension the reference cell lives in
    * (provided as a template argument), return the ReferenceCell object
@@ -1443,7 +1459,6 @@ namespace ReferenceCells
   template <int dim>
   ReferenceCell<dim>
   n_vertices_to_reference_cell(const unsigned int n_vertices);
-
 
   /**
    * Return the maximum number of vertices an object of dimension `structdim`
@@ -3408,6 +3423,29 @@ ReferenceCell<dim>::standard_to_real_face_line(
 namespace ReferenceCells
 {
   template <int dim>
+  constexpr const std::vector<ReferenceCell<dim>>
+  get_reference_cells_in_dim()
+  {
+    if constexpr (dim == 0)
+      return {{ReferenceCells::Vertex}};
+    else if constexpr (dim == 1)
+      return {{ReferenceCells::Line}};
+    else if constexpr (dim == 2)
+      return {{ReferenceCells::Triangle, ReferenceCells::Quadrilateral}};
+    else if constexpr (dim == 3)
+      return {{ReferenceCells::Tetrahedron,
+               ReferenceCells::Pyramid,
+               ReferenceCells::Wedge,
+               ReferenceCells::Hexahedron}};
+    else
+      DEAL_II_NOT_IMPLEMENTED();
+
+    return {};
+  }
+
+
+
+  template <int dim>
   inline constexpr const ReferenceCell<dim> &
   get_simplex()
   {
@@ -4003,6 +4041,25 @@ ReferenceCell<dim>::face_normal_vector(const unsigned int face_no) const
   DEAL_II_NOT_IMPLEMENTED();
 
   return {};
+}
+
+
+
+template <int dim>
+constexpr unsigned int
+n_reference_cells_in_dim()
+{
+  // alternative approach via std::pow(2, std::max(0,dim-1)) but std::pow
+  // isn't constexpr until C++26.
+  if constexpr (dim == 0 || dim == 1)
+    return 1; // Vertex or Line
+  else if (dim == 2)
+    return 2; // Quad and Tri
+  else if (dim == 3)
+    return 4; // Tet, Pyramid, Wedge and Hex
+  else
+    DEAL_II_NOT_IMPLEMENTED();
+  return 0;
 }
 
 

--- a/tests/grid/reference_cell_face_indices_by_type.cc
+++ b/tests/grid/reference_cell_face_indices_by_type.cc
@@ -24,8 +24,8 @@
 // general test case
 template <int dim>
 void
-execute_test(const std::initializer_list<ReferenceCell<dim>>     &cell_types,
-             const std::initializer_list<ReferenceCell<dim - 1>> &face_types)
+execute_test(const std::vector<ReferenceCell<dim>>     &cell_types,
+             const std::vector<ReferenceCell<dim - 1>> &face_types)
 {
   Triangulation<dim> triangulation;
 
@@ -114,40 +114,12 @@ execute_test(const std::initializer_list<ReferenceCell<dim>>     &cell_types,
     }
 }
 
+template <unsigned int dim>
 void
-test_1d()
+test()
 {
-  // All known 1d cell types
-  auto cell_types = {ReferenceCells::Line};
-  // All known face types of 1d cells
-  auto face_types = {ReferenceCells::Vertex};
-
-  execute_test<1>(cell_types, face_types);
-}
-
-void
-test_2d()
-{
-  // All known 2d cell types
-  auto cell_types = {ReferenceCells::Triangle, ReferenceCells::Quadrilateral};
-  // All known face types of 2d cells
-  auto face_types = {ReferenceCells::Line};
-
-  execute_test<2>(cell_types, face_types);
-}
-
-void
-test_3d()
-{
-  // All known 3d cell types
-  auto cell_types = {ReferenceCells::Tetrahedron,
-                     ReferenceCells::Pyramid,
-                     ReferenceCells::Wedge,
-                     ReferenceCells::Hexahedron};
-  // All known face types of 3d cells
-  auto face_types = {ReferenceCells::Triangle, ReferenceCells::Quadrilateral};
-
-  execute_test<3>(cell_types, face_types);
+  execute_test<dim>(ReferenceCells::get_reference_cells_in_dim<dim>(),
+                    ReferenceCells::get_reference_cells_in_dim<dim - 1>());
 }
 
 int
@@ -156,7 +128,7 @@ main()
   initlog();
 
   // TODO: Add test for 0D (or skip it...)
-  test_1d();
-  test_2d();
-  test_3d();
+  test<1>();
+  test<2>();
+  test<3>();
 }


### PR DESCRIPTION
I think this might be quite useful in certain situations. One such situation is the test [`reference_cell_face_indices_by_type`](https://github.com/dealii/dealii/blob/0b3ceb52dface3c30399adc84b94da6306187cc7/tests/grid/reference_cell_face_indices_by_type.cc) which I modified to underline the argument.

I am not too sure about the container I chose. Maybe `std::array` would be a better choice?