### PR TITLE
PETScWrappers::VectorBase: use a small vector for indices.

### DIFF
--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -20,8 +20,9 @@
 #  include <deal.II/lac/petsc_compatibility.h>
 #  include <deal.II/lac/petsc_vector.h>
 
-#  include <cmath>
+#  include <boost/container/small_vector.hpp>
 
+#  include <cmath>
 
 #endif // DEAL_II_WITH_PETSC
 
@@ -1114,7 +1115,7 @@ namespace PETScWrappers
            internal::VectorReference::ExcWrongMode(action, last_action));
     Assert(!has_ghost_elements(), ExcGhostsPresent());
 
-    std::vector<PetscInt> petsc_indices(n_elements);
+    boost::container::small_vector<PetscInt, 200> petsc_indices(n_elements);
     for (size_type i = 0; i < n_elements; ++i)
       {
         const auto petsc_index = static_cast<PetscInt>(indices[i]);


### PR DESCRIPTION
Another small allocation patch.