### PR TITLE
Arkode: round the ARKStep Butcher tables test stats data

### DIFF
--- a/tests/sundials/arkode_arkstep_order_butcher.cc
+++ b/tests/sundials/arkode_arkstep_order_butcher.cc
@@ -80,28 +80,21 @@ struct RunResult
 static void
 print_work_stats(const RunResult &result)
 {
+  const auto fsteps = result.n_step_attempts < 1000 ? 10 : 100;
   deallog << "work stats:" << std::endl;
-  deallog << "  steps = " << result.n_steps << std::endl;
-  deallog << "  step attempts = " << result.n_step_attempts << std::endl;
-  deallog << "  error test failures = " << result.n_error_test_failures
+  deallog << "  steps = " << fsteps * (result.n_steps / fsteps) << std::endl;
+  deallog << "  step attempts = " << fsteps * (result.n_step_attempts / fsteps)
           << std::endl;
-  deallog << "  explicit rhs evals = " << result.n_explicit_rhs_evaluations
-          << std::endl;
-  deallog << "  implicit rhs evals = " << result.n_implicit_rhs_evaluations
-          << std::endl;
-  deallog << "  nonlinear iterations = " << result.n_nonlinear_iterations
-          << std::endl;
+  deallog << "  error test failures = "
+          << fsteps * (result.n_error_test_failures / fsteps) << std::endl;
+  deallog << "  explicit rhs evals = "
+          << 100 * (result.n_explicit_rhs_evaluations / 100) << std::endl;
+  deallog << "  implicit rhs evals = "
+          << 100 * (result.n_implicit_rhs_evaluations / 100) << std::endl;
+  deallog << "  nonlinear iterations = "
+          << 100 * (result.n_nonlinear_iterations / 100) << std::endl;
   deallog << "  nonlinear convergence failures = "
-          << result.n_nonlinear_conv_failures << std::endl;
-
-  if (result.n_step_attempts > 0 && result.n_steps >= 0)
-    {
-      const double rejection_rate =
-        static_cast<double>(result.n_step_attempts - result.n_steps) /
-        static_cast<double>(result.n_step_attempts);
-      deallog << "  rejection rate = " << std::setprecision(6) << rejection_rate
-              << std::endl;
-    }
+          << 100 * (result.n_nonlinear_conv_failures / 100) << std::endl;
 }
 
 // Set up ARKode AdditionalData for the Prothero-Robinson benchmark.

--- a/tests/sundials/arkode_arkstep_order_butcher.output
+++ b/tests/sundials/arkode_arkstep_order_butcher.output
@@ -2,22 +2,20 @@
 DEAL::=== Order 3 ===
 DEAL::final = -0.958924 0.283662
 DEAL::work stats:
-DEAL::  steps = 3469
-DEAL::  step attempts = 3469
+DEAL::  steps = 3400
+DEAL::  step attempts = 3400
 DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 13877
-DEAL::  implicit rhs evals = 34691
-DEAL::  nonlinear iterations = 20814
+DEAL::  explicit rhs evals = 13800
+DEAL::  implicit rhs evals = 34600
+DEAL::  nonlinear iterations = 20800
 DEAL::  nonlinear convergence failures = 0
-DEAL::  rejection rate = 0.000000
 DEAL::=== Butcher tables order 5 ===
 DEAL::final = -0.958924 0.283662
 DEAL::work stats:
-DEAL::  steps = 294
-DEAL::  step attempts = 294
+DEAL::  steps = 290
+DEAL::  step attempts = 290
 DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 2354
-DEAL::  implicit rhs evals = 6470
-DEAL::  nonlinear iterations = 4116
+DEAL::  explicit rhs evals = 2300
+DEAL::  implicit rhs evals = 6400
+DEAL::  nonlinear iterations = 4100
 DEAL::  nonlinear convergence failures = 0
-DEAL::  rejection rate = 0.000000

--- a/tests/sundials/arkode_arkstep_order_butcher.output.sundials73
+++ b/tests/sundials/arkode_arkstep_order_butcher.output.sundials73
@@ -2,22 +2,20 @@
 DEAL::=== Order 3 ===
 DEAL::final = -0.958924 0.283662
 DEAL::work stats:
-DEAL::  steps = 2635
-DEAL::  step attempts = 2635
+DEAL::  steps = 2600
+DEAL::  step attempts = 2600
 DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 10540
-DEAL::  implicit rhs evals = 26350
-DEAL::  nonlinear iterations = 15810
+DEAL::  explicit rhs evals = 10500
+DEAL::  implicit rhs evals = 26300
+DEAL::  nonlinear iterations = 15800
 DEAL::  nonlinear convergence failures = 0
-DEAL::  rejection rate = 0.000000
 DEAL::=== Butcher tables order 5 ===
 DEAL::final = -0.958924 0.283662
 DEAL::work stats:
-DEAL::  steps = 214
-DEAL::  step attempts = 214
+DEAL::  steps = 210
+DEAL::  step attempts = 210
 DEAL::  error test failures = 0
-DEAL::  explicit rhs evals = 1712
-DEAL::  implicit rhs evals = 4708
-DEAL::  nonlinear iterations = 2996
+DEAL::  explicit rhs evals = 1700
+DEAL::  implicit rhs evals = 4700
+DEAL::  nonlinear iterations = 2900
 DEAL::  nonlinear convergence failures = 0
-DEAL::  rejection rate = 0.000000


### PR DESCRIPTION
As seen in https://cdash.dealii.org/tests/9900962, the stats values can fluctuate slightly. So I decided to use the strategy from #19743 to make the reference output more robust. Let's see if it works better.