### PR TITLE
Enable generic linear algebra header without Epetra

### DIFF
--- a/include/deal.II/lac/generic_linear_algebra.h
+++ b/include/deal.II/lac/generic_linear_algebra.h
@@ -19,6 +19,8 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 #include <deal.II/lac/block_vector.h>
 #include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
@@ -157,7 +159,7 @@ namespace LinearAlgebraPETSc
 } // namespace LinearAlgebraPETSc
 #endif // DEAL_II_WITH_PETSC
 
-#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+#ifdef DEAL_II_WITH_TRILINOS
 
 /**
  * A namespace in which the wrappers to the Trilinos linear algebra classes
@@ -167,6 +169,7 @@ namespace LinearAlgebraPETSc
  */
 namespace LinearAlgebraTrilinos
 {
+#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
   /**
    * Typedef for the CG solver type used.
    */
@@ -176,6 +179,19 @@ namespace LinearAlgebraTrilinos
    * Typedef for the GMRES solver type used.
    */
   using SolverGMRES = TrilinosWrappers::SolverGMRES;
+#  else
+#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
+  /**
+   * Typedef for the CG solver type used.
+   */
+  using SolverCG = dealii::SolverCG<TrilinosWrappers::MPI::Vector>;
+
+  /**
+   * Typedef for the GMRES solver type used.
+   */
+  using SolverGMRES = dealii::SolverGMRES<TrilinosWrappers::MPI::Vector>;
+#    endif
+#  endif
 
   /**
    * A namespace with alias to generic names for parallel Trilinos linear
@@ -205,13 +221,13 @@ namespace LinearAlgebraTrilinos
      */
     using BlockSparseMatrix = TrilinosWrappers::BlockSparseMatrix;
 
+#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
     /**
      * Typedef for the type used for compressed block sparsity pattern.
      */
     using BlockCompressedSparsityPattern =
       TrilinosWrappers::BlockSparsityPattern;
 
-#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
     /**
      * Typedef for the AMG preconditioner type.
      */


### PR DESCRIPTION
In a similar vein to #19783 and #19785 this will make it easier to use the Tpetra classes once the Epetra classes disappear.

This PR does two things which could also be split or only partially implemented (but they are closely connected in the same file so I made just 1 PR):

1. `namespace LinearAlgebraTrilinos` should be available either way no matter if we use Epetra or Tpetra. Most of the types are available in any case since #19423 (as aliases to either the Epetra or Tpetra classes). In the current form, all code that includes `generic_linear_algebra.h` is missing types.

2. There are some types that are not yet available with the Tpetra classes, in particular `SolverCG`, `SolverGMRES` (we dont provide any Tpetra based iterative solvers afaik), and `BlockSparsityPattern` (I never got back to #19403). We need to decide what to do about them. For this PR I remove the `BlockSparsityPattern` alias, and I redirect `SolverCG` and `SolverGMRES` to the deal.II solvers. The deal.II solvers do work - I got step-40 with SolverCG to work - but their AdditionalData options are different, so users might still run into trouble with missing options. I could also deactivate `SolverCG` and `SolverGMRES`, but then we need to modify examples to use the deal.II solvers (or deactivate them).