### PR TITLE
Get rid of an extra allocation in EnableObserverPointer.

### DIFF
--- a/include/deal.II/base/enable_observer_pointer.h
+++ b/include/deal.II/base/enable_observer_pointer.h
@@ -170,7 +170,8 @@ public:
   DeclException2(ExcNoSubscriber,
                  std::string,
                  std::string,
-                 << "No subscriber with identifier <" << arg2
+                 << "No subscriber with identifier <"
+                 << (arg2.empty() ? "unknown subscriber" : arg2.c_str())
                  << "> subscribes to this object of class " << arg1
                  << ". Consequently, it cannot be unsubscribed.");
   /** @} */

--- a/include/deal.II/base/enable_observer_pointer.h
+++ b/include/deal.II/base/enable_observer_pointer.h
@@ -218,16 +218,6 @@ private:
   mutable std::map<std::string, unsigned int> counter_map;
 
   /**
-   * The data type used in #counter_map.
-   */
-  using map_value_type = decltype(counter_map)::value_type;
-
-  /**
-   * The iterator type used in #counter_map.
-   */
-  using map_iterator = decltype(counter_map)::iterator;
-
-  /**
    * In this vector, we store pointers to the validity bool in the
    * ObserverPointer objects that subscribe to this class.
    */

--- a/source/base/enable_observer_pointer.cc
+++ b/source/base/enable_observer_pointer.cc
@@ -163,7 +163,7 @@ EnableObserverPointer::unsubscribe(std::atomic<bool> *const validity,
 
   std::lock_guard<std::mutex> lock(mutex);
 
-  map_iterator it = counter_map.find(id);
+  auto it = counter_map.find(id);
   if (it == counter_map.end())
     {
       AssertNothrow(it != counter_map.end(),

--- a/source/base/enable_observer_pointer.cc
+++ b/source/base/enable_observer_pointer.cc
@@ -31,9 +31,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-static const char *unknown_subscriber = "unknown subscriber";
-
-
 std::mutex EnableObserverPointer::mutex;
 
 
@@ -145,9 +142,7 @@ EnableObserverPointer::subscribe(std::atomic<bool> *const validity,
     object_info = &typeid(*this);
   ++counter;
 
-  const std::string &name = id.empty() ? unknown_subscriber : id;
-
-  ++counter_map[name];
+  ++counter_map[id];
 
   *validity = true;
   validity_pointers.push_back(validity);
@@ -159,28 +154,26 @@ void
 EnableObserverPointer::unsubscribe(std::atomic<bool> *const validity,
                                    const std::string       &id) const
 {
-  const std::string &name = id.empty() ? unknown_subscriber : id;
-
   if (counter == 0)
     {
-      AssertNothrow(counter > 0, ExcNoSubscriber(object_info->name(), name));
+      AssertNothrow(counter > 0, ExcNoSubscriber(object_info->name(), id));
       // This is for the case that we do not abort after the exception
       return;
     }
 
   std::lock_guard<std::mutex> lock(mutex);
 
-  map_iterator it = counter_map.find(name);
+  map_iterator it = counter_map.find(id);
   if (it == counter_map.end())
     {
       AssertNothrow(it != counter_map.end(),
-                    ExcNoSubscriber(object_info->name(), name));
+                    ExcNoSubscriber(object_info->name(), id));
       // This is for the case that we do not abort after the exception
       return;
     }
   if (it->second == 0)
     {
-      AssertNothrow(it->second > 0, ExcNoSubscriber(object_info->name(), name));
+      AssertNothrow(it->second > 0, ExcNoSubscriber(object_info->name(), id));
       // This is for the case that we do not abort after the exception
       return;
     }


### PR DESCRIPTION
Since the string `"unknown subscriber"` has 19 characters (with a `NUL`) it is too long for the libstdc++ small-string limit of 16 (but not the libc++ limit of 24). Hence, if we call `subscribe()` or `unsubscribe()` with no object name (the common case!) we allocate that string (i.e., convert it from a string literal to a `std::string`).

Since we use `"unknown subscriber"` for 100% of empty names, we can instead let the empty name mean exactly that and move that string literal into the exception itself to completely avoid the allocation.