### PR TITLE
Remove FindPythonLibs.

### DIFF
--- a/contrib/python-bindings/CMakeLists.txt
+++ b/contrib/python-bindings/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## -----------------------------------------------------------------------------
 ##
 ## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-## Copyright (C) 2016 - 2023 by the deal.II authors
+## Copyright (C) 2016 - 2026 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -18,11 +18,7 @@ if(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   #
   # Find Python:
   #
-  find_package(Python3)
-  set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
-  set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
-  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-  include(FindPythonLibs)
+  find_package(Python COMPONENTS Development Interpreter)
 
   if(DEAL_II_FEATURE_BOOST_BUNDLED_CONFIGURED)
     message(FATAL_ERROR
@@ -44,7 +40,7 @@ if(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   if(${BOOST_VERSION} VERSION_LESS 1.67)
     find_package(Boost 1.59 COMPONENTS python REQUIRED)
   else()
-    find_package(Boost 1.67 COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
+    find_package(Boost 1.67 COMPONENTS python${Python_VERSION_MAJOR}${Python_VERSION_MINOR} REQUIRED)
   endif()
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
 
@@ -78,7 +74,7 @@ if(DEAL_II_COMPONENT_PYTHON_BINDINGS)
   set_if_empty(PYTHON_BINDINGS_RELEASE_NAME "Release")
 
   set_if_empty(DEAL_II_PYTHON_RELDIR
-    "${DEAL_II_LIBRARY_RELDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/${PYTHON_BINDINGS_BASE_NAME}"
+    "${DEAL_II_LIBRARY_RELDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/${PYTHON_BINDINGS_BASE_NAME}"
     )
 
   add_subdirectory(source)

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## -----------------------------------------------------------------------------
 ##
 ## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-## Copyright (C) 2016 - 2023 by the deal.II authors
+## Copyright (C) 2016 - 2026 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -24,7 +24,7 @@ include_directories(
 # DEAL_II_BUILD_TYPES (usually PyDealIIDebug and PyDealIIRelease)
 #
 
-include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
+include_directories(SYSTEM ${Python_INCLUDE_DIRS})
 
 set(_src
   wrappers.cc
@@ -48,7 +48,7 @@ set(_src
 foreach(_build ${DEAL_II_BUILD_TYPES})
   string(TOLOWER ${_build} _build_lowercase)
 
-  PYTHON_ADD_MODULE(PyDealII_${_build_lowercase} ${_src})
+  Python_add_library(PyDealII_${_build_lowercase} ${_src})
 
   set_target_properties(PyDealII_${_build_lowercase} PROPERTIES
     OUTPUT_NAME "${PYTHON_BINDINGS_${_build}_NAME}"
@@ -67,10 +67,9 @@ foreach(_build ${DEAL_II_BUILD_TYPES})
       )
   endif()
 
-  target_link_libraries(PyDealII_${_build_lowercase}
+  target_link_libraries(PyDealII_${_build_lowercase} PRIVATE
     ${DEAL_II_TARGET_NAME}_${_build_lowercase}
     ${Boost_LIBRARIES}
-    ${PYTHON_LIBRARIES}
     )
 
   export(TARGETS PyDealII_${_build_lowercase}
@@ -78,7 +77,7 @@ foreach(_build ${DEAL_II_BUILD_TYPES})
     APPEND
     )
 
-  install(TARGETS  PyDealII_${_build_lowercase}
+  install(TARGETS PyDealII_${_build_lowercase}
     COMPONENT python_bindings
     EXPORT ${DEAL_II_PROJECT_CONFIG_NAME}Targets
     LIBRARY DESTINATION ${DEAL_II_PYTHON_RELDIR}

--- a/contrib/python-bindings/tests/CMakeLists.txt
+++ b/contrib/python-bindings/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 ## -----------------------------------------------------------------------------
 ##
 ## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
-## Copyright (C) 2020 - 2022 by the deal.II authors
+## Copyright (C) 2020 - 2026 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -20,7 +20,7 @@ file(GLOB _tests "${CMAKE_CURRENT_SOURCE_DIR}/*.py")
 foreach(_test_path ${_tests})
  get_filename_component(_test ${_test_path} NAME_WE)
  get_filename_component(_test_directory ${_test_path} DIRECTORY)
- add_test(NAME python-bindings/${_test} COMMAND ${PYTHON_EXECUTABLE} ${_test_path})
+ add_test(NAME python-bindings/${_test} COMMAND ${Python_EXECUTABLE} ${_test_path})
  set_tests_properties(python-bindings/${_test} PROPERTIES ENVIRONMENT
    "PYTHONPATH=${CMAKE_BINARY_DIR}/${DEAL_II_PYTHON_RELDIR}/../:$ENV{PYTHONPATH};DEAL_II_PYTHON_TESTPATH=${_test_directory}"
    )


### PR DESCRIPTION
Fixes #19718.

`FindPythonLibs` has been deprecated since CMake 3.12. Since deal.II requires CMake 3.13.4, we are safe to use the modernized way. The `python-bindings` tests pass on my machine.

References:
- https://cmake.org/cmake/help/latest/module/FindPython.html
- https://cmake.org/cmake/help/latest/module/FindPythonLibs.html