### PR TITLE
Disable extra diagnostics to suppress warning.

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
@@ -1146,6 +1146,11 @@ namespace internal
                                               transpose>
   {
   public:
+    // Compiling with gcc 16.1.1 results in an annoying warning for the
+    // following constructor: <unknown>’ may be used uninitialized
+    // This may be due to (*this) being passed to the base class constructor.
+    // We disable this warning.
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     inline DEAL_II_ALWAYS_INLINE_RELEASE
     Helper(const unsigned int &given_degree,
            const bool         &type_x,
@@ -1177,6 +1182,7 @@ namespace internal
     {
       static_assert(fe_degree == -1, "Only working for fe_degree = -1.");
     }
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
     const unsigned int points;
 
@@ -1306,6 +1312,11 @@ namespace internal
                                               transpose>
   {
   public:
+    // Compiling with gcc 16.1.1 results in an annoying warning for the
+    // following constructor: <unknown>’ may be used uninitialized
+    // This may be due to (*this) being passed to the base class constructor.
+    // We disable this warning.
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
     inline DEAL_II_ALWAYS_INLINE_RELEASE
     Helper(const unsigned int &given_degree,
            const bool         &type_x,
@@ -1336,6 +1347,7 @@ namespace internal
     {
       static_assert(fe_degree != -1, "Only working for fe_degree != -1.");
     }
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
     inline DEAL_II_ALWAYS_INLINE_RELEASE unsigned int


### PR DESCRIPTION
Fixes #19722.

This patch suppresses the warnings reported with gcc 16.1.1 in #19722.

I could not figure out what the actual warnings refer to. I suspect they are related to the self-assignments (?) e.g.:
https://github.com/dealii/dealii/blob/31c557fba00bb1342e90f051e24039a194d47a1b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h#L1168

@kronbichler @peterrum -- FYI. Maybe you have a better idea?