### PR TITLE
Document all function arguments in include/deal.II/base.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -80,6 +80,8 @@ public:
   /**
    * Range constructor.
    *
+   * @param begin The begin of the range.
+   * @param end The end of the range.
    * @note Unlike std::vector, this constructor uses random-access iterators so
    * that the copy may be parallelized.
    *
@@ -97,6 +99,8 @@ public:
    * T().
    *
    * @dealiiOperationIsMultithreaded
+   * @param size The number of elements to allocate.
+   * @param init The value used to initialize each newly created entry.
    */
   explicit AlignedVector(const size_type size, const T &init = T());
 
@@ -109,12 +113,15 @@ public:
    * Copy constructor.
    *
    * @dealiiOperationIsMultithreaded
+   * @param vec The vector with which to initialize, copy, or exchange the
+   * current contents.
    */
   AlignedVector(const AlignedVector<T> &vec);
 
   /**
    * Move constructor. Create a new aligned vector by stealing the contents of
    * @p vec.
+   * @param vec The vector to move from.
    */
   AlignedVector(AlignedVector<T> &&vec) noexcept;
 
@@ -122,12 +129,15 @@ public:
    * Assignment to the input vector @p vec.
    *
    * @dealiiOperationIsMultithreaded
+   * @param vec The vector with which to initialize, copy, or exchange the
+   * current contents.
    */
   AlignedVector &
   operator=(const AlignedVector<T> &vec);
 
   /**
    * Move assignment operator.
+   * @param vec The vector to move from.
    */
   AlignedVector &
   operator=(AlignedVector<T> &&vec) noexcept;
@@ -148,6 +158,7 @@ public:
    * refers to the fact that for trivially default constructible types `T`, this
    * function omits the initialization of new elements.
    *
+   * @param new_size The new size.
    * @note This method can only be invoked for classes @p T that define a
    * default constructor, @p T(). Otherwise, compilation will fail.
    */
@@ -165,6 +176,7 @@ public:
    * value. The destructors of released elements are also called.
    *
    * @dealiiOperationIsMultithreaded
+   * @param new_size The new size.
    */
   void
   resize(const size_type new_size);
@@ -179,6 +191,8 @@ public:
    * the size of the current object is of course set to the requested
    * value.
    *
+   * @param new_size The new size.
+   * @param init The value used to initialize each newly created entry.
    * @note This method can only be invoked for classes that define the copy
    * assignment operator. Otherwise, compilation will fail.
    *
@@ -206,6 +220,7 @@ public:
    * are run, though the existing elements may be moved to a new location (which
    * involves running the move constructor at the new location and the
    * destructor at the old location).
+   * @param new_allocated_size The new allocated size.
    */
   void
   reserve(const size_type new_allocated_size);
@@ -227,6 +242,7 @@ public:
    * Inserts an element at the end of the vector, increasing the vector size
    * by one. Note that the allocated size will double whenever the previous
    * space is not enough to hold the new element.
+   * @param in_data The in data.
    */
   void
   push_back(const T in_data);
@@ -246,6 +262,8 @@ public:
   /**
    * Inserts several elements at the end of the vector given by a range of
    * elements.
+   * @param begin The begin of the range.
+   * @param end The end of the range.
    */
   template <typename ForwardIterator>
   void
@@ -254,6 +272,9 @@ public:
   /**
    * Insert the range specified by @p begin and @p end after the element @p position.
    *
+   * @param position The position at which the range is inserted.
+   * @param begin The begin of the range.
+   * @param end The end of the range.
    * @note Unlike std::vector, this function uses random-access iterators so
    * that the copy may be parallelized.
    *
@@ -284,6 +305,8 @@ public:
   /**
    * Fills the vector with size() copies of the given input.
    *
+   * @param element The value assigned to each entry that is initialized by
+   * this operation.
    * @note This method can only be invoked for classes that define the copy
    * assignment operator. Otherwise, compilation will fail.
    *
@@ -334,6 +357,8 @@ public:
    * process may also result in a modification of elements visible on other
    * processes, assuming they are located within one shared memory node.
    *
+   * @param communicator The MPI communicator.
+   * @param root_process The root process.
    * @note The use of shared memory between MPI processes requires
    *   that the detected MPI installation supports the necessary operations.
    *   This is the case for MPI 3.0 and higher.
@@ -385,6 +410,8 @@ public:
 
   /**
    * Swaps the given vector with the calling vector.
+   * @param vec The vector with which to initialize, copy, or exchange the
+   * current contents.
    */
   void
   swap(AlignedVector<T> &vec) noexcept;
@@ -410,12 +437,14 @@ public:
 
   /**
    * Read-write access to entry @p index in the vector.
+   * @param index The index of the entry.
    */
   reference
   operator[](const size_type index);
 
   /**
    * Read-only access to entry @p index in the vector.
+   * @param index The index of the entry.
    */
   const_reference
   operator[](const size_type index) const;
@@ -501,6 +530,8 @@ public:
    * Exception message for changing the vector after a call to
    * replicate_across_communicator().
    *
+   * @param ExcAlignedVectorChangeAfterReplication The exc aligned vector
+   * change after replication used by this operation.
    * @ingroup Exceptions
    */
   DeclExceptionMsg(ExcAlignedVectorChangeAfterReplication,
@@ -615,6 +646,7 @@ private:
      * Constructor. When this constructor is called, it installs an
      * action that corresponds to "regular" memory allocation that
      * needs to be handled by using `std::free()`.
+     * @param owning_object The owning object.
      */
     Deleter(AlignedVector<T> *owning_object);
 
@@ -625,6 +657,11 @@ private:
      * needs to be handled by letting MPI de-allocate the shared memory
      * window, plus destroying the MPI communicator, and doing other
      * clean-up work.
+     * @param owning_object The owning object.
+     * @param is_shmem_root The is shmem root.
+     * @param aligned_shmem_pointer The aligned shmem pointer.
+     * @param shmem_group_communicator The shmem group communicator.
+     * @param shmem_window The shmem window.
      */
     Deleter(AlignedVector<T> *owning_object,
             const bool        is_shmem_root,
@@ -637,6 +674,8 @@ private:
      * The operator called by `std::unique_ptr` to destroy the data it
      * is storing. This function dispatches to the different actions that
      * this class implements.
+     * @param ptr The pointer to the first element of the memory region to
+     * destroy or release.
      */
     void
     operator()(T *ptr);
@@ -647,6 +686,7 @@ private:
      * from one AlignedVector object -- i.e., the pointer itself remains
      * unchanged, but the deleter object needs to be updated to know who
      * the new owner now is.
+     * @param new_aligned_vector_ptr The new aligned vector ptr.
      */
     void
     reset_owning_object(const AlignedVector<T> *new_aligned_vector_ptr);
@@ -667,6 +707,9 @@ private:
        * The function that implements the action of de-allocating memory.
        * It receives as arguments a pointer to the owning AlignedVector object
        * as well as a pointer to the memory being de-allocated.
+       * @param owning_aligned_vector The owning aligned vector.
+       * @param ptr A pointer to the first element of the memory region on
+       * which this operation acts.
        */
       virtual void
       delete_array(const AlignedVector<T> *owning_aligned_vector, T *ptr) = 0;
@@ -684,6 +727,10 @@ private:
       /**
        * Constructor. Store the various pieces of information necessary to
        * identify the MPI window in which the data resides.
+       * @param is_shmem_root The is shmem root.
+       * @param aligned_shmem_pointer The aligned shmem pointer.
+       * @param shmem_group_communicator The shmem group communicator.
+       * @param shmem_window The shmem window.
        */
       MPISharedMemDeleterAction(const bool is_shmem_root,
                                 T         *aligned_shmem_pointer,
@@ -694,6 +741,9 @@ private:
        * The function that implements the action of de-allocating memory.
        * It receives as arguments a pointer to the owning AlignedVector object
        * as well as a pointer to the memory being de-allocated.
+       * @param aligned_vector The aligned vector.
+       * @param ptr A pointer to the first element of the memory region on
+       * which this operation acts.
        */
       virtual void
       delete_array(const AlignedVector<T> *aligned_vector, T *ptr) override;
@@ -788,6 +838,8 @@ namespace internal
      *
      * The elements from the source array are simply copied via the placement
      * new copy constructor.
+     * @param destination The destination memory range into which objects are
+     * constructed.
      */
     AlignedVectorCopyConstruct(RandomAccessIterator source_begin,
                                RandomAccessIterator source_end,
@@ -808,6 +860,8 @@ namespace internal
     /**
      * This method moves elements from the source to the destination given in
      * the constructor on a subrange given by two integers.
+     * @param begin The begin of the range.
+     * @param end The end of the range.
      */
     virtual void
     apply_to_subrange(const std::size_t begin,
@@ -856,6 +910,8 @@ namespace internal
      *
      * The data is moved between the two arrays by invoking the destructor on
      * the source range (preparing for a subsequent call to free).
+     * @param destination The destination memory range into which objects are
+     * constructed.
      */
     AlignedVectorMoveConstruct(RandomAccessIterator source_begin,
                                RandomAccessIterator source_end,
@@ -876,6 +932,8 @@ namespace internal
     /**
      * This method moves elements from the source to the destination given in
      * the constructor on a subrange given by two integers.
+     * @param begin The begin of the range.
+     * @param end The end of the range.
      */
     virtual void
     apply_to_subrange(const std::size_t begin,
@@ -961,6 +1019,8 @@ namespace internal
 
     /**
      * This sets elements on a subrange given by two integers.
+     * @param begin The begin of the range.
+     * @param end The end of the range.
      */
     virtual void
     apply_to_subrange(const std::size_t begin,
@@ -1031,6 +1091,8 @@ namespace internal
     /**
      * Constructor. Issues a parallel call if there are sufficiently many
      * elements, otherwise work in serial.
+     * @param destination The destination memory range into which objects are
+     * constructed.
      */
     AlignedVectorDefaultInitialize(const std::size_t size, T *const destination)
       : destination_(destination)
@@ -1047,6 +1109,8 @@ namespace internal
 
     /**
      * This initializes elements on a subrange given by two integers.
+     * @param begin The begin of the range.
+     * @param end The end of the range.
      */
     virtual void
     apply_to_subrange(const std::size_t begin,

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -132,6 +132,7 @@ public:
 
   /**
    * Copy constructor.
+   * @param view The view used by this operation.
    */
   ArrayView(const ArrayView &view) = default;
 
@@ -146,6 +147,7 @@ public:
    * argument points to `const` elements, the conversion is clearly
    * not valid because it would remove the `const`ness of the
    * argument.
+   * @param view The view used by this operation.
    */
   template <typename OtherElementType,
             typename = std::enable_if_t<
@@ -156,6 +158,8 @@ public:
   /**
    * A constructor that automatically creates a view from a single value_type
    * object. The view so created then has length one.
+   * @param element The value assigned to each entry that is initialized by
+   * this operation.
    */
   explicit ArrayView(value_type &element);
 
@@ -223,6 +227,7 @@ public:
    * a function that takes an ArrayView object as argument, and passing in
    * a container.
    *
+   * @param container The container used by this operation.
    * @note This constructor takes a reference to a @p const container as argument.
    *   It can only be used to initialize ArrayView objects that point to
    *   @p const memory locations, such as <code>ArrayView@<const double@></code>.
@@ -250,6 +255,7 @@ public:
    * a function that takes an ArrayView object as argument, and passing in
    * a container.
    *
+   * @param container The container used by this operation.
    * @note This constructor takes a reference to a non-@p const container as
    *   argument. It can be used to initialize ArrayView objects that point to
    *   either @p const memory locations, such as
@@ -332,6 +338,7 @@ public:
 
   /**
    * Copy operator.
+   * @param view The view used by this operation.
    */
   ArrayView<ElementType, MemorySpaceType> &
   operator=(const ArrayView &view) = default;
@@ -347,6 +354,7 @@ public:
    * argument points to `const` elements, the conversion is clearly
    * not valid because it would remove the `const`ness of the
    * argument.
+   * @param view The view used by this operation.
    */
   template <typename OtherElementType,
             typename = std::enable_if_t<
@@ -389,6 +397,7 @@ public:
    * views point to are the same.
    *
    * This version always compares with the const value_type.
+   * @param other_view The other view.
    */
   bool
   operator==(
@@ -406,6 +415,7 @@ public:
    * views point to are the same.
    *
    * This version always compares with the non-const value_type.
+   * @param other_view The other view.
    */
   bool
   operator==(const ArrayView<std::remove_const_t<value_type>, MemorySpaceType>
@@ -426,6 +436,7 @@ public:
    * views point to are the same.
    *
    * This version always compares with the const value_type.
+   * @param other_view The other view.
    */
   bool
   operator!=(
@@ -443,6 +454,7 @@ public:
    * views point to are the same.
    *
    * This version always compares with the non-const value_type.
+   * @param other_view The other view.
    */
   bool
   operator!=(const ArrayView<std::remove_const_t<value_type>, MemorySpaceType>
@@ -503,6 +515,7 @@ public:
    *
    * This function is only allowed to be called if the underlying data is indeed
    * stored in CPU memory.
+   * @param i The index of the entry.
    */
   value_type &
   operator[](const std::size_t i) const;
@@ -864,6 +877,7 @@ public:
    *
    * This function is only allowed to be called if the underlying data is indeed
    * stored in CPU memory.
+   * @param i The index of the entry.
    */
   value_type &
   operator[](const std::size_t i) const;
@@ -984,6 +998,8 @@ namespace internal
  * of the ArrayView is inferred from the value type of the iterator (e.g., the
  * view created from two const iterators will have a const type).
  *
+ * @param begin The begin of the range.
+ * @param end The end of the range.
  * @warning The iterators @p begin and @p end must bound (in the usual half-open
  * way) a contiguous in memory range of values. This function is intended for
  * use with iterators into containers like
@@ -1028,6 +1044,8 @@ make_array_view(const Iterator begin, const Iterator end)
  * Create a view from a pair of pointers. <code>ElementType</code> may be
  * const-qualified.
  *
+ * @param begin The begin of the range.
+ * @param end The end of the range.
  * @warning The pointers @p begin and @p end must bound (in the usual
  * half-open way) a contiguous in memory range of values.
  *
@@ -1271,6 +1289,7 @@ make_array_view(const std::vector<ElementType> &vector,
  * information.
  *
  * @relatesalso ArrayView
+ * @param vector The vector used by this operation.
  */
 template <typename ElementType>
 inline ArrayView<ElementType>
@@ -1287,6 +1306,7 @@ make_array_view(AlignedVector<ElementType> &vector)
  * information.
  *
  * @relatesalso ArrayView
+ * @param vector The vector used by this operation.
  */
 template <typename ElementType>
 inline ArrayView<const ElementType>
@@ -1303,6 +1323,9 @@ make_array_view(const AlignedVector<ElementType> &vector)
  * information.
  *
  * @relatesalso ArrayView
+ * @param vector The vector used by this operation.
+ * @param starting_index The starting index.
+ * @param size_of_view The size of view.
  */
 template <typename ElementType>
 inline ArrayView<ElementType>
@@ -1325,6 +1348,9 @@ make_array_view(AlignedVector<ElementType> &vector,
  * information.
  *
  * @relatesalso ArrayView
+ * @param vector The vector used by this operation.
+ * @param starting_index The starting index.
+ * @param size_of_view The size of view.
  */
 template <typename ElementType>
 inline ArrayView<const ElementType>

--- a/include/deal.II/base/auto_derivative_function.h
+++ b/include/deal.II/base/auto_derivative_function.h
@@ -125,6 +125,9 @@ public:
    * Sets DifferenceFormula <tt>formula</tt> to the default <tt>Euler</tt>
    * formula of the set_formula() function. Change this preset formula by
    * calling the set_formula() function.
+   * @param h The h used by this operation.
+   * @param n_components The number of components.
+   * @param initial_time The initial time.
    */
   AutoDerivativeFunction(const double       h,
                          const unsigned int n_components = 1,
@@ -138,6 +141,7 @@ public:
   /**
    * Choose the difference formula. See the enum #DifferenceFormula for
    * available choices.
+   * @param formula The formula used by this operation.
    */
   void
   set_formula(const DifferenceFormula formula = Euler);
@@ -149,6 +153,7 @@ public:
    * local variation of the function. Setting <tt>h=1e-6</tt> might be a good
    * choice for functions with an absolute value of about 1, that furthermore
    * does not vary to much.
+   * @param h The h used by this operation.
    */
   void
   set_h(const double h);
@@ -159,6 +164,8 @@ public:
    *
    * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual Tensor<1, dim>
   gradient(const Point<dim>  &p,
@@ -169,6 +176,8 @@ public:
    *
    * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
+   * @param p The point at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradient(const Point<dim>            &p,
@@ -182,6 +191,9 @@ public:
    *
    * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
+   * @param component The component to evaluate.
    */
   virtual void
   gradient_list(const std::vector<Point<dim>> &points,
@@ -199,6 +211,8 @@ public:
    *
    * Compute numerical difference quotients using the preset
    * #DifferenceFormula.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradient_list(
@@ -207,6 +221,7 @@ public:
 
   /**
    * Return a #DifferenceFormula of the order <tt>ord</tt> at minimum.
+   * @param ord The ord used by this operation.
    */
   static DifferenceFormula
   get_formula_of_order(const unsigned int ord);

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -154,17 +154,20 @@ public:
 
   /**
    * Standard copy constructor operator.
+   * @param box The box used by this operation.
    */
   BoundingBox(const BoundingBox<spacedim, Number> &box) = default;
 
   /**
    * Standard copy assignment operator.
+   * @param t The time associated with the evaluation.
    */
   BoundingBox<spacedim, Number> &
   operator=(const BoundingBox<spacedim, Number> &t) = default;
 
   /**
    * Standard constructor for an empty box around a point @p point.
+   * @param point The point at which to evaluate the function.
    */
   BoundingBox(const Point<spacedim, Number> &point);
 
@@ -172,6 +175,7 @@ public:
    * Standard constructor for non-empty boxes: it uses a pair of points
    * which describe the box: one for the bottom and one for the top
    * corner.
+   * @param boundary_points The boundary points.
    */
   BoundingBox(const std::pair<Point<spacedim, Number>, Point<spacedim, Number>>
                 &boundary_points);
@@ -200,12 +204,14 @@ public:
 
   /**
    * Test for equality.
+   * @param box The box used by this operation.
    */
   bool
   operator==(const BoundingBox<spacedim, Number> &box) const;
 
   /**
    * Test for inequality.
+   * @param box The box used by this operation.
    */
   bool
   operator!=(const BoundingBox<spacedim, Number> &box) const;
@@ -213,6 +219,8 @@ public:
   /**
    * Check if the current object and @p other_bbox are neighbors, i.e. if the boxes
    * have dimension spacedim, check if their intersection is non empty.
+   * @param other_bbox The other bbox.
+   * @param tolerance The tolerance used by this operation.
    */
   bool
   has_overlap_with(
@@ -221,6 +229,8 @@ public:
 
   /**
    * Check which NeighborType @p other_bbox is to the current object.
+   * @param other_bbox The other bbox.
+   * @param tolerance The tolerance used by this operation.
    */
   NeighborType
   get_neighbor_type(
@@ -231,6 +241,7 @@ public:
    * Enlarge the current object so that it contains @p other_bbox .
    * If the current object already contains @p other_bbox then it is not changed
    * by this function.
+   * @param other_bbox The other bbox.
    */
   void
   merge_with(const BoundingBox<spacedim, Number> &other_bbox);
@@ -240,6 +251,8 @@ public:
    * parameter @p tolerance is a factor by which the bounding box is enlarged
    * relative to the dimensions of the bounding box in order to determine in a
    * numerically robust way whether the point is inside.
+   * @param p The point at which to evaluate the function.
+   * @param tolerance The tolerance used by this operation.
    */
   bool
   point_inside(
@@ -255,6 +268,7 @@ public:
    * If you call this method with a negative number, and one of the axes of the
    * original bounding box is smaller than amount/2, the method will trigger
    * an assertion.
+   * @param amount The amount used by this operation.
    */
   void
   extend(const Number amount);
@@ -262,6 +276,7 @@ public:
   /**
    * The same as above with the difference that a new BoundingBox instance is
    * created without changing the current object.
+   * @param amount The amount used by this operation.
    */
   BoundingBox<spacedim, Number>
   create_extended(const Number amount) const;
@@ -278,6 +293,7 @@ public:
    * If you call this method with a negative number, and one of the axes of the
    * original bounding box is smaller than relative_amount *
    * side_length(direction) / 2, the method will trigger an assertion.
+   * @param relative_amount The relative amount.
    */
   BoundingBox<spacedim, Number>
   create_extended_relative(const Number relative_amount) const;
@@ -296,24 +312,28 @@ public:
 
   /**
    * Returns the side length of the box in @p direction.
+   * @param direction The coordinate direction to which this operation refers.
    */
   Number
   side_length(const unsigned int direction) const;
 
   /**
    * Return the lower bound of the box in @p direction.
+   * @param direction The coordinate direction to which this operation refers.
    */
   Number
   lower_bound(const unsigned int direction) const;
 
   /**
    * Return the upper bound of the box in @p direction.
+   * @param direction The coordinate direction to which this operation refers.
    */
   Number
   upper_bound(const unsigned int direction) const;
 
   /**
    * Return the bounds of the box in @p direction, as a one-dimensional box.
+   * @param direction The coordinate direction to which this operation refers.
    */
   BoundingBox<1, Number>
   bounds(const unsigned int direction) const;
@@ -321,6 +341,7 @@ public:
   /**
    * Returns the indexth vertex of the box. Vertex is meant in the same way as
    * for a cell, so that @p index $\in [0, 2^{\text{dim}} - 1]$.
+   * @param index The index of the entry.
    */
   Point<spacedim, Number>
   vertex(const unsigned int index) const;
@@ -328,6 +349,7 @@ public:
   /**
    * Returns the indexth child of the box. Child is meant in the same way as for
    * a cell.
+   * @param index The index of the entry.
    */
   BoundingBox<spacedim, Number>
   child(const unsigned int index) const;
@@ -336,6 +358,7 @@ public:
    * Returns the cross section of the box orthogonal to @p direction.
    * This is a box in one dimension lower.
    *
+   * @param direction The coordinate direction to which this operation refers.
    * @note Calling this method in 1d will result in an exception since
    * <code>BoundingBox&lt;0&gt;</code> is not implemented.
    */
@@ -349,6 +372,7 @@ public:
    * If $B$ is this bounding box, and $\hat{B}$ is the unit bounding box,
    * compute the affine mapping that satisfies $G(B) = \hat{B}$ and apply it to
    * @p point.
+   * @param point The point at which to evaluate the function.
    */
   Point<spacedim, Number>
   real_to_unit(const Point<spacedim, Number> &point) const;
@@ -360,6 +384,7 @@ public:
    * If $B$ is this bounding box, and $\hat{B}$ is the unit bounding box,
    * compute the affine mapping that satisfies $F(\hat{B}) = B$ and apply it to
    * @p point.
+   * @param point The point at which to evaluate the function.
    */
   Point<spacedim, Number>
   unit_to_real(const Point<spacedim, Number> &point) const;
@@ -369,6 +394,8 @@ public:
    * interval described by the bounds of the rectangle in the respective
    * direction, zero for points on the interval boundary and positive for points
    * outside.
+   * @param point The point at which to evaluate the function.
+   * @param direction The coordinate direction to which this operation refers.
    */
   Number
   signed_distance(const Point<spacedim, Number> &point,
@@ -378,6 +405,7 @@ public:
    * Returns the signed distance from a @p point to the bounds of the box. The
    * signed distance is negative for points inside the rectangle, zero for
    * points on the rectangle and positive for points outside the rectangle.
+   * @param point The point at which to evaluate the function.
    */
   Number
   signed_distance(const Point<spacedim, Number> &point) const;

--- a/include/deal.II/base/complex_overloads.h
+++ b/include/deal.II/base/complex_overloads.h
@@ -36,6 +36,8 @@ struct ProductType;
  * types. Annoyingly, the standard library does not provide such an
  * operator.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  * @note Because the C++ standard does not provide for mixed-precision complex
  *   operators, code such as the following does not compile:
  *   @code
@@ -77,6 +79,8 @@ operator*(const std::complex<T> &left, const std::complex<U> &right)
  * types. Annoyingly, the standard library does not provide such an
  * operator.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  * @note Because the C++ standard does not provide for mixed-precision complex
  *   operators, code such as the following does not compile:
  *   @code
@@ -118,6 +122,8 @@ operator/(const std::complex<T> &left, const std::complex<U> &right)
  * floating point type with a different real floating point type. Annoyingly,
  * the standard library does not provide such an operator.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  * @note Because the C++ standard does not provide for mixed-precision complex
  *   operators, code such as the following does not compile:
  *   @code
@@ -157,6 +163,8 @@ operator*(const std::complex<T> &left, const U &right)
  * floating point type with a different real floating point type. Annoyingly,
  * the standard library does not provide such an operator.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  * @note Because the C++ standard does not provide for mixed-precision complex
  *   operators, code such as the following does not compile:
  *   @code
@@ -196,6 +204,8 @@ operator/(const std::complex<T> &left, const U &right)
  * floating point type with a different complex floating point type.
  * Annoyingly, the standard library does not provide such an operator.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  * @note Because the C++ standard does not provide for mixed-precision complex
  *   operators, code such as the following does not compile:
  *   @code
@@ -235,6 +245,8 @@ operator*(const T &left, const std::complex<U> &right)
  * floating point type with a different complex floating point type.
  * Annoyingly, the standard library does not provide such an operator.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  * @note Because the C++ standard does not provide for mixed-precision complex
  *   operators, code such as the following does not compile:
  *   @code

--- a/include/deal.II/base/conditional_ostream.h
+++ b/include/deal.II/base/conditional_ostream.h
@@ -81,6 +81,8 @@ public:
    * Constructor. Set the stream to which we want to write, and the condition
    * based on which writes are actually forwarded. Per default the condition
    * of an object is active.
+   * @param stream The output stream to which data is written.
+   * @param active Whether to active.
    */
   explicit ConditionalOStream(std::ostream &stream, const bool active = true);
 
@@ -88,6 +90,7 @@ public:
    * Depending on the <tt>active</tt> flag set the condition of this stream to
    * active (true) or non-active (false). An object of this class prints to
    * <tt>cout</tt> if and only if its condition is active.
+   * @param active Whether to active.
    */
   void
   set_condition(const bool active);

--- a/include/deal.II/base/convergence_table.h
+++ b/include/deal.II/base/convergence_table.h
@@ -11,17 +11,17 @@
 // -----------------------------------------------------------------------------
 
 #ifndef dealii_convergence_table_h
-#define dealii_convergence_table_h
+#  define dealii_convergence_table_h
 
 
-#include <deal.II/base/config.h>
+#  include <deal.II/base/config.h>
 
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/table_handler.h>
-#include <deal.II/base/types.h>
+#  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/table_handler.h>
+#  include <deal.II/base/types.h>
 
-#include <ostream>
-#include <string>
+#  include <ostream>
+#  include <string>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -129,6 +129,10 @@ public:
    * described by the last parameter of this function, the formula needs to be
    * $ C (1/\sqrt[dim]{k})^r $.
    *
+   * @param data_column_key The data column key.
+   * @param reference_column_key The reference column key.
+   * @param rate_mode The rate mode.
+   * @param dim The dim used by this operation.
    * @note Since this function adds columns to the table after several rows
    * have already been filled, it switches off the auto fill mode of the
    * TableHandler base class. If you intend to add further data with auto
@@ -152,6 +156,8 @@ public:
    * one of the data column. This may be changed by using the
    * set_tex_supercaption() function of the base class TableHandler.
    *
+   * @param data_column_key The data column key.
+   * @param rate_mode The rate mode.
    * @note Since this function adds columns to the table after several rows
    * have already been filled, it switches off the auto fill mode of the
    * TableHandler base class. If you intend to add further data with auto
@@ -167,6 +173,7 @@ public:
    *
    * The Column::flag==1 is reserved for omitting the column from convergence
    * rate evaluation.
+   * @param key The key used by this operation.
    */
   void
   omit_column_from_convergence_rate_evaluation(const std::string &key);
@@ -184,6 +191,8 @@ public:
    * wanted to be omitted in the evaluation of the convergence rates. Hence
    * they should omitted by calling the
    * omit_column_from_convergence_rate_evaluation().
+   * @param reference_column_key The reference column key.
+   * @param rate_mode The rate mode.
    */
   void
   evaluate_all_convergence_rates(const std::string &reference_column_key,
@@ -201,6 +210,7 @@ public:
    * wanted to be omitted in the evaluation of the convergence rates. Hence
    * they should omitted by calling the
    * omit_column_from_convergence_rate_evaluation().
+   * @param rate_mode The rate mode.
    */
   void
   evaluate_all_convergence_rates(const RateMode rate_mode);
@@ -216,10 +226,6 @@ public:
   DeclException1(ExcRateColumnAlreadyExists,
                  std::string,
                  << "Rate column <" << arg1 << "> does already exist.");
-  /** @} */
-};
-
-
-DEAL_II_NAMESPACE_CLOSE
-
-#endif
+  /**
+   *  @} */
+  ****AL_II_NAMESPACE_CLOSE **ndif * /

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -354,6 +354,8 @@ namespace DataOutBase
     /**
      * Compare the present patch for equality with another one. This is used
      * in a few of the automated tests in our testsuite.
+     * @param patch The patch that describes one cells geometry and data
+     * values.
      */
     bool
     operator==(const Patch &patch) const;
@@ -369,6 +371,7 @@ namespace DataOutBase
 
     /**
      * Swap the current object's contents with those of the given argument.
+     * @param other_patch The object in which to store the other patch.
      */
     void
     swap(Patch<dim, spacedim> &other_patch) noexcept;
@@ -393,26 +396,27 @@ namespace DataOutBase
       << "It is not possible to have a structural dimension of " << arg1
       << " to be larger than the space dimension of the surrounding"
       << " space " << arg2);
-    /** @} */
-  };
-
-
-
-  /**
-   * A specialization of the general Patch<dim,spacedim> template that is
-   * tailored to the case of points, i.e., zero-dimensional objects embedded
-   * in @p spacedim dimensional space.
-   *
-   * The current class is compatible with the general template to allow for
-   * using the same functions accessing patches of arbitrary dimensionality
-   * in a generic way. However, it makes some variables that are nonsensical
-   * for zero-dimensional patches into @p static variables that exist only
-   * once in the entire program, as opposed to once per patch. Specifically,
-   * this is the case for the @p neighbors array and the @p n_subdivisions
-   * member variable that make no sense for zero-dimensional patches because
-   * points have no natural neighbors across their non-existent faces, nor
-   * can they reasonably be subdivided.
-   */
+    /**
+     *  @} */
+     *
+     *
+     *
+     *
+     *
+     *  A specialization of the general Patch<dim,spacedim> template that is
+     *  tailored to the case of points, i.e., zero-dimensional objects embedded
+     *  in @p spacedim dimensional space.
+     *
+     *  The current class is compatible with the general template to allow for
+     *  using the same functions accessing patches of arbitrary dimensionality
+     *  in a generic way. However, it makes some variables that are nonsensical
+     *  for zero-dimensional patches into @p static variables that exist only
+     *  once in the entire program, as opposed to once per patch. Specifically,
+     *  this is the case for the @p neighbors array and the @p n_subdivisions
+     *  member variable that make no sense for zero-dimensional patches because
+     *  points have no natural neighbors across their non-existent faces, nor
+     *  can they reasonably be subdivided.
+     */
   template <int spacedim>
   struct Patch<0, spacedim>
   {
@@ -506,6 +510,8 @@ namespace DataOutBase
     /**
      * Compare the present patch for equality with another one. This is used
      * in a few of the automated tests in our testsuite.
+     * @param patch The patch that describes one cells geometry and data
+     * values.
      */
     bool
     operator==(const Patch &patch) const;
@@ -521,6 +527,7 @@ namespace DataOutBase
 
     /**
      * Swap the current object's contents with those of the given argument.
+     * @param other_patch The object in which to store the other patch.
      */
     void
     swap(Patch<0, spacedim> &other_patch) noexcept;
@@ -545,21 +552,22 @@ namespace DataOutBase
       << "It is not possible to have a structural dimension of " << arg1
       << " to be larger than the space dimension of the surrounding"
       << " space " << arg2);
-    /** @} */
-  };
-
-
-  /**
-   * Base class describing common functionality between different output
-   * flags.
-   *
-   * This is implemented with the "Curiously Recurring Template Pattern";
-   * derived classes use their own type to fill in the typename so that
-   * <tt>memory_consumption</tt> works correctly. See the Wikipedia page on
-   * the pattern for more information.
-   *
-   * @ingroup output
-   */
+    /**
+     *  @} */
+     *
+     *
+     *
+     *
+     *  Base class describing common functionality between different output
+     *  flags.
+     *
+     *  This is implemented with the "Curiously Recurring Template Pattern";
+     *  derived classes use their own type to fill in the typename so that
+     *  <tt>memory_consumption</tt> works correctly. See the Wikipedia page on
+     *  the pattern for more information.
+     *
+     *  @ingroup output
+     */
   template <typename FlagsType>
   struct OutputFlagsBase
   {
@@ -569,6 +577,7 @@ namespace DataOutBase
      *
      * This method does nothing, but child classes may override this method to
      * add fields to <tt>prm</tt>.
+     * @param prm The prm used by this operation.
      */
     static void
     declare_parameters(ParameterHandler &prm);
@@ -579,6 +588,7 @@ namespace DataOutBase
      *
      * This method does nothing, but child classes may override this method to
      * add fields to <tt>prm</tt>.
+     * @param prm The prm used by this operation.
      */
     void
     parse_parameters(const ParameterHandler &prm);
@@ -619,2937 +629,3273 @@ namespace DataOutBase
    *
    * @ingroup output
    */
-  struct DXFlags : public OutputFlagsBase<DXFlags>
-  {
-    /**
-     * Write neighbor information. This information is necessary for instance,
-     * if OpenDX is supposed to compute integral curves (streamlines). If it
-     * is not present, streamlines end at cell boundaries.
-     */
-    bool write_neighbors;
-    /**
-     * Write integer values of the Triangulation in binary format.
-     */
-    bool int_binary;
-    /**
-     * Write coordinate vectors in binary format.
-     */
-    bool coordinates_binary;
-
-    /**
-     * Write data vectors in binary format.
-     */
-    bool data_binary;
-
-    /**
-     * Write binary coordinate vectors as double (64 bit) numbers instead of
-     * float (32 bit).
-     */
-    bool data_double;
-
-    /**
-     * Constructor.
-     */
-    DXFlags(const bool write_neighbors    = false,
-            const bool int_binary         = false,
-            const bool coordinates_binary = false,
-            const bool data_binary        = false);
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void
-    declare_parameters(ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void
-    parse_parameters(const ParameterHandler &prm);
-  };
-
-  /**
-   * Flags controlling the details of output in UCD format for AVS.
-   *
-   * @ingroup output
-   */
-  struct UcdFlags : public OutputFlagsBase<UcdFlags>
-  {
-    /**
-     * Write a comment at the beginning of the file stating the date of
-     * creation and some other data.  While this is supported by the UCD
-     * format and AVS, some other programs get confused by this, so the
-     * default is to not write a preamble. However, a preamble can be written
-     * using this flag.
-     *
-     * Default: <code>false</code>.
-     */
-    bool write_preamble;
-
-    /**
-     * Constructor.
-     */
-    UcdFlags(const bool write_preamble = false);
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void
-    declare_parameters(ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void
-    parse_parameters(const ParameterHandler &prm);
-  };
-
-  /**
-   * Flags controlling the details of output in Gnuplot format.
-   *
-   * @ingroup output
-   */
-  struct GnuplotFlags : public OutputFlagsBase<GnuplotFlags>
-  {
-    /**
-     * Default constructor. Sets up the dimension labels with the default values
-     * of <tt>"x"</tt>, <tt>"y"</tt>, and <tt>"z"</tt>.
-     */
-    GnuplotFlags();
-
-    /**
-     * Constructor which sets up non-default values for the dimension labels.
-     */
-    GnuplotFlags(const std::vector<std::string> &space_dimension_labels);
-
-    /**
-     * Labels to use in each spatial dimension. These default to <tt>"x"</tt>,
-     * <tt>"y"</tt>, and <tt>"z"</tt>. Labels are printed to the Gnuplot file
-     * surrounded by angle brackets: For example, if the space dimension is 2
-     * and the labels are <tt>"x"</tt> and <tt>"t"</tt>, then the relevant
-     * line will start with
-     * @verbatim
-     * # <x> <t>
-     * @endverbatim
-     * Any extra labels will be ignored.
-     *
-     * If you specify these labels yourself then there should be at least
-     * <tt>spacedim</tt> labels, where <tt>spacedim</tt> is the spatial
-     * dimension of the output data.
-     */
-    std::vector<std::string> space_dimension_labels;
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object.
-     */
-    std::size_t
-    memory_consumption() const;
-
-    /**
-     * Exception to raise when there are not enough specified dimension
-     * labels.
-     */
-    DeclExceptionMsg(ExcNotEnoughSpaceDimensionLabels,
-                     "There should be at least one space dimension per spatial "
-                     "dimension (extras are ignored).");
-  };
-
-  /**
-   * Flags controlling the details of output in Povray format. Several flags
-   * are implemented, see their respective documentation.
-   *
-   * @ingroup output
-   */
-  struct PovrayFlags : public OutputFlagsBase<PovrayFlags>
-  {
-    /**
-     * Normal vector interpolation, if set to true
-     *
-     * default = false
-     */
-    bool smooth;
-
-    /**
-     * Use bicubic patches (b-splines) instead of triangles.
-     *
-     * default = false
-     */
-    bool bicubic_patch;
-
-    /**
-     * include external "data.inc" with camera, light and texture definition
-     * for the scene.
-     *
-     * default = false
-     */
-    bool external_data;
-
-    /**
-     * Constructor.
-     */
-    PovrayFlags(const bool smooth        = false,
-                const bool bicubic_patch = false,
-                const bool external_data = false);
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void
-    declare_parameters(ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void
-    parse_parameters(const ParameterHandler &prm);
-  };
-
-
-  /**
-   * Flags controlling the details of output in encapsulated postscript
-   * format.
-   *
-   * @ingroup output
-   */
-  struct EpsFlags : public OutputFlagsBase<EpsFlags>
-  {
-    /**
-     * This denotes the number of the data vector which shall be used for
-     * generating the height information. By default, the first data vector is
-     * taken, i.e. <tt>height_vector==0</tt>, if there is any data vector. If
-     * there is no data vector, no height information is generated.
-     */
-    unsigned int height_vector;
-
-    /**
-     * Number of the vector which is to be taken to colorize cells. The same
-     * applies as for #height_vector.
-     */
-    unsigned int color_vector;
-
-    /**
-     * Enum denoting the possibilities whether the scaling should be done such
-     * that the given <tt>size</tt> equals the width or the height of the
-     * resulting picture.
-     */
-    enum SizeType
-    {
-      /// Scale to given width
-      width,
-      /// Scale to given height
-      height
-    };
-
-    /**
-     * See above. Default is <tt>width</tt>.
-     */
-    SizeType size_type;
-
-    /**
-     * Width or height of the output as given in postscript units This usually
-     * is given by the strange unit 1/72 inch. Whether this is height or width
-     * is specified by the flag <tt>size_type</tt>.
-     *
-     * Default is 300, which represents a size of roughly 10 cm.
-     */
-    unsigned int size;
-
-    /**
-     * Width of a line in postscript units. Default is 0.5.
-     */
-    double line_width;
-
-    /**
-     * Angle of the line origin-viewer against the z-axis in degrees.
-     *
-     * Default is the Gnuplot-default of 60.
-     */
-    double azimut_angle;
-
-    /**
-     * Angle by which the viewers position projected onto the x-y-plane is
-     * rotated around the z-axis, in positive sense when viewed from above.
-     * The unit are degrees, and zero equals a position above or below the
-     * negative y-axis.
-     *
-     * Default is the Gnuplot-default of 30.  An example of a Gnuplot-default
-     * of 0 is the following:
-     *
-     * @verbatim
-     *
-     *          3________7
-     *          /       /|
-     *         /       / |
-     *       2/______6/  |
-     *       |   |   |   |
-     * O-->  |   0___|___4
-     *       |  /    |  /
-     *       | /     | /
-     *      1|/______5/
-     *
-     * @endverbatim
-     */
-    double turn_angle;
-
-    /**
-     * Factor by which the z-axis is to be stretched as compared to the x- and
-     * y-axes. This is to compensate for the different sizes that coordinate
-     * and solution values may have and to prevent that the plot looks to much
-     * out-of-place (no elevation at all if solution values are much smaller
-     * than coordinate values, or the common "extremely mountainous area" in
-     * the opposite case.
-     *
-     * Default is <tt>1.0</tt>.
-     */
-    double z_scaling;
-
-    /**
-     * Flag the determines whether the lines bounding the cells (or the parts
-     * of each patch) are to be plotted.
-     *
-     * Default: <tt>true</tt>.
-     */
-    bool draw_mesh;
-
-    /**
-     * Flag whether to fill the regions between the lines bounding the cells
-     * or not. If not, no hidden line removal is performed, which in this
-     * crude implementation is done through writing the cells in a
-     * back-to-front order, thereby hiding the cells in the background by
-     * cells in the foreground.
-     *
-     * If this flag is <tt>false</tt> and #draw_mesh is <tt>false</tt> as
-     * well, nothing will be printed.
-     *
-     * If this flag is <tt>true</tt>, then the cells will be drawn either
-     * colored by one of the data sets (if #shade_cells is <tt>true</tt>), or
-     * pure white (if #shade_cells is false or if there are no data sets).
-     *
-     * Default is <tt>true</tt>.
-     */
-    bool draw_cells;
-
-    /**
-     * Flag to determine whether the cells shall be colorized by the data set
-     * denoted by #color_vector, or simply be painted in white. This flag only
-     * makes sense if <tt>#draw_cells==true</tt>. Colorization is done through
-     * #color_function.
-     *
-     * Default is <tt>true</tt>.
-     */
-    bool shade_cells;
-
-    /**
-     * Structure keeping the three color values in the RGB system.
-     */
-    struct RgbValues
-    {
-      float red;
-      float green;
-      float blue;
-
-      /**
-       * Return <tt>true</tt> if the color represented by the three color
-       * values is a grey scale, i.e. all components are equal.
-       */
-      bool
-      is_grey() const;
-    };
-
-    /**
-     * Definition of a function pointer type taking a value and returning a
-     * triple of color values in RGB values.
-     *
-     * Besides the actual value by which the color is to be computed, min and
-     * max values of the data to be colorized are given as well.
-     */
-    using ColorFunction = RgbValues (*)(const double value,
-                                        const double min_value,
-                                        const double max_value);
-
-    /**
-     * This is a pointer to the function which is used to colorize the cells.
-     * By default, it points to the static function default_color_function()
-     * which is a member of this class.
-     */
-    ColorFunction color_function;
-
-
-    /**
-     * Default colorization function. This one does what one usually wants: It
-     * shifts colors from black (lowest value) through blue, green and red to
-     * white (highest value). For the exact definition of the color scale
-     * refer to the implementation.
-     *
-     * This function was originally written by Stefan Nauber.
-     */
-    static RgbValues
-    default_color_function(const double value,
-                           const double min_value,
-                           const double max_value);
-
-    /**
-     * This is an alternative color function producing a grey scale between
-     * black (lowest values) and white (highest values). You may use it by
-     * setting the #color_function variable to the address of this function.
-     */
-    static RgbValues
-    grey_scale_color_function(const double value,
-                              const double min_value,
-                              const double max_value);
-
-    /**
-     * This is one more alternative color function producing a grey scale
-     * between white (lowest values) and black (highest values), i.e. the
-     * scale is reversed to the previous one. You may use it by setting the
-     * #color_function variable to the address of this function.
-     */
-    static RgbValues
-    reverse_grey_scale_color_function(const double value,
-                                      const double min_value,
-                                      const double max_value);
-
-    /**
-     * Constructor.
-     */
-    EpsFlags(const unsigned int  height_vector  = 0,
-             const unsigned int  color_vector   = 0,
-             const SizeType      size_type      = width,
-             const unsigned int  size           = 300,
-             const double        line_width     = 0.5,
-             const double        azimut_angle   = 60,
-             const double        turn_angle     = 30,
-             const double        z_scaling      = 1.0,
-             const bool          draw_mesh      = true,
-             const bool          draw_cells     = true,
-             const bool          shade_cells    = true,
-             const ColorFunction color_function = &default_color_function);
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     *
-     * For coloring, only the color functions declared in this class are
-     * offered.
-     */
-    static void
-    declare_parameters(ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in declare_parameters() and set the flags
-     * for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void
-    parse_parameters(const ParameterHandler &prm);
-  };
-
-  /**
-   * Flags controlling the details of output in GMV format. At present no
-   * flags are implemented.
-   *
-   * @ingroup output
-   */
-  struct GmvFlags : public OutputFlagsBase<GmvFlags>
-  {};
-
-  /**
-   * Flags controlling the details of output in HDF5 format.
-   *
-   * @ingroup output
-   */
-  struct Hdf5Flags : public OutputFlagsBase<Hdf5Flags>
-  {
-    /**
-     * Flag determining the compression level at which zlib, if available, is
-     * run. The default is <tt>best_speed</tt>.
-     */
-    DataOutBase::CompressionLevel compression_level;
-
-    explicit Hdf5Flags(
-      const CompressionLevel compression_level = CompressionLevel::best_speed);
-  };
-
-  /**
-   * Flags controlling the details of output in Tecplot format.
-   *
-   * @ingroup output
-   */
-  struct TecplotFlags : public OutputFlagsBase<TecplotFlags>
-  {
-    /**
-     * Tecplot allows to assign names to zones. This variable stores this
-     * name.
-     */
-    const char *zone_name;
-
-    /**
-     * Solution time for each zone in a strand. This value must be
-     * non-negative, otherwise it will not be written to file. Do not assign any
-     * value for this in case of a static zone.
-     */
-    double solution_time;
-
-    /**
-     * Constructor.
-     */
-    TecplotFlags(const char  *zone_name     = nullptr,
-                 const double solution_time = -1.0);
-
-    /**
-     * Return an estimate for the memory consumption, in bytes, of this
-     * object.
-     */
-    std::size_t
-    memory_consumption() const;
-  };
-
-  /**
-   * Flags controlling the details of output in VTK format.
-   *
-   * @ingroup output
-   */
-  struct VtkFlags : public OutputFlagsBase<VtkFlags>
-  {
-    /**
-     * The time of the time step if this file is part of a time dependent
-     * simulation.
-     *
-     * The value of this variable is written into the output file according to
-     * the instructions provided in
-     * http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
-     * unless it is at its default value of
-     * @verbatim std::numeric_limits<unsigned int>::min() @endverbatim.
-     */
-    double time;
-
-    /**
-     * The number of the time step if this file is part of a time dependent
-     * simulation, or the cycle within a nonlinear or other iteration.
-     *
-     * The value of this variable is written into the output file according to
-     * the instructions provided in
-     * http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
-     * unless it is at its default value of
-     * @verbatim numbers::invalid_unsigned_int @endverbatim.
-     */
-    unsigned int cycle;
-
-    /**
-     * Flag to determine whether the current date and time shall be printed as
-     * a comment in the file's second line.
-     *
-     * Default is <tt>true</tt>.
-     */
-    bool print_date_and_time;
-
-    /**
-     * Flag determining the compression level at which zlib, if available, is
-     * run. The default is <tt>best_speed</tt>.
-     */
-    DataOutBase::CompressionLevel compression_level;
-
-    /**
-     * Flag determining whether to write patches as linear cells
-     * or as a high-order Lagrange cell.
-     *
-     * Default is <tt>false</tt>.
-     *
-     * @note The ability to write data that corresponds to higher order
-     * polynomials rather than simply linear or bilinear is a feature that was
-     * only introduced in VTK 8.1.0 in December 2017. You will need at least
-     * Paraview version 5.5.0 released in April 2018 or a similarly recent
-     * version of VisIt for this feature to work (for example, VisIt 3.1.1,
-     * released in February 2020, does not yet support this feature). Older
-     * versions of these programs are likely going to result in errors when
-     * trying to read files generated with this flag set to true. Experience
-     * with these programs shows that these error messages are likely going to
-     * be rather less descriptive and more obscure.
-     */
-    bool write_higher_order_cells;
-
-    /**
-     * A map that describes for (some or all) of the output quantities what
-     * the physical units are. This field is ignored for VTK file format, but
-     * used for VTU format where it is attached to the individual scalar,
-     * vector, or tensor fields for use by visualization or other postprocessing
-     * tools. The default is to not attach any physical units to fields at all,
-     * i.e., an empty map.
-     *
-     * If the map does not contain an entry for a specific output variable, then
-     * no unit will be written into the output file. In other words, it is not
-     * an error to provide units for only some variables.
-     *
-     * step-19, step-44 and step-69 all demonstrate how to use this variable.
-     *
-     * @note While the functions that make use of this information do not care
-     *   about how physical units are specified, downstream postprocessing tools
-     *   should and do. As a consequence, these units should be specified in a
-     *   format that is understandable to these postprocessing tools. As an
-     *   example, the [unyt project](https://unyt.readthedocs.io/en/stable/)
-     *   describes a standard for describing and converting units.
-     */
-    std::map<std::string, std::string> physical_units;
-
-    /**
-     * Constructor. Initializes the member variables with names corresponding
-     * to the argument names of this function.
-     */
-    explicit VtkFlags(
-      const double           time  = std::numeric_limits<double>::lowest(),
-      const unsigned int     cycle = numbers::invalid_unsigned_int,
-      const bool             print_date_and_time = true,
-      const CompressionLevel compression_level   = CompressionLevel::best_speed,
-      const bool             write_higher_order_cells          = false,
-      const std::map<std::string, std::string> &physical_units = {});
-  };
-
-
-  /**
-   * Flags for SVG output.
-   *
-   * @ingroup output
-   */
-  struct SvgFlags : public OutputFlagsBase<SvgFlags>
-  {
-    /**
-     * Height of the image in SVG units. Default value is 4000.
-     */
-    unsigned int height;
-
-    /**
-     * Width of the image in SVG units. If left zero, the width is computed
-     * from the height.
-     */
-    unsigned int width;
-
-    /**
-     * This denotes the number of the data vector which shall be used for
-     * generating the height information. By default, the first data vector is
-     * taken, i.e. <tt>#height_vector==0</tt>, if there is any data vector. If
-     * there is no data vector, no height information is generated.
-     */
-    unsigned int height_vector;
-
-    /**
-     * Angles for the perspective view
-     */
-    int azimuth_angle, polar_angle;
-
-    unsigned int line_thickness;
-
-    /**
-     * Draw a margin of 5% around the plotted area
-     */
-    bool margin;
-
-    /**
-     * Draw a colorbar encoding the cell coloring
-     */
-    bool draw_colorbar;
-
-    /**
-     * Constructor.
-     */
-    SvgFlags(const unsigned int height_vector  = 0,
-             const int          azimuth_angle  = 37,
-             const int          polar_angle    = 45,
-             const unsigned int line_thickness = 1,
-             const bool         margin         = true,
-             const bool         draw_colorbar  = true);
-  };
-
-
-  /**
-   * Flags controlling the details of output in deal.II intermediate format.
-   * At present no flags are implemented.
-   *
-   * @ingroup output
-   */
-  struct Deal_II_IntermediateFlags
-    : public OutputFlagsBase<Deal_II_IntermediateFlags>
-  {
-    /**
-     * An indicator of the current file format version used to write
-     * intermediate format. We do not attempt to be backward compatible, so
-     * this number is used only to verify that the format we are writing is
-     * what the current readers and writers understand.
-     */
-    static const unsigned int format_version;
-  };
-
-  /**
-   * Flags controlling the behavior of the DataOutFilter class.
-   *
-   * @ingroup output
-   */
-  struct DataOutFilterFlags
-  {
-    /**
-     * Whether or not to filter out duplicate vertices and associated values.
-     * Setting this value to `true` will drastically
-     * reduce the output data size but will result in an output file that
-     * does not faithfully represent the actual data if the data corresponds
-     * to discontinuous fields. In particular, along subdomain boundaries
-     * the data will still be discontinuous, while it will look like a
-     * continuous field inside of the subdomain.
-     */
-    bool filter_duplicate_vertices;
-
-    /**
-     * Whether the XDMF output refers to HDF5 files. This affects how output
-     * is structured.
-     */
-    bool xdmf_hdf5_output;
-
-    /**
-     * Constructor.
-     */
-    DataOutFilterFlags(const bool filter_duplicate_vertices = false,
-                       const bool xdmf_hdf5_output          = false);
-
-    /**
-     * Declare all flags with name and type as offered by this class, for use
-     * in input files.
-     */
-    static void
-    declare_parameters(ParameterHandler &prm);
-
-    /**
-     * Read the parameters declared in <tt>declare_parameters</tt> and set the
-     * flags for this output format accordingly.
-     *
-     * The flags thus obtained overwrite all previous contents of this object.
-     */
-    void
-    parse_parameters(const ParameterHandler &prm);
-
-    /**
-     * Determine an estimate for the memory consumption (in bytes) of this
-     * object.
-     */
-    std::size_t
-    memory_consumption() const;
-  };
-
-  /**
-   * DataOutFilter provides a way to remove redundant vertices and values
-   * generated by the deal.II output. By default, DataOutBase and the classes
-   * that build on it output data at each vertex of each cell. This means that
-   * data is output multiple times for each vertex of the mesh, once for each
-   * cell adjacent to the vertex. The purpose of
-   * this scheme is to support output of discontinuous quantities, either
-   * because the finite element space is discontinuous or because the quantity
-   * that is output is computed from a solution field and is discontinuous
-   * across faces (for example for quantities computed via DataPostprocessor;
-   * typical cases where output quantities are discontinuous are when a
-   * postprocessor computes a quantity using the *gradient* of the solution,
-   * which is generally discontinuous even if the element itself is
-   * continuous). Other cases where the output is discontinuous are if the
-   * data to be output is not a finite element field but, for example,
-   * results from a class such as MatrixOut.
-   *
-   * This class is an attempt to rein in the amount of data that is written.
-   * If the fields that are written to files are indeed discontinuous, the
-   * only way to faithfully represent them is indeed to write multiple values
-   * for each vertex (this is typically done by creating multiple logical nodes
-   * in the output file, all of which have the same physical location; data is
-   * then associated to nodes, allowing to have multiple values associated
-   * with the same location). However,
-   * for fine meshes, one may not necessarily be interested in an exact
-   * representation of output fields that will likely only have small
-   * discontinuities. Rather, it may be sufficient to just output one value
-   * per vertex, which may be chosen arbitrarily from among those that are
-   * defined at this vertex, i.e., chosen arbitrarily from any of the
-   * adjacent cells.
-   */
-  class DataOutFilter
-  {
-  public:
-    /**
-     * Default constructor.
-     */
-    DataOutFilter();
-
-    /**
-     * Constructor with a given set of flags. See DataOutFilterFlags for
-     * possible flags.
-     */
-    DataOutFilter(const DataOutBase::DataOutFilterFlags &flags);
-
-    /**
-     * Write a point with the specified index into the filtered data set. If
-     * the point already exists and we are filtering redundant values, the
-     * provided index will internally refer to another recorded point.
-     */
-    template <int dim>
-    void
-    write_point(const unsigned int index, const Point<dim> &p);
-
-    /**
-     * Record a deal.II cell in the internal reordered format.
-     */
-    template <int dim>
-    void
-    write_cell(const unsigned int                   index,
-               const unsigned int                   start,
-               const std::array<unsigned int, dim> &offsets);
-
-    /**
-     * Record a single deal.II cell without subdivisions (e.g. simplex) in the
-     * internal reordered format.
-     */
-    template <int dim>
-    void
-    write_cell_single(const unsigned int        index,
-                      const unsigned int        start,
-                      const unsigned int        n_points,
-                      const ReferenceCell<dim> &reference_cell);
-
-    /**
-     * Filter and record a data set. If there are multiple values at a given
-     * vertex and redundant values are being removed, one is arbitrarily
-     * chosen as the recorded value. In the future this can be expanded to
-     * average/min/max multiple values at a given vertex.
-     */
-    void
-    write_data_set(const std::string      &name,
-                   const unsigned int      dimension,
-                   const unsigned int      set_num,
-                   const Table<2, double> &data_vectors);
-
-    /**
-     * Resize and fill a vector with all the filtered node vertex points, for
-     * output to a file.
-     */
-    void
-    fill_node_data(std::vector<double> &node_data) const;
-
-    /**
-     * Resize and fill a vector with all the filtered cell vertex indices, for
-     * output to a file.
-     */
-    void
-    fill_cell_data(const unsigned int         local_node_offset,
-                   std::vector<unsigned int> &cell_data) const;
-
-    /**
-     * Get the name of the data set indicated by the set number.
-     */
-    std::string
-    get_data_set_name(const unsigned int set_num) const;
-
-    /**
-     * Get the dimensionality of the data set indicated by the set number.
-     */
-    unsigned int
-    get_data_set_dim(const unsigned int set_num) const;
-
-    /**
-     * Get the raw double valued data of the data set indicated by the set
-     * number.
-     */
-    const double *
-    get_data_set(const unsigned int set_num) const;
-
-    /**
-     * Return the number of nodes in this DataOutFilter. This may be smaller
-     * than the original number of nodes if filtering is enabled.
-     */
-    unsigned int
-    n_nodes() const;
-
-    /**
-     * Return the number of filtered cells in this DataOutFilter. Cells are
-     * not filtered so this will be the original number of cells.
-     */
-    unsigned int
-    n_cells() const;
-
-    /**
-     * Return the number of filtered data sets in this DataOutFilter. Data
-     * sets are not filtered so this will be the original number of data sets.
-     */
-    unsigned int
-    n_data_sets() const;
-
-    /**
-     * Empty functions to do base class inheritance.
-     */
-    void
-    flush_points();
-
-    /**
-     * Empty functions to do base class inheritance.
-     */
-    void
-    flush_cells();
-
-
-  private:
-    /**
-     * Empty class to provide comparison function for Map3dPoint.
-     */
-    struct Point3Comp
-    {
-      bool
-      operator()(const Point<3> &one, const Point<3> &two) const
-      {
-        /*
-         * The return statement below is an optimized version of the following
-         * code:
-         *
-         * for (unsigned int d=0; d<3; ++d)
-         * {
-         *   if (one(d) < two(d))
-         *     return true;
-         *   else if (one(d) > two(d))
-         *     return false;
-         * }
-         * return false;
-         */
-
-        return (one[0] < two[0] ||
-                (!(two[0] < one[0]) &&
-                 (one[1] < two[1] || (!(two[1] < one[1]) && one[2] < two[2]))));
-      }
-    };
-
-    using Map3DPoint = std::multimap<Point<3>, unsigned int, Point3Comp>;
-
-    /**
-     * Flags used to specify filtering behavior.
-     */
-    DataOutBase::DataOutFilterFlags flags;
-
-    /**
-     * The number of space dimensions in which the vertices represented
-     * by the current object live. This corresponds to the usual
-     * @p dim argument, but since this class is not templated on the
-     * dimension, we need to store it here.
-     */
-    unsigned int node_dim;
-
-    /**
-     * The number of cells stored in
-     * @ref filtered_cells.
-     */
-    unsigned int num_cells;
-
-    /**
-     * Map of points to an internal index.
-     */
-    Map3DPoint existing_points;
-
-    /**
-     * Map of actual point index to internal point index.
-     */
-    std::map<unsigned int, unsigned int> filtered_points;
-
-    /**
-     * Map of cells to the filtered points.
-     */
-    std::map<unsigned int, unsigned int> filtered_cells;
-
-    /**
-     * Data set names.
-     */
-    std::vector<std::string> data_set_names;
-
-    /**
-     * Data set dimensions.
-     */
-    std::vector<unsigned int> data_set_dims;
-
-    /**
-     * Data set data.
-     */
-    std::vector<std::vector<double>> data_sets;
-
-    /**
-     * Record a cell vertex index based on the internal reordering.
-     */
-    void
-    internal_add_cell(const unsigned int cell_index,
-                      const unsigned int pt_index);
-  };
-
-
-  /**
-   * Provide a data type specifying the presently supported output formats.
-   */
-  enum OutputFormat
-  {
-    /**
-     * Use the format already stored in the object.
-     */
-    default_format,
-
-    /**
-     * Do not write any output.
-     */
-    none,
-
-    /**
-     * Output for OpenDX.
-     */
-    dx,
-
-    /**
-     * Output in the UCD format for AVS.
-     */
-    ucd,
-
-    /**
-     * Output for the Gnuplot tool.
-     */
-    gnuplot,
-
-    /**
-     * Output for the Povray raytracer.
-     */
-    povray,
-
-    /**
-     * Output in encapsulated PostScript.
-     */
-    eps,
-
-    /**
-     * Output for GMV.
-     */
-    gmv,
-
-    /**
-     * Output for Tecplot in text format.
-     */
-    tecplot,
-
-    /**
-     * Output in VTK format.
-     */
-    vtk,
-
-    /**
-     * Output in VTK format.
-     */
-    vtu,
-
-    /**
-     * Output in SVG format.
-     */
-    svg,
-
-    /**
-     * Output in deal.II intermediate format.
-     */
-    deal_II_intermediate,
-
-    /**
-     * Output in HDF5 format.
-     */
-    hdf5
-  };
-
-
-  /**
-   * Write the given list of patches to the output stream in OpenDX format.
-   */
-  template <int dim, int spacedim>
-  void
-  write_dx(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                  &nonscalar_data_ranges,
-    const DXFlags &flags,
-    std::ostream  &out);
-
-  /**
-   * Write the given list of patches to the output stream in eps format.
-   *
-   * Output in this format circumvents the use of auxiliary graphic programs
-   * converting some output format into a graphics format. This has the
-   * advantage that output is easy and fast, and the disadvantage that you
-   * have to give a whole bunch of parameters which determine the direction of
-   * sight, the mode of colorization, the scaling of the height axis, etc. (Of
-   * course, all these parameters have reasonable default values, which you
-   * may want to change.)
-   *
-   * This function only supports output for two-dimensional domains (i.e.,
-   * with dim==2), with values in the vertical direction taken from a data
-   * vector.
-   *
-   * Basically, output consists of the mesh and the cells in between them. You
-   * can draw either of these, or both, or none if you are really interested
-   * in an empty picture. If written, the mesh uses black lines. The cells in
-   * between the mesh are either not printed (this will result in a loss of
-   * hidden line removal, i.e.  you can "see through" the cells to lines
-   * behind), printed in white (which does nothing apart from the hidden line
-   * removal), or colorized using one of the data vectors (which need not be
-   * the same as the one used for computing the height information) and a
-   * customizable color function. The default color functions chooses the
-   * color between black, blue, green, red and white, with growing values of
-   * the data field chosen for colorization. At present, cells are displayed
-   * with one color per cell only, which is taken from the value of the data
-   * field at the center of the cell; bilinear interpolation of the color on a
-   * cell is not used.
-   *
-   * By default, the viewpoint is chosen like the default viewpoint in
-   * GNUPLOT, i.e.  with an angle of 60 degrees with respect to the positive
-   * z-axis and rotated 30 degrees in positive sense (as seen from above) away
-   * from the negative y-axis.  Of course you can change these settings.
-   *
-   * EPS output is written without a border around the picture, i.e. the
-   * bounding box is close to the output on all four sides. Coordinates are
-   * written using at most five digits, to keep picture size at a reasonable
-   * size.
-   *
-   * All parameters along with their default values are listed in the
-   * documentation of the <tt>EpsFlags</tt> member class of this class. See
-   * there for more and detailed information.
-   */
-  template <int spacedim>
-  void
-  write_eps(
-    const std::vector<Patch<2, spacedim>> &patches,
-    const std::vector<std::string>        &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const EpsFlags &flags,
-    std::ostream   &out);
-
-  /**
-   * This is the same function as above except for domains that are not
-   * two-dimensional. This function is not implemented (and will throw an error
-   * if called) but is declared to allow for dimension-independent programs.
-   */
-  template <int dim, int spacedim>
-  void
-  write_eps(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const EpsFlags &flags,
-    std::ostream   &out);
-
-
-  /**
-   * Write the given list of patches to the output stream in GMV format.
-   *
-   * Data is written in the following format: nodes are considered the points
-   * of the patches. In spatial dimensions less than three, zeroes are
-   * inserted for the missing coordinates. The data vectors are written as
-   * node or cell data, where for the first the data space is interpolated to
-   * (bi-,tri-)linear elements.
-   */
-  template <int dim, int spacedim>
-  void
-  write_gmv(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const GmvFlags &flags,
-    std::ostream   &out);
-
-  /**
-   * Write the given list of patches to the output stream in gnuplot format.
-   * Visualization of two-dimensional data can then be achieved by starting
-   * <tt>gnuplot</tt> and entering the commands
-   *
-   * @verbatim
-   * set data style lines
-   * splot "filename" using 1:2:n
-   * @endverbatim
-   * This example assumes that the number of the data vector displayed is
-   * <b>n-2</b>.
-   *
-   * The GNUPLOT format is not able to handle data on unstructured grids
-   * directly. Directly would mean that you only give the vertices and the
-   * solution values thereon and the program constructs its own grid to
-   * represent the data. This is only possible for a structured tensor product
-   * grid in two dimensions. However, it is possible to give several such
-   * patches within one file, which is exactly what the respective function of
-   * this class does: writing each cell's data as a patch of data, at least if
-   * the patches as passed from derived classes represent cells. Note that the
-   * functions on patches need not be continuous at interfaces between
-   * patches, so this method also works for discontinuous elements. Note also,
-   * that GNUPLOT can do hidden line removal for patched data.
-   *
-   * While this discussion applies to two spatial dimensions, it is more
-   * complicated in 3d. The reason is that we could still use patches, but it
-   * is difficult when trying to visualize them, since if we use a cut through
-   * the data (by, for example, using x- and z-coordinates, a fixed y-value
-   * and plot function values in z-direction, then the patched data is not a
-   * patch in the sense GNUPLOT wants it any more. Therefore, we use another
-   * approach, namely writing the data on the 3d grid as a sequence of lines,
-   * i.e. two points each associated with one or more data sets.  There are
-   * therefore 12 lines for each subcells of a patch.
-   *
-   * Given the lines as described above, a cut through this data in Gnuplot
-   * can then be achieved like this:
-   * @verbatim
-   *   set data style lines
-   *   splot [:][:][0:] "T" using 1:2:(\$3==.5 ? \$4 : -1)
-   * @endverbatim
-   *
-   * This command plots data in $x$- and $y$-direction unbounded, but in
-   * $z$-direction only those data points which are above the $x$-$y$-plane (we
-   * assume here a positive solution, if it has negative values, you might
-   * want to decrease the lower bound). Furthermore, it only takes the data
-   * points with z-values (<tt>&3</tt>) equal to 0.5, i.e. a cut through the
-   * domain at <tt>z=0.5</tt>. For the data points on this plane, the data
-   * values of the first data set (<tt>&4</tt>) are raised in z-direction
-   * above the x-y-plane; all other points are denoted the value <tt>-1</tt>
-   * instead of the value of the data vector and are not plotted due to the
-   * lower bound in z plotting direction, given in the third pair of brackets.
-   *
-   * More complex cuts are possible, including nonlinear ones. Note however,
-   * that only those points which are actually on the cut-surface are plotted.
-   */
-  template <int dim, int spacedim>
-  void
-  write_gnuplot(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
+  struct DXFlags :
+     public
+       OutputFlagsBase<DXFlags>
+       {
+         /**
+          * Write neighbor information. This information is necessary for
+          * instance, if OpenDX is supposed to compute integral curves
+          * (streamlines). If it is not present, streamlines end at cell
+          * boundaries.
+          */
+         bool write_neighbors;
+         /**
+          * Write integer values of the Triangulation in binary format.
+          */
+         bool int_binary;
+         /**
+          * Write coordinate vectors in binary format.
+          */
+         bool coordinates_binary;
+
+         /**
+          * Write data vectors in binary format.
+          */
+         bool data_binary;
+
+         /**
+          * Write binary coordinate vectors as double (64 bit) numbers instead
+          * of float (32 bit).
+          */
+         bool data_double;
+
+         /**
+          * Constructor.
+          * @param write_neighbors The write neighbors.
+          * @param int_binary The int binary.
+          * @param coordinates_binary The coordinates binary.
+          * @param data_binary The data binary.
+          */
+         DXFlags(const bool write_neighbors    = false,
+                 const bool int_binary         = false,
+                 const bool coordinates_binary = false,
+                 const bool data_binary        = false);
+
+         /**
+          * Declare all flags with name and type as offered by this class, for
+          * use in input files.
+          * @param prm The prm used by this operation.
+          */
+         static void declare_parameters(ParameterHandler & prm);
+
+         /**
+          * Read the parameters declared in declare_parameters() and set the
+          * flags for this output format accordingly.
+          *
+          * The flags thus obtained overwrite all previous contents of this
+          * object.
+          * @param prm The prm used by this operation.
+          */
+         void parse_parameters(const ParameterHandler &prm);
+       };
+
+       /**
+        * Flags controlling the details of output in UCD format for AVS.
+        *
+        * @ingroup output
+        */
+       struct UcdFlags : public OutputFlagsBase<UcdFlags>
+       {
+         /**
+          * Write a comment at the beginning of the file stating the date of
+          * creation and some other data.  While this is supported by the UCD
+          * format and AVS, some other programs get confused by this, so the
+          * default is to not write a preamble. However, a preamble can be
+          * written using this flag.
+          *
+          * Default: <code>false</code>.
+          */
+         bool write_preamble;
+
+         /**
+          * Constructor.
+          * @param write_preamble The write preamble.
+          */
+         UcdFlags(const bool write_preamble = false);
+
+         /**
+          * Declare all flags with name and type as offered by this class, for
+          * use in input files.
+          * @param prm The prm used by this operation.
+          */
+         static void
+         declare_parameters(ParameterHandler &prm);
+
+         /**
+          * Read the parameters declared in declare_parameters() and set the
+          * flags for this output format accordingly.
+          *
+          * The flags thus obtained overwrite all previous contents of this
+          * object.
+          * @param prm The prm used by this operation.
+          */
+         void
+         parse_parameters(const ParameterHandler &prm);
+       };
+
+       /**
+        * Flags controlling the details of output in Gnuplot format.
+        *
+        * @ingroup output
+        */
+       struct GnuplotFlags : public OutputFlagsBase<GnuplotFlags>
+       {
+         /**
+          * Default constructor. Sets up the dimension labels with the default
+          * values of <tt>"x"</tt>, <tt>"y"</tt>, and <tt>"z"</tt>.
+          */
+         GnuplotFlags();
+
+         /**
+          * Constructor which sets up non-default values for the dimension
+          * labels.
+          * @param space_dimension_labels The space dimension labels.
+          */
+         GnuplotFlags(const std::vector<std::string> &space_dimension_labels);
+
+         /**
+          * Labels to use in each spatial dimension. These default to
+          * <tt>"x"</tt>, <tt>"y"</tt>, and <tt>"z"</tt>. Labels are printed to
+          * the Gnuplot file surrounded by angle brackets: For example, if the
+          * space dimension is 2 and the labels are <tt>"x"</tt> and
+          * <tt>"t"</tt>, then the relevant line will start with
+          * @verbatim
+          * # <x> <t>
+          * @endverbatim
+          * Any extra labels will be ignored.
+          *
+          * If you specify these labels yourself then there should be at least
+          * <tt>spacedim</tt> labels, where <tt>spacedim</tt> is the spatial
+          * dimension of the output data.
+          */
+         std::vector<std::string> space_dimension_labels;
+
+         /**
+          * Return an estimate for the memory consumption, in bytes, of this
+          * object.
+          */
+         std::size_t
+         memory_consumption() const;
+
+         /**
+          * Exception to raise when there are not enough specified dimension
+          * labels.
+          * @param ExcNotEnoughSpaceDimensionLabels The exc not enough space
+          * dimension labels used by this operation.
+          */
+         DeclExceptionMsg(
+           ExcNotEnoughSpaceDimensionLabels,
+           "There should be at least one space dimension per spatial "
+           "dimension (extras are ignored).");
+       };
+
+       /**
+        * Flags controlling the details of output in Povray format. Several
+        * flags are implemented, see their respective documentation.
+        *
+        * @ingroup output
+        */
+       struct PovrayFlags : public OutputFlagsBase<PovrayFlags>
+       {
+         /**
+          * Normal vector interpolation, if set to true
+          *
+          * default = false
+          */
+         bool smooth;
+
+         /**
+          * Use bicubic patches (b-splines) instead of triangles.
+          *
+          * default = false
+          */
+         bool bicubic_patch;
+
+         /**
+          * include external "data.inc" with camera, light and texture
+          * definition for the scene.
+          *
+          * default = false
+          */
+         bool external_data;
+
+         /**
+          * Constructor.
+          * @param smooth Whether to smooth.
+          * @param bicubic_patch The bicubic patch.
+          * @param external_data The external data.
+          */
+         PovrayFlags(const bool smooth        = false,
+                     const bool bicubic_patch = false,
+                     const bool external_data = false);
+
+         /**
+          * Declare all flags with name and type as offered by this class, for
+          * use in input files.
+          * @param prm The prm used by this operation.
+          */
+         static void
+         declare_parameters(ParameterHandler &prm);
+
+         /**
+          * Read the parameters declared in declare_parameters() and set the
+          * flags for this output format accordingly.
+          *
+          * The flags thus obtained overwrite all previous contents of this
+          * object.
+          * @param prm The prm used by this operation.
+          */
+         void
+         parse_parameters(const ParameterHandler &prm);
+       };
+
+
+       /**
+        * Flags controlling the details of output in encapsulated postscript
+        * format.
+        *
+        * @ingroup output
+        */
+       struct EpsFlags : public OutputFlagsBase<EpsFlags>
+       {
+         /**
+          * This denotes the number of the data vector which shall be used for
+          * generating the height information. By default, the first data vector
+          * is taken, i.e. <tt>height_vector==0</tt>, if there is any data
+          * vector. If there is no data vector, no height information is
+          * generated.
+          */
+         unsigned int height_vector;
+
+         /**
+          * Number of the vector which is to be taken to colorize cells. The
+          * same applies as for #height_vector.
+          */
+         unsigned int color_vector;
+
+         /**
+          * Enum denoting the possibilities whether the scaling should be done
+          * such that the given <tt>size</tt> equals the width or the height of
+          * the resulting picture.
+          */
+         enum SizeType
+         {
+           /// Scale to given width
+           width,
+           /// Scale to given height
+           height
+         };
+
+         /**
+          * See above. Default is <tt>width</tt>.
+          */
+         SizeType size_type;
+
+         /**
+          * Width or height of the output as given in postscript units This
+          * usually is given by the strange unit 1/72 inch. Whether this is
+          * height or width is specified by the flag <tt>size_type</tt>.
+          *
+          * Default is 300, which represents a size of roughly 10 cm.
+          */
+         unsigned int size;
+
+         /**
+          * Width of a line in postscript units. Default is 0.5.
+          */
+         double line_width;
+
+         /**
+          * Angle of the line origin-viewer against the z-axis in degrees.
+          *
+          * Default is the Gnuplot-default of 60.
+          */
+         double azimut_angle;
+
+         /**
+          * Angle by which the viewers position projected onto the x-y-plane is
+          * rotated around the z-axis, in positive sense when viewed from above.
+          * The unit are degrees, and zero equals a position above or below the
+          * negative y-axis.
+          *
+          * Default is the Gnuplot-default of 30.  An example of a
+          * Gnuplot-default of 0 is the following:
+          *
+          * @verbatim
+          *
+          *          3________7
+          *          /       /|
+          *         /       / |
+          *       2/______6/  |
+          *       |   |   |   |
+          * O-->  |   0___|___4
+          *       |  /    |  /
+          *       | /     | /
+          *      1|/______5/
+          *
+          * @endverbatim
+          */
+         double turn_angle;
+
+         /**
+          * Factor by which the z-axis is to be stretched as compared to the x-
+          * and y-axes. This is to compensate for the different sizes that
+          * coordinate and solution values may have and to prevent that the plot
+          * looks to much out-of-place (no elevation at all if solution values
+          * are much smaller than coordinate values, or the common "extremely
+          * mountainous area" in the opposite case.
+          *
+          * Default is <tt>1.0</tt>.
+          */
+         double z_scaling;
+
+         /**
+          * Flag the determines whether the lines bounding the cells (or the
+          * parts of each patch) are to be plotted.
+          *
+          * Default: <tt>true</tt>.
+          */
+         bool draw_mesh;
+
+         /**
+          * Flag whether to fill the regions between the lines bounding the
+          * cells or not. If not, no hidden line removal is performed, which in
+          * this crude implementation is done through writing the cells in a
+          * back-to-front order, thereby hiding the cells in the background by
+          * cells in the foreground.
+          *
+          * If this flag is <tt>false</tt> and #draw_mesh is <tt>false</tt> as
+          * well, nothing will be printed.
+          *
+          * If this flag is <tt>true</tt>, then the cells will be drawn either
+          * colored by one of the data sets (if #shade_cells is <tt>true</tt>),
+          * or pure white (if #shade_cells is false or if there are no data
+          * sets).
+          *
+          * Default is <tt>true</tt>.
+          */
+         bool draw_cells;
+
+         /**
+          * Flag to determine whether the cells shall be colorized by the data
+          * set denoted by #color_vector, or simply be painted in white. This
+          * flag only makes sense if <tt>#draw_cells==true</tt>. Colorization is
+          * done through #color_function.
+          *
+          * Default is <tt>true</tt>.
+          */
+         bool shade_cells;
+
+         /**
+          * Structure keeping the three color values in the RGB system.
+          */
+         struct RgbValues
+         {
+           float red;
+           float green;
+           float blue;
+
+           /**
+            * Return <tt>true</tt> if the color represented by the three color
+            * values is a grey scale, i.e. all components are equal.
+            */
+           bool
+           is_grey() const;
+         };
+
+         /**
+          * Definition of a function pointer type taking a value and returning a
+          * triple of color values in RGB values.
+          *
+          * Besides the actual value by which the color is to be computed, min
+          * and max values of the data to be colorized are given as well.
+          */
+         using ColorFunction = RgbValues (*)(const double value,
+                                             const double min_value,
+                                             const double max_value);
+
+         /**
+          * This is a pointer to the function which is used to colorize the
+          * cells. By default, it points to the static function
+          * default_color_function() which is a member of this class.
+          */
+         ColorFunction color_function;
+
+
+         /**
+          * Default colorization function. This one does what one usually wants:
+          * It shifts colors from black (lowest value) through blue, green and
+          * red to white (highest value). For the exact definition of the color
+          * scale refer to the implementation.
+          *
+          * This function was originally written by Stefan Nauber.
+          * @param value The value associated with the function.
+          * @param min_value The min value.
+          * @param max_value The max value.
+          */
+         static RgbValues
+         default_color_function(const double value,
+                                const double min_value,
+                                const double max_value);
+
+         /**
+          * This is an alternative color function producing a grey scale between
+          * black (lowest values) and white (highest values). You may use it by
+          * setting the #color_function variable to the address of this
+          * function.
+          * @param value The value associated with the function.
+          * @param min_value The min value.
+          * @param max_value The max value.
+          */
+         static RgbValues
+         grey_scale_color_function(const double value,
+                                   const double min_value,
+                                   const double max_value);
+
+         /**
+          * This is one more alternative color function producing a grey scale
+          * between white (lowest values) and black (highest values), i.e. the
+          * scale is reversed to the previous one. You may use it by setting the
+          * #color_function variable to the address of this function.
+          * @param value The value associated with the function.
+          * @param min_value The min value.
+          * @param max_value The max value.
+          */
+         static RgbValues
+         reverse_grey_scale_color_function(const double value,
+                                           const double min_value,
+                                           const double max_value);
+
+         /**
+          * Constructor.
+          * @param height_vector The height vector.
+          * @param color_vector The color vector.
+          * @param size_type The size type.
+          * @param size The number of entries in the object to create or resize.
+          * @param line_width The line width.
+          * @param azimut_angle The azimut angle.
+          * @param turn_angle The turn angle.
+          * @param z_scaling The z scaling.
+          * @param draw_mesh The draw mesh.
+          * @param draw_cells The draw cells.
+          * @param shade_cells The shade cells.
+          * @param color_function The color function.
+          */
+         EpsFlags(const unsigned int  height_vector  = 0,
+                  const unsigned int  color_vector   = 0,
+                  const SizeType      size_type      = width,
+                  const unsigned int  size           = 300,
+                  const double        line_width     = 0.5,
+                  const double        azimut_angle   = 60,
+                  const double        turn_angle     = 30,
+                  const double        z_scaling      = 1.0,
+                  const bool          draw_mesh      = true,
+                  const bool          draw_cells     = true,
+                  const bool          shade_cells    = true,
+                  const ColorFunction color_function = &default_color_function);
+
+         /**
+          * Declare all flags with name and type as offered by this class, for
+          * use in input files.
+          *
+          * For coloring, only the color functions declared in this class are
+          * offered.
+          * @param prm The prm used by this operation.
+          */
+         static void
+         declare_parameters(ParameterHandler &prm);
+
+         /**
+          * Read the parameters declared in declare_parameters() and set the
+          * flags for this output format accordingly.
+          *
+          * The flags thus obtained overwrite all previous contents of this
+          * object.
+          * @param prm The prm used by this operation.
+          */
+         void
+         parse_parameters(const ParameterHandler &prm);
+       };
+
+       /**
+        * Flags controlling the details of output in GMV format. At present no
+        * flags are implemented.
+        *
+        * @ingroup output
+        */
+       struct GmvFlags : public OutputFlagsBase<GmvFlags>
+       {};
+
+       /**
+        * Flags controlling the details of output in HDF5 format.
+        *
+        * @ingroup output
+        */
+       struct Hdf5Flags : public OutputFlagsBase<Hdf5Flags>
+       {
+         /**
+          * Flag determining the compression level at which zlib, if available,
+          * is run. The default is <tt>best_speed</tt>.
+          */
+         DataOutBase::CompressionLevel compression_level;
+
+         explicit Hdf5Flags(const CompressionLevel compression_level =
+                              CompressionLevel::best_speed);
+       };
+
+       /**
+        * Flags controlling the details of output in Tecplot format.
+        *
+        * @ingroup output
+        */
+       struct TecplotFlags : public OutputFlagsBase<TecplotFlags>
+       {
+         /**
+          * Tecplot allows to assign names to zones. This variable stores this
+          * name.
+          */
+         const char *zone_name;
+
+         /**
+          * Solution time for each zone in a strand. This value must be
+          * non-negative, otherwise it will not be written to file. Do not
+          * assign any value for this in case of a static zone.
+          */
+         double solution_time;
+
+         /**
+          * Constructor.
+          * @param zone_name The zone name.
+          * @param solution_time The solution time.
+          */
+         TecplotFlags(const char  *zone_name     = nullptr,
+                      const double solution_time = -1.0);
+
+         /**
+          * Return an estimate for the memory consumption, in bytes, of this
+          * object.
+          */
+         std::size_t
+         memory_consumption() const;
+       };
+
+       /**
+        * Flags controlling the details of output in VTK format.
+        *
+        * @ingroup output
+        */
+       struct VtkFlags : public OutputFlagsBase<VtkFlags>
+       {
+         /**
+          * The time of the time step if this file is part of a time dependent
+          * simulation.
+          *
+          * The value of this variable is written into the output file according
+          * to the instructions provided in
+          * http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
+          * unless it is at its default value of
+          * @verbatim std::numeric_limits<unsigned int>::min() @endverbatim.
+          */
+         double time;
+
+         /**
+          * The number of the time step if this file is part of a time dependent
+          * simulation, or the cycle within a nonlinear or other iteration.
+          *
+          * The value of this variable is written into the output file according
+          * to the instructions provided in
+          * http://www.visitusers.org/index.php?title=Time_and_Cycle_in_VTK_files
+          * unless it is at its default value of
+          * @verbatim numbers::invalid_unsigned_int @endverbatim.
+          */
+         unsigned int cycle;
+
+         /**
+          * Flag to determine whether the current date and time shall be printed
+          * as a comment in the file's second line.
+          *
+          * Default is <tt>true</tt>.
+          */
+         bool print_date_and_time;
+
+         /**
+          * Flag determining the compression level at which zlib, if available,
+          * is run. The default is <tt>best_speed</tt>.
+          */
+         DataOutBase::CompressionLevel compression_level;
+
+         /**
+          * Flag determining whether to write patches as linear cells
+          * or as a high-order Lagrange cell.
+          *
+          * Default is <tt>false</tt>.
+          *
+          * @note The ability to write data that corresponds to higher order
+          * polynomials rather than simply linear or bilinear is a feature that
+          * was only introduced in VTK 8.1.0 in December 2017. You will need at
+          * least Paraview version 5.5.0 released in April 2018 or a similarly
+          * recent version of VisIt for this feature to work (for example,
+          * VisIt 3.1.1, released in February 2020, does not yet support this
+          * feature). Older versions of these programs are likely going to
+          * result in errors when trying to read files generated with this flag
+          * set to true. Experience with these programs shows that these error
+          * messages are likely going to be rather less descriptive and more
+          * obscure.
+          */
+         bool write_higher_order_cells;
+
+         /**
+          * A map that describes for (some or all) of the output quantities what
+          * the physical units are. This field is ignored for VTK file format,
+          * but used for VTU format where it is attached to the individual
+          * scalar, vector, or tensor fields for use by visualization or other
+          * postprocessing tools. The default is to not attach any physical
+          * units to fields at all, i.e., an empty map.
+          *
+          * If the map does not contain an entry for a specific output variable,
+          * then no unit will be written into the output file. In other words,
+          * it is not an error to provide units for only some variables.
+          *
+          * step-19, step-44 and step-69 all demonstrate how to use this
+          * variable.
+          *
+          * @note While the functions that make use of this information do not care
+          *   about how physical units are specified, downstream postprocessing
+          * tools should and do. As a consequence, these units should be
+          * specified in a format that is understandable to these postprocessing
+          * tools. As an example, the [unyt
+          * project](https://unyt.readthedocs.io/en/stable/) describes a
+          * standard for describing and converting units.
+          */
+         std::map<std::string, std::string> physical_units;
+
+         /**
+          * Constructor. Initializes the member variables with names
+          * corresponding to the argument names of this function.
+          * @param time The time associated with the evaluation.
+          * @param cycle The cycle used by this operation.
+          * @param print_date_and_time The print date and time.
+          * @param compression_level The compression level.
+          * @param write_higher_order_cells The write higher order cells.
+          * @param physical_units The physical units.
+          */
+         explicit VtkFlags(
+           const double           time  = std::numeric_limits<double>::lowest(),
+           const unsigned int     cycle = numbers::invalid_unsigned_int,
+           const bool             print_date_and_time = true,
+           const CompressionLevel compression_level =
+             CompressionLevel::best_speed,
+           const bool write_higher_order_cells                      = false,
+           const std::map<std::string, std::string> &physical_units = {});
+       };
+
+
+       /**
+        * Flags for SVG output.
+        *
+        * @ingroup output
+        */
+       struct SvgFlags : public OutputFlagsBase<SvgFlags>
+       {
+         /**
+          * Height of the image in SVG units. Default value is 4000.
+          */
+         unsigned int height;
+
+         /**
+          * Width of the image in SVG units. If left zero, the width is computed
+          * from the height.
+          */
+         unsigned int width;
+
+         /**
+          * This denotes the number of the data vector which shall be used for
+          * generating the height information. By default, the first data vector
+          * is taken, i.e. <tt>#height_vector==0</tt>, if there is any data
+          * vector. If there is no data vector, no height information is
+          * generated.
+          */
+         unsigned int height_vector;
+
+         /**
+          * Angles for the perspective view
+          */
+         int azimuth_angle, polar_angle;
+
+         unsigned int line_thickness;
+
+         /**
+          * Draw a margin of 5% around the plotted area
+          */
+         bool margin;
+
+         /**
+          * Draw a colorbar encoding the cell coloring
+          */
+         bool draw_colorbar;
+
+         /**
+          * Constructor.
+          * @param height_vector The height vector.
+          * @param azimuth_angle The azimuth angle.
+          * @param polar_angle The polar angle.
+          * @param line_thickness The line thickness.
+          * @param margin Whether to margin.
+          * @param draw_colorbar The draw colorbar.
+          */
+         SvgFlags(const unsigned int height_vector  = 0,
+                  const int          azimuth_angle  = 37,
+                  const int          polar_angle    = 45,
+                  const unsigned int line_thickness = 1,
+                  const bool         margin         = true,
+                  const bool         draw_colorbar  = true);
+       };
+
+
+       /**
+        * Flags controlling the details of output in deal.II intermediate
+        * format. At present no flags are implemented.
+        *
+        * @ingroup output
+        */
+       struct Deal_II_IntermediateFlags
+         : public OutputFlagsBase<Deal_II_IntermediateFlags>
+       {
+         /**
+          * An indicator of the current file format version used to write
+          * intermediate format. We do not attempt to be backward compatible, so
+          * this number is used only to verify that the format we are writing is
+          * what the current readers and writers understand.
+          */
+         static const unsigned int format_version;
+       };
+
+       /**
+        * Flags controlling the behavior of the DataOutFilter class.
+        *
+        * @ingroup output
+        */
+       struct DataOutFilterFlags
+       {
+         /**
+          * Whether or not to filter out duplicate vertices and associated
+          * values. Setting this value to `true` will drastically reduce the
+          * output data size but will result in an output file that does not
+          * faithfully represent the actual data if the data corresponds to
+          * discontinuous fields. In particular, along subdomain boundaries the
+          * data will still be discontinuous, while it will look like a
+          * continuous field inside of the subdomain.
+          */
+         bool filter_duplicate_vertices;
+
+         /**
+          * Whether the XDMF output refers to HDF5 files. This affects how
+          * output is structured.
+          */
+         bool xdmf_hdf5_output;
+
+         /**
+          * Constructor.
+          * @param filter_duplicate_vertices The filter duplicate vertices.
+          * @param xdmf_hdf5_output The xdmf hdf5 output.
+          */
+         DataOutFilterFlags(const bool filter_duplicate_vertices = false,
+                            const bool xdmf_hdf5_output          = false);
+
+         /**
+          * Declare all flags with name and type as offered by this class, for
+          * use in input files.
+          * @param prm The prm used by this operation.
+          */
+         static void
+         declare_parameters(ParameterHandler &prm);
+
+         /**
+          * Read the parameters declared in <tt>declare_parameters</tt> and set
+          * the flags for this output format accordingly.
+          *
+          * The flags thus obtained overwrite all previous contents of this
+          * object.
+          * @param prm The prm used by this operation.
+          */
+         void
+         parse_parameters(const ParameterHandler &prm);
+
+         /**
+          * Determine an estimate for the memory consumption (in bytes) of this
+          * object.
+          */
+         std::size_t
+         memory_consumption() const;
+       };
+
+       /**
+        * DataOutFilter provides a way to remove redundant vertices and values
+        * generated by the deal.II output. By default, DataOutBase and the
+        * classes that build on it output data at each vertex of each cell. This
+        * means that data is output multiple times for each vertex of the mesh,
+        * once for each cell adjacent to the vertex. The purpose of this scheme
+        * is to support output of discontinuous quantities, either because the
+        * finite element space is discontinuous or because the quantity that is
+        * output is computed from a solution field and is discontinuous across
+        * faces (for example for quantities computed via DataPostprocessor;
+        * typical cases where output quantities are discontinuous are when a
+        * postprocessor computes a quantity using the *gradient* of the
+        * solution, which is generally discontinuous even if the element itself
+        * is continuous). Other cases where the output is discontinuous are if
+        * the data to be output is not a finite element field but, for example,
+        * results from a class such as MatrixOut.
+        *
+        * This class is an attempt to rein in the amount of data that is
+        * written. If the fields that are written to files are indeed
+        * discontinuous, the only way to faithfully represent them is indeed to
+        * write multiple values for each vertex (this is typically done by
+        * creating multiple logical nodes in the output file, all of which have
+        * the same physical location; data is then associated to nodes, allowing
+        * to have multiple values associated with the same location). However,
+        * for fine meshes, one may not necessarily be interested in an exact
+        * representation of output fields that will likely only have small
+        * discontinuities. Rather, it may be sufficient to just output one value
+        * per vertex, which may be chosen arbitrarily from among those that are
+        * defined at this vertex, i.e., chosen arbitrarily from any of the
+        * adjacent cells.
+        */
+       class DataOutFilter
+       {
+       public:
+         /**
+          * Default constructor.
+          */
+         DataOutFilter();
+
+         /**
+          * Constructor with a given set of flags. See DataOutFilterFlags for
+          * possible flags.
+          * @param flags The flags that control how points and cells are filtered
+          * before writing.
+          */
+         DataOutFilter(const DataOutBase::DataOutFilterFlags &flags);
+
+         /**
+          * Write a point with the specified index into the filtered data set.
+          * If the point already exists and we are filtering redundant values,
+          * the provided index will internally refer to another recorded point.
+          * @param index The index of the entry.
+          * @param p The point at which to evaluate the function.
+          */
+         template <int dim>
+         void
+         write_point(const unsigned int index, const Point<dim> &p);
+
+         /**
+          * Record a deal.II cell in the internal reordered format.
+          * @param index The index of the entry.
+          * @param start The start used by this operation.
+          * @param offsets The offsets that map local vertices or points to their
+          * position in the output connectivity arrays.
+          */
+         template <int dim>
+         void
+         write_cell(const unsigned int                   index,
+                    const unsigned int                   start,
+                    const std::array<unsigned int, dim> &offsets);
+
+         /**
+          * Record a single deal.II cell without subdivisions (e.g. simplex) in
+          * the internal reordered format.
+          * @param index The index of the entry.
+          * @param start The start used by this operation.
+          * @param n_points The number of points.
+          * @param reference_cell The reference cell.
+          */
+         template <int dim>
+         void
+         write_cell_single(const unsigned int        index,
+                           const unsigned int        start,
+                           const unsigned int        n_points,
+                           const ReferenceCell<dim> &reference_cell);
+
+         /**
+          * Filter and record a data set. If there are multiple values at a
+          * given vertex and redundant values are being removed, one is
+          * arbitrarily chosen as the recorded value. In the future this can be
+          * expanded to average/min/max multiple values at a given vertex.
+          * @param name The name associated with the object being created or
+          * queried.
+          * @param dimension The dimension used by this operation.
+          * @param set_num The set num.
+          * @param data_vectors The data vectors.
+          */
+         void
+         write_data_set(const std::string      &name,
+                        const unsigned int      dimension,
+                        const unsigned int      set_num,
+                        const Table<2, double> &data_vectors);
+
+         /**
+          * Resize and fill a vector with all the filtered node vertex points,
+          * for output to a file.
+          * @param node_data The object in which to store the node data.
+          */
+         void
+         fill_node_data(std::vector<double> &node_data) const;
+
+         /**
+          * Resize and fill a vector with all the filtered cell vertex indices,
+          * for output to a file.
+          * @param local_node_offset The local node offset.
+          * @param cell_data The object in which to store the cell data.
+          */
+         void
+         fill_cell_data(const unsigned int         local_node_offset,
+                        std::vector<unsigned int> &cell_data) const;
+
+         /**
+          * Get the name of the data set indicated by the set number.
+          * @param set_num The set num.
+          */
+         std::string
+         get_data_set_name(const unsigned int set_num) const;
+
+         /**
+          * Get the dimensionality of the data set indicated by the set number.
+          * @param set_num The set num.
+          */
+         unsigned int
+         get_data_set_dim(const unsigned int set_num) const;
+
+         /**
+          * Get the raw double valued data of the data set indicated by the set
+          * number.
+          * @param set_num The set num.
+          */
+         const double *
+         get_data_set(const unsigned int set_num) const;
+
+         /**
+          * Return the number of nodes in this DataOutFilter. This may be
+          * smaller than the original number of nodes if filtering is enabled.
+          */
+         unsigned int
+         n_nodes() const;
+
+         /**
+          * Return the number of filtered cells in this DataOutFilter. Cells are
+          * not filtered so this will be the original number of cells.
+          */
+         unsigned int
+         n_cells() const;
+
+         /**
+          * Return the number of filtered data sets in this DataOutFilter. Data
+          * sets are not filtered so this will be the original number of data
+          * sets.
+          */
+         unsigned int
+         n_data_sets() const;
+
+         /**
+          * Empty functions to do base class inheritance.
+          */
+         void
+         flush_points();
+
+         /**
+          * Empty functions to do base class inheritance.
+          */
+         void
+         flush_cells();
+
+
+       private:
+         /**
+          * Empty class to provide comparison function for Map3dPoint.
+          */
+         struct Point3Comp
+         {
+           bool
+           operator()(const Point<3> &one, const Point<3> &two) const
+           {
+             /*
+              * The return statement below is an optimized version of the
+              * following code:
+              *
+              * for (unsigned int d=0; d<3; ++d)
+              * {
+              *   if (one(d) < two(d))
+              *     return true;
+              *   else if (one(d) > two(d))
+              *     return false;
+              * }
+              * return false;
+              */
+
+             return (
+               one[0] < two[0] ||
+               (!(two[0] < one[0]) &&
+                (one[1] < two[1] || (!(two[1] < one[1]) && one[2] < two[2]))));
+           }
+         };
+
+         using Map3DPoint = std::multimap<Point<3>, unsigned int, Point3Comp>;
+
+         /**
+          * Flags used to specify filtering behavior.
+          */
+         DataOutBase::DataOutFilterFlags flags;
+
+         /**
+          * The number of space dimensions in which the vertices represented
+          * by the current object live. This corresponds to the usual
+          * @p dim argument, but since this class is not templated on the
+          * dimension, we need to store it here.
+          */
+         unsigned int node_dim;
+
+         /**
+          * The number of cells stored in
+          * @ref filtered_cells.
+          */
+         unsigned int num_cells;
+
+         /**
+          * Map of points to an internal index.
+          */
+         Map3DPoint existing_points;
+
+         /**
+          * Map of actual point index to internal point index.
+          */
+         std::map<unsigned int, unsigned int> filtered_points;
+
+         /**
+          * Map of cells to the filtered points.
+          */
+         std::map<unsigned int, unsigned int> filtered_cells;
+
+         /**
+          * Data set names.
+          */
+         std::vector<std::string> data_set_names;
+
+         /**
+          * Data set dimensions.
+          */
+         std::vector<unsigned int> data_set_dims;
+
+         /**
+          * Data set data.
+          */
+         std::vector<std::vector<double>> data_sets;
+
+         /**
+          * Record a cell vertex index based on the internal reordering.
+          */
+         void
+         internal_add_cell(const unsigned int cell_index,
+                           const unsigned int pt_index);
+       };
+
+
+       /**
+        * Provide a data type specifying the presently supported output formats.
+        */
+       enum OutputFormat
+       {
+         /**
+          * Use the format already stored in the object.
+          */
+         default_format,
+
+         /**
+          * Do not write any output.
+          */
+         none,
+
+         /**
+          * Output for OpenDX.
+          */
+         dx,
+
+         /**
+          * Output in the UCD format for AVS.
+          */
+         ucd,
+
+         /**
+          * Output for the Gnuplot tool.
+          */
+         gnuplot,
+
+         /**
+          * Output for the Povray raytracer.
+          */
+         povray,
+
+         /**
+          * Output in encapsulated PostScript.
+          */
+         eps,
+
+         /**
+          * Output for GMV.
+          */
+         gmv,
+
+         /**
+          * Output for Tecplot in text format.
+          */
+         tecplot,
+
+         /**
+          * Output in VTK format.
+          */
+         vtk,
+
+         /**
+          * Output in VTK format.
+          */
+         vtu,
+
+         /**
+          * Output in SVG format.
+          */
+         svg,
+
+         /**
+          * Output in deal.II intermediate format.
+          */
+         deal_II_intermediate,
+
+         /**
+          * Output in HDF5 format.
+          */
+         hdf5
+       };
+
+
+       /**
+        * Write the given list of patches to the output stream in OpenDX format.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_dx(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
                        &nonscalar_data_ranges,
-    const GnuplotFlags &flags,
-    std::ostream       &out);
+         const DXFlags &flags,
+         std::ostream  &out);
 
-  /**
-   * Write the given list of patches to the output stream for the Povray
-   * raytracer.
-   *
-   * Output in this format creates a povray source file, include standard
-   * camera and light source definition for rendering with povray 3.1 At
-   * present, this format only supports output for two-dimensional data, with
-   * values in the third direction taken from a data vector.
-   *
-   * The output uses two different povray-objects:
-   *
-   * <ul>
-   * <li> <tt>BICUBIC_PATCH</tt> A <tt>bicubic_patch</tt> is a 3-dimensional
-   * Bezier patch. It consists of 16 Points describing the surface. The 4
-   * corner points are touched by the object, while the other 12 points pull
-   * and stretch the patch into shape. One <tt>bicubic_patch</tt> is generated
-   * on each patch. Therefore the number of subdivisions has to be 3 to provide
-   * the patch with 16 points. A bicubic patch is not exact but generates very
-   * smooth images.
-   *
-   * <li> <tt>MESH</tt> The mesh object is used to store large number of
-   * triangles. Every square of the patch data is split into one upper-left
-   * and one lower-right triangle. If the number of subdivisions is three, 32
-   * triangle are generated for every patch.
-   *
-   * Using the smooth flag povray interpolates the normals on the triangles,
-   * imitating a curved surface
-   * </ul>
-   *
-   * All objects get one texture definition called Tex. This texture has to be
-   * declared somewhere before the object data. This may be in an external
-   * data file or at the beginning of the output file. Setting the
-   * <tt>external_data</tt> flag to false, an standard camera, light and
-   * texture (scaled to fit the scene) is added to the output file. Set to
-   * true an include file "data.inc" is included. This file is not generated
-   * by deal and has to include camera, light and the texture definition Tex.
-   *
-   * You need povray (>=3.0) to render the scene. The minimum options for
-   * povray are:
-   * @verbatim
-   *   povray +I<inputfile> +W<horiz. size> +H<ver. size> +L<include path>
-   * @endverbatim
-   * If the external file "data.inc" is used, the path to this file has to be
-   * included in the povray options.
-   */
-  template <int dim, int spacedim>
-  void
-  write_povray(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                      &nonscalar_data_ranges,
-    const PovrayFlags &flags,
-    std::ostream      &out);
+       /**
+        * Write the given list of patches to the output stream in eps format.
+        *
+        * Output in this format circumvents the use of auxiliary graphic
+        * programs converting some output format into a graphics format. This
+        * has the advantage that output is easy and fast, and the disadvantage
+        * that you have to give a whole bunch of parameters which determine the
+        * direction of sight, the mode of colorization, the scaling of the
+        * height axis, etc. (Of course, all these parameters have reasonable
+        * default values, which you may want to change.)
+        *
+        * This function only supports output for two-dimensional domains (i.e.,
+        * with dim==2), with values in the vertical direction taken from a data
+        * vector.
+        *
+        * Basically, output consists of the mesh and the cells in between them.
+        * You can draw either of these, or both, or none if you are really
+        * interested in an empty picture. If written, the mesh uses black lines.
+        * The cells in between the mesh are either not printed (this will result
+        * in a loss of hidden line removal, i.e.  you can "see through" the
+        * cells to lines behind), printed in white (which does nothing apart
+        * from the hidden line removal), or colorized using one of the data
+        * vectors (which need not be the same as the one used for computing the
+        * height information) and a customizable color function. The default
+        * color functions chooses the color between black, blue, green, red and
+        * white, with growing values of the data field chosen for colorization.
+        * At present, cells are displayed with one color per cell only, which is
+        * taken from the value of the data field at the center of the cell;
+        * bilinear interpolation of the color on a cell is not used.
+        *
+        * By default, the viewpoint is chosen like the default viewpoint in
+        * GNUPLOT, i.e.  with an angle of 60 degrees with respect to the
+        * positive z-axis and rotated 30 degrees in positive sense (as seen from
+        * above) away from the negative y-axis.  Of course you can change these
+        * settings.
+        *
+        * EPS output is written without a border around the picture, i.e. the
+        * bounding box is close to the output on all four sides. Coordinates are
+        * written using at most five digits, to keep picture size at a
+        * reasonable size.
+        *
+        * All parameters along with their default values are listed in the
+        * documentation of the <tt>EpsFlags</tt> member class of this class. See
+        * there for more and detailed information.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int spacedim>
+       void
+       write_eps(
+         const std::vector<Patch<2, spacedim>> &patches,
+         const std::vector<std::string>        &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const EpsFlags &flags,
+         std::ostream   &out);
 
-  /**
-   * Write the given list of patches to the output stream in Tecplot ASCII
-   * format (FEBLOCK).
-   *
-   * For more information consult the Tecplot Users and Reference manuals.
-   */
-  template <int dim, int spacedim>
-  void
-  write_tecplot(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
+       /**
+        * This is the same function as above except for domains that are not
+        * two-dimensional. This function is not implemented (and will throw an
+        * error if called) but is declared to allow for dimension-independent
+        * programs.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_eps(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const EpsFlags &flags,
+         std::ostream   &out);
+
+
+       /**
+        * Write the given list of patches to the output stream in GMV format.
+        *
+        * Data is written in the following format: nodes are considered the
+        * points of the patches. In spatial dimensions less than three, zeroes
+        * are inserted for the missing coordinates. The data vectors are written
+        * as node or cell data, where for the first the data space is
+        * interpolated to (bi-,tri-)linear elements.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_gmv(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const GmvFlags &flags,
+         std::ostream   &out);
+
+       /**
+        * Write the given list of patches to the output stream in gnuplot
+        * format. Visualization of two-dimensional data can then be achieved by
+        * starting <tt>gnuplot</tt> and entering the commands
+        *
+        * @verbatim
+        * set data style lines
+        * splot "filename" using 1:2:n
+        * @endverbatim
+        * This example assumes that the number of the data vector displayed is
+        * <b>n-2</b>.
+        *
+        * The GNUPLOT format is not able to handle data on unstructured grids
+        * directly. Directly would mean that you only give the vertices and the
+        * solution values thereon and the program constructs its own grid to
+        * represent the data. This is only possible for a structured tensor
+        * product grid in two dimensions. However, it is possible to give
+        * several such patches within one file, which is exactly what the
+        * respective function of this class does: writing each cell's data as a
+        * patch of data, at least if the patches as passed from derived classes
+        * represent cells. Note that the functions on patches need not be
+        * continuous at interfaces between patches, so this method also works
+        * for discontinuous elements. Note also, that GNUPLOT can do hidden line
+        * removal for patched data.
+        *
+        * While this discussion applies to two spatial dimensions, it is more
+        * complicated in 3d. The reason is that we could still use patches, but
+        * it is difficult when trying to visualize them, since if we use a cut
+        * through the data (by, for example, using x- and z-coordinates, a fixed
+        * y-value and plot function values in z-direction, then the patched data
+        * is not a patch in the sense GNUPLOT wants it any more. Therefore, we
+        * use another approach, namely writing the data on the 3d grid as a
+        * sequence of lines, i.e. two points each associated with one or more
+        * data sets.  There are therefore 12 lines for each subcells of a patch.
+        *
+        * Given the lines as described above, a cut through this data in Gnuplot
+        * can then be achieved like this:
+        * @verbatim
+        *   set data style lines
+        *   splot [:][:][0:] "T" using 1:2:(\$3==.5 ? \$4 : -1)
+        * @endverbatim
+        *
+        * This command plots data in $x$- and $y$-direction unbounded, but in
+        * $z$-direction only those data points which are above the $x$-$y$-plane
+        * (we assume here a positive solution, if it has negative values, you
+        * might want to decrease the lower bound). Furthermore, it only takes
+        * the data points with z-values (<tt>&3</tt>) equal to 0.5, i.e. a cut
+        * through the domain at <tt>z=0.5</tt>. For the data points on this
+        * plane, the data values of the first data set (<tt>&4</tt>) are raised
+        * in z-direction above the x-y-plane; all other points are denoted the
+        * value <tt>-1</tt> instead of the value of the data vector and are not
+        * plotted due to the lower bound in z plotting direction, given in the
+        * third pair of brackets.
+        *
+        * More complex cuts are possible, including nonlinear ones. Note
+        * however, that only those points which are actually on the cut-surface
+        * are plotted.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_gnuplot(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                            &nonscalar_data_ranges,
+         const GnuplotFlags &flags,
+         std::ostream       &out);
+
+       /**
+        * Write the given list of patches to the output stream for the Povray
+        * raytracer.
+        *
+        * Output in this format creates a povray source file, include standard
+        * camera and light source definition for rendering with povray 3.1 At
+        * present, this format only supports output for two-dimensional data,
+        * with values in the third direction taken from a data vector.
+        *
+        * The output uses two different povray-objects:
+        *
+        * <ul>
+        * <li> <tt>BICUBIC_PATCH</tt> A <tt>bicubic_patch</tt> is a 3-dimensional
+        * Bezier patch. It consists of 16 Points describing the surface. The 4
+        * corner points are touched by the object, while the other 12 points
+        * pull and stretch the patch into shape. One <tt>bicubic_patch</tt> is
+        * generated on each patch. Therefore the number of subdivisions has to
+        * be 3 to provide the patch with 16 points. A bicubic patch is not exact
+        * but generates very smooth images.
+        *
+        * <li> <tt>MESH</tt> The mesh object is used to store large number of
+        * triangles. Every square of the patch data is split into one upper-left
+        * and one lower-right triangle. If the number of subdivisions is three,
+        * 32 triangle are generated for every patch.
+        *
+        * Using the smooth flag povray interpolates the normals on the
+        * triangles, imitating a curved surface
+        * </ul>
+        *
+        * All objects get one texture definition called Tex. This texture has to
+        * be declared somewhere before the object data. This may be in an
+        * external data file or at the beginning of the output file. Setting the
+        * <tt>external_data</tt> flag to false, an standard camera, light and
+        * texture (scaled to fit the scene) is added to the output file. Set to
+        * true an include file "data.inc" is included. This file is not
+        * generated by deal and has to include camera, light and the texture
+        * definition Tex.
+        *
+        * You need povray (>=3.0) to render the scene. The minimum options for
+        * povray are:
+        * @verbatim
+        *   povray +I<inputfile> +W<horiz. size> +H<ver. size> +L<include path>
+        * @endverbatim
+        * If the external file "data.inc" is used, the path to this file has to
+        * be included in the povray options.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_povray(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                           &nonscalar_data_ranges,
+         const PovrayFlags &flags,
+         std::ostream      &out);
+
+       /**
+        * Write the given list of patches to the output stream in Tecplot ASCII
+        * format (FEBLOCK).
+        *
+        * For more information consult the Tecplot Users and Reference manuals.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_tecplot(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                            &nonscalar_data_ranges,
+         const TecplotFlags &flags,
+         std::ostream       &out);
+
+       /**
+        * Write the given list of patches to the output stream in UCD format
+        * described in the AVS developer's guide (now AVS). Due to limitations
+        * in the present format, only node based data can be output, which in
+        * one reason why we invented the patch concept. In order to write higher
+        * order elements, you may split them up into several subdivisions of
+        * each cell. These subcells will then, however, also appear as different
+        * cells by programs which understand the UCD format.
+        *
+        * No use is made of the possibility to give model data since these are
+        * not supported by all UCD aware programs. You may give cell data in
+        * derived classes by setting all values of a given data set on a patch
+        * to the same value.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_ucd(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const UcdFlags &flags,
+         std::ostream   &out);
+
+       /**
+        * Write the given list of patches to the output stream in VTK format.
+        * The data is written in the traditional VTK format as opposed to the
+        * XML-based format that write_vtu() produces.
+        *
+        * The nonscalar_data_ranges argument denotes ranges of components in the
+        * output that are considered a vector, rather than simply a collection
+        * of scalar fields. The VTK output format has special provisions that
+        * allow these components to be output by a single name rather than
+        * having to group several scalar fields into a vector later on in the
+        * visualization program.
+        *
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        * @note VTK is a legacy format and has largely been supplanted by the VTU
+        * format (an XML-structured version of VTK). In particular, VTU allows
+        * for the compression of data and consequently leads to much smaller
+        * file sizes that equivalent VTK files for large files. Since all
+        * visualization programs that support VTK also support VTU, you should
+        * consider using the latter file format instead, by using the
+        * write_vtu() function.
+        */
+       template <int dim, int spacedim>
+       void
+       write_vtk(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const VtkFlags &flags,
+         std::ostream   &out);
+
+
+       /**
+        * Write the given list of patches to the output stream in VTU format.
+        * The data is written in the XML-based VTK format as opposed to the
+        * traditional format that write_vtk() produces.
+        *
+        * The nonscalar_data_ranges argument denotes ranges of components in the
+        * output that are considered a vector, rather than simply a collection
+        * of scalar fields. The VTK output format has special provisions that
+        * allow these components to be output by a single name rather than
+        * having to group several scalar fields into a vector later on in the
+        * visualization program.
+        *
+        * Some visualization programs, such as ParaView, can read several
+        * separate VTU files to parallelize visualization. In that case, you
+        * need a <code>.pvtu</code> file that describes which VTU files form a
+        * group. The DataOutInterface::write_pvtu_record() function can generate
+        * such a centralized record. Likewise,
+        * DataOutInterface::write_visit_record() does the same for VisIt
+        * (although VisIt can also read <code>pvtu</code> records since
+        * version 2.5.1). Finally, for time dependent problems, you may also
+        * want to look at DataOutInterface::write_pvd_record()
+        *
+        * The use of this function is explained in step-40.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_vtu(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const VtkFlags &flags,
+         std::ostream   &out);
+
+       /**
+        * This writes the header for the xml based vtu file format. This routine
+        * is used internally together with DataOutInterface::write_vtu_footer()
+        * and DataOutInterface::write_vtu_main() by DataOutBase::write_vtu().
+        * @param out The output stream to which data is written.
+        * @param flags The flags that control how the output is written.
+        */
+       void
+       write_vtu_header(std::ostream &out, const VtkFlags &flags);
+
+       /**
+        * This function writes the footer for the xml based vtu file format.
+        * This routine is used internally together with
+        * DataOutInterface::write_vtu_header() and
+        * DataOutInterface::write_vtu_main() by DataOutBase::write_vtu().
+        * @param out The output stream to which data is written.
+        */
+       void
+       write_vtu_footer(std::ostream &out);
+
+       /**
+        * This function writes the main part for the xml based vtu file format.
+        * This routine is used internally together with
+        * DataOutInterface::write_vtu_header() and
+        * DataOutInterface::write_vtu_footer() by DataOutBase::write_vtu().
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_vtu_main(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const VtkFlags &flags,
+         std::ostream   &out);
+
+       /**
+        * Some visualization programs, such as ParaView, can read several
+        * separate VTU files that all form part of the same simulation, in order
+        * to parallelize visualization. In that case, you need a
+        * <code>.pvtu</code> file that describes which VTU files (written, for
+        * example, through the DataOutInterface::write_vtu() function) form a
+        * group. The current function can generate such a centralized record.
+        *
+        * This function is typically not called by itself from user space, but
+        * you may want to call it through DataOutInterface::write_pvtu_record()
+        * since the DataOutInterface class has access to information that you
+        * would have to provide to the current function by hand.
+        *
+        * In any case, whether this function is called directly or via
+        * DataOutInterface::write_pvtu_record(), the central record file so
+        * written contains a list of (scalar or vector) fields that describes
+        * which fields can actually be found in the individual files that
+        * comprise the set of parallel VTU files along with the names of these
+        * files. This function gets the names and types of fields through the
+        * third and fourth argument; you can determine these by hand, but in
+        * practice, this function is most easily called by calling
+        * DataOutInterfaces::write_pvtu_record(), which determines the last two
+        * arguments by calling DataOutInterface::get_dataset_names() and
+        * DataOutInterface::get_nonscalar_data_ranges() functions. The second
+        * argument to this function specifies the names of the files that form
+        * the parallel set.
+        *
+        * @param out The output stream to which data is written.
+        * @param piece_names The piece names.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @note Use DataOutBase::write_vtu() and DataOutInterface::write_vtu()
+        * for writing each piece. Also note that
+        * only one parallel process needs to call the current function, listing
+        * the names of the files written by all parallel processes.
+        *
+        * @note In order to tell Paraview to group together multiple
+        * <code>pvtu</code> files that each describe one time step of a time
+        * dependent simulation, see the DataOutBase::write_pvd_record()
+        * function.
+        *
+        * @note Older versions of VisIt (before 2.5.1), can not read
+        * <code>pvtu</code> records. However, it can read visit records as
+        * written by the write_visit_record() function.
+        */
+       void
+       write_pvtu_record(
+         std::ostream                   &out,
+         const std::vector<std::string> &piece_names,
+         const std::vector<std::string> &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const VtkFlags &flags);
+
+       /**
+        * In ParaView it is possible to visualize time-dependent data tagged
+        * with the current integration time of a time dependent simulation. To
+        * use this feature you need a <code>.pvd</code> file that describes
+        * which VTU or PVTU file belongs to which timestep. This function writes
+        * a file that provides this mapping, i.e., it takes a list of pairs each
+        * of which indicates a particular time instant and the corresponding
+        * file that contains the graphical data for this time instant.
+        *
+        * A typical use case, in program that computes a time dependent
+        * solution, would be the following (<code>time</code> and
+        * <code>time_step</code> are member variables of the class with types
+        * <code>double</code> and <code>unsigned int</code>, respectively; the
+        * variable <code>times_and_names</code> is of type
+        * <code>std::vector@<std::pair@<double,std::string@> @></code>):
+        *
+        * @code
+        * template <int dim>
+        * void MyEquation<dim>::output_results () const
+        * {
+        *   DataOut<dim> data_out;
+        *
+        *   data_out.attach_dof_handler(dof_handler);
+        *   data_out.add_data_vector(solution, "U");
+        *   data_out.build_patches();
+        *
+        *   const std::string filename = "solution-" +
+        *                                Utilities::int_to_string (timestep_n,
+        * 3) +
+        *                                ".vtu";
+        *   std::ofstream output(filename);
+        *   data_out.write_vtu(output);
+        *
+        *   times_and_names.emplace_back (time, filename);
+        *   std::ofstream pvd_output ("solution.pvd");
+        *   DataOutBase::write_pvd_record (pvd_output, times_and_names);
+        * }
+        * @endcode
+        *
+        * @param out The output stream to which data is written.
+        * @param times_and_names The times and names.
+        * @note See DataOutInterface::write_vtu, DataOutInterface::write_pvtu_record,
+        * and DataOutInterface::write_vtu_in_parallel
+        * for writing solutions at each timestep.
+        *
+        * @note The second element of each pair, i.e., the file in which the
+        * graphical data for each time is stored, may itself be again a file
+        * that references other files. For example, it could be the name for a
+        * <code>.pvtu</code> file that references multiple parts of a parallel
+        * computation.
+        */
+       void
+       write_pvd_record(
+         std::ostream                                      &out,
+         const std::vector<std::pair<double, std::string>> &times_and_names);
+
+       /**
+        * This function is the exact equivalent of the write_pvtu_record()
+        * function but for older versions of the VisIt visualization program and
+        * for one visualization graph (or one time step only). See there for the
+        * purpose of this function.
+        *
+        * This function is documented in the "Creating a master file for
+        * parallel" section (section 5.7) of the "Getting data into VisIt"
+        * report that can be found here:
+        * https://visit-dav.github.io/visit-website/pdfs/GettingDataIntoVisIt2.0.0.pdf
+        * @param out The output stream to which data is written.
+        * @param piece_names The piece names.
+        */
+       void
+       write_visit_record(std::ostream                   &out,
+                          const std::vector<std::string> &piece_names);
+
+       /**
+        * This function is equivalent to the write_visit_record() above but for
+        * multiple time steps. Here is an example of how the function would be
+        * used:
+        * @code
+        * const unsigned int number_of_time_steps = 3;
+        * std::vector<std::vector<std::string > >
+        * piece_names(number_of_time_steps);
+        *
+        * piece_names[0].emplace_back("subdomain_01.time_step_0.vtk");
+        * piece_names[0].emplace_back("subdomain_02.time_step_0.vtk");
+        *
+        * piece_names[1].emplace_back("subdomain_01.time_step_1.vtk");
+        * piece_names[1].emplace_back("subdomain_02.time_step_1.vtk");
+        *
+        * piece_names[2].emplace_back("subdomain_01.time_step_2.vtk");
+        * piece_names[2].emplace_back("subdomain_02.time_step_2.vtk");
+        *
+        * std::ofstream visit_output ("solution.visit");
+        *
+        * DataOutBase::write_visit_record(visit_output, piece_names);
+        * @endcode
+        *
+        * This function is documented in the "Creating a master file for
+        * parallel" section (section 5.7) of the "Getting data into VisIt"
+        * report that can be found here:
+        * https://visit-dav.github.io/visit-website/pdfs/GettingDataIntoVisIt2.0.0.pdf
+        * @param out The output stream to which data is written.
+        * @param piece_names The piece names.
+        */
+       void
+       write_visit_record(
+         std::ostream                                &out,
+         const std::vector<std::vector<std::string>> &piece_names);
+
+       /**
+        * This function is equivalent to the write_visit_record() above but for
+        * multiple time steps and with additional information about the time for
+        * each timestep. Here is an example of how the function would be
+        * used:
+        * @code
+        * const unsigned int number_of_time_steps = 3;
+        * std::vector<std::pair<double,std::vector<std::string > > >
+        * times_and_piece_names(number_of_time_steps);
+        *
+        * times_and_piece_names[0].first = 0.0;
+        * times_and_piece_names[0].second.emplace_back("subdomain_01.time_step_0.vtk");
+        * times_and_piece_names[0].second.emplace_back("subdomain_02.time_step_0.vtk");
+        *
+        * times_and_piece_names[1].first = 0.5;
+        * times_and_piece_names[1].second.emplace_back("subdomain_01.time_step_1.vtk");
+        * times_and_piece_names[1].second.emplace_back("subdomain_02.time_step_1.vtk");
+        *
+        * times_and_piece_names[2].first = 1.0;
+        * times_and_piece_names[2].second.emplace_back("subdomain_01.time_step_2.vtk");
+        * times_and_piece_names[2].second.emplace_back("subdomain_02.time_step_2.vtk");
+        *
+        * std::ofstream visit_output ("solution.visit");
+        *
+        * DataOutBase::write_visit_record(visit_output, times_and_piece_names);
+        * @endcode
+        *
+        * This function is documented in the "Creating a master file for
+        * parallel" section (section 5.7) of the "Getting data into VisIt"
+        * report that can be found here:
+        * https://visit-dav.github.io/visit-website/pdfs/GettingDataIntoVisIt2.0.0.pdf
+        * @param out The output stream to which data is written.
+        * @param times_and_piece_names The times and piece names.
+        */
+       void
+       write_visit_record(
+         std::ostream &out,
+         const std::vector<std::pair<double, std::vector<std::string>>>
+           &times_and_piece_names);
+
+       /**
+        * Write the given list of patches to the output stream in SVG format.
+        *
+        * SVG (Scalable Vector Graphics) is an XML-based vector image format
+        * developed and maintained by the World Wide Web Consortium (W3C). This
+        * function conforms to the latest specification SVG 1.1, released on
+        * August 16, 2011. Controlling the graphic output is possible by setting
+        * or clearing the respective flags (see the SvgFlags struct). At
+        * present, this format only supports output for two-dimensional data,
+        * with values in the third direction taken from a data vector.
+        *
+        * For the output, each patch is subdivided into four triangles which are
+        * then written as polygons and filled with a linear color gradient. The
+        * arising coloring of the patches visualizes the data values at the
+        * vertices taken from the specified data vector. A colorbar can be drawn
+        * to encode the coloring.
+        *
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        * @note This function is so far only implemented for two dimensions with an
+        * additional dimension reserved for data information.
+        */
+       template <int spacedim>
+       void
+       write_svg(
+         const std::vector<Patch<2, spacedim>> &patches,
+         const std::vector<std::string>        &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                        &nonscalar_data_ranges,
+         const SvgFlags &flags,
+         std::ostream   &out);
+
+       /**
+        * Write the given list of patches to the output stream in deal.II
+        * intermediate format. This is not a format understood by any other
+        * graphics program, but is rather a direct dump of the intermediate
+        * internal format used by deal.II. This internal format is generated by
+        * the various classes that can generate output using the DataOutBase
+        * class, for example from a finite element solution, and is then
+        * converted in the present class to the final graphics format.
+        *
+        * Note that the intermediate format is what its name suggests: a direct
+        * representation of internal data. It isn't standardized and will change
+        * whenever we change our internal representation. You can only expect to
+        * process files written in this format using the same version of deal.II
+        * that was used for writing.
+        *
+        * The reason why we offer to write out this intermediate format is that
+        * it can be read back into a deal.II program using the DataOutReader
+        * class, which is helpful in at least two contexts: First, this can be
+        * used to later generate graphical output in any other graphics format
+        * presently understood; this way, it is not necessary to know at
+        * run-time which output format is requested, or if multiple output files
+        * in different formats are needed. Secondly, in contrast to almost all
+        * other graphics formats, it is possible to merge several files that
+        * contain intermediate format data, and generate a single output file
+        * from it, which may be again in intermediate format or any of the final
+        * formats. This latter option is most helpful for parallel programs: as
+        * demonstrated in the step-17 example program, it is possible to let
+        * only one processor generate the graphical output for the entire
+        * parallel program, but this can become vastly inefficient if many
+        * processors are involved, because the load is no longer balanced. The
+        * way out is to let each processor generate intermediate graphical
+        * output for its chunk of the domain, and the later merge the different
+        * files into one, which is an operation that is much cheaper than the
+        * generation of the intermediate data.
+        *
+        * Intermediate format deal.II data is usually stored in files with the
+        * ending <tt>.d2</tt>.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param out The output stream to which data is written.
+        */
+       template <int dim, int spacedim>
+       void
+       write_deal_II_intermediate(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                                         &nonscalar_data_ranges,
+         const Deal_II_IntermediateFlags &flags,
+         std::ostream                    &out);
+
+       /**
+        * Like write_deal_II_intermediate() but write all patches from all ranks
+        * using MPI I/O
+        * into a single file with name @p name. Compression using zlib is optional and controlled
+        * by the @p compression argument.
+        *
+        * The files typically have the extension <tt>.pd2</tt>.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param flags The flags that control how the output is written.
+        * @param filename The file name.
+        * @param comm The MPI communicator.
+        * @param compression The compression used by this operation.
+        */
+       template <int dim, int spacedim>
+       void
+       write_deal_II_intermediate_in_parallel(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
+                                         &nonscalar_data_ranges,
+         const Deal_II_IntermediateFlags &flags,
+         const std::string               &filename,
+         const MPI_Comm                   comm,
+         const CompressionLevel           compression);
+
+       /**
+        * Write the data in @p data_filter to a single HDF5 file containing both the
+        * mesh and solution values.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_filter The data filter.
+        * @param flags The flags that control how points and cells are filtered
+        * before writing.
+        * @param filename The file name.
+        * @param comm The MPI communicator.
+        */
+       template <int dim, int spacedim>
+       void
+       write_hdf5_parallel(const std::vector<Patch<dim, spacedim>> &patches,
+                           const DataOutFilter                     &data_filter,
+                           const DataOutBase::Hdf5Flags            &flags,
+                           const std::string                       &filename,
+                           const MPI_Comm                           comm);
+
+       /**
+        * Write the data in @p data_filter to HDF5 file(s). If @p write_mesh_file is
+        * false, the mesh data will not be written and the solution file will
+        * contain only the solution values. If @p write_mesh_file is true and the
+        * filenames are the same, the resulting file will contain both mesh data
+        * and solution values.
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_filter The data filter.
+        * @param flags The flags that control how points and cells are filtered
+        * before writing.
+        * @param write_mesh_file The write mesh file.
+        * @param mesh_filename The mesh filename.
+        * @param solution_filename The solution filename.
+        * @param comm The MPI communicator.
+        */
+       template <int dim, int spacedim>
+       void
+       write_hdf5_parallel(const std::vector<Patch<dim, spacedim>> &patches,
+                           const DataOutFilter                     &data_filter,
+                           const DataOutBase::Hdf5Flags            &flags,
+                           const bool         write_mesh_file,
+                           const std::string &mesh_filename,
+                           const std::string &solution_filename,
+                           const MPI_Comm     comm);
+
+       /**
+        * DataOutFilter is an intermediate data format that reduces the amount
+        * of data that will be written to files. The object filled by this
+        * function can then later be used again to write data in a concrete file
+        * format; see, for example, DataOutBase::write_hdf5_parallel().
+        * @param patches The patches that describe the cells and data values to
+        * write.
+        * @param data_names The data names.
+        * @param nonscalar_data_ranges The nonscalar data ranges.
+        * @param filtered_data The object in which to store the filtered data.
+        */
+       template <int dim, int spacedim>
+       void
+       write_filtered_data(
+         const std::vector<Patch<dim, spacedim>> &patches,
+         const std::vector<std::string>          &data_names,
+         const std::vector<
+           std::tuple<unsigned int,
+                      unsigned int,
+                      std::string,
+                      DataComponentInterpretation::DataComponentInterpretation>>
                        &nonscalar_data_ranges,
-    const TecplotFlags &flags,
-    std::ostream       &out);
+         DataOutFilter &filtered_data);
 
-  /**
-   * Write the given list of patches to the output stream in UCD format
-   * described in the AVS developer's guide (now AVS). Due to limitations in
-   * the present format, only node based data can be output, which in one
-   * reason why we invented the patch concept. In order to write higher order
-   * elements, you may split them up into several subdivisions of each cell.
-   * These subcells will then, however, also appear as different cells by
-   * programs which understand the UCD format.
+       /**
+        * Given an input stream that contains data written by
+        * write_deal_II_intermediate(), determine the <tt>dim</tt> and
+        * <tt>spacedim</tt> template parameters with which that function was
+        * called, and return them as a pair of values.
+        *
+        * Note that this function eats a number of elements at the present
+        * position of the stream, and therefore alters it. In order to read from
+        * it using, for example, the DataOutReader class, you may wish to either
+        * reset the stream to its previous position, or close and reopen it.
+        * @param input The input data or stream from which values are read.
+        */
+       std::pair<unsigned int, unsigned int>
+       determine_intermediate_format_dimensions(std::istream &input);
+
+       /**
+        * Return the OutputFormat value corresponding to the given string. If
+        * the string does not match any known format, an exception is thrown.
+        *
+        * The main purpose of this function is to allow a program to use any
+        * implemented output format without the need to extend the program's
+        * parser each time a new format is implemented.
+        *
+        * To get a list of presently available format names, e.g. to give it to
+        * the ParameterHandler class, use the function
+        * get_output_format_names().
+        * @param format_name The format name.
+        */
+       OutputFormat
+       parse_output_format(const std::string &format_name);
+
+       /**
+        * Return a list of implemented output formats. The different names are
+        * separated by vertical bar signs (<tt>`|'</tt>) as used by the
+        * ParameterHandler classes.
+        */
+       std::string
+       get_output_format_names();
+
+       /**
+        * Provide a function which tells us which suffix a file with a given
+        * output format usually has. At present the following formats are
+        * defined: <ul>
+        * <li> <tt>dx</tt>: <tt>.dx</tt>
+        * <li> <tt>ucd</tt>: <tt>.inp</tt>
+        * <li> <tt>gnuplot</tt>: <tt>.gnuplot</tt>
+        * <li> <tt>povray</tt>: <tt>.pov</tt>
+        * <li> <tt>eps</tt>: <tt>.eps</tt>
+        * <li> <tt>gmv</tt>: <tt>.gmv</tt>
+        * <li> <tt>tecplot</tt>: <tt>.dat</tt>
+        * <li> <tt>vtk</tt>: <tt>.vtk</tt>
+        * <li> <tt>vtu</tt>: <tt>.vtu</tt>
+        * <li> <tt>svg</tt>: <tt>.svg</tt>
+        * <li> <tt>deal_II_intermediate</tt>: <tt>.d2</tt>.
+        * </ul>
+        *
+        * @deprecated Using Tecplot binary output is deprecated.
+        * @param output_format The output format.
+        */
+       std::string
+       default_suffix(const OutputFormat output_format);
+
+       /**
+        * @addtogroup Exceptions
+        * @{
+        */
+
+       /**
+        * Exception
+        */
+       DeclException2(ExcInvalidDatasetSize,
+                      int,
+                      int,
+                      << "The number of points in this data set is " << arg1
+                      << ", but we expected " << arg2
+                      << " in each space direction.");
+       /**
+        * An output function did not receive any patches for writing.
+        * @param ExcNoPatches The exc no patches used by this operation.
+        */
+       DeclExceptionMsg(
+         ExcNoPatches,
+         "You are trying to write graphical data into a file, but "
+         "no data is available in the intermediate format that "
+         "the DataOutBase functions require. Did you forget to "
+         "call a function such as DataOut::build_patches()?");
+       /**
+        * Exception
+        * @param ExcTecplotAPIError The exc tecplot apierror used by this
+        * operation.
+        */
+       DeclExceptionMsg(ExcTecplotAPIError,
+                        "The error code of one of the Tecplot functions was "
+                        "not zero as expected.");
+       /**
+        * Exception
+        */
+       DeclException1(ExcErrorOpeningTecplotFile,
+                      char *,
+                      << "There was an error opening Tecplot file " << arg1
+                      << " for output.");
+
+       /**
+        *  @} */
+   * // namespace DataOutBase
    *
-   * No use is made of the possibility to give model data since these are not
-   * supported by all UCD aware programs. You may give cell data in derived
-   * classes by setting all values of a given data set on a patch to the same
-   * value.
+   *
+   *
+   *
+   *  This class is the interface to the functions in the DataOutBase namespace,
+   *  as already its name might suggest. It does not offer much functionality
+   *  apart from a way to access the implemented formats and a way to dynamically
+   *  dispatch what output format to chose.
+   *
+   *  This class is thought as a base class to classes actually generating data
+   *  for output. It has two abstract virtual functions, get_patches() and
+   *  get_dataset_names() that produce the data to be visualized and have to be
+   *  overridden by a derived class. Additionally, to generate data where certain
+   *  data sets are to be interpreted as vectors or tensors, the function
+   *  get_nonscalar_data_ranges() can be overridden to provide this information.
+   *
+   *  The user of a derived class of DataOutInterface typically interacts with
+   *  the <tt>write_*</tt> functions. They exist for each output format
+   *  supported by DataOutBase and pass the patches generated by get_patches()
+   *  to the corresponding raw output functions in the DataOutBase namespace.
+   *
+   *  The purpose of this class is mainly two-fold: to support storing flags by
+   *  which the output in the different output formats are controlled, and means
+   *  to work with output in a way where output format, flags and other things
+   *  are determined at run time. In addition to that it offers the abstract
+   *  interface to derived classes briefly discussed above.
+   *
+   *
+   *  <h3>Output flags</h3>
+   *
+   *  The way we treat flags in this class is very similar to that used in the
+   *  <tt>GridOut</tt> class. For detailed information on the why's and how's, as
+   *  well as an example of programming, we refer to the documentation of that
+   *  class.
+   *
+   *  Basically, this class stores a set of flags for each output format
+   *  supported by the underlying <tt>DataOutBase</tt> class. These are used
+   *  whenever one of the <tt>write_*</tt> functions is used. By default, the
+   *  values of these flags are set to reasonable start-ups, but in case you want
+   *  to change them, you can create a structure holding the flags for one of the
+   *  output formats and set it using the <tt>set_flags</tt> functions of this
+   *  class to determine all future output the object might produce by that
+   *  output format.
+   *
+   *  For information on what parameters are supported by different output
+   *  functions, please see the documentation of the <tt>DataOutBase</tt> class
+   *  and its member classes.
+   *
+   *
+   *  <h3>Run time selection of output parameters</h3>
+   *
+   *  In the output flags classes, described above, many flags are defined for
+   *  output in the different formats. In order to make them available to the
+   *  input file handler class <tt>ParameterHandler</tt>, each of these has a
+   *  function declaring these flags to the parameter handler and to read them
+   *  back from an actual input file. In order to avoid that in user programs
+   *  these functions have to be called for each available output format and the
+   *  respective flag class, the present <tt>DataOutInterface</tt> class offers a
+   *  function <tt>declare_parameters</tt> which calls the respective function of
+   *  all known output format flags classes. The flags of each such format are
+   *  packed together in a subsection in the input file. Likewise, there is a
+   *  function <tt>parse_parameters</tt> which reads these parameters and stores
+   *  them in the flags associated with this object (see above).
+   *
+   *  Using these functions, you do not have to track which formats are presently
+   *  implemented.
+   *
+   *  Usage is as follows:
+     *@code * // within function declaring parameters:
+        *prm.enter_subsection("Output format options");
+     *DataOutInterface<dim>::declare_parameters(prm);
+     *prm.leave_subsection();
+     **... * // within function doing the output:
+         *DataOut<dim>
+          out;
+     *prm.enter_subsection("Output format options");
+     *out.parse_parameters(prm);
+     *prm.leave_subsection();
+   *  @endcode
+   *  Note that in the present example, the class <tt>DataOut</tt> was used.
+   *  However, any other class derived from <tt>DataOutInterface</tt> would work
+   *  alike.
+   *
+   *
+   *  <h3>Run time selection of formats</h3>
+   *
+   *  This class, much like the <tt>GridOut</tt> class, has a set of functions
+   *  providing a list of supported output formats, an <tt>enum</tt> denoting all
+   *  these and a function to parse a string and return the respective
+   *  <tt>enum</tt> value if it is a valid output format's name (actually, these
+   *  functions are inherited from the base class). Finally, there is a function
+   *  <tt>write</tt>, which takes a value of this <tt>enum</tt> and dispatches to
+   *  one of the actual <tt>write_*</tt> functions depending on the output format
+   *  selected by this value.
+   *
+   *  The functions offering the different output format names are, respectively,
+   *  <tt>default_suffix</tt>, <tt>parse_output_format</tt>, and
+   *  <tt>get_output_format_names</tt>. They make the selection of output formats
+   *  in parameter files much easier, and especially independent of the formats
+   *  presently implemented. User programs need therefore not be changed whenever
+   *  a new format is implemented.
+   *
+   *  Additionally, objects of this class have a default format, which can be set
+   *  by the parameter "Output format" of the parameter file. Within a program,
+   *  this can be changed by the member function <tt>set_default_format</tt>.
+   *  Using this default format, it is possible to leave the format selection
+   *  completely to the parameter file. A suitable suffix for the output file
+   *  name can be obtained by <tt>default_suffix</tt> without arguments.
+   *
+   *  @ingroup output
    */
-  template <int dim, int spacedim>
-  void
-  write_ucd(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const UcdFlags &flags,
-    std::ostream   &out);
-
-  /**
-   * Write the given list of patches to the output stream in VTK format. The
-   * data is written in the traditional VTK format as opposed to the XML-based
-   * format that write_vtu() produces.
-   *
-   * The nonscalar_data_ranges argument denotes ranges of components in the
-   * output that are considered a vector, rather than simply a collection of
-   * scalar fields. The VTK output format has special provisions that allow
-   * these components to be output by a single name rather than having to
-   * group several scalar fields into a vector later on in the visualization
-   * program.
-   *
-   * @note VTK is a legacy format and has largely been supplanted by the VTU
-   * format (an XML-structured version of VTK). In particular, VTU allows for
-   * the compression of data and consequently leads to much smaller file sizes
-   * that equivalent VTK files for large files. Since all visualization
-   * programs that support VTK also support VTU, you should consider using the
-   * latter file format instead, by using the write_vtu() function.
-   */
-  template <int dim, int spacedim>
-  void
-  write_vtk(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream   &out);
-
-
-  /**
-   * Write the given list of patches to the output stream in VTU format. The
-   * data is written in the XML-based VTK format as opposed to the traditional
-   * format that write_vtk() produces.
-   *
-   * The nonscalar_data_ranges argument denotes ranges of components in the
-   * output that are considered a vector, rather than simply a collection of
-   * scalar fields. The VTK output format has special provisions that allow
-   * these components to be output by a single name rather than having to
-   * group several scalar fields into a vector later on in the visualization
-   * program.
-   *
-   * Some visualization programs, such as ParaView, can read several separate
-   * VTU files to parallelize visualization. In that case, you need a
-   * <code>.pvtu</code> file that describes which VTU files form a group. The
-   * DataOutInterface::write_pvtu_record() function can generate such a
-   * centralized record. Likewise, DataOutInterface::write_visit_record() does
-   * the same for VisIt (although VisIt can also read <code>pvtu</code> records
-   * since version 2.5.1). Finally, for time dependent problems, you may also
-   * want to look at DataOutInterface::write_pvd_record()
-   *
-   * The use of this function is explained in step-40.
-   */
-  template <int dim, int spacedim>
-  void
-  write_vtu(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream   &out);
-
-  /**
-   * This writes the header for the xml based vtu file format. This routine is
-   * used internally together with DataOutInterface::write_vtu_footer() and
-   * DataOutInterface::write_vtu_main() by DataOutBase::write_vtu().
-   */
-  void
-  write_vtu_header(std::ostream &out, const VtkFlags &flags);
-
-  /**
-   * This function writes the footer for the xml based vtu file format. This
-   * routine is used internally together with
-   * DataOutInterface::write_vtu_header() and DataOutInterface::write_vtu_main()
-   * by DataOutBase::write_vtu().
-   */
-  void
-  write_vtu_footer(std::ostream &out);
-
-  /**
-   * This function writes the main part for the xml based vtu file format. This
-   * routine is used internally together with
-   * DataOutInterface::write_vtu_header() and
-   * DataOutInterface::write_vtu_footer() by DataOutBase::write_vtu().
-   */
-  template <int dim, int spacedim>
-  void
-  write_vtu_main(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const VtkFlags &flags,
-    std::ostream   &out);
-
-  /**
-   * Some visualization programs, such as ParaView, can read several separate
-   * VTU files that all form part of the same simulation, in order to
-   * parallelize visualization. In that case, you need a
-   * <code>.pvtu</code> file that describes which VTU files (written, for
-   * example, through the DataOutInterface::write_vtu() function) form a group.
-   * The current function can generate such a centralized record.
-   *
-   * This function is typically not called by itself from user space, but
-   * you may want to call it through DataOutInterface::write_pvtu_record()
-   * since the DataOutInterface class has access to information that you
-   * would have to provide to the current function by hand.
-   *
-   * In any case, whether this function is called directly or via
-   * DataOutInterface::write_pvtu_record(), the central record file so
-   * written contains a list of (scalar or vector) fields that describes which
-   * fields can actually be found in the individual files that comprise the set
-   * of parallel VTU files along with the names of these files. This function
-   * gets the names and types of fields through the third and fourth
-   * argument; you can determine these by hand, but in practice, this function
-   * is most easily called by calling DataOutInterfaces::write_pvtu_record(),
-   * which determines the last two arguments by calling
-   * DataOutInterface::get_dataset_names() and
-   * DataOutInterface::get_nonscalar_data_ranges() functions. The second
-   * argument to this function specifies the names of the files that form the
-   * parallel set.
-   *
-   * @note Use DataOutBase::write_vtu() and DataOutInterface::write_vtu()
-   * for writing each piece. Also note that
-   * only one parallel process needs to call the current function, listing the
-   * names of the files written by all parallel processes.
-   *
-   * @note In order to tell Paraview to group together multiple
-   * <code>pvtu</code> files that each describe one time step of a time
-   * dependent simulation, see the DataOutBase::write_pvd_record()
-   * function.
-   *
-   * @note Older versions of VisIt (before 2.5.1), can not read
-   * <code>pvtu</code> records. However, it can read visit records as written
-   * by the write_visit_record() function.
-   */
-  void
-  write_pvtu_record(
-    std::ostream                   &out,
-    const std::vector<std::string> &piece_names,
-    const std::vector<std::string> &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const VtkFlags &flags);
-
-  /**
-   * In ParaView it is possible to visualize time-dependent data tagged with
-   * the current integration time of a time dependent simulation. To use this
-   * feature you need a <code>.pvd</code> file that describes which VTU or
-   * PVTU file belongs to which timestep. This function writes a file that
-   * provides this mapping, i.e., it takes a list of pairs each of which
-   * indicates a particular time instant and the corresponding file that
-   * contains the graphical data for this time instant.
-   *
-   * A typical use case, in program that computes a time dependent solution,
-   * would be the following (<code>time</code> and <code>time_step</code> are
-   * member variables of the class with types <code>double</code> and
-   * <code>unsigned int</code>, respectively; the variable
-   * <code>times_and_names</code> is of type
-   * <code>std::vector@<std::pair@<double,std::string@> @></code>):
-   *
-   * @code
-   * template <int dim>
-   * void MyEquation<dim>::output_results () const
-   * {
-   *   DataOut<dim> data_out;
-   *
-   *   data_out.attach_dof_handler(dof_handler);
-   *   data_out.add_data_vector(solution, "U");
-   *   data_out.build_patches();
-   *
-   *   const std::string filename = "solution-" +
-   *                                Utilities::int_to_string (timestep_n, 3) +
-   *                                ".vtu";
-   *   std::ofstream output(filename);
-   *   data_out.write_vtu(output);
-   *
-   *   times_and_names.emplace_back (time, filename);
-   *   std::ofstream pvd_output ("solution.pvd");
-   *   DataOutBase::write_pvd_record (pvd_output, times_and_names);
-   * }
-   * @endcode
-   *
-   * @note See DataOutInterface::write_vtu, DataOutInterface::write_pvtu_record,
-   * and DataOutInterface::write_vtu_in_parallel
-   * for writing solutions at each timestep.
-   *
-   * @note The second element of each pair, i.e., the file in which the
-   * graphical data for each time is stored, may itself be again a file that
-   * references other files. For example, it could be the name for a
-   * <code>.pvtu</code> file that references multiple parts of a parallel
-   * computation.
-   */
-  void
-  write_pvd_record(
-    std::ostream                                      &out,
-    const std::vector<std::pair<double, std::string>> &times_and_names);
-
-  /**
-   * This function is the exact equivalent of the write_pvtu_record() function
-   * but for older versions of the VisIt visualization program and for one
-   * visualization graph (or one time step only). See there for the purpose of
-   * this function.
-   *
-   * This function is documented in the "Creating a master file for parallel"
-   * section (section 5.7) of the "Getting data into VisIt" report that can be
-   * found here:
-   * https://visit-dav.github.io/visit-website/pdfs/GettingDataIntoVisIt2.0.0.pdf
-   */
-  void
-  write_visit_record(std::ostream                   &out,
-                     const std::vector<std::string> &piece_names);
-
-  /**
-   * This function is equivalent to the write_visit_record() above but for
-   * multiple time steps. Here is an example of how the function would be
-   * used:
-   * @code
-   * const unsigned int number_of_time_steps = 3;
-   * std::vector<std::vector<std::string > > piece_names(number_of_time_steps);
-   *
-   * piece_names[0].emplace_back("subdomain_01.time_step_0.vtk");
-   * piece_names[0].emplace_back("subdomain_02.time_step_0.vtk");
-   *
-   * piece_names[1].emplace_back("subdomain_01.time_step_1.vtk");
-   * piece_names[1].emplace_back("subdomain_02.time_step_1.vtk");
-   *
-   * piece_names[2].emplace_back("subdomain_01.time_step_2.vtk");
-   * piece_names[2].emplace_back("subdomain_02.time_step_2.vtk");
-   *
-   * std::ofstream visit_output ("solution.visit");
-   *
-   * DataOutBase::write_visit_record(visit_output, piece_names);
-   * @endcode
-   *
-   * This function is documented in the "Creating a master file for parallel"
-   * section (section 5.7) of the "Getting data into VisIt" report that can be
-   * found here:
-   * https://visit-dav.github.io/visit-website/pdfs/GettingDataIntoVisIt2.0.0.pdf
-   */
-  void
-  write_visit_record(std::ostream                                &out,
-                     const std::vector<std::vector<std::string>> &piece_names);
-
-  /**
-   * This function is equivalent to the write_visit_record() above but for
-   * multiple time steps and with additional information about the time for
-   * each timestep. Here is an example of how the function would be
-   * used:
-   * @code
-   * const unsigned int number_of_time_steps = 3;
-   * std::vector<std::pair<double,std::vector<std::string > > >
-   * times_and_piece_names(number_of_time_steps);
-   *
-   * times_and_piece_names[0].first = 0.0;
-   * times_and_piece_names[0].second.emplace_back("subdomain_01.time_step_0.vtk");
-   * times_and_piece_names[0].second.emplace_back("subdomain_02.time_step_0.vtk");
-   *
-   * times_and_piece_names[1].first = 0.5;
-   * times_and_piece_names[1].second.emplace_back("subdomain_01.time_step_1.vtk");
-   * times_and_piece_names[1].second.emplace_back("subdomain_02.time_step_1.vtk");
-   *
-   * times_and_piece_names[2].first = 1.0;
-   * times_and_piece_names[2].second.emplace_back("subdomain_01.time_step_2.vtk");
-   * times_and_piece_names[2].second.emplace_back("subdomain_02.time_step_2.vtk");
-   *
-   * std::ofstream visit_output ("solution.visit");
-   *
-   * DataOutBase::write_visit_record(visit_output, times_and_piece_names);
-   * @endcode
-   *
-   * This function is documented in the "Creating a master file for parallel"
-   * section (section 5.7) of the "Getting data into VisIt" report that can be
-   * found here:
-   * https://visit-dav.github.io/visit-website/pdfs/GettingDataIntoVisIt2.0.0.pdf
-   */
-  void
-  write_visit_record(
-    std::ostream &out,
-    const std::vector<std::pair<double, std::vector<std::string>>>
-      &times_and_piece_names);
-
-  /**
-   * Write the given list of patches to the output stream in SVG format.
-   *
-   * SVG (Scalable Vector Graphics) is an XML-based vector image format
-   * developed and maintained by the World Wide Web Consortium (W3C). This
-   * function conforms to the latest specification SVG 1.1, released on August
-   * 16, 2011. Controlling the graphic output is possible by setting or
-   * clearing the respective flags (see the SvgFlags struct). At present, this
-   * format only supports output for two-dimensional data, with values in the
-   * third direction taken from a data vector.
-   *
-   * For the output, each patch is subdivided into four triangles which are
-   * then written as polygons and filled with a linear color gradient. The
-   * arising coloring of the patches visualizes the data values at the
-   * vertices taken from the specified data vector. A colorbar can be drawn to
-   * encode the coloring.
-   *
-   * @note This function is so far only implemented for two dimensions with an
-   * additional dimension reserved for data information.
-   */
-  template <int spacedim>
-  void
-  write_svg(
-    const std::vector<Patch<2, spacedim>> &patches,
-    const std::vector<std::string>        &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                   &nonscalar_data_ranges,
-    const SvgFlags &flags,
-    std::ostream   &out);
-
-  /**
-   * Write the given list of patches to the output stream in deal.II
-   * intermediate format. This is not a format understood by any other
-   * graphics program, but is rather a direct dump of the intermediate
-   * internal format used by deal.II. This internal format is generated by the
-   * various classes that can generate output using the DataOutBase class, for
-   * example from a finite element solution, and is then converted in the
-   * present class to the final graphics format.
-   *
-   * Note that the intermediate format is what its name suggests: a direct
-   * representation of internal data. It isn't standardized and will change
-   * whenever we change our internal representation. You can only expect to
-   * process files written in this format using the same version of deal.II
-   * that was used for writing.
-   *
-   * The reason why we offer to write out this intermediate format is that it
-   * can be read back into a deal.II program using the DataOutReader class,
-   * which is helpful in at least two contexts: First, this can be used to
-   * later generate graphical output in any other graphics format presently
-   * understood; this way, it is not necessary to know at run-time which
-   * output format is requested, or if multiple output files in different
-   * formats are needed. Secondly, in contrast to almost all other graphics
-   * formats, it is possible to merge several files that contain intermediate
-   * format data, and generate a single output file from it, which may be
-   * again in intermediate format or any of the final formats. This latter
-   * option is most helpful for parallel programs: as demonstrated in the
-   * step-17 example program, it is possible to let only one processor
-   * generate the graphical output for the entire parallel program, but this
-   * can become vastly inefficient if many processors are involved, because
-   * the load is no longer balanced. The way out is to let each processor
-   * generate intermediate graphical output for its chunk of the domain, and
-   * the later merge the different files into one, which is an operation that
-   * is much cheaper than the generation of the intermediate data.
-   *
-   * Intermediate format deal.II data is usually stored in files with the
-   * ending <tt>.d2</tt>.
-   */
-  template <int dim, int spacedim>
-  void
-  write_deal_II_intermediate(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                                    &nonscalar_data_ranges,
-    const Deal_II_IntermediateFlags &flags,
-    std::ostream                    &out);
-
-  /**
-   * Like write_deal_II_intermediate() but write all patches from all ranks
-   * using MPI I/O
-   * into a single file with name @p name. Compression using zlib is optional and controlled
-   * by the @p compression argument.
-   *
-   * The files typically have the extension <tt>.pd2</tt>.
-   */
-  template <int dim, int spacedim>
-  void
-  write_deal_II_intermediate_in_parallel(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                                    &nonscalar_data_ranges,
-    const Deal_II_IntermediateFlags &flags,
-    const std::string               &filename,
-    const MPI_Comm                   comm,
-    const CompressionLevel           compression);
-
-  /**
-   * Write the data in @p data_filter to a single HDF5 file containing both the
-   * mesh and solution values.
-   */
-  template <int dim, int spacedim>
-  void
-  write_hdf5_parallel(const std::vector<Patch<dim, spacedim>> &patches,
-                      const DataOutFilter                     &data_filter,
-                      const DataOutBase::Hdf5Flags            &flags,
-                      const std::string                       &filename,
-                      const MPI_Comm                           comm);
-
-  /**
-   * Write the data in @p data_filter to HDF5 file(s). If @p write_mesh_file is
-   * false, the mesh data will not be written and the solution file will
-   * contain only the solution values. If @p write_mesh_file is true and the
-   * filenames are the same, the resulting file will contain both mesh data
-   * and solution values.
-   */
-  template <int dim, int spacedim>
-  void
-  write_hdf5_parallel(const std::vector<Patch<dim, spacedim>> &patches,
-                      const DataOutFilter                     &data_filter,
-                      const DataOutBase::Hdf5Flags            &flags,
-                      const bool                               write_mesh_file,
-                      const std::string                       &mesh_filename,
-                      const std::string &solution_filename,
-                      const MPI_Comm     comm);
-
-  /**
-   * DataOutFilter is an intermediate data format that reduces the amount of
-   * data that will be written to files. The object filled by this function
-   * can then later be used again to write data in a concrete file format;
-   * see, for example, DataOutBase::write_hdf5_parallel().
-   */
-  template <int dim, int spacedim>
-  void
-  write_filtered_data(
-    const std::vector<Patch<dim, spacedim>> &patches,
-    const std::vector<std::string>          &data_names,
-    const std::vector<
-      std::tuple<unsigned int,
-                 unsigned int,
-                 std::string,
-                 DataComponentInterpretation::DataComponentInterpretation>>
-                  &nonscalar_data_ranges,
-    DataOutFilter &filtered_data);
-
-  /**
-   * Given an input stream that contains data written by
-   * write_deal_II_intermediate(), determine the <tt>dim</tt> and
-   * <tt>spacedim</tt> template parameters with which that function was
-   * called, and return them as a pair of values.
-   *
-   * Note that this function eats a number of elements at the present position
-   * of the stream, and therefore alters it. In order to read from it using,
-   * for example, the DataOutReader class, you may wish to either reset the
-   * stream to its previous position, or close and reopen it.
-   */
-  std::pair<unsigned int, unsigned int>
-  determine_intermediate_format_dimensions(std::istream &input);
-
-  /**
-   * Return the OutputFormat value corresponding to the given string. If the
-   * string does not match any known format, an exception is thrown.
-   *
-   * The main purpose of this function is to allow a program to use any
-   * implemented output format without the need to extend the program's parser
-   * each time a new format is implemented.
-   *
-   * To get a list of presently available format names, e.g. to give it to the
-   * ParameterHandler class, use the function get_output_format_names().
-   */
-  OutputFormat
-  parse_output_format(const std::string &format_name);
-
-  /**
-   * Return a list of implemented output formats. The different names are
-   * separated by vertical bar signs (<tt>`|'</tt>) as used by the
-   * ParameterHandler classes.
-   */
-  std::string
-  get_output_format_names();
-
-  /**
-   * Provide a function which tells us which suffix a file with a given output
-   * format usually has. At present the following formats are defined:
-   * <ul>
-   * <li> <tt>dx</tt>: <tt>.dx</tt>
-   * <li> <tt>ucd</tt>: <tt>.inp</tt>
-   * <li> <tt>gnuplot</tt>: <tt>.gnuplot</tt>
-   * <li> <tt>povray</tt>: <tt>.pov</tt>
-   * <li> <tt>eps</tt>: <tt>.eps</tt>
-   * <li> <tt>gmv</tt>: <tt>.gmv</tt>
-   * <li> <tt>tecplot</tt>: <tt>.dat</tt>
-   * <li> <tt>vtk</tt>: <tt>.vtk</tt>
-   * <li> <tt>vtu</tt>: <tt>.vtu</tt>
-   * <li> <tt>svg</tt>: <tt>.svg</tt>
-   * <li> <tt>deal_II_intermediate</tt>: <tt>.d2</tt>.
-   * </ul>
-   *
-   * @deprecated Using Tecplot binary output is deprecated.
-   */
-  std::string
-  default_suffix(const OutputFormat output_format);
-
-  /**
-   * @addtogroup Exceptions
-   * @{
-   */
-
-  /**
-   * Exception
-   */
-  DeclException2(ExcInvalidDatasetSize,
-                 int,
-                 int,
-                 << "The number of points in this data set is " << arg1
-                 << ", but we expected " << arg2
-                 << " in each space direction.");
-  /**
-   * An output function did not receive any patches for writing.
-   */
-  DeclExceptionMsg(ExcNoPatches,
-                   "You are trying to write graphical data into a file, but "
-                   "no data is available in the intermediate format that "
-                   "the DataOutBase functions require. Did you forget to "
-                   "call a function such as DataOut::build_patches()?");
-  /**
-   * Exception
-   */
-  DeclExceptionMsg(ExcTecplotAPIError,
-                   "The error code of one of the Tecplot functions was "
-                   "not zero as expected.");
-  /**
-   * Exception
-   */
-  DeclException1(ExcErrorOpeningTecplotFile,
-                 char *,
-                 << "There was an error opening Tecplot file " << arg1
-                 << " for output.");
-
-  /** @} */
-} // namespace DataOutBase
-
-
-
-/**
- * This class is the interface to the functions in the DataOutBase namespace,
- * as already its name might suggest. It does not offer much functionality
- * apart from a way to access the implemented formats and a way to dynamically
- * dispatch what output format to chose.
- *
- * This class is thought as a base class to classes actually generating data
- * for output. It has two abstract virtual functions, get_patches() and
- * get_dataset_names() that produce the data to be visualized and have to be
- * overridden by a derived class. Additionally, to generate data where certain
- * data sets are to be interpreted as vectors or tensors, the function
- * get_nonscalar_data_ranges() can be overridden to provide this information.
- *
- * The user of a derived class of DataOutInterface typically interacts with
- * the <tt>write_*</tt> functions. They exist for each output format
- * supported by DataOutBase and pass the patches generated by get_patches()
- * to the corresponding raw output functions in the DataOutBase namespace.
- *
- * The purpose of this class is mainly two-fold: to support storing flags by
- * which the output in the different output formats are controlled, and means
- * to work with output in a way where output format, flags and other things
- * are determined at run time. In addition to that it offers the abstract
- * interface to derived classes briefly discussed above.
- *
- *
- * <h3>Output flags</h3>
- *
- * The way we treat flags in this class is very similar to that used in the
- * <tt>GridOut</tt> class. For detailed information on the why's and how's, as
- * well as an example of programming, we refer to the documentation of that
- * class.
- *
- * Basically, this class stores a set of flags for each output format
- * supported by the underlying <tt>DataOutBase</tt> class. These are used
- * whenever one of the <tt>write_*</tt> functions is used. By default, the
- * values of these flags are set to reasonable start-ups, but in case you want
- * to change them, you can create a structure holding the flags for one of the
- * output formats and set it using the <tt>set_flags</tt> functions of this
- * class to determine all future output the object might produce by that
- * output format.
- *
- * For information on what parameters are supported by different output
- * functions, please see the documentation of the <tt>DataOutBase</tt> class
- * and its member classes.
- *
- *
- * <h3>Run time selection of output parameters</h3>
- *
- * In the output flags classes, described above, many flags are defined for
- * output in the different formats. In order to make them available to the
- * input file handler class <tt>ParameterHandler</tt>, each of these has a
- * function declaring these flags to the parameter handler and to read them
- * back from an actual input file. In order to avoid that in user programs
- * these functions have to be called for each available output format and the
- * respective flag class, the present <tt>DataOutInterface</tt> class offers a
- * function <tt>declare_parameters</tt> which calls the respective function of
- * all known output format flags classes. The flags of each such format are
- * packed together in a subsection in the input file. Likewise, there is a
- * function <tt>parse_parameters</tt> which reads these parameters and stores
- * them in the flags associated with this object (see above).
- *
- * Using these functions, you do not have to track which formats are presently
- * implemented.
- *
- * Usage is as follows:
- * @code
- *   // within function declaring parameters:
- *   prm.enter_subsection("Output format options");
- *   DataOutInterface<dim>::declare_parameters(prm);
- *   prm.leave_subsection();
- *
- *   ...
- *   // within function doing the output:
- *   DataOut<dim> out;
- *   prm.enter_subsection("Output format options");
- *   out.parse_parameters(prm);
- *   prm.leave_subsection();
- * @endcode
- * Note that in the present example, the class <tt>DataOut</tt> was used.
- * However, any other class derived from <tt>DataOutInterface</tt> would work
- * alike.
- *
- *
- * <h3>Run time selection of formats</h3>
- *
- * This class, much like the <tt>GridOut</tt> class, has a set of functions
- * providing a list of supported output formats, an <tt>enum</tt> denoting all
- * these and a function to parse a string and return the respective
- * <tt>enum</tt> value if it is a valid output format's name (actually, these
- * functions are inherited from the base class). Finally, there is a function
- * <tt>write</tt>, which takes a value of this <tt>enum</tt> and dispatches to
- * one of the actual <tt>write_*</tt> functions depending on the output format
- * selected by this value.
- *
- * The functions offering the different output format names are, respectively,
- * <tt>default_suffix</tt>, <tt>parse_output_format</tt>, and
- * <tt>get_output_format_names</tt>. They make the selection of output formats
- * in parameter files much easier, and especially independent of the formats
- * presently implemented. User programs need therefore not be changed whenever
- * a new format is implemented.
- *
- * Additionally, objects of this class have a default format, which can be set
- * by the parameter "Output format" of the parameter file. Within a program,
- * this can be changed by the member function <tt>set_default_format</tt>.
- * Using this default format, it is possible to leave the format selection
- * completely to the parameter file. A suitable suffix for the output file
- * name can be obtained by <tt>default_suffix</tt> without arguments.
- *
- * @ingroup output
- */
 template <int dim, int spacedim = dim>
 class DataOutInterface
-{
-public:
-  /**
-   * Constructor.
-   */
-  DataOutInterface();
-
-  /**
-   * Destructor. Does nothing, but is declared virtual since this class has
-   * virtual functions.
-   */
-  virtual ~DataOutInterface() = default;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in OpenDX
-   * format. See DataOutBase::write_dx.
-   */
-  void
-  write_dx(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in EPS
-   * format. See DataOutBase::write_eps.
-   */
-  void
-  write_eps(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in GMV
-   * format. See DataOutBase::write_gmv.
-   */
-  void
-  write_gmv(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in GNUPLOT
-   * format. See DataOutBase::write_gnuplot.
-   */
-  void
-  write_gnuplot(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in POVRAY
-   * format. See DataOutBase::write_povray.
-   */
-  void
-  write_povray(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in Tecplot
-   * format. See DataOutBase::write_tecplot.
-   */
-  void
-  write_tecplot(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in UCD
-   * format for AVS. See DataOutBase::write_ucd.
-   */
-  void
-  write_ucd(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in Vtk
-   * format. See DataOutBase::write_vtk.
-   *
-   * @note VTK is a legacy format and has largely been supplanted by the VTU
-   * format (an XML-structured version of VTK). In particular, VTU allows for
-   * the compression of data and consequently leads to much smaller file sizes
-   * that equivalent VTK files for large files. Since all visualization
-   * programs that support VTK also support VTU, you should consider using the
-   * latter file format instead, by using the write_vtu() function.
-   */
-  void
-  write_vtk(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in Vtu
-   * (VTK's XML) format. See DataOutBase::write_vtu.
-   *
-   * Some visualization programs, such as ParaView, can read several separate
-   * VTU files to parallelize visualization. In that case, you need a
-   * <code>.pvtu</code> file that describes which VTU files form a group. The
-   * DataOutInterface::write_pvtu_record() function can generate such a
-   * centralized record. Likewise, DataOutInterface::write_visit_record() does
-   * the same for older versions of VisIt (although VisIt can also read
-   * <code>pvtu</code> records since version 2.5.1). Finally,
-   * DataOutInterface::write_pvd_record() can be used to group together the
-   * files that jointly make up a time dependent simulation.
-   */
-  void
-  write_vtu(std::ostream &out) const;
-
-  /**
-   * Collective MPI call to write the solution from all participating nodes
-   * (those in the given communicator) to a single compressed .vtu file on a
-   * shared file system.  The communicator can be a sub communicator of the
-   * one used by the computation. This routine uses MPI I/O to achieve high
-   * performance on parallel filesystems. In order to use this function,
-   * you need to be using a file system that supports parallel MPI I/O,
-   * and you will get error messages about failed MPI calls if you do not.
-   * Also see DataOutInterface::write_vtu().
-   */
-  void
-  write_vtu_in_parallel(const std::string &filename, const MPI_Comm comm) const;
-
-  /**
-   * Some visualization programs, such as ParaView and VisIt, can read several
-   * separate VTU files that all form part of the same simulation, in order to
-   * parallelize visualization. In that case, you need a
-   * <code>.pvtu</code> file that describes which VTU files (written, for
-   * example, through the DataOutInterface::write_vtu() function) form a group.
-   * The current function can generate such a centralized record.
-   *
-   * The central record file generated by this function
-   * contains a list of (scalar or vector) fields that describes which
-   * fields can actually be found in the individual files that comprise the set
-   * of parallel VTU files along with the names of these files. This function
-   * gets the names and types of fields through the get_dataset_names() and
-   * get_nonscalar_data_ranges() functions of this class. The second argument
-   * to this function specifies the names of the files that form the parallel
-   * set.
-   *
-   * @note Use DataOutBase::write_vtu() and DataOutInterface::write_vtu()
-   * for writing each piece. Also note that
-   * only one parallel process needs to call the current function, listing the
-   * names of the files written by all parallel processes.
-   *
-   * @note The use of this function is explained in step-40.
-   *
-   * @note In order to tell Paraview to group together multiple
-   * <code>pvtu</code> files that each describe one time step of a time
-   * dependent simulation, see the DataOutBase::write_pvd_record()
-   * function.
-   *
-   * @note Older versions of VisIt (before 2.5.1), can not read
-   * <code>pvtu</code> records. However, it can read visit records as written
-   * by the write_visit_record() function.
-   */
-  void
-  write_pvtu_record(std::ostream                   &out,
-                    const std::vector<std::string> &piece_names) const;
-
-  /**
-   * This function writes several .vtu files and a .pvtu record in parallel
-   * and constructs the filenames automatically. It is a combination of
-   * DataOutInterface::write_vtu() or
-   * DataOutInterface::write_vtu_in_parallel(), and
-   * DataOutInterface::write_pvtu_record().
-   *
-   * For example, running
-   * <code> write_vtu_with_pvtu_record("output/", "solution", 3, comm, 4, 2)
-   * </code> on 10 processes generates the files
-   * @code
-   * output/solution_0003.0.vtu
-   * output/solution_0003.1.vtu
-   * output/solution_0003.pvtu
-   * @endcode
-   * where the `.0.vtu` file contains the output of the first half of the
-   * processes grouped together, and the `.1.vtu` the data from the remaining
-   * half.
-   *
-   * A specified @p directory and a @p filename_without_extension
-   * form the first part of the filename. The filename is then extended with
-   * a @p counter labeling the current timestep/iteration/etc., the processor ID,
-   * and finally the .vtu/.pvtu ending. Since the number of timesteps to be
-   * written depends on the application, the number of digits to be reserved in
-   * the filename can be specified as parameter @p n_digits_for_counter, and the number
-   * is not padded with leading zeros if this parameter is left at its default
-   * value numbers::invalid_unsigned_int. If more than one file identifier
-   * is needed (e.g. time step number and iteration counter of solver), the
-   * last identifier is used as @p counter, while all other identifiers have to be
-   * added to @p filename_without_extension when calling this function.
-   *
-   * In a
-   * parallel setting, several files are typically written per time step. The
-   * number of files written in parallel depends on the number of MPI processes
-   * (see parameter @p mpi_communicator), and a
-   * specified number of @p n_groups with default value 0. The background is that
-   * VTU file output supports grouping files from several CPUs into a given
-   * number of files using MPI I/O when writing on a parallel filesystem. The
-   * default value of @p n_groups is 0, meaning that every MPI rank will write one
-   * file. A value of 1 will generate one big file containing the solution over
-   * the whole domain, while a larger value will create @p n_groups files (but not
-   * more than there are MPI ranks). For all values other than `n_groups==0`,
-   * this function calls write_vtu_in_parallel(); for this function to work you
-   * need to be using a file system that supports parallel MPI I/O, and you will
-   * get error messages about failed MPI calls if you do not.
-   *
-   * Note that only one processor needs to
-   * generate the .pvtu file, where processor zero is chosen to take over this
-   * job.
-   *
-   * The return value is the filename of the centralized file for the pvtu
-   * record.
-   *
-   * @note The code simply combines the strings @p directory and
-   * @p filename_without_extension, i.e., the user has to make sure that
-   * @p directory contains a trailing character, e.g. "/", that separates the
-   * directory from the filename.
-   *
-   * @note Use an empty string "" for the first argument if output is to be
-   * written in the current working directory.
-   */
-  std::string
-  write_vtu_with_pvtu_record(
-    const std::string &directory,
-    const std::string &filename_without_extension,
-    const unsigned int counter,
-    const MPI_Comm     mpi_communicator,
-    const unsigned int n_digits_for_counter = numbers::invalid_unsigned_int,
-    const unsigned int n_groups             = 0) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in SVG
-   * format. See DataOutBase::write_svg.
-   */
-  void
-  write_svg(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it to <tt>out</tt> in deal.II
-   * intermediate format. See DataOutBase::write_deal_II_intermediate.
-   *
-   * Note that the intermediate format is what its name suggests: a direct
-   * representation of internal data. It isn't standardized and will change
-   * whenever we change our internal representation. You can only expect to
-   * process files written in this format using the same version of deal.II
-   * that was used for writing.
-   */
-  void
-  write_deal_II_intermediate(std::ostream &out) const;
-
-  /**
-   * Obtain data through get_patches() and write it using MPI I/O in parallel
-   * to the file @p filename in the parallel
-   * deal.II intermediate format. See
-   * DataOutBase::write_deal_II_intermediate_in_parallel().
-   */
-  void
-  write_deal_II_intermediate_in_parallel(
-    const std::string                  &filename,
-    const MPI_Comm                      comm,
-    const DataOutBase::CompressionLevel compression) const;
-
-  /**
-   * Create an XDMFEntry based on the data in the data_filter. This assumes
-   * the mesh and solution data were written to a single file. See
-   * write_xdmf_file() for an example of usage.
-   */
-  XDMFEntry
-  create_xdmf_entry(const DataOutBase::DataOutFilter &data_filter,
-                    const std::string                &h5_filename,
-                    const double                      cur_time,
-                    const MPI_Comm                    comm) const;
-
-  /**
-   * Create an XDMFEntry based on the data in the data_filter. This assumes
-   * the mesh and solution data were written to separate files. See
-   * write_xdmf_file() for an example of usage.
-   */
-  XDMFEntry
-  create_xdmf_entry(const DataOutBase::DataOutFilter &data_filter,
-                    const std::string                &h5_mesh_filename,
-                    const std::string                &h5_solution_filename,
-                    const double                      cur_time,
-                    const MPI_Comm                    comm) const;
-
-  /**
-   * Write an XDMF file based on the provided vector of XDMFEntry objects.
-   * Below is an example of how to use this function with HDF5 and the
-   * DataOutFilter:
-   *
-   * @code
-   * DataOutBase::DataOutFilterFlags flags(true, true);
-   * DataOutBase::DataOutFilter data_filter(flags);
-   * std::vector<XDMFEntry> xdmf_entries;
-   * // Filter the data and store it in data_filter
-   * data_out.write_filtered_data(data_filter);
-   * // Write the filtered data to HDF5
-   * data_out.write_hdf5_parallel(data_filter, "solution.h5", MPI_COMM_WORLD);
-   * // Create an XDMF entry detailing the HDF5 file
-   * auto new_xdmf_entry = data_out.create_xdmf_entry(data_filter,
-   *                                                  "solution.h5",
-   *                                                  simulation_time,
-   *                                                  MPI_COMM_WORLD);
-   * // Add the XDMF entry to the list
-   * xdmf_entries.push_back(new_xdmf_entry);
-   * // Create an XDMF file from all stored entries
-   * data_out.write_xdmf_file(xdmf_entries, "solution.xdmf", MPI_COMM_WORLD);
-   * @endcode
-   */
-  void
-  write_xdmf_file(const std::vector<XDMFEntry> &entries,
-                  const std::string            &filename,
-                  const MPI_Comm                comm) const;
-
-  /**
-   * Write the data in @p data_filter to a single HDF5 file containing both the
-   * mesh and solution values. Below is an example of how to use this function
-   * with the DataOutFilter:
-   *
-   * @code
-   * DataOutBase::DataOutFilterFlags flags(true, true);
-   * DataOutBase::DataOutFilter data_filter(flags);
-   * // Filter the data and store it in data_filter
-   * data_out.write_filtered_data(data_filter);
-   * // Write the filtered data to HDF5
-   * data_out.write_hdf5_parallel(data_filter, "solution.h5", MPI_COMM_WORLD);
-   * @endcode
-   */
-  void
-  write_hdf5_parallel(const DataOutBase::DataOutFilter &data_filter,
-                      const std::string                &filename,
-                      const MPI_Comm                    comm) const;
-
-  /**
-   * Write the data in data_filter to HDF5 file(s). If write_mesh_file is
-   * false, the mesh data will not be written and the solution file will
-   * contain only the solution values. If write_mesh_file is true and the
-   * filenames are the same, the resulting file will contain both mesh data
-   * and solution values.
-   */
-  void
-  write_hdf5_parallel(const DataOutBase::DataOutFilter &data_filter,
-                      const bool                        write_mesh_file,
-                      const std::string                &mesh_filename,
-                      const std::string                &solution_filename,
-                      const MPI_Comm                    comm) const;
-
-  /**
-   * DataOutFilter is an intermediate data format that reduces the amount of
-   * data that will be written to files. The object filled by this function
-   * can then later be used again to write data in a concrete file format;
-   * see, for example, DataOutBase::write_hdf5_parallel().
-   */
-  void
-  write_filtered_data(DataOutBase::DataOutFilter &filtered_data) const;
-
-
-  /**
-   * Write data and grid to <tt>out</tt> according to the given data format.
-   * This function simply calls the appropriate <tt>write_*</tt> function. If
-   * no output format is requested, the <tt>default_format</tt> is written.
-   *
-   * An error occurs if no format is provided and the default format is
-   * <tt>default_format</tt>.
-   */
-  void
-  write(std::ostream                   &out,
-        const DataOutBase::OutputFormat output_format =
-          DataOutBase::default_format) const;
-
-  /**
-   * Set the default format. The value set here is used anytime, output for
-   * format <tt>default_format</tt> is requested.
-   */
-  void
-  set_default_format(const DataOutBase::OutputFormat default_format);
-
-
-  /**
-   * Set the flags to be used for output. This method expects <tt>flags</tt>
-   * to be a member of one of the child classes of <tt>OutputFlagsBase</tt>.
-   */
-  template <typename FlagType>
-  void
-  set_flags(const FlagType &flags);
-
-
-  /**
-   * A function that returns the same string as the respective function in the
-   * base class does; the only exception being that if the parameter is
-   * omitted, then the value for the present default format is returned, i.e.
-   * the correct suffix for the format that was set through
-   * set_default_format() or parse_parameters() before calling this function.
-   */
-  std::string
-  default_suffix(const DataOutBase::OutputFormat output_format =
-                   DataOutBase::default_format) const;
-
-  /**
-   * Declare parameters for all output formats by declaring subsections within
-   * the parameter file for each output format and call the respective
-   * <tt>declare_parameters</tt> functions of the flag classes for each output
-   * format.
-   *
-   * Some of the declared subsections may not contain entries, if the
-   * respective format does not export any flags.
-   *
-   * Note that the top-level parameters denoting the number of subdivisions
-   * per patch and the output format are not declared, since they are only
-   * passed to virtual functions and are not stored inside objects of this
-   * type. You have to declare them yourself.
-   */
-  static void
-  declare_parameters(ParameterHandler &prm);
-
-  /**
-   * Read the parameters declared in declare_parameters() and set the flags
-   * for the output formats accordingly.
-   *
-   * The flags thus obtained overwrite all previous contents of the flag
-   * objects as default-constructed or set by the set_flags() function.
-   */
-  void
-  parse_parameters(ParameterHandler &prm);
-
-  /**
-   * Return an estimate for the memory consumption, in bytes, of this object.
-   * This is not exact (but will usually be close) because calculating the
-   * memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
-   */
-  std::size_t
-  memory_consumption() const;
-
-protected:
-  /**
-   * This is the abstract function through which derived classes propagate
-   * preprocessed data in the form of Patch structures (declared in the base
-   * class DataOutBase) to the actual output function. You need to overload
-   * this function to allow the output functions to know what they shall
-   * print.
-   */
-  virtual const std::vector<DataOutBase::Patch<dim, spacedim>> &
-  get_patches() const = 0;
-
-  /**
-   * Abstract virtual function through which the names of data sets are
-   * obtained by the output functions of the base class.
-   */
-  virtual std::vector<std::string>
-  get_dataset_names() const = 0;
-
-  /**
-   * This functions returns information about how the individual components of
-   * output files that consist of more than one data set are to be
-   * interpreted.
-   *
-   * It returns a list of index pairs and corresponding name and type indicating
-   * which components of the output are to be considered vector- or
-   * tensor-valued rather than just a collection of scalar data. The index pairs
-   * are inclusive; for example, if we have a Stokes problem in 2d with
-   * components (u,v,p), then the corresponding vector data range should be
-   * (0,1), and the returned list would consist of only a single element with a
-   * tuple such as (0,1,"velocity",component_is_part_of_vector).
-   *
-   * Since some of the derived classes do not know about non-scalar data, this
-   * function has a default implementation that simply returns an empty
-   * string, meaning that all data is to be considered a collection of scalar
-   * fields.
-   */
-  virtual std::vector<
-    std::tuple<unsigned int,
-               unsigned int,
-               std::string,
-               DataComponentInterpretation::DataComponentInterpretation>>
-  get_nonscalar_data_ranges() const;
-
-  /**
-   * Validate that the names of the datasets returned by get_dataset_names() and
-   * get_nonscalar_data_ranges() are valid. This currently consists of checking
-   * that names are not used more than once. If an invalid state is encountered,
-   * an Assert() will be triggered in debug mode.
-   */
-  void
-  validate_dataset_names() const;
-
-
-  /**
-   * The default number of subdivisions for patches. This is filled by
-   * parse_parameters() and should be obeyed by build_patches() in derived
-   * classes.
-   */
-  unsigned int default_subdivisions;
-
-private:
-  /**
-   * Standard output format.  Use this format, if output format default_format
-   * is requested. It can be changed by the <tt>set_format</tt> function or in
-   * a parameter file.
-   */
-  DataOutBase::OutputFormat default_fmt;
-
-  /**
-   * Flags to be used upon output of OpenDX data. Can be changed by using the
-   * <tt>set_flags</tt> function.
-   */
-  DataOutBase::DXFlags dx_flags;
-
-  /**
-   * Flags to be used upon output of UCD data. Can be changed by using the
-   * <tt>set_flags</tt> function.
-   */
-  DataOutBase::UcdFlags ucd_flags;
-
-  /**
-   * Flags to be used upon output of GNUPLOT data. Can be changed by using the
-   * <tt>set_flags</tt> function.
-   */
-  DataOutBase::GnuplotFlags gnuplot_flags;
-
-  /**
-   * Flags to be used upon output of POVRAY data. Can be changed by using the
-   * <tt>set_flags</tt> function.
-   */
-  DataOutBase::PovrayFlags povray_flags;
-
-  /**
-   * Flags to be used upon output of EPS data in one space dimension. Can be
-   * changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::EpsFlags eps_flags;
-
-  /**
-   * Flags to be used upon output of gmv data in one space dimension. Can be
-   * changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::GmvFlags gmv_flags;
-
-  /**
-   * Flags to be used upon output of hdf5 data in one space dimension. Can be
-   * changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::Hdf5Flags hdf5_flags;
-
-  /**
-   * Flags to be used upon output of Tecplot data in one space dimension. Can
-   * be changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::TecplotFlags tecplot_flags;
-
-  /**
-   * Flags to be used upon output of vtk data in one space dimension. Can be
-   * changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::VtkFlags vtk_flags;
-
-  /**
-   * Flags to be used upon output of svg data in one space dimension. Can be
-   * changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::SvgFlags svg_flags;
-
-  /**
-   * Flags to be used upon output of deal.II intermediate data in one space
-   * dimension. Can be changed by using the <tt>set_flags</tt> function.
-   */
-  DataOutBase::Deal_II_IntermediateFlags deal_II_intermediate_flags;
-};
-
-
-
-/**
- * A class that is used to read data written in deal.II intermediate format
- * back in, so that it can be written out in any of the other supported
- * graphics formats. This class has two main purposes:
- *
- * The first use of this class is so that application programs can defer the
- * decision of which graphics format to use until after the program has been
- * run. The data is written in intermediate format into a file, and later on
- * it can then be converted into any graphics format you wish. This may be
- * useful, for example, if you want to convert it to gnuplot format to get a
- * quick glimpse and later on want to convert it to OpenDX format as well to
- * get a high quality version of the data. The present class allows to read
- * this intermediate format back into the program, and allows it to be written
- * in any other supported format using the relevant functions of the base
- * class.
- *
- * The second use is mostly useful in parallel programs: rather than having
- * one central process generate the graphical output for the entire program,
- * one can let each process generate the graphical data for the cells it owns,
- * and write it into a separate file in intermediate format. Later on, all
- * these intermediate files can then be read back in and merged together, a
- * process that is fast compared to generating the data in the first place.
- * The use of the intermediate format is mostly because it allows separate
- * files to be merged, while this is almost impossible once the data has been
- * written out in any of the supported established graphics formats.
- *
- * This second use scenario is explained in some detail in the step-18 example
- * program.
- *
- * In order to read data back into this object, you have to know the template
- * parameters for the space dimension which were used when writing the
- * data. If this knowledge is available at compile time, then this is no
- * problem. However, if it is not (such as in a simple format converter), then
- * it needs to be figured out at run time, even though the compiler already
- * needs it at compile time. A way around using the
- * DataOutBase::determine_intermediate_format_dimensions() function.
- *
- * Note that the intermediate format is what its name suggests: a direct
- * representation of internal data. It isn't standardized and will change
- * whenever we change our internal representation. You can only expect to
- * process files written in this format using the same version of deal.II that
- * was used for writing.
- *
- * @ingroup input output
- */
-template <int dim, int spacedim = dim>
-class DataOutReader : public DataOutInterface<dim, spacedim>
-{
-public:
-  /**
-   * Read a sequence of patches as written previously by
-   * <tt>DataOutBase::write_deal_II_intermediate</tt> and store them in the
-   * present object. This overwrites any previous content.
-   */
-  void
-  read(std::istream &in);
-
-  /**
-   * Read all data previously written using
-   * DataOutBase::write_deal_II_intermediate_in_parallel() from all
-   * MPI ranks into this data structure.
-   */
-  void
-  read_whole_parallel_file(std::istream &in);
-
-  /**
-   * This function can be used to merge the patches read by the other object
-   * into the patches that this present object stores. This is sometimes handy
-   * if one has, for example, a domain decomposition algorithm where each
-   * block is represented by a DoFHandler of its own, but one wants to output
-   * the solution on all the blocks at the same time. Alternatively, it may
-   * also be used for parallel programs, where each process only generates
-   * output for its share of the cells, even if all processes can see all
-   * cells.
-   *
-   * For this to work, the input files for the present object and the given
-   * argument need to have the same number of output vectors, and they need to
-   * use the same number of subdivisions per patch. The output will probably
-   * look rather funny if patches in both objects overlap in space.
-   *
-   * If you call read() for this object after merging in patches, the previous
-   * state is overwritten, and the merged-in patches are lost.
-   *
-   * This function will fail if either this or the other object did not yet
-   * set up any patches.
-   */
-  void
-  merge(const DataOutReader<dim, spacedim> &other);
-
-  /**
-   * Exception
-   */
-  DeclExceptionMsg(ExcIncompatibleDatasetNames,
-                   "You are trying to merge two sets of patches for which the "
-                   "declared names of the variables do not match.");
-  /**
-   * Exception
-   */
-  DeclExceptionMsg(ExcIncompatiblePatchLists,
-                   "You are trying to merge two sets of patches for which the "
-                   "number of subdivisions or the number of vector components "
-                   "do not match.");
-  /**
-   * Exception
-   */
-  DeclException4(ExcIncompatibleDimensions,
-                 int,
-                 int,
-                 int,
-                 int,
-                 << "Either the dimensions <" << arg1 << "> and <" << arg2
-                 << "> or the space dimensions <" << arg3 << "> and <" << arg4
-                 << "> do not match!");
-
-protected:
-  /**
-   * This is the function through which this class propagates preprocessed
-   * data in the form of Patch structures (declared in the base class
-   * DataOutBase) to the actual output function.
-   *
-   * It returns the patches as read the last time a stream was given to the
-   * read() function.
-   */
-  virtual const std::vector<dealii::DataOutBase::Patch<dim, spacedim>> &
-  get_patches() const override;
-
-  /**
-   * Abstract virtual function through which the names of data sets are
-   * obtained by the output functions of the base class.
-   *
-   * Return the names of the variables as read the last time we read a file.
-   */
-  virtual std::vector<std::string>
-  get_dataset_names() const override;
-
-  /**
-   * This functions returns information about how the individual components of
-   * output files that consist of more than one data set are to be
-   * interpreted.
-   *
-   * It returns a list of index pairs and corresponding name indicating which
-   * components of the output are to be considered vector-valued rather than
-   * just a collection of scalar data. The index pairs are inclusive; for
-   * example, if we have a Stokes problem in 2d with components (u,v,p), then
-   * the corresponding vector data range should be (0,1), and the returned
-   * list would consist of only a single element with a tuple such as
-   * (0,1,"velocity").
-   *
-   * Since some of the derived classes do not know about vector data, this
-   * function has a default implementation that simply returns an empty
-   * string, meaning that all data is to be considered a collection of scalar
-   * fields.
-   */
-  virtual std::vector<
-    std::tuple<unsigned int,
-               unsigned int,
-               std::string,
-               DataComponentInterpretation::DataComponentInterpretation>>
-  get_nonscalar_data_ranges() const override;
-
-private:
-  /**
-   * Arrays holding the set of patches as well as the names of output
-   * variables, all of which we read from an input stream.
-   */
-  std::vector<dealii::DataOutBase::Patch<dim, spacedim>> patches;
-  std::vector<std::string>                               dataset_names;
-
-  /**
-   * Information about whether certain components of the output field are to
-   * be considered vectors.
-   */
-  std::vector<
-    std::tuple<unsigned int,
-               unsigned int,
-               std::string,
-               DataComponentInterpretation::DataComponentInterpretation>>
-    nonscalar_data_ranges;
-};
-
-
-
-/**
- * A class to store relevant data to use when writing a lightweight XDMF
- * file. The XDMF file in turn points to heavy data files (such as HDF5)
- * where the actual simulation data is stored.
- * This allows flexibility in arranging the data, and also
- * allows the mesh to be separated from the point data.
- */
-class XDMFEntry
-{
-public:
-  /**
-   * Default constructor that creates an invalid object.
-   */
-  XDMFEntry();
-
-  /**
-   * Simplified constructor that calls the complete constructor for
-   * cases where <code>solution_filename == mesh_filename</code>, and
-   * <code>dim==spacedim</code>.
-   */
-  template <int dim>
-  XDMFEntry(const std::string        &filename,
-            const double              time,
-            const std::uint64_t       nodes,
-            const std::uint64_t       cells,
-            const unsigned int        dim_,
-            const ReferenceCell<dim> &cell_type);
-
-  /**
-   * Simplified constructor that calls the complete constructor for
-   * cases where <code>dim==spacedim</code>.
-   */
-  template <int dim>
-  XDMFEntry(const std::string        &mesh_filename,
-            const std::string        &solution_filename,
-            const double              time,
-            const std::uint64_t       nodes,
-            const std::uint64_t       cells,
-            const unsigned int        dim_,
-            const ReferenceCell<dim> &cell_type);
-
-  /**
-   * Constructor that sets all members to provided parameters.
-   */
-  template <int dim>
-  XDMFEntry(const std::string        &mesh_filename,
-            const std::string        &solution_filename,
-            const double              time,
-            const std::uint64_t       nodes,
-            const std::uint64_t       cells,
-            const unsigned int        dim_,
-            const unsigned int        spacedim,
-            const ReferenceCell<dim> &cell_type);
-
-  /**
-   * Record an attribute and associated dimensionality.
-   */
-  void
-  add_attribute(const std::string &attr_name, const unsigned int dimension);
-
-  /**
-   * Read or write the data of this object for serialization using the
-   * [BOOST serialization
-   * library](https://www.boost.org/doc/libs/1_74_0/libs/serialization/doc/index.html).
-   */
-  template <class Archive>
-  void
-  serialize(Archive &ar, const unsigned int /*version*/)
-  {
-    ar &valid &h5_sol_filename &h5_mesh_filename &entry_time &num_nodes
-      &num_cells &dimension &space_dimension &cell_type_name
-        &n_vertices_per_cell &attribute_dims;
-  }
-
-  /**
-   * Get the XDMF content associated with this entry.
-   * If the entry is not valid, this returns an empty string.
-   */
-  std::string
-  get_xdmf_content(const unsigned int indent_level) const;
-
-private:
-  /**
-   * Whether this entry is valid and contains data to be written.
-   */
-  bool valid;
-
-  /**
-   * The name of the HDF5 heavy data solution file this entry references.
-   */
-  std::string h5_sol_filename;
-
-  /**
-   * The name of the HDF5 mesh file this entry references.
-   */
-  std::string h5_mesh_filename;
-
-  /**
-   * The simulation time associated with this entry.
-   */
-  double entry_time;
-
-  /**
-   * The number of data nodes.
-   */
-  std::uint64_t num_nodes;
-
-  /**
-   * The number of data cells.
-   */
-  std::uint64_t num_cells;
-
-  /**
-   * The dimension associated with the data.
-   */
-  unsigned int dimension;
-
-  /**
-   * The dimension of the space the data lives in.
-   * Note that dimension <= space_dimension.
-   */
-  unsigned int space_dimension;
-
-  /**
-   * The type of cell in XDMF language. We currently only support
-   * xdmf entries where all cells have the same type.
-   *
-   * XDMFEntry objects can reference meshes independent of their
-   * dimension -- the dimension and space dimension is stored as an
-   * explicit variable. But we do have to store the ReferenceCell
-   * type of the mesh so that we can output information about. In
-   * practice, we only need a symbol name for each type of reference
-   * cell, and its number of vertices, so store only that, instead of
-   * the ReferenceCell object.
-   */
-  std::string cell_type_name;
-
-  /**
-   * The only other property of the cell type we need is the number
-   * of vertices per cell. Store that explicitly as well.
-   */
-  unsigned int n_vertices_per_cell;
-
-  /**
-   * The attributes associated with this entry and their dimension.
-   */
-  std::map<std::string, unsigned int> attribute_dims;
-};
-
-
-
-/* -------------------- inline functions ------------------- */
-
-namespace DataOutBase
-{
-  inline bool
-  EpsFlags::RgbValues::is_grey() const
-  {
-    return (red == green) && (red == blue);
-  }
-
-
-  /* -------------------- template functions ------------------- */
-
-  /**
-   * Output operator for an object of type <tt>DataOutBase::Patch</tt>. This
-   * operator dumps the intermediate graphics format represented by the patch
-   * data structure. It may later be converted into regular formats for a
-   * number of graphics programs.
-   */
-  template <int dim, int spacedim>
-  std::ostream &
-  operator<<(std::ostream &out, const Patch<dim, spacedim> &patch);
-
-
-
-  /**
-   * Input operator for an object of type <tt>DataOutBase::Patch</tt>. This
-   * operator reads the intermediate graphics format represented by the patch
-   * data structure, using the format in which it was written using the
-   * operator<<.
-   */
-  template <int dim, int spacedim>
-  std::istream &
-  operator>>(std::istream &in, Patch<dim, spacedim> &patch);
-} // namespace DataOutBase
-
-
-DEAL_II_NAMESPACE_CLOSE
+   {
+   public:
+     /**
+      * Constructor.
+      */
+     DataOutInterface();
+
+     /**
+      * Destructor. Does nothing, but is declared virtual since this class has
+      * virtual functions.
+      */
+     virtual ~DataOutInterface() = default;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in OpenDX
+      * format. See DataOutBase::write_dx.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_dx(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in EPS
+      * format. See DataOutBase::write_eps.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_eps(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in GMV
+      * format. See DataOutBase::write_gmv.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_gmv(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in
+      * GNUPLOT format. See DataOutBase::write_gnuplot.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_gnuplot(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in POVRAY
+      * format. See DataOutBase::write_povray.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_povray(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in
+      * Tecplot format. See DataOutBase::write_tecplot.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_tecplot(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in UCD
+      * format for AVS. See DataOutBase::write_ucd.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_ucd(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in Vtk
+      * format. See DataOutBase::write_vtk.
+      *
+      * @param out The output stream to which data is written.
+      * @note VTK is a legacy format and has largely been supplanted by the VTU
+      * format (an XML-structured version of VTK). In particular, VTU allows for
+      * the compression of data and consequently leads to much smaller file
+      * sizes that equivalent VTK files for large files. Since all visualization
+      * programs that support VTK also support VTU, you should consider using
+      * the latter file format instead, by using the write_vtu() function.
+      */
+     void
+     write_vtk(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in Vtu
+      * (VTK's XML) format. See DataOutBase::write_vtu.
+      *
+      * Some visualization programs, such as ParaView, can read several separate
+      * VTU files to parallelize visualization. In that case, you need a
+      * <code>.pvtu</code> file that describes which VTU files form a group. The
+      * DataOutInterface::write_pvtu_record() function can generate such a
+      * centralized record. Likewise, DataOutInterface::write_visit_record()
+      * does the same for older versions of VisIt (although VisIt can also read
+      * <code>pvtu</code> records since version 2.5.1). Finally,
+      * DataOutInterface::write_pvd_record() can be used to group together the
+      * files that jointly make up a time dependent simulation.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_vtu(std::ostream &out) const;
+
+     /**
+      * Collective MPI call to write the solution from all participating nodes
+      * (those in the given communicator) to a single compressed .vtu file on a
+      * shared file system.  The communicator can be a sub communicator of the
+      * one used by the computation. This routine uses MPI I/O to achieve high
+      * performance on parallel filesystems. In order to use this function,
+      * you need to be using a file system that supports parallel MPI I/O,
+      * and you will get error messages about failed MPI calls if you do not.
+      * Also see DataOutInterface::write_vtu().
+      * @param filename The file name.
+      * @param comm The MPI communicator.
+      */
+     void
+     write_vtu_in_parallel(const std::string &filename,
+                           const MPI_Comm     comm) const;
+
+     /**
+      * Some visualization programs, such as ParaView and VisIt, can read
+      * several separate VTU files that all form part of the same simulation, in
+      * order to parallelize visualization. In that case, you need a
+      * <code>.pvtu</code> file that describes which VTU files (written, for
+      * example, through the DataOutInterface::write_vtu() function) form a
+      * group. The current function can generate such a centralized record.
+      *
+      * The central record file generated by this function
+      * contains a list of (scalar or vector) fields that describes which
+      * fields can actually be found in the individual files that comprise the
+      * set of parallel VTU files along with the names of these files. This
+      * function gets the names and types of fields through the
+      * get_dataset_names() and get_nonscalar_data_ranges() functions of this
+      * class. The second argument to this function specifies the names of the
+      * files that form the parallel set.
+      *
+      * @param out The output stream to which data is written.
+      * @param piece_names The piece names.
+      * @note Use DataOutBase::write_vtu() and DataOutInterface::write_vtu()
+      * for writing each piece. Also note that
+      * only one parallel process needs to call the current function, listing
+      * the names of the files written by all parallel processes.
+      *
+      * @note The use of this function is explained in step-40.
+      *
+      * @note In order to tell Paraview to group together multiple
+      * <code>pvtu</code> files that each describe one time step of a time
+      * dependent simulation, see the DataOutBase::write_pvd_record()
+      * function.
+      *
+      * @note Older versions of VisIt (before 2.5.1), can not read
+      * <code>pvtu</code> records. However, it can read visit records as written
+      * by the write_visit_record() function.
+      */
+     void
+     write_pvtu_record(std::ostream                   &out,
+                       const std::vector<std::string> &piece_names) const;
+
+     /**
+      * This function writes several .vtu files and a .pvtu record in parallel
+      * and constructs the filenames automatically. It is a combination of
+      * DataOutInterface::write_vtu() or
+      * DataOutInterface::write_vtu_in_parallel(), and
+      * DataOutInterface::write_pvtu_record().
+      *
+      * For example, running
+      * <code> write_vtu_with_pvtu_record("output/", "solution", 3, comm, 4, 2)
+      * </code> on 10 processes generates the files
+      * @code
+      * output/solution_0003.0.vtu
+      * output/solution_0003.1.vtu
+      * output/solution_0003.pvtu
+      * @endcode
+      * where the `.0.vtu` file contains the output of the first half of the
+      * processes grouped together, and the `.1.vtu` the data from the remaining
+      * half.
+      *
+      * A specified @p directory and a @p filename_without_extension
+      * form the first part of the filename. The filename is then extended with
+      * a @p counter labeling the current timestep/iteration/etc., the processor ID,
+      * and finally the .vtu/.pvtu ending. Since the number of timesteps to be
+      * written depends on the application, the number of digits to be reserved
+      * in
+      * the filename can be specified as parameter @p n_digits_for_counter, and the number
+      * is not padded with leading zeros if this parameter is left at its
+      * default value numbers::invalid_unsigned_int. If more than one file
+      * identifier is needed (e.g. time step number and iteration counter of
+      * solver), the
+      * last identifier is used as @p counter, while all other identifiers have to be
+      * added to @p filename_without_extension when calling this function.
+      *
+      * In a
+      * parallel setting, several files are typically written per time step. The
+      * number of files written in parallel depends on the number of MPI
+      * processes
+      * (see parameter @p mpi_communicator), and a
+      * specified number of @p n_groups with default value 0. The background is that
+      * VTU file output supports grouping files from several CPUs into a given
+      * number of files using MPI I/O when writing on a parallel filesystem. The
+      * default value of @p n_groups is 0, meaning that every MPI rank will write one
+      * file. A value of 1 will generate one big file containing the solution
+      * over
+      * the whole domain, while a larger value will create @p n_groups files (but not
+      * more than there are MPI ranks). For all values other than `n_groups==0`,
+      * this function calls write_vtu_in_parallel(); for this function to work
+      * you need to be using a file system that supports parallel MPI I/O, and
+      * you will get error messages about failed MPI calls if you do not.
+      *
+      * Note that only one processor needs to
+      * generate the .pvtu file, where processor zero is chosen to take over
+      * this job.
+      *
+      * The return value is the filename of the centralized file for the pvtu
+      * record.
+      *
+      * @param directory The directory used by this operation.
+      * @param filename_without_extension The filename without extension.
+      * @param counter The counter used by this operation.
+      * @param mpi_communicator The MPI communicator.
+      * @param n_digits_for_counter The number of digits for counter.
+      * @param n_groups The number of groups.
+      * @note The code simply combines the strings @p directory and
+      * @p filename_without_extension, i.e., the user has to make sure that
+      * @p directory contains a trailing character, e.g. "/", that separates the
+      * directory from the filename.
+      *
+      * @note Use an empty string "" for the first argument if output is to be
+      * written in the current working directory.
+      */
+     std::string
+     write_vtu_with_pvtu_record(
+       const std::string &directory,
+       const std::string &filename_without_extension,
+       const unsigned int counter,
+       const MPI_Comm     mpi_communicator,
+       const unsigned int n_digits_for_counter = numbers::invalid_unsigned_int,
+       const unsigned int n_groups             = 0) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in SVG
+      * format. See DataOutBase::write_svg.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_svg(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it to <tt>out</tt> in
+      * deal.II intermediate format. See
+      * DataOutBase::write_deal_II_intermediate.
+      *
+      * Note that the intermediate format is what its name suggests: a direct
+      * representation of internal data. It isn't standardized and will change
+      * whenever we change our internal representation. You can only expect to
+      * process files written in this format using the same version of deal.II
+      * that was used for writing.
+      * @param out The output stream to which data is written.
+      */
+     void
+     write_deal_II_intermediate(std::ostream &out) const;
+
+     /**
+      * Obtain data through get_patches() and write it using MPI I/O in parallel
+      * to the file @p filename in the parallel
+      * deal.II intermediate format. See
+      * DataOutBase::write_deal_II_intermediate_in_parallel().
+      * @param filename The file name.
+      * @param comm The MPI communicator.
+      * @param compression The compression used by this operation.
+      */
+     void
+     write_deal_II_intermediate_in_parallel(
+       const std::string                  &filename,
+       const MPI_Comm                      comm,
+       const DataOutBase::CompressionLevel compression) const;
+
+     /**
+      * Create an XDMFEntry based on the data in the data_filter. This assumes
+      * the mesh and solution data were written to a single file. See
+      * write_xdmf_file() for an example of usage.
+      * @param data_filter The data filter.
+      * @param h5_filename The h5 filename.
+      * @param cur_time The cur time.
+      * @param comm The MPI communicator.
+      */
+     XDMFEntry
+     create_xdmf_entry(const DataOutBase::DataOutFilter &data_filter,
+                       const std::string                &h5_filename,
+                       const double                      cur_time,
+                       const MPI_Comm                    comm) const;
+
+     /**
+      * Create an XDMFEntry based on the data in the data_filter. This assumes
+      * the mesh and solution data were written to separate files. See
+      * write_xdmf_file() for an example of usage.
+      * @param data_filter The data filter.
+      * @param h5_mesh_filename The h5 mesh filename.
+      * @param h5_solution_filename The h5 solution filename.
+      * @param cur_time The cur time.
+      * @param comm The MPI communicator.
+      */
+     XDMFEntry
+     create_xdmf_entry(const DataOutBase::DataOutFilter &data_filter,
+                       const std::string                &h5_mesh_filename,
+                       const std::string                &h5_solution_filename,
+                       const double                      cur_time,
+                       const MPI_Comm                    comm) const;
+
+     /**
+      * Write an XDMF file based on the provided vector of XDMFEntry objects.
+      * Below is an example of how to use this function with HDF5 and the
+      * DataOutFilter:
+      *
+      * @code
+      * DataOutBase::DataOutFilterFlags flags(true, true);
+      * DataOutBase::DataOutFilter data_filter(flags);
+      * std::vector<XDMFEntry> xdmf_entries;
+      * // Filter the data and store it in data_filter
+      * data_out.write_filtered_data(data_filter);
+      * // Write the filtered data to HDF5
+      * data_out.write_hdf5_parallel(data_filter, "solution.h5",
+      * MPI_COMM_WORLD);
+      * // Create an XDMF entry detailing the HDF5 file
+      * auto new_xdmf_entry = data_out.create_xdmf_entry(data_filter,
+      *                                                  "solution.h5",
+      *                                                  simulation_time,
+      *                                                  MPI_COMM_WORLD);
+      * // Add the XDMF entry to the list
+      * xdmf_entries.push_back(new_xdmf_entry);
+      * // Create an XDMF file from all stored entries
+      * data_out.write_xdmf_file(xdmf_entries, "solution.xdmf", MPI_COMM_WORLD);
+      * @endcode
+      * @param entries The entries used by this operation.
+      * @param filename The file name.
+      * @param comm The MPI communicator.
+      */
+     void
+     write_xdmf_file(const std::vector<XDMFEntry> &entries,
+                     const std::string            &filename,
+                     const MPI_Comm                comm) const;
+
+     /**
+      * Write the data in @p data_filter to a single HDF5 file containing both the
+      * mesh and solution values. Below is an example of how to use this
+      * function with the DataOutFilter:
+      *
+      * @code
+      * DataOutBase::DataOutFilterFlags flags(true, true);
+      * DataOutBase::DataOutFilter data_filter(flags);
+      * // Filter the data and store it in data_filter
+      * data_out.write_filtered_data(data_filter);
+      * // Write the filtered data to HDF5
+      * data_out.write_hdf5_parallel(data_filter, "solution.h5",
+      * MPI_COMM_WORLD);
+      * @endcode
+      * @param data_filter The data filter.
+      * @param filename The file name.
+      * @param comm The MPI communicator.
+      */
+     void
+     write_hdf5_parallel(const DataOutBase::DataOutFilter &data_filter,
+                         const std::string                &filename,
+                         const MPI_Comm                    comm) const;
+
+     /**
+      * Write the data in data_filter to HDF5 file(s). If write_mesh_file is
+      * false, the mesh data will not be written and the solution file will
+      * contain only the solution values. If write_mesh_file is true and the
+      * filenames are the same, the resulting file will contain both mesh data
+      * and solution values.
+      * @param data_filter The data filter.
+      * @param write_mesh_file The write mesh file.
+      * @param mesh_filename The mesh filename.
+      * @param solution_filename The solution filename.
+      * @param comm The MPI communicator.
+      */
+     void
+     write_hdf5_parallel(const DataOutBase::DataOutFilter &data_filter,
+                         const bool                        write_mesh_file,
+                         const std::string                &mesh_filename,
+                         const std::string                &solution_filename,
+                         const MPI_Comm                    comm) const;
+
+     /**
+      * DataOutFilter is an intermediate data format that reduces the amount of
+      * data that will be written to files. The object filled by this function
+      * can then later be used again to write data in a concrete file format;
+      * see, for example, DataOutBase::write_hdf5_parallel().
+      * @param filtered_data The object in which to store the filtered data.
+      */
+     void
+     write_filtered_data(DataOutBase::DataOutFilter &filtered_data) const;
+
+
+     /**
+      * Write data and grid to <tt>out</tt> according to the given data format.
+      * This function simply calls the appropriate <tt>write_*</tt> function. If
+      * no output format is requested, the <tt>default_format</tt> is written.
+      *
+      * An error occurs if no format is provided and the default format is
+      * <tt>default_format</tt>.
+      * @param out The output stream to which data is written.
+      * @param output_format The output format.
+      */
+     void
+     write(std::ostream                   &out,
+           const DataOutBase::OutputFormat output_format =
+             DataOutBase::default_format) const;
+
+     /**
+      * Set the default format. The value set here is used anytime, output for
+      * format <tt>default_format</tt> is requested.
+      * @param default_format The default format.
+      */
+     void
+     set_default_format(const DataOutBase::OutputFormat default_format);
+
+
+     /**
+      * Set the flags to be used for output. This method expects <tt>flags</tt>
+      * to be a member of one of the child classes of <tt>OutputFlagsBase</tt>.
+      * @param flags The flags that control how the output is written.
+      */
+     template <typename FlagType>
+     void
+     set_flags(const FlagType &flags);
+
+
+     /**
+      * A function that returns the same string as the respective function in
+      * the base class does; the only exception being that if the parameter is
+      * omitted, then the value for the present default format is returned, i.e.
+      * the correct suffix for the format that was set through
+      * set_default_format() or parse_parameters() before calling this function.
+      * @param output_format The output format.
+      */
+     std::string
+     default_suffix(const DataOutBase::OutputFormat output_format =
+                      DataOutBase::default_format) const;
+
+     /**
+      * Declare parameters for all output formats by declaring subsections
+      * within the parameter file for each output format and call the respective
+      * <tt>declare_parameters</tt> functions of the flag classes for each
+      * output format.
+      *
+      * Some of the declared subsections may not contain entries, if the
+      * respective format does not export any flags.
+      *
+      * Note that the top-level parameters denoting the number of subdivisions
+      * per patch and the output format are not declared, since they are only
+      * passed to virtual functions and are not stored inside objects of this
+      * type. You have to declare them yourself.
+      * @param prm The prm used by this operation.
+      */
+     static void
+     declare_parameters(ParameterHandler &prm);
+
+     /**
+      * Read the parameters declared in declare_parameters() and set the flags
+      * for the output formats accordingly.
+      *
+      * The flags thus obtained overwrite all previous contents of the flag
+      * objects as default-constructed or set by the set_flags() function.
+      * @param prm The prm used by this operation.
+      */
+     void
+     parse_parameters(ParameterHandler &prm);
+
+     /**
+      * Return an estimate for the memory consumption, in bytes, of this object.
+      * This is not exact (but will usually be close) because calculating the
+      * memory usage of trees (e.g., <tt>std::map</tt>) is difficult.
+      */
+     std::size_t
+     memory_consumption() const;
+
+   protected:
+     /**
+      * This is the abstract function through which derived classes propagate
+      * preprocessed data in the form of Patch structures (declared in the base
+      * class DataOutBase) to the actual output function. You need to overload
+      * this function to allow the output functions to know what they shall
+      * print.
+      */
+     virtual const std::vector<DataOutBase::Patch<dim, spacedim>> &
+     get_patches() const = 0;
+
+     /**
+      * Abstract virtual function through which the names of data sets are
+      * obtained by the output functions of the base class.
+      */
+     virtual std::vector<std::string>
+     get_dataset_names() const = 0;
+
+     /**
+      * This functions returns information about how the individual components
+      * of output files that consist of more than one data set are to be
+      * interpreted.
+      *
+      * It returns a list of index pairs and corresponding name and type
+      * indicating which components of the output are to be considered vector-
+      * or tensor-valued rather than just a collection of scalar data. The index
+      * pairs are inclusive; for example, if we have a Stokes problem in 2d with
+      * components (u,v,p), then the corresponding vector data range should be
+      * (0,1), and the returned list would consist of only a single element with
+      * a tuple such as (0,1,"velocity",component_is_part_of_vector).
+      *
+      * Since some of the derived classes do not know about non-scalar data,
+      * this function has a default implementation that simply returns an empty
+      * string, meaning that all data is to be considered a collection of scalar
+      * fields.
+      */
+     virtual std::vector<
+       std::tuple<unsigned int,
+                  unsigned int,
+                  std::string,
+                  DataComponentInterpretation::DataComponentInterpretation>>
+     get_nonscalar_data_ranges() const;
+
+     /**
+      * Validate that the names of the datasets returned by get_dataset_names()
+      * and get_nonscalar_data_ranges() are valid. This currently consists of
+      * checking that names are not used more than once. If an invalid state is
+      * encountered, an Assert() will be triggered in debug mode.
+      */
+     void
+     validate_dataset_names() const;
+
+
+     /**
+      * The default number of subdivisions for patches. This is filled by
+      * parse_parameters() and should be obeyed by build_patches() in derived
+      * classes.
+      */
+     unsigned int default_subdivisions;
+
+   private:
+     /**
+      * Standard output format.  Use this format, if output format
+      * default_format is requested. It can be changed by the
+      * <tt>set_format</tt> function or in a parameter file.
+      */
+     DataOutBase::OutputFormat default_fmt;
+
+     /**
+      * Flags to be used upon output of OpenDX data. Can be changed by using the
+      * <tt>set_flags</tt> function.
+      */
+     DataOutBase::DXFlags dx_flags;
+
+     /**
+      * Flags to be used upon output of UCD data. Can be changed by using the
+      * <tt>set_flags</tt> function.
+      */
+     DataOutBase::UcdFlags ucd_flags;
+
+     /**
+      * Flags to be used upon output of GNUPLOT data. Can be changed by using
+      * the <tt>set_flags</tt> function.
+      */
+     DataOutBase::GnuplotFlags gnuplot_flags;
+
+     /**
+      * Flags to be used upon output of POVRAY data. Can be changed by using the
+      * <tt>set_flags</tt> function.
+      */
+     DataOutBase::PovrayFlags povray_flags;
+
+     /**
+      * Flags to be used upon output of EPS data in one space dimension. Can be
+      * changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::EpsFlags eps_flags;
+
+     /**
+      * Flags to be used upon output of gmv data in one space dimension. Can be
+      * changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::GmvFlags gmv_flags;
+
+     /**
+      * Flags to be used upon output of hdf5 data in one space dimension. Can be
+      * changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::Hdf5Flags hdf5_flags;
+
+     /**
+      * Flags to be used upon output of Tecplot data in one space dimension. Can
+      * be changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::TecplotFlags tecplot_flags;
+
+     /**
+      * Flags to be used upon output of vtk data in one space dimension. Can be
+      * changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::VtkFlags vtk_flags;
+
+     /**
+      * Flags to be used upon output of svg data in one space dimension. Can be
+      * changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::SvgFlags svg_flags;
+
+     /**
+      * Flags to be used upon output of deal.II intermediate data in one space
+      * dimension. Can be changed by using the <tt>set_flags</tt> function.
+      */
+     DataOutBase::Deal_II_IntermediateFlags deal_II_intermediate_flags;
+   };
+
+
+
+   /**
+    * A class that is used to read data written in deal.II intermediate format
+    * back in, so that it can be written out in any of the other supported
+    * graphics formats. This class has two main purposes:
+    *
+    * The first use of this class is so that application programs can defer the
+    * decision of which graphics format to use until after the program has been
+    * run. The data is written in intermediate format into a file, and later on
+    * it can then be converted into any graphics format you wish. This may be
+    * useful, for example, if you want to convert it to gnuplot format to get a
+    * quick glimpse and later on want to convert it to OpenDX format as well to
+    * get a high quality version of the data. The present class allows to read
+    * this intermediate format back into the program, and allows it to be
+    * written in any other supported format using the relevant functions of the
+    * base class.
+    *
+    * The second use is mostly useful in parallel programs: rather than having
+    * one central process generate the graphical output for the entire program,
+    * one can let each process generate the graphical data for the cells it
+    * owns, and write it into a separate file in intermediate format. Later on,
+    * all these intermediate files can then be read back in and merged together,
+    * a process that is fast compared to generating the data in the first place.
+    * The use of the intermediate format is mostly because it allows separate
+    * files to be merged, while this is almost impossible once the data has been
+    * written out in any of the supported established graphics formats.
+    *
+    * This second use scenario is explained in some detail in the step-18
+    * example program.
+    *
+    * In order to read data back into this object, you have to know the template
+    * parameters for the space dimension which were used when writing the
+    * data. If this knowledge is available at compile time, then this is no
+    * problem. However, if it is not (such as in a simple format converter),
+    * then it needs to be figured out at run time, even though the compiler
+    * already needs it at compile time. A way around using the
+    * DataOutBase::determine_intermediate_format_dimensions() function.
+    *
+    * Note that the intermediate format is what its name suggests: a direct
+    * representation of internal data. It isn't standardized and will change
+    * whenever we change our internal representation. You can only expect to
+    * process files written in this format using the same version of deal.II
+    * that was used for writing.
+    *
+    * @ingroup input output
+    */
+   template <int dim, int spacedim = dim>
+   class DataOutReader : public DataOutInterface<dim, spacedim>
+   {
+   public:
+     /**
+      * Read a sequence of patches as written previously by
+      * <tt>DataOutBase::write_deal_II_intermediate</tt> and store them in the
+      * present object. This overwrites any previous content.
+      * @param in The input data or stream from which values are read.
+      */
+     void
+     read(std::istream &in);
+
+     /**
+      * Read all data previously written using
+      * DataOutBase::write_deal_II_intermediate_in_parallel() from all
+      * MPI ranks into this data structure.
+      * @param in The input data or stream from which values are read.
+      */
+     void
+     read_whole_parallel_file(std::istream &in);
+
+     /**
+      * This function can be used to merge the patches read by the other object
+      * into the patches that this present object stores. This is sometimes
+      * handy if one has, for example, a domain decomposition algorithm where
+      * each block is represented by a DoFHandler of its own, but one wants to
+      * output the solution on all the blocks at the same time. Alternatively,
+      * it may also be used for parallel programs, where each process only
+      * generates output for its share of the cells, even if all processes can
+      * see all cells.
+      *
+      * For this to work, the input files for the present object and the given
+      * argument need to have the same number of output vectors, and they need
+      * to use the same number of subdivisions per patch. The output will
+      * probably look rather funny if patches in both objects overlap in space.
+      *
+      * If you call read() for this object after merging in patches, the
+      * previous state is overwritten, and the merged-in patches are lost.
+      *
+      * This function will fail if either this or the other object did not yet
+      * set up any patches.
+      * @param other The object to copy or move from.
+      */
+     void
+     merge(const DataOutReader<dim, spacedim> &other);
+
+     /**
+      * Exception
+      * @param ExcIncompatibleDatasetNames The exc incompatible dataset names
+      * used by this operation.
+      */
+     DeclExceptionMsg(
+       ExcIncompatibleDatasetNames,
+       "You are trying to merge two sets of patches for which the "
+       "declared names of the variables do not match.");
+     /**
+      * Exception
+      * @param ExcIncompatiblePatchLists The exc incompatible patch lists used by
+      * this operation.
+      */
+     DeclExceptionMsg(
+       ExcIncompatiblePatchLists,
+       "You are trying to merge two sets of patches for which the "
+       "number of subdivisions or the number of vector components "
+       "do not match.");
+     /**
+      * Exception
+      */
+     DeclException4(ExcIncompatibleDimensions,
+                    int,
+                    int,
+                    int,
+                    int,
+                    << "Either the dimensions <" << arg1 << "> and <" << arg2
+                    << "> or the space dimensions <" << arg3 << "> and <"
+                    << arg4 << "> do not match!");
+
+   protected:
+     /**
+      * This is the function through which this class propagates preprocessed
+      * data in the form of Patch structures (declared in the base class
+      * DataOutBase) to the actual output function.
+      *
+      * It returns the patches as read the last time a stream was given to the
+      * read() function.
+      */
+     virtual const std::vector<dealii::DataOutBase::Patch<dim, spacedim>> &
+     get_patches() const override;
+
+     /**
+      * Abstract virtual function through which the names of data sets are
+      * obtained by the output functions of the base class.
+      *
+      * Return the names of the variables as read the last time we read a file.
+      */
+     virtual std::vector<std::string>
+     get_dataset_names() const override;
+
+     /**
+      * This functions returns information about how the individual components
+      * of output files that consist of more than one data set are to be
+      * interpreted.
+      *
+      * It returns a list of index pairs and corresponding name indicating which
+      * components of the output are to be considered vector-valued rather than
+      * just a collection of scalar data. The index pairs are inclusive; for
+      * example, if we have a Stokes problem in 2d with components (u,v,p), then
+      * the corresponding vector data range should be (0,1), and the returned
+      * list would consist of only a single element with a tuple such as
+      * (0,1,"velocity").
+      *
+      * Since some of the derived classes do not know about vector data, this
+      * function has a default implementation that simply returns an empty
+      * string, meaning that all data is to be considered a collection of scalar
+      * fields.
+      */
+     virtual std::vector<
+       std::tuple<unsigned int,
+                  unsigned int,
+                  std::string,
+                  DataComponentInterpretation::DataComponentInterpretation>>
+     get_nonscalar_data_ranges() const override;
+
+   private:
+     /**
+      * Arrays holding the set of patches as well as the names of output
+      * variables, all of which we read from an input stream.
+      */
+     std::vector<dealii::DataOutBase::Patch<dim, spacedim>> patches;
+     std::vector<std::string>                               dataset_names;
+
+     /**
+      * Information about whether certain components of the output field are to
+      * be considered vectors.
+      */
+     std::vector<
+       std::tuple<unsigned int,
+                  unsigned int,
+                  std::string,
+                  DataComponentInterpretation::DataComponentInterpretation>>
+       nonscalar_data_ranges;
+   };
+
+
+
+   /**
+    * A class to store relevant data to use when writing a lightweight XDMF
+    * file. The XDMF file in turn points to heavy data files (such as HDF5)
+    * where the actual simulation data is stored.
+    * This allows flexibility in arranging the data, and also
+    * allows the mesh to be separated from the point data.
+    */
+   class XDMFEntry
+   {
+   public:
+     /**
+      * Default constructor that creates an invalid object.
+      */
+     XDMFEntry();
+
+     /**
+      * Simplified constructor that calls the complete constructor for
+      * cases where <code>solution_filename == mesh_filename</code>, and
+      * <code>dim==spacedim</code>.
+      * @param filename The file name.
+      * @param time The time associated with the evaluation.
+      * @param nodes The nodes used by this operation.
+      * @param cells The cells used by this operation.
+      * @param dim_ The dim .
+      * @param cell_type The cell type.
+      */
+     template <int dim>
+     XDMFEntry(const std::string        &filename,
+               const double              time,
+               const std::uint64_t       nodes,
+               const std::uint64_t       cells,
+               const unsigned int        dim_,
+               const ReferenceCell<dim> &cell_type);
+
+     /**
+      * Simplified constructor that calls the complete constructor for
+      * cases where <code>dim==spacedim</code>.
+      * @param mesh_filename The mesh filename.
+      * @param solution_filename The solution filename.
+      * @param time The time associated with the evaluation.
+      * @param nodes The nodes used by this operation.
+      * @param cells The cells used by this operation.
+      * @param dim_ The dim .
+      * @param cell_type The cell type.
+      */
+     template <int dim>
+     XDMFEntry(const std::string        &mesh_filename,
+               const std::string        &solution_filename,
+               const double              time,
+               const std::uint64_t       nodes,
+               const std::uint64_t       cells,
+               const unsigned int        dim_,
+               const ReferenceCell<dim> &cell_type);
+
+     /**
+      * Constructor that sets all members to provided parameters.
+      * @param mesh_filename The mesh filename.
+      * @param solution_filename The solution filename.
+      * @param time The time associated with the evaluation.
+      * @param nodes The nodes used by this operation.
+      * @param cells The cells used by this operation.
+      * @param dim_ The dim .
+      * @param spacedim The spacedim used by this operation.
+      * @param cell_type The cell type.
+      */
+     template <int dim>
+     XDMFEntry(const std::string        &mesh_filename,
+               const std::string        &solution_filename,
+               const double              time,
+               const std::uint64_t       nodes,
+               const std::uint64_t       cells,
+               const unsigned int        dim_,
+               const unsigned int        spacedim,
+               const ReferenceCell<dim> &cell_type);
+
+     /**
+      * Record an attribute and associated dimensionality.
+      * @param attr_name The attr name.
+      * @param dimension The dimension used by this operation.
+      */
+     void
+     add_attribute(const std::string &attr_name, const unsigned int dimension);
+
+     /**
+      * Read or write the data of this object for serialization using the
+      * [BOOST serialization
+      * library](https://www.boost.org/doc/libs/1_74_0/libs/serialization/doc/index.html).
+      */
+     template <class Archive>
+     void
+     serialize(Archive &ar, const unsigned int /*version*/)
+     {
+       ar &valid &h5_sol_filename &h5_mesh_filename &entry_time &num_nodes
+         &num_cells &dimension &space_dimension &cell_type_name
+           &n_vertices_per_cell &attribute_dims;
+     }
+
+     /**
+      * Get the XDMF content associated with this entry.
+      * If the entry is not valid, this returns an empty string.
+      * @param indent_level The indent level.
+      */
+     std::string
+     get_xdmf_content(const unsigned int indent_level) const;
+
+   private:
+     /**
+      * Whether this entry is valid and contains data to be written.
+      */
+     bool valid;
+
+     /**
+      * The name of the HDF5 heavy data solution file this entry references.
+      */
+     std::string h5_sol_filename;
+
+     /**
+      * The name of the HDF5 mesh file this entry references.
+      */
+     std::string h5_mesh_filename;
+
+     /**
+      * The simulation time associated with this entry.
+      */
+     double entry_time;
+
+     /**
+      * The number of data nodes.
+      */
+     std::uint64_t num_nodes;
+
+     /**
+      * The number of data cells.
+      */
+     std::uint64_t num_cells;
+
+     /**
+      * The dimension associated with the data.
+      */
+     unsigned int dimension;
+
+     /**
+      * The dimension of the space the data lives in.
+      * Note that dimension <= space_dimension.
+      */
+     unsigned int space_dimension;
+
+     /**
+      * The type of cell in XDMF language. We currently only support
+      * xdmf entries where all cells have the same type.
+      *
+      * XDMFEntry objects can reference meshes independent of their
+      * dimension -- the dimension and space dimension is stored as an
+      * explicit variable. But we do have to store the ReferenceCell
+      * type of the mesh so that we can output information about. In
+      * practice, we only need a symbol name for each type of reference
+      * cell, and its number of vertices, so store only that, instead of
+      * the ReferenceCell object.
+      */
+     std::string cell_type_name;
+
+     /**
+      * The only other property of the cell type we need is the number
+      * of vertices per cell. Store that explicitly as well.
+      */
+     unsigned int n_vertices_per_cell;
+
+     /**
+      * The attributes associated with this entry and their dimension.
+      */
+     std::map<std::string, unsigned int> attribute_dims;
+   };
+
+
+
+   /* -------------------- inline functions ------------------- */
+
+   namespace DataOutBase
+   {
+     inline bool
+     EpsFlags::RgbValues::is_grey() const
+     {
+       return (red == green) && (red == blue);
+     }
+
+
+     /* -------------------- template functions ------------------- */
+
+     /**
+      * Output operator for an object of type <tt>DataOutBase::Patch</tt>. This
+      * operator dumps the intermediate graphics format represented by the patch
+      * data structure. It may later be converted into regular formats for a
+      * number of graphics programs.
+      */
+     template <int dim, int spacedim>
+     std::ostream &
+     operator<<(std::ostream &out, const Patch<dim, spacedim> &patch);
+
+
+
+     /**
+      * Input operator for an object of type <tt>DataOutBase::Patch</tt>. This
+      * operator reads the intermediate graphics format represented by the patch
+      * data structure, using the format in which it was written using the
+      * operator<<.
+      * @param in The input data or stream from which values are read.
+      * @param patch The patch that describes one cells geometry and data values.
+      */
+     template <int dim, int spacedim>
+     std::istream &
+     operator>>(std::istream &in, Patch<dim, spacedim> &patch);
+   } // namespace DataOutBase
+
+
+   DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -81,12 +81,14 @@ public:
 
   /**
    * Read-Write access operator.
+   * @param i The index of the entry.
    */
   Tensor<order, dim, Number> &
   operator[](const unsigned int i);
 
   /**
    * Read-only access operator.
+   * @param i The index of the entry.
    */
   const Tensor<order, dim, Number> &
   operator[](const unsigned int i) const;
@@ -111,6 +113,7 @@ public:
 
   /**
    * Number conversion operator.
+   * @param df The df used by this operation.
    */
   template <typename OtherNumber>
   DerivativeForm &
@@ -491,6 +494,8 @@ operator<<(std::ostream                                       &out,
  * $[\Delta \mathbf x] [\nabla \mathbf F(\mathbf x)]^T$ in matrix notation.
  *
  * @relatesalso DerivativeForm
+ * @param grad_F The grad f.
+ * @param d_x The d x.
  */
 template <int spacedim, int dim, typename Number1, typename Number2>
 inline Tensor<1, spacedim, typename ProductType<Number1, Number2>::type>
@@ -563,6 +568,7 @@ apply_transformation(const DerivativeForm<1, dim, dim, Number1> &grad_F,
  * by @p grad_F.
  *
  * @relatesalso DerivativeForm
+ * @param grad_F The grad f.
  */
 template <int spacedim,
           int dim,
@@ -602,6 +608,8 @@ apply_transformation(
  * @f]
  *
  * @relatesalso DerivativeForm
+ * @param DF1 The df1 used by this operation.
+ * @param DF2 The df2 used by this operation.
  */
 template <int spacedim, int dim, typename Number1, typename Number2>
 inline Tensor<2, spacedim, typename ProductType<Number1, Number2>::type>
@@ -623,6 +631,7 @@ apply_transformation(const DerivativeForm<1, dim, spacedim, Number1> &DF1,
  * reasons.
  *
  * @relatesalso DerivativeForm
+ * @param DF The df used by this operation.
  */
 template <int dim, int spacedim, typename Number>
 inline DerivativeForm<1, spacedim, dim, Number>
@@ -637,6 +646,8 @@ transpose(const DerivativeForm<1, dim, spacedim, Number> &DF)
  * Specialization of apply_transformation() for a diagonal DerivativeForm.
  *
  * @relatesalso DerivativeForm
+ * @param grad_F The grad f.
+ * @param d_x The d x.
  */
 template <int spacedim, int dim, typename Number1, typename Number2>
 inline Tensor<1, spacedim, typename ProductType<Number1, Number2>::type>
@@ -662,6 +673,7 @@ apply_diagonal_transformation(
  * notation.
  *
  * @relatesalso DerivativeForm
+ * @param grad_F The grad f.
  */
 template <int dim, typename Number1, typename Number2>
 inline Tensor<2, dim, typename ProductType<Number1, Number2>::type>
@@ -684,6 +696,7 @@ apply_diagonal_transformation(
  * by @p grad_F.
  *
  * @relatesalso DerivativeForm
+ * @param grad_F The grad f.
  */
 template <int spacedim,
           int dim,

--- a/include/deal.II/base/discrete_time.h
+++ b/include/deal.II/base/discrete_time.h
@@ -347,6 +347,7 @@ public:
    * approximates the end time (but falls just slightly short of it), the step
    * size is adjusted such that the next simulation time exactly matches the
    * end time.
+   * @param time_step_size The time step size.
    */
   void
   set_desired_next_step_size(const double time_step_size);
@@ -356,6 +357,7 @@ public:
    * method, we are indicating the next time advance_time() is called,
    * @p time_step_size is to be used to advance the simulation time.
    *
+   * @param time_step_size The time step size.
    * @note The difference between set_next_step_size() and
    * set_desired_next_step_size() is that the former uses the provided $dt$
    * exactly without any adjustment, but produces an

--- a/include/deal.II/base/enable_observer_pointer.h
+++ b/include/deal.II/base/enable_observer_pointer.h
@@ -128,6 +128,7 @@ public:
 
   /**
    * List the subscribers to the input @p stream.
+   * @param stream The stream used by this operation.
    */
   template <typename StreamType>
   void
@@ -259,6 +260,8 @@ private:
   /**
    * Subscribes a user of the object by storing the pointer @p validity. The
    * subscriber may be identified by text supplied as @p identifier.
+   * @param validity The validity used by this operation.
+   * @param identifier The identifier used by this operation.
    */
   void
   subscribe(std::atomic<bool> *const validity,
@@ -267,6 +270,8 @@ private:
   /**
    * Unsubscribes a user from the object.
    *
+   * @param validity The validity used by this operation.
+   * @param identifier The identifier used by this operation.
    * @note The @p identifier and the @p validity pointer must be the same as
    * the one supplied to subscribe().
    */
@@ -293,74 +298,74 @@ private:
   template <typename, typename>
   friend class ObserverPointer;
 
-  /** @} */
-};
+  /**
+   *  @}
+   */
+
+  /**
+   *  A type alias for the EnableObserverPointer class that makes sure
+   *  the previous name of the class, Subscriptor, continues to be available.
+   *
+   *  @deprecated Use the new name of the class, ObserverPointer, instead.
+   */
+  using Subscriptor DEAL_II_DEPRECATED_WITH_COMMENT(
+    "Use the new name of the class, EnableObserverPointer.") =
+    EnableObserverPointer;
 
 
-/**
- * A type alias for the EnableObserverPointer class that makes sure
- * the previous name of the class, Subscriptor, continues to be available.
- *
- * @deprecated Use the new name of the class, ObserverPointer, instead.
- */
-using Subscriptor DEAL_II_DEPRECATED_WITH_COMMENT(
-  "Use the new name of the class, EnableObserverPointer.") =
-  EnableObserverPointer;
+  //---------------------------------------------------------------------------
 
-
-//---------------------------------------------------------------------------
-
-inline EnableObserverPointer::EnableObserverPointer()
-  : counter(0)
-  , object_info(nullptr)
-{}
-
-
-
-inline EnableObserverPointer::EnableObserverPointer(
-  const EnableObserverPointer &)
-  : counter(0)
-  , object_info(nullptr)
-{}
+  inline EnableObserverPointer::EnableObserverPointer()
+    : counter(0)
+    , object_info(nullptr)
+  {}
 
 
 
-inline EnableObserverPointer &
-EnableObserverPointer::operator=(const EnableObserverPointer &s)
-{
-  object_info = s.object_info;
-  return *this;
-}
+  inline EnableObserverPointer::EnableObserverPointer(
+    const EnableObserverPointer &)
+    : counter(0)
+    , object_info(nullptr)
+  {}
 
 
 
-inline unsigned int
-EnableObserverPointer::n_subscriptions() const
-{
-  return counter;
-}
+  inline EnableObserverPointer &
+  EnableObserverPointer::operator=(const EnableObserverPointer &s)
+  {
+    object_info = s.object_info;
+    return *this;
+  }
 
 
 
-template <class Archive>
-inline void
-EnableObserverPointer::serialize(Archive &, const unsigned int)
-{
-  // do nothing, as explained in the
-  // documentation of this function
-}
+  inline unsigned int
+  EnableObserverPointer::n_subscriptions() const
+  {
+    return counter;
+  }
 
-template <typename StreamType>
-inline void
-EnableObserverPointer::list_subscribers(StreamType &stream) const
-{
-  std::lock_guard<std::mutex> lock(mutex);
 
-  for (const auto &it : counter_map)
-    stream << it.second << '/' << counter << " subscriptions from \""
-           << it.first << '\"' << std::endl;
-}
 
-DEAL_II_NAMESPACE_CLOSE
+  template <class Archive>
+  inline void
+  EnableObserverPointer::serialize(Archive &, const unsigned int)
+  {
+    // do nothing, as explained in the
+    // documentation of this function
+  }
+
+  template <typename StreamType>
+  inline void
+  EnableObserverPointer::list_subscribers(StreamType &stream) const
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    for (const auto &it : counter_map)
+      stream << it.second << '/' << counter << " subscriptions from \""
+             << it.first << '\"' << std::endl;
+  }
+
+  DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/base/event.h
+++ b/include/deal.II/base/event.h
@@ -50,6 +50,8 @@ namespace Algorithms
      * This function registers a new event type and assigns a unique
      * identifier to it. The result of this function should be stored for
      * later use.
+     * @param name The name associated with the object being created or
+     * queried.
      */
     static Event
     assign(const std::string &name);
@@ -79,12 +81,14 @@ namespace Algorithms
 
     /**
      * Add the flags of the other event
+     * @param event The event used by this operation.
      */
     Event &
     operator+=(const Event &event);
 
     /**
      * Clear the flags of the other event
+     * @param event The event used by this operation.
      */
     Event &
     operator-=(const Event &event);
@@ -92,6 +96,7 @@ namespace Algorithms
     /**
      * Test whether all the flags set in the other Event are also set in this
      * one.
+     * @param event The event used by this operation.
      */
     bool
     test(const Event &event) const;

--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -365,9 +365,12 @@
  *
  * @ingroup Exceptions
  */
-#  define DeclException1(Exception1, type1, outsequence) \
-    /** @ingroup Exceptions */                           \
-    /** @dealiiExceptionMessage{outsequence} */          \
+#  define DeclException1(Exception1, type1, outsequence)                      \
+    /**                                                                       \
+     * @ingroup Exceptions                                                    \
+     * @param arg1 The run-time value substituted into the exception message. \
+     * @dealiiExceptionMessage{outsequence}                                   \
+     */                                                                       \
     static dealii::ExceptionBase &Exception1(type1 arg1)
 
 
@@ -388,9 +391,15 @@
  *
  * @ingroup Exceptions
  */
-#  define DeclException2(Exception2, type1, type2, outsequence) \
-    /** @ingroup Exceptions */                                  \
-    /** @dealiiExceptionMessage{outsequence} */                 \
+#  define DeclException2(Exception2, type1, type2, outsequence)             \
+    /**                                                                     \
+     * @ingroup Exceptions                                                  \
+     * @param arg1 The first run-time value substituted into the exception  \
+     * message.                                                             \
+     * @param arg2 The second run-time value substituted into the exception \
+     * message.                                                             \
+     * @dealiiExceptionMessage{outsequence}                                 \
+     */                                                                     \
     static dealii::ExceptionBase &Exception2(type1 arg1, type2 arg2)
 
 
@@ -411,9 +420,17 @@
  *
  * @ingroup Exceptions
  */
-#  define DeclException3(Exception3, type1, type2, type3, outsequence) \
-    /** @ingroup Exceptions */                                         \
-    /** @dealiiExceptionMessage{outsequence} */                        \
+#  define DeclException3(Exception3, type1, type2, type3, outsequence)      \
+    /**                                                                     \
+     * @ingroup Exceptions                                                  \
+     * @param arg1 The first run-time value substituted into the exception  \
+     * message.                                                             \
+     * @param arg2 The second run-time value substituted into the exception \
+     * message.                                                             \
+     * @param arg3 The third run-time value substituted into the exception  \
+     * message.                                                             \
+     * @dealiiExceptionMessage{outsequence}                                 \
+     */                                                                     \
     static dealii::ExceptionBase &Exception3(type1 arg1, type2 arg2, type3 arg3)
 
 
@@ -435,8 +452,18 @@
  * @ingroup Exceptions
  */
 #  define DeclException4(Exception4, type1, type2, type3, type4, outsequence) \
-    /** @ingroup Exceptions */                                                \
-    /** @dealiiExceptionMessage{outsequence} */                               \
+    /**                                                                       \
+     * @ingroup Exceptions                                                    \
+     * @param arg1 The first run-time value substituted into the exception    \
+     * message.                                                               \
+     * @param arg2 The second run-time value substituted into the exception   \
+     * message.                                                               \
+     * @param arg3 The third run-time value substituted into the exception    \
+     * message.                                                               \
+     * @param arg4 The fourth run-time value substituted into the exception   \
+     * message.                                                               \
+     * @dealiiExceptionMessage{outsequence}                                   \
+     */                                                                       \
     static dealii::ExceptionBase &Exception4(type1 arg1,                      \
                                              type2 arg2,                      \
                                              type3 arg3,                      \
@@ -460,11 +487,23 @@
  *
  * @ingroup Exceptions
  */
-#  define DeclException5(                                       \
-    Exception5, type1, type2, type3, type4, type5, outsequence) \
-    /** @ingroup Exceptions */                                  \
-    /** @dealiiExceptionMessage{outsequence} */                 \
-    static dealii::ExceptionBase &Exception5(                   \
+#  define DeclException5(                                                   \
+    Exception5, type1, type2, type3, type4, type5, outsequence)             \
+    /**                                                                     \
+     * @ingroup Exceptions                                                  \
+     * @param arg1 The first run-time value substituted into the exception  \
+     * message.                                                             \
+     * @param arg2 The second run-time value substituted into the exception \
+     * message.                                                             \
+     * @param arg3 The third run-time value substituted into the exception  \
+     * message.                                                             \
+     * @param arg4 The fourth run-time value substituted into the exception \
+     * message.                                                             \
+     * @param arg5 The fifth run-time value substituted into the exception  \
+     * message.                                                             \
+     * @dealiiExceptionMessage{outsequence}                                 \
+     */                                                                     \
+    static dealii::ExceptionBase &Exception5(                               \
       type1 arg1, type2 arg2, type3 arg3, type4 arg4, type5 arg5)
 
 #endif /*ifndef DOXYGEN*/

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -62,6 +62,7 @@ public:
 
   /**
    * Copy constructor.
+   * @param exc The exception object that is stored, rethrown, or reported.
    */
   ExceptionBase(const ExceptionBase &exc);
 
@@ -81,6 +82,11 @@ public:
    * Set the file name and line of where the exception appeared as well as the
    * violated condition and the name of the exception as a char pointer. This
    * function also populates the stacktrace.
+   * @param file The file name or path associated with the operation.
+   * @param line The source line number at which the error was detected.
+   * @param function The function object.
+   * @param cond The textual representation of the condition that failed.
+   * @param exc_name The exc name.
    */
   void
   set_fields(const char *file,
@@ -104,6 +110,7 @@ public:
 
   /**
    * Print out the general part of the error information.
+   * @param out The output stream to which data is written.
    */
   void
   print_exc_data(std::ostream &out) const;
@@ -111,6 +118,7 @@ public:
   /**
    * Print more specific information about the exception which occurred.
    * Overload this function in your own exception classes.
+   * @param out The output stream to which data is written.
    */
   virtual void
   print_info(std::ostream &out) const;
@@ -118,6 +126,7 @@ public:
   /**
    * Print a stacktrace, if one has been recorded previously, to the given
    * stream.
+   * @param out The output stream to which data is written.
    */
   void
   print_stack_trace(std::ostream &out) const;
@@ -196,6 +205,7 @@ namespace StandardExceptions
 
   /**
    * Exception denoting a division by zero.
+   * @param ExcDivideByZero The exc divide by zero used by this operation.
    */
   DeclExceptionMsg(ExcDivideByZero,
                    "A piece of code is attempting a division by zero. This is "
@@ -268,6 +278,7 @@ namespace StandardExceptions
 
   /**
    * An error occurred reading or writing a file.
+   * @param ExcIO The exc io used by this operation.
    */
   DeclExceptionMsg(ExcIO,
                    "An input/output error has occurred. There are a number of "
@@ -321,6 +332,7 @@ namespace StandardExceptions
    * implement. It is therefore quite worth the effort to take a look at the
    * corresponding place and see whether it can be implemented without too
    * much effort.
+   * @param ExcNotImplemented The exc not implemented used by this operation.
    */
   DeclExceptionMsg(ExcNotImplemented,
                    "You are trying to use functionality in deal.II that is "
@@ -353,6 +365,7 @@ namespace StandardExceptions
    * sometimes happens that an algorithm does not work in very rare corner
    * cases. These cases will then be trapped sooner or later by the exception,
    * so that the algorithm can then be fixed for these cases as well.
+   * @param ExcInternalError The exc internal error used by this operation.
    */
   DeclExceptionMsg(ExcInternalError,
                    "This exception -- which is used in many places in the "
@@ -439,11 +452,13 @@ namespace StandardExceptions
 
   /**
    * This exception is used if some object is found uninitialized.
+   * @param ExcNotInitialized The exc not initialized used by this operation.
    */
   DeclException0(ExcNotInitialized);
 
   /**
    * The object is in a state not suitable for this operation.
+   * @param ExcInvalidState The exc invalid state used by this operation.
    */
   DeclException0(ExcInvalidState);
 
@@ -476,6 +491,7 @@ namespace StandardExceptions
 
   /**
    * A number is zero, but it should not be here.
+   * @param ExcZero The exc zero used by this operation.
    */
   DeclExceptionMsg(ExcZero,
                    "In a check in the code, deal.II encountered a zero in "
@@ -487,6 +503,7 @@ namespace StandardExceptions
   /**
    * The object should have been filled with something before this member
    * function is called.
+   * @param ExcEmptyObject The exc empty object used by this operation.
    */
   DeclExceptionMsg(ExcEmptyObject,
                    "The object you are trying to access is empty but it makes "
@@ -625,6 +642,8 @@ namespace StandardExceptions
    *
    * Typically, this will be an internal error of deal.II, because the
    * increment and decrement operators should never yield an invalid iterator.
+   * @param ExcInvalidIterator The iterator associated with the range
+   * processed by this operation.
    */
   DeclExceptionMsg(ExcInvalidIterator,
                    "You are trying to use an iterator, but the iterator is "
@@ -635,6 +654,8 @@ namespace StandardExceptions
   /**
    * This exception is thrown if the iterator you incremented or decremented
    * was already at its final state.
+   * @param ExcIteratorPastEnd The iterator associated with the range
+   * processed by this operation.
    */
   DeclExceptionMsg(ExcIteratorPastEnd,
                    "You are trying to use an iterator, but the iterator is "
@@ -659,6 +680,7 @@ namespace StandardExceptions
 
   /**
    * Parallel vectors with ghost elements are read-only vectors.
+   * @param ExcGhostsPresent The exc ghosts present used by this operation.
    */
   DeclExceptionMsg(ExcGhostsPresent,
                    "You are trying an operation on a vector that is only "
@@ -696,6 +718,8 @@ namespace StandardExceptions
    * presumably because the user has not yet called
    * Triangulation::prepare_coarsening_and_refinement() after flagging
    * some cells for refinement and/or coarsening.
+   * @param ExcInconsistentCoarseningFlags The exc inconsistent coarsening
+   * flags used by this operation.
    */
   DeclExceptionMsg(
     ExcInconsistentCoarseningFlags,
@@ -710,6 +734,8 @@ namespace StandardExceptions
    *
    * In many cases, this assignment operator makes sense <b>only</b> for the
    * argument zero. In other cases, this exception is thrown.
+   * @param ExcScalarAssignmentOnlyForZeroValue The exc scalar assignment only
+   * for zero value used by this operation.
    */
   DeclExceptionMsg(ExcScalarAssignmentOnlyForZeroValue,
                    "You are trying an operation of the form 'vector = C', "
@@ -725,6 +751,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the LAPACK library.
+   * @param ExcNeedsLAPACK The exc needs lapack used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsLAPACK,
@@ -740,6 +767,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the HDF5 library.
+   * @param ExcNeedsHDF5 The exc needs hdf5 used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsHDF5,
@@ -755,6 +783,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the MPI library.
+   * @param ExcNeedsMPI The exc needs mpi used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsMPI,
@@ -769,6 +798,8 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the FunctionParser library.
+   * @param ExcNeedsFunctionparser The exc needs functionparser used by this
+   * operation.
    */
   DeclExceptionMsg(
     ExcNeedsFunctionparser,
@@ -787,6 +818,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the Assimp library.
+   * @param ExcNeedsAssimp The exc needs assimp used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsAssimp,
@@ -802,6 +834,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the Exodus II library.
+   * @param ExcNeedsExodusII The exc needs exodus ii used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsExodusII,
@@ -817,6 +850,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the CGAL library.
+   * @param ExcNeedsCGAL The exc needs cgal used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsCGAL,
@@ -832,6 +866,7 @@ namespace StandardExceptions
 
   /**
    * This function requires support for the GMSH API.
+   * @param ExcNeedsGMSHAPI The exc needs gmshapi used by this operation.
    */
   DeclExceptionMsg(
     ExcNeedsGMSHAPI,
@@ -902,6 +937,7 @@ namespace StandardExceptions
 
     /**
      * Print a description of the error to the given stream.
+     * @param out The output stream to which data is written.
      */
     virtual void
     print_info(std::ostream &out) const override;
@@ -916,6 +952,8 @@ namespace StandardExceptions
   /**
    * An exception to be thrown in user call-backs. See the glossary entry
    * on user call-back functions for more information.
+   * @param RecoverableUserCallbackError The recoverable user callback error
+   * used by this operation.
    */
   DeclExceptionMsg(
     RecoverableUserCallbackError,
@@ -928,7 +966,7 @@ namespace StandardExceptions
 
   /** @} */
 
-} /*namespace StandardExceptions*/
+} /* namespace StandardExceptions */
 
 
 
@@ -943,11 +981,11 @@ namespace deal_II_exceptions
   namespace internals
   {
     /**
-     * Setting this variable to false will disable deal.II's exception mechanism
-     * to abort the problem. The Assert() macro will throw the exception instead
-     * and the AssertNothrow() macro will just print the error message. This
-     * variable should not be changed directly. Use disable_abort_on_exception()
-     * instead.
+     * Setting this variable to false will disable deal.II's exception
+     * mechanism to abort the problem. The Assert() macro will throw the
+     * exception instead and the AssertNothrow() macro will just print the
+     * error message. This variable should not be changed directly. Use
+     * disable_abort_on_exception() instead.
      */
     extern bool allow_abort_on_exception;
   } // namespace internals
@@ -968,6 +1006,7 @@ namespace deal_II_exceptions
    * Previously set additional output is replaced by the argument given to
    * this function.
    *
+   * @param p The point at which to evaluate the function.
    * @see Exceptions
    */
   void
@@ -1026,6 +1065,7 @@ namespace deal_II_exceptions
     /**
      * Abort the program by printing the
      * error message provided by @p exc and calling <tt>std::abort()</tt>.
+     * @param exc The exception object that is stored, rethrown, or reported.
      */
     [[noreturn]] void
     abort(const ExceptionBase &exc) noexcept;
@@ -1063,6 +1103,13 @@ namespace deal_II_exceptions
      * -- the performance implications are pretty minimal anyway.
      *
      * @ref ExceptionBase
+     * @param handling The handling used by this operation.
+     * @param file The file name or path associated with the operation.
+     * @param line The source line number at which the error was detected.
+     * @param function The function object.
+     * @param cond The textual representation of the condition that failed.
+     * @param exc_name The exc name.
+     * @param e The exception object that is stored, rethrown, or reported.
      */
     template <typename ExceptionType>
     [[noreturn]] void
@@ -1105,6 +1152,10 @@ namespace deal_II_exceptions
     /**
      * Internal function that performs the error handling when
      * DEAL_II_ASSERT_UNREACHABLE is triggered.
+     * @param file The file name or path associated with the operation.
+     * @param line The source line number at which the error was detected.
+     * @param function The function object.
+     * @param msg The message text that describes the error.
      */
     [[noreturn]] DEAL_II_HOST_DEVICE inline void
     do_unreachable(const char *file,
@@ -1140,8 +1191,8 @@ namespace deal_II_exceptions
                            ::dealii::StandardExceptions::ExcMessage(msg));
 #endif
       // This workaround is necessary, otherwise nvcc will complain that we
-      // might return from this function, even though we will never get here (we
-      // will throw or abort above).
+      // might return from this function, even though we will never get here
+      // (we will throw or abort above).
       while (true)
         {
         }
@@ -1152,6 +1203,9 @@ namespace deal_II_exceptions
     /**
      * Internal function that performs the error handling when
      * DEAL_II_NOT_IMPLEMENTED is triggered.
+     * @param file The file name or path associated with the operation.
+     * @param line The source line number at which the error was detected.
+     * @param function The function object.
      */
     [[noreturn]] DEAL_II_HOST_DEVICE inline void
     do_not_implemented(const char *file, int line, const char *function)
@@ -1185,8 +1239,8 @@ namespace deal_II_exceptions
                            ::dealii::StandardExceptions::ExcNotImplemented());
 #endif
       // This workaround is necessary, otherwise nvcc will complain that we
-      // might return from this function, even though we will never get here (we
-      // will throw or abort above).
+      // might return from this function, even though we will never get here
+      // (we will throw or abort above).
       while (true)
         {
         }
@@ -1196,6 +1250,7 @@ namespace deal_II_exceptions
 
     /**
      * Internal function that does the work of issue_error_nothrow.
+     * @param e The exception object that is stored, rethrown, or reported.
      */
     void
     do_issue_error_nothrow(const ExceptionBase &e) noexcept;
@@ -1205,6 +1260,12 @@ namespace deal_II_exceptions
      *
      * @ref ExceptionBase
      *
+     * @param file The file name or path associated with the operation.
+     * @param line The source line number at which the error was detected.
+     * @param function The function object.
+     * @param cond The textual representation of the condition that failed.
+     * @param exc_name The exc name.
+     * @param e The exception object that is stored, rethrown, or reported.
      * @note This function is defined with a template for the same reasons as
      * issue_error_noreturn().
      */
@@ -1248,6 +1309,8 @@ namespace deal_II_exceptions
      * a device that has a separate memory space. The copy this implies
      * is generally not problematic because we apply this function to
      * scalar values with integer types.
+     * @param t The time associated with the evaluation.
+     * @param u The value on which this function operates.
      */
     template <typename T, typename U>
     inline DEAL_II_HOST_DEVICE constexpr bool
@@ -1259,8 +1322,8 @@ namespace deal_II_exceptions
 
 
     /**
-     * A function that compares two values with `operator<`, after converting to
-     * a common type to avoid compiler warnings when comparing objects of
+     * A function that compares two values with `operator<`, after converting
+     * to a common type to avoid compiler warnings when comparing objects of
      * different types (e.g., unsigned and signed variables).
      *
      * This function takes its arguments by value, rather than reference,
@@ -1271,6 +1334,8 @@ namespace deal_II_exceptions
      * a device that has a separate memory space. The copy this implies
      * is generally not problematic because we apply this function to
      * scalar values with integer types.
+     * @param t The time associated with the evaluation.
+     * @param u The value on which this function operates.
      */
     template <typename T, typename U>
     inline DEAL_II_HOST_DEVICE constexpr bool

--- a/include/deal.II/base/floating_point_comparator.h
+++ b/include/deal.II/base/floating_point_comparator.h
@@ -60,6 +60,9 @@ struct FloatingPointComparator
 
   /**
    * Constructor.
+   * @param tolerance The tolerance used by this operation.
+   * @param use_absolute_tolerance The use absolute tolerance.
+   * @param mask The mask used by this operation.
    */
   FloatingPointComparator(
     const ScalarNumber        tolerance,
@@ -75,6 +78,8 @@ struct FloatingPointComparator
    * object is less than the second one. This function calls the compare()
    * functions below, so only types supported by compare() will work with this
    * function.
+   * @param object1 The left-hand object in the comparison.
+   * @param object2 The right-hand object in the comparison.
    */
   template <typename T>
   bool
@@ -84,6 +89,8 @@ struct FloatingPointComparator
    * Compare two vectors of numbers (not necessarily of the same length),
    * where vectors of different lengths are first sorted by their length and
    * then by the entries.
+   * @param v1 The v1 used by this operation.
+   * @param v2 The v2 used by this operation.
    */
   template <typename T>
   ComparisonResult
@@ -91,6 +98,8 @@ struct FloatingPointComparator
 
   /**
    * Compare two arrays.
+   * @param t1 The first object to compare.
+   * @param t2 The second object to compare.
    */
   template <std::size_t dim, typename T>
   ComparisonResult
@@ -98,6 +107,8 @@ struct FloatingPointComparator
 
   /**
    * Compare two tensors.
+   * @param t1 The first object to compare.
+   * @param t2 The second object to compare.
    */
   template <int rank, int dim, typename T>
   ComparisonResult
@@ -105,6 +116,8 @@ struct FloatingPointComparator
 
   /**
    * Compare two derivative forms.
+   * @param t1 The first object to compare.
+   * @param t2 The second object to compare.
    */
   template <int rank, int dim, int spacedim, typename T>
   ComparisonResult
@@ -113,6 +126,8 @@ struct FloatingPointComparator
 
   /**
    * Compare two tables.
+   * @param t1 The first object to compare.
+   * @param t2 The second object to compare.
    */
   template <typename T>
   ComparisonResult
@@ -120,12 +135,16 @@ struct FloatingPointComparator
 
   /**
    * Compare two scalar numbers.
+   * @param s1 The s1 used by this operation.
+   * @param s2 The s2 used by this operation.
    */
   ComparisonResult
   compare(const ScalarNumber s1, const ScalarNumber s2) const;
 
   /**
    * Compare two VectorizedArray instances.
+   * @param v1 The v1 used by this operation.
+   * @param v2 The v2 used by this operation.
    */
   ComparisonResult
   compare(const VectorizedArray<ScalarNumber, width> &v1,

--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -63,6 +63,7 @@ namespace Functions
     /**
      * Store an adjustment for the pressure function, such that its mean value
      * is <tt>p</tt>.
+     * @param p The point at which to evaluate the function.
      */
     void
     pressure_adjustment(double p);
@@ -71,6 +72,8 @@ namespace Functions
      * Values in a structure more suitable for vector valued functions. The
      * outer vector is indexed by solution component, the inner by quadrature
      * point.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_values(const std::vector<Point<dim>>    &points,
@@ -79,6 +82,8 @@ namespace Functions
      * Gradients in a structure more suitable for vector valued functions. The
      * outer vector is indexed by solution component, the inner by quadrature
      * point.
+     * @param points The points at which to evaluate the function.
+     * @param gradients The object in which to store the computed gradients.
      */
     virtual void
     vector_gradients(
@@ -89,6 +94,8 @@ namespace Functions
      * The outer vector is indexed by solution component, the inner by
      * quadrature point.
      *
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      * @warning This is not the true Laplacian, but the force term to be used
      * as right hand side in Stokes' equations
      */
@@ -111,6 +118,8 @@ namespace Functions
       std::vector<std::vector<Tensor<1, dim>>> &gradients) const override;
     /**
      * The force term in the momentum equation.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_laplacian_list(const std::vector<Point<dim>> &points,
@@ -159,6 +168,8 @@ namespace Functions
     /**
      * Construct an object for the given channel radius <tt>r</tt> and the
      * Reynolds number <tt>Re</tt>.
+     * @param r The value on which this function operates.
+     * @param Re The re used by this operation.
      */
     PoisseuilleFlow(const double r, const double Re);
 
@@ -200,10 +211,14 @@ namespace Functions
     /**
      * Constructor setting the Reynolds number required for pressure
      * computation and scaling of the right hand side.
+     * @param viscosity The viscosity used by this operation.
+     * @param reaction The reaction used by this operation.
      */
     StokesCosine(const double viscosity = 1., const double reaction = 0.);
     /**
      * Change the viscosity and the reaction parameter.
+     * @param viscosity The viscosity used by this operation.
+     * @param reaction The reaction used by this operation.
      */
     void
     set_parameters(const double viscosity, const double reaction);
@@ -307,6 +322,8 @@ namespace Functions
      * equation returned by vector_laplacians() contains the nonlinearity,
      * such that the Kovasznay solution can be obtained as the solution to a
      * Stokes problem.
+     * @param Re The re used by this operation.
+     * @param Stokes Whether to stokes.
      */
     Kovasznay(const double Re, bool Stokes = false);
 

--- a/include/deal.II/base/function.h
+++ b/include/deal.II/base/function.h
@@ -171,12 +171,15 @@ public:
    * Constructor. May take an initial value for the number of components
    * (which defaults to one, i.e. a scalar function), and the time variable,
    * which defaults to zero.
+   * @param n_components The number of components.
+   * @param initial_time The initial time.
    */
   explicit Function(const unsigned int n_components = 1,
                     const time_type    initial_time = 0.0);
 
   /**
    * Copy constructor.
+   * @param f The function object.
    */
   Function(const Function &f) = default;
 
@@ -208,6 +211,7 @@ public:
    * derived classes in containers, or assign them otherwise. It will raise an
    * exception if the object from which you assign has a different number of
    * components than the one being assigned to.
+   * @param f The function object.
    */
   Function &
   operator=(const Function &f);
@@ -217,6 +221,8 @@ public:
    * one component (i.e. the function is scalar), you should state the
    * component you want to have evaluated; it defaults to zero, i.e. the first
    * component.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   value(const Point<dim> &p, const unsigned int component = 0) const;
@@ -227,6 +233,8 @@ public:
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
    *
    * The default implementation will call value() for each component.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_value(const Point<dim> &p, Vector<RangeNumberType> &values) const;
@@ -239,6 +247,9 @@ public:
    *
    * By default, this function repeatedly calls value() for each point
    * separately, to fill the output array.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param component The component to evaluate.
    */
   virtual void
   value_list(const std::vector<Point<dim>> &points,
@@ -254,6 +265,8 @@ public:
    *
    * By default, this function repeatedly calls vector_value() for each point
    * separately, to fill the output array.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_value_list(const std::vector<Point<dim>>        &points,
@@ -266,6 +279,8 @@ public:
    * The default implementation of this function in Function calls
    * value_list() for each component. In order to improve performance, this
    * can be reimplemented in derived classes to speed up performance.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_values(const std::vector<Point<dim>>             &points,
@@ -274,12 +289,16 @@ public:
   /**
    * Return the gradient of the specified component of the function at the
    * given point.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual Tensor<1, dim, RangeNumberType>
   gradient(const Point<dim> &p, const unsigned int component = 0) const;
 
   /**
    * Return the gradient of all components of the function at the given point.
+   * @param p The point at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradient(
@@ -291,6 +310,9 @@ public:
    * function at the <tt>points</tt>.  It is assumed that <tt>gradients</tt>
    * already has the right size, i.e.  the same size as the <tt>points</tt>
    * array.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
+   * @param component The component to evaluate.
    */
   virtual void
   gradient_list(const std::vector<Point<dim>>                &points,
@@ -304,6 +326,8 @@ public:
    * The default implementation of this function in Function calls
    * value_list() for each component. In order to improve performance, this
    * can be reimplemented in derived classes to speed up performance.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradients(
@@ -318,6 +342,8 @@ public:
    *
    * The outer loop over <tt>gradients</tt> is over the points in the list,
    * the inner loop over the different components of the function.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradient_list(
@@ -326,6 +352,8 @@ public:
 
   /**
    * Compute the Laplacian of a given component at point <tt>p</tt>.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   laplacian(const Point<dim> &p, const unsigned int component = 0) const;
@@ -333,12 +361,17 @@ public:
   /**
    * Compute the Laplacian of all components at point <tt>p</tt> and store
    * them in <tt>values</tt>.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_laplacian(const Point<dim> &p, Vector<RangeNumberType> &values) const;
 
   /**
    * Compute the Laplacian of one component at a set of points.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param component The component to evaluate.
    */
   virtual void
   laplacian_list(const std::vector<Point<dim>> &points,
@@ -347,6 +380,8 @@ public:
 
   /**
    * Compute the Laplacians of all components at a set of points.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_laplacian_list(const std::vector<Point<dim>>        &points,
@@ -355,6 +390,8 @@ public:
   /**
    * Compute the Hessian of a given component at point <tt>p</tt>, that is the
    * gradient of the gradient of the function.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual SymmetricTensor<2, dim, RangeNumberType>
   hessian(const Point<dim> &p, const unsigned int component = 0) const;
@@ -362,6 +399,8 @@ public:
   /**
    * Compute the Hessian of all components at point <tt>p</tt> and store them
    * in <tt>values</tt>.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_hessian(
@@ -370,6 +409,9 @@ public:
 
   /**
    * Compute the Hessian of one component at a set of points.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param component The component to evaluate.
    */
   virtual void
   hessian_list(const std::vector<Point<dim>>                         &points,
@@ -378,6 +420,8 @@ public:
 
   /**
    * Compute the Hessians of all components at a set of points.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_hessian_list(
@@ -411,6 +455,8 @@ namespace Functions
     /**
      * Constructor; set values of all components to the provided one. The
      * default number of components is one.
+     * @param value The constant value.
+     * @param n_components The number of components.
      */
     explicit ConstantFunction(const RangeNumberType value,
                               const unsigned int    n_components = 1);
@@ -419,6 +465,7 @@ namespace Functions
      * Constructor; takes an <tt>std::vector<RangeNumberType></tt> object as an
      * argument. The number of components is determined by
      * <tt>values.size()</tt>.
+     * @param values The values associated with the function.
      */
     explicit ConstantFunction(const std::vector<RangeNumberType> &values);
 
@@ -426,12 +473,15 @@ namespace Functions
      * Constructor; takes an <tt>Vector<RangeNumberType></tt> object as an
      * argument. The number of components is determined by
      * <tt>values.size()</tt>.
+     * @param values The values associated with the function.
      */
     explicit ConstantFunction(const Vector<RangeNumberType> &values);
 
     /**
      * Constructor; uses whatever stores in [begin_ptr, begin_ptr+n_components)
      * to initialize a new object.
+     * @param begin_ptr A pointer to the first stored value.
+     * @param n_components The number of components.
      */
     ConstantFunction(const RangeNumberType *begin_ptr,
                      const unsigned int     n_components);
@@ -510,6 +560,7 @@ namespace Functions
   public:
     /**
      * Constructor. The number of components is preset to one.
+     * @param n_components The number of components.
      */
     explicit ZeroFunction(const unsigned int n_components = 1);
   };
@@ -535,12 +586,16 @@ namespace Functions
 
     /**
      * @copydoc Function::value()
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual RangeNumberType
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * @copydoc Function::gradient()
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim, RangeNumberType>
     gradient(const Point<dim>  &p,
@@ -548,6 +603,8 @@ namespace Functions
 
     /**
      * @copydoc Function::laplacian()
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual RangeNumberType
     laplacian(const Point<dim>  &p,
@@ -555,6 +612,8 @@ namespace Functions
 
     /**
      * @copydoc Function::hessian()
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual SymmetricTensor<2, dim, RangeNumberType>
     hessian(const Point<dim>  &p,
@@ -584,6 +643,9 @@ public:
    * Constructor if only a single component shall be non-zero. Arguments
    * denote the component selected, the value for that component and the total
    * number of vector components.
+   * @param selected The selected component or component range.
+   * @param value The value associated with the function.
+   * @param n_components The number of components.
    */
   ComponentSelectFunction(const unsigned int    selected,
                           const RangeNumberType value,
@@ -592,6 +654,8 @@ public:
   /**
    * Constructor. As before, but the value for the selected component is
    * assumed to be one. In essence, this function then works as a mask.
+   * @param selected The selected component or component range.
+   * @param n_components The number of components.
    */
   ComponentSelectFunction(const unsigned int selected,
                           const unsigned int n_components);
@@ -602,6 +666,8 @@ public:
    * denotes a half-open interval of components (for example std::pair(0,dim)
    * for the first dim components), and the second argument is the total
    * number of vector components.
+   * @param selected The selected component or component range.
+   * @param n_components The number of components.
    */
   ComponentSelectFunction(const std::pair<unsigned int, unsigned int> &selected,
                           const unsigned int n_components);
@@ -616,6 +682,7 @@ public:
    * <tt>ComponentSelectFunction@<dim, RangeNumberType@></tt> class can only
    * have same value for all components.
    *
+   * @param f The function object.
    * @note We copy the underlying component value data from @p f from its
    * beginning. So the number of components of @p f cannot be less than the
    * calling object.
@@ -626,6 +693,8 @@ public:
 
   /**
    * Return the value of the function at the given point for all components.
+   * @param p The point at which to evaluate the function.
+   * @param return_value The object in which to store the computed values.
    */
   virtual void
   vector_value(const Point<dim>        &p,
@@ -636,6 +705,8 @@ public:
    * <tt>points</tt>, for all components. It is assumed that <tt>values</tt>
    * already has the right size, i.e. the same size as the <tt>points</tt>
    * array.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_value_list(
@@ -805,6 +876,7 @@ public:
    * Given a function object that takes a Point and returns a RangeNumberType
    * value, convert this into an object that matches the Function<dim,
    * RangeNumberType> interface.
+   * @param function_object The function object.
    */
   explicit ScalarFunctionFromFunctionObject(
     const std::function<RangeNumberType(const Point<dim> &)> &function_object);
@@ -813,6 +885,7 @@ public:
    * Given a function object that takes  a time and a Point and returns a
    * RangeNumberType value, convert this into an object that matches the
    * Function<dim, RangeNumberType> interface.
+   * @param function_object_t The function object t.
    */
   explicit ScalarFunctionFromFunctionObject(
     const std::function<RangeNumberType(const double, const Point<dim> &)>
@@ -821,6 +894,8 @@ public:
   /**
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -899,6 +974,8 @@ public:
   /**
    * Return the value of the function at the given point. Returns the value
    * the function given to the constructor produces for this point.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -907,6 +984,8 @@ public:
    * Return all components of a vector-valued function at a given point.
    *
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_value(const Point<dim>        &p,
@@ -973,6 +1052,8 @@ public:
    * usable function, you need to call at least the set_function_values()
    * method. If you need also the gradients of the solution, then you must
    * also call the set_function_gradients() method.
+   * @param n_components The number of components.
+   * @param initial_time The initial time.
    */
   explicit FunctionFromFunctionObjects(const unsigned int n_components = 1,
                                        const double       initial_time = 0);
@@ -984,6 +1065,8 @@ public:
    * of the vector @p values. A call to the FunctionFromFunctionObject::gradient()
    * method will trigger an exception, unless you first call the
    * set_function_gradients() method.
+   * @param values The values associated with the function.
+   * @param initial_time The initial time.
    */
   explicit FunctionFromFunctionObjects(
     const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
@@ -997,6 +1080,9 @@ public:
    * A call to the FunctionFromFunctionObject::gradient()
    * method will trigger an exception, unless you first call the
    * set_function_gradients() method.
+   * @param values The values associated with the function.
+   * @param n_components The number of components.
+   * @param initial_time The initial time.
    */
   explicit FunctionFromFunctionObjects(
     const std::function<RangeNumberType(const Point<dim> &, const unsigned int)>
@@ -1011,6 +1097,9 @@ public:
    * The resulting function will have a number of components equal to the size
    * of the vector @p values. If the size of @p values and @p gradients does not
    * match, an exception is triggered.
+   * @param values The values associated with the function.
+   * @param gradients The gradients associated with the function.
+   * @param initial_time The initial time.
    */
   FunctionFromFunctionObjects(
     const std::vector<std::function<RangeNumberType(const Point<dim> &)>>
@@ -1026,6 +1115,8 @@ public:
    * one component (i.e. the function is scalar), you should state the
    * component you want to have evaluated; it defaults to zero, i.e. the first
    * component.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -1035,6 +1126,8 @@ public:
    * only one component (i.e. the function is scalar), you should state the
    * component you want to have evaluated; it defaults to zero, i.e. the first
    * component.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual Tensor<1, dim, RangeNumberType>
   gradient(const Point<dim>  &p,
@@ -1044,6 +1137,7 @@ public:
    * Reset the function values of this object. An assertion is thrown if the
    * size of the @p values parameter does not match the number of components of
    * this object.
+   * @param values The values associated with the function.
    */
   void
   set_function_values(
@@ -1054,6 +1148,7 @@ public:
    * Reset the function gradients of this object. An assertion is thrown if the
    * size of the @p gradients parameter does not match the number of components of
    * this object.
+   * @param gradients The gradients associated with the function.
    */
   void
   set_function_gradients(
@@ -1145,6 +1240,8 @@ public:
 
   /**
    * Return a single component of a vector-valued function at a given point.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -1153,6 +1250,8 @@ public:
    * Return all components of a vector-valued function at a given point.
    *
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_value(const Point<dim>        &p,
@@ -1164,6 +1263,8 @@ public:
    * <tt>value_list</tt> shall be the same size as <tt>points</tt> and each
    * element of the vector will be passed to vector_value() to evaluate the
    * function
+   * @param points The points at which to evaluate the function.
+   * @param value_list The object in which to store the computed values.
    */
   virtual void
   vector_value_list(
@@ -1173,6 +1274,8 @@ public:
   /**
    * Return the gradient of the specified component of the function at the given
    * point.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual Tensor<1, dim, RangeNumberType>
   gradient(const Point<dim>  &p,
@@ -1180,6 +1283,8 @@ public:
 
   /**
    * Return the gradient of all components of the function at the given point.
+   * @param p The point at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradient(
@@ -1191,6 +1296,9 @@ public:
    * function at the <tt>points</tt>.  It is assumed that <tt>gradients</tt>
    * already has the right size, i.e.  the same size as the <tt>points</tt>
    * array.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
+   * @param component The component to evaluate.
    */
   virtual void
   gradient_list(const std::vector<Point<dim>>                &points,
@@ -1204,6 +1312,8 @@ public:
    * The default implementation of this function in Function calls
    * value_list() for each component. In order to improve performance, this
    * can be reimplemented in derived classes to speed up performance.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradients(const std::vector<Point<dim>> &points,
@@ -1218,6 +1328,8 @@ public:
    *
    * The outer loop over <tt>gradients</tt> is over the points in the list,
    * the inner loop over the different components of the function.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   vector_gradient_list(const std::vector<Point<dim>> &points,
@@ -1310,6 +1422,8 @@ public:
 
   /**
    * Return a single component of a vector-valued function at a given point.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual RangeNumberType
   value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -1318,6 +1432,8 @@ public:
    * Return all components of a vector-valued function at a given point.
    *
    * <tt>values</tt> shall have the right size beforehand, i.e. #n_components.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   vector_value(const Point<dim>        &p,
@@ -1329,6 +1445,8 @@ public:
    * <tt>value_list</tt> shall be the same size as <tt>points</tt> and each
    * element of the vector will be passed to vector_value() to evaluate the
    * function
+   * @param points The points at which to evaluate the function.
+   * @param value_list The object in which to store the computed values.
    */
   virtual void
   vector_value_list(

--- a/include/deal.II/base/function.templates.h
+++ b/include/deal.II/base/function.templates.h
@@ -775,6 +775,7 @@ VectorFunctionFromScalarFunctionObject<dim, RangeNumberType>::vector_value(
 /**
  * The constructor for <tt>VectorFunctionFromTensorFunction</tt> which
  * initiates the return vector to be size <tt>n_components</tt>.
+ * @param selected_component The selected component.
  */
 template <int dim, typename RangeNumberType>
 VectorFunctionFromTensorFunction<dim, RangeNumberType>::
@@ -848,6 +849,8 @@ VectorFunctionFromTensorFunction<dim, RangeNumberType>::vector_value(
  * using the <tt>vector_value</tt> member function.  Again, this function is
  * written so as to not replicate the function definition but passes each
  * point on to <tt>vector_value</tt> to be evaluated.
+ * @param points The points at which to evaluate the function.
+ * @param value_list The object in which to store the computed values.
  */
 template <int dim, typename RangeNumberType>
 void
@@ -1142,6 +1145,8 @@ VectorFunctionFromTensorFunctionObject<dim, RangeNumberType>::vector_value(
  * using the <tt>vector_value</tt> member function.  Again, this function is
  * written so as to not replicate the function definition but passes each
  * point on to <tt>vector_value</tt> to be evaluated.
+ * @param points The points at which to evaluate the function.
+ * @param value_list The object in which to store the computed values.
  */
 template <int dim, typename RangeNumberType>
 void

--- a/include/deal.II/base/function_bessel.h
+++ b/include/deal.II/base/function_bessel.h
@@ -37,6 +37,9 @@ namespace Functions
   public:
     /**
      * Constructor. @p wave_number must be nonnegative.
+     * @param order The order used by this operation.
+     * @param wave_number The wave number.
+     * @param center The point associated with this operation.
      */
     Bessel1(const unsigned int order,
             const double       wave_number,

--- a/include/deal.II/base/function_cspline.h
+++ b/include/deal.II/base/function_cspline.h
@@ -89,6 +89,8 @@ namespace Functions
      * Constructor which should be provided with a set of points at which
      * interpolation is to be done @p interpolation_points and a set of function
      * values @p interpolation_values .
+     * @param interpolation_points The interpolation points.
+     * @param interpolation_values The interpolation values.
      */
     CSpline(const std::vector<double> &interpolation_points,
             const std::vector<double> &interpolation_values);

--- a/include/deal.II/base/function_derivative.h
+++ b/include/deal.II/base/function_derivative.h
@@ -47,6 +47,9 @@ public:
    * Constructor. Provided are the functions to compute derivatives of, the
    * direction vector of the differentiation and the step size <tt>h</tt> of
    * the difference formula.
+   * @param f The function object.
+   * @param direction The coordinate direction to which this operation refers.
+   * @param h The h used by this operation.
    */
   FunctionDerivative(const Function<dim> &f,
                      const Point<dim>    &direction,
@@ -63,6 +66,9 @@ public:
    *
    * The number of quadrature point must still be the same, when values are
    * accessed.
+   * @param f The function object.
+   * @param direction The coordinate direction to which this operation refers.
+   * @param h The h used by this operation.
    */
   FunctionDerivative(const Function<dim>           &f,
                      const std::vector<Point<dim>> &direction,
@@ -75,12 +81,14 @@ public:
    * Formulas implemented right now are first order backward Euler
    * (<tt>UpwindEuler</tt>), second order symmetric Euler (<tt>Euler</tt>) and
    * a symmetric fourth order formula (<tt>FourthOrder</tt>).
+   * @param formula The formula used by this operation.
    */
   void
   set_formula(typename AutoDerivativeFunction<dim>::DifferenceFormula formula =
                 AutoDerivativeFunction<dim>::Euler);
   /**
    * Change the base step size of the difference formula
+   * @param h The h used by this operation.
    */
   void
   set_h(const double h);

--- a/include/deal.II/base/function_lib.h
+++ b/include/deal.II/base/function_lib.h
@@ -115,6 +115,8 @@ namespace Functions
 
     /**
      * Laplacian of the function at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -122,6 +124,9 @@ namespace Functions
 
     /**
      * Laplacian of the function at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     laplacian_list(const std::vector<Point<dim>> &points,
@@ -152,17 +157,24 @@ namespace Functions
     /**
      * Constructor. Provide a constant that will be added to each function
      * value.
+     * @param offset The offset into the underlying storage or file at which
+     * the operation starts.
      */
     PillowFunction(const double offset = 0.);
 
     /**
      * The value at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -171,6 +183,8 @@ namespace Functions
 
     /**
      * Gradient at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -178,6 +192,9 @@ namespace Functions
 
     /**
      * Gradients at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param gradients The object in which to store the computed gradients.
+     * @param component The component to evaluate.
      */
     virtual void
     gradient_list(const std::vector<Point<dim>> &points,
@@ -186,6 +203,8 @@ namespace Functions
 
     /**
      * Laplacian at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -193,6 +212,9 @@ namespace Functions
 
     /**
      * Laplacian at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     laplacian_list(const std::vector<Point<dim>> &points,
@@ -219,6 +241,7 @@ namespace Functions
     /**
      * Constructor which allows to optionally generate a vector valued cosine
      * function with the same value in each component.
+     * @param n_components The number of components.
      */
     CosineFunction(const unsigned int n_components = 1);
 
@@ -254,6 +277,8 @@ namespace Functions
 
     /**
      * Second derivatives at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual SymmetricTensor<2, dim>
     hessian(const Point<dim>  &p,
@@ -261,6 +286,9 @@ namespace Functions
 
     /**
      * Second derivatives at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param hessians The object in which to store the computed hessians.
+     * @param component The component to evaluate.
      */
     virtual void
     hessian_list(const std::vector<Point<dim>>        &points,
@@ -332,12 +360,17 @@ namespace Functions
   public:
     /**
      * The value at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -346,6 +379,8 @@ namespace Functions
 
     /**
      * Gradient at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -353,6 +388,9 @@ namespace Functions
 
     /**
      * Gradients at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param gradients The object in which to store the computed gradients.
+     * @param component The component to evaluate.
      */
     virtual void
     gradient_list(const std::vector<Point<dim>> &points,
@@ -361,6 +399,8 @@ namespace Functions
 
     /**
      * Laplacian at a single point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -368,6 +408,9 @@ namespace Functions
 
     /**
      * Laplacian at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     laplacian_list(const std::vector<Point<dim>> &points,
@@ -609,17 +652,25 @@ namespace Functions
     /**
      * Constructor. Provide the advection direction here and the steepness of
      * the slope.
+     * @param direction The coordinate direction to which this operation
+     * refers.
+     * @param steepness The steepness used by this operation.
      */
     JumpFunction(const Point<dim> &direction, const double steepness);
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -628,6 +679,8 @@ namespace Functions
 
     /**
      * Gradient at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -635,6 +688,9 @@ namespace Functions
 
     /**
      * Gradients at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param gradients The object in which to store the computed gradients.
+     * @param component The component to evaluate.
      */
     virtual void
     gradient_list(const std::vector<Point<dim>> &points,
@@ -643,6 +699,8 @@ namespace Functions
 
     /**
      * Laplacian of the function at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -650,6 +708,9 @@ namespace Functions
 
     /**
      * Laplacian of the function at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     laplacian_list(const std::vector<Point<dim>> &points,
@@ -712,6 +773,7 @@ namespace Functions
     /**
      * Constructor. Take the Fourier coefficients in each space direction as
      * argument.
+     * @param fourier_coefficients The fourier coefficients.
      */
     FourierCosineFunction(const Tensor<1, dim> &fourier_coefficients);
 
@@ -720,6 +782,8 @@ namespace Functions
      * only one component (i.e. the function is scalar), you should state the
      * component you want to have evaluated; it defaults to zero, i.e. the
      * first component.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -727,6 +791,8 @@ namespace Functions
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -734,6 +800,8 @@ namespace Functions
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -766,6 +834,7 @@ namespace Functions
     /**
      * Constructor. Take the Fourier coefficients in each space direction as
      * argument.
+     * @param fourier_coefficients The fourier coefficients.
      */
     FourierSineFunction(const Tensor<1, dim> &fourier_coefficients);
 
@@ -774,6 +843,8 @@ namespace Functions
      * only one component (i.e. the function is scalar), you should state the
      * component you want to have evaluated; it defaults to zero, i.e. the
      * first component.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -781,6 +852,8 @@ namespace Functions
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -788,6 +861,8 @@ namespace Functions
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -816,6 +891,9 @@ namespace Functions
     /**
      * Constructor. Take the Fourier coefficients in each space direction as
      * argument.
+     * @param fourier_coefficients The fourier coefficients.
+     * @param weights The weights used in the quadrature rule or linear
+     * combination.
      */
     FourierSineSum(const std::vector<Point<dim>> &fourier_coefficients,
                    const std::vector<double>     &weights);
@@ -825,6 +903,8 @@ namespace Functions
      * only one component (i.e. the function is scalar), you should state the
      * component you want to have evaluated; it defaults to zero, i.e. the
      * first component.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -832,6 +912,8 @@ namespace Functions
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -839,6 +921,8 @@ namespace Functions
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -870,6 +954,9 @@ namespace Functions
     /**
      * Constructor. Take the Fourier coefficients in each space direction as
      * argument.
+     * @param fourier_coefficients The fourier coefficients.
+     * @param weights The weights used in the quadrature rule or linear
+     * combination.
      */
     FourierCosineSum(const std::vector<Point<dim>> &fourier_coefficients,
                      const std::vector<double>     &weights);
@@ -879,6 +966,8 @@ namespace Functions
      * only one component (i.e. the function is scalar), you should state the
      * component you want to have evaluated; it defaults to zero, i.e. the
      * first component.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -886,6 +975,8 @@ namespace Functions
     /**
      * Return the gradient of the specified component of the function at the
      * given point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -893,6 +984,8 @@ namespace Functions
 
     /**
      * Compute the Laplacian of a given component at point <tt>p</tt>.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     laplacian(const Point<dim>  &p,
@@ -958,12 +1051,14 @@ namespace Functions
 
     /**
      * Set the center of the ball to the point @p p.
+     * @param p The point at which to evaluate the function.
      */
     virtual void
     set_center(const Point<dim> &p);
 
     /**
      * Set the radius of the ball to @p r
+     * @param r The value on which this function operates.
      */
     virtual void
     set_radius(const double r);
@@ -1042,6 +1137,11 @@ namespace Functions
      *
      * If you try to use this class before you call the set_base() method,
      * and exception will be triggered.
+     * @param radius The radius used by this operation.
+     * @param center The point associated with this operation.
+     * @param n_components The number of components.
+     * @param select The select used by this operation.
+     * @param integrate_to_one The integrate to one.
      */
     CutOffFunctionTensorProduct(
       double             radius       = 1.0,
@@ -1060,24 +1160,30 @@ namespace Functions
 
     /**
      * Set the new center.
+     * @param center The point associated with this operation.
      */
     virtual void
     set_center(const Point<dim> &center) override;
 
     /**
      * Set the new radius.
+     * @param radius The radius used by this operation.
      */
     virtual void
     set_radius(const double radius) override;
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Function gradient at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -1108,6 +1214,10 @@ namespace Functions
      *
      * If an argument <tt>select</tt> is given and not -1, the cut-off
      * function will be non-zero for this component only.
+     * @param radius The radius used by this operation.
+     * @param n_components The number of components.
+     * @param select The select used by this operation.
+     * @param integrate_to_one The integrate to one.
      */
     CutOffFunctionLinfty(
       const double radius             = 1.,
@@ -1118,12 +1228,17 @@ namespace Functions
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -1132,6 +1247,8 @@ namespace Functions
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value_list(const std::vector<Point<dim>> &points,
@@ -1156,6 +1273,10 @@ namespace Functions
      *
      * If an argument <tt>select</tt> is given, the cut-off function will be
      * non-zero for this component only.
+     * @param radius The radius used by this operation.
+     * @param n_components The number of components.
+     * @param select The select used by this operation.
+     * @param integrate_to_one The integrate to one.
      */
     CutOffFunctionW1(
       const double radius             = 1.,
@@ -1166,12 +1287,17 @@ namespace Functions
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -1180,6 +1306,8 @@ namespace Functions
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value_list(const std::vector<Point<dim>> &points,
@@ -1205,6 +1333,10 @@ namespace Functions
   public:
     /**
      * Constructor.
+     * @param radius The radius used by this operation.
+     * @param n_components The number of components.
+     * @param select The select used by this operation.
+     * @param integrate_to_one The integrate to one.
      */
     CutOffFunctionC1(
       const double radius             = 1.,
@@ -1215,12 +1347,17 @@ namespace Functions
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -1229,6 +1366,8 @@ namespace Functions
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value_list(const std::vector<Point<dim>> &points,
@@ -1236,6 +1375,8 @@ namespace Functions
 
     /**
      * Function gradient at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -1261,6 +1402,10 @@ namespace Functions
      *
      * If an argument <tt>select</tt> is given, the cut-off function will be
      * non-zero for this component only.
+     * @param radius The radius used by this operation.
+     * @param n_components The number of components.
+     * @param select The select used by this operation.
+     * @param integrate_to_one The integrate to one.
      */
     CutOffFunctionCinfty(
       const double radius             = 1.,
@@ -1271,12 +1416,17 @@ namespace Functions
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -1285,6 +1435,8 @@ namespace Functions
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value_list(const std::vector<Point<dim>> &points,
@@ -1292,6 +1444,8 @@ namespace Functions
 
     /**
      * Function gradient at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -1322,12 +1476,16 @@ namespace Functions
      * of the class. The second argument denotes the number of vector
      * components this object shall represent. All vector components will have
      * the same value.
+     * @param exponents The tensor argument supplied to this operation.
+     * @param n_components The number of components.
      */
     Monomial(const Tensor<1, dim, Number> &exponents,
              const unsigned int            n_components = 1);
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Number
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -1337,12 +1495,17 @@ namespace Functions
      *
      * <tt>values</tt> shall have the right size beforehand, i.e.
      * #n_components.
+     * @param p The point at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value(const Point<dim> &p, Vector<Number> &values) const override;
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -1351,6 +1514,8 @@ namespace Functions
 
     /**
      * Function gradient at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim, Number>
     gradient(const Point<dim>  &p,
@@ -1486,6 +1651,8 @@ namespace Functions
      * InterpolatedTensorProductGridData object. See the
      * TableBase::replicate_across_communicator() function on how to share a
      * data set between multiple processes.
+     * @param coordinate_values The object in which to store the coordinate values.
+     * @param data_values The object in which to store the data values.
      */
     InterpolatedTensorProductGridData(
       std::array<std::vector<double>, dim> &&coordinate_values,
@@ -1631,6 +1798,9 @@ namespace Functions
      * InterpolatedUniformGridData object. See the
      * TableBase::replicate_across_communicator() function on how to share a
      * data set between multiple processes.
+     * @param interval_endpoints The object in which to store the interval endpoints.
+     * @param n_subintervals The number of subintervals.
+     * @param data_values The object in which to store the data values.
      */
     InterpolatedUniformGridData(
       std::array<std::pair<double, double>, dim> &&interval_endpoints,
@@ -1725,12 +1895,16 @@ namespace Functions
      * ${\alpha_{i,d}}$ exponents of the i-th monomial $a_{i}\prod_{d=1}^{dim}
      * x_{d}^{\alpha_{i,d}}$. The i-th element of the coefficients vector
      * contains the coefficient $a_{i}$ for the i-th monomial.
+     * @param exponents The exponents used by this operation.
+     * @param coefficients The coefficients used by this operation.
      */
     Polynomial(const Table<2, double>    &exponents,
                const std::vector<double> &coefficients);
 
     /**
      * Function value at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -1738,6 +1912,9 @@ namespace Functions
 
     /**
      * Function values at multiple points.
+     * @param points The points at which to evaluate the function.
+     * @param values The object in which to store the computed values.
+     * @param component The component to evaluate.
      */
     virtual void
     value_list(const std::vector<Point<dim>> &points,
@@ -1746,6 +1923,8 @@ namespace Functions
 
     /**
      * Function gradient at one point.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -1818,11 +1997,14 @@ namespace Functions
   public:
     /**
      * Constructor.
+     * @param T The time associated with the evaluation.
      */
     RayleighKotheVortex(const double T = 1.0);
 
     /**
      * Return all components of a vector-valued function at a given point.
+     * @param point The point at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value(const Point<dim> &point,

--- a/include/deal.II/base/function_parser.h
+++ b/include/deal.II/base/function_parser.h
@@ -11,25 +11,25 @@
 // -----------------------------------------------------------------------------
 
 #ifndef dealii_function_parser_h
-#define dealii_function_parser_h
+#  define dealii_function_parser_h
 
 
-#include <deal.II/base/config.h>
+#  include <deal.II/base/config.h>
 
-#include <deal.II/base/auto_derivative_function.h>
-#include <deal.II/base/mu_parser_internal.h>
-#include <deal.II/base/point.h>
+#  include <deal.II/base/auto_derivative_function.h>
+#  include <deal.II/base/mu_parser_internal.h>
+#  include <deal.II/base/point.h>
 
-#include <map>
-#include <vector>
+#  include <map>
+#  include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declaration
-#ifndef DOXYGEN
+#  ifndef DOXYGEN
 template <typename>
 class Vector;
-#endif
+#  endif
 
 /**
  * This class implements a function object that gets its value by parsing a
@@ -229,6 +229,9 @@ public:
    * initialize() method before you can use it. If an attempt to use this
    * function is made before the initialize() method has been called, then an
    * exception is thrown.
+   * @param n_components The number of components.
+   * @param initial_time The initial time.
+   * @param h The h used by this operation.
    */
   FunctionParser(const unsigned int n_components = 1,
                  const double       initial_time = 0.0,
@@ -239,6 +242,10 @@ public:
    * list of expressions (one for each component of the function), an optional
    * comma-separated list of constants, variable names and step size for the
    * computation of first order derivatives by finite differences.
+   * @param expression The expression used by this operation.
+   * @param constants The constants used by this operation.
+   * @param variable_names The variable names.
+   * @param h The h used by this operation.
    */
   FunctionParser(const std::string &expression,
                  const std::string &constants      = "",
@@ -323,6 +330,10 @@ public:
    * are expected to be separated by a semicolon. An exception is thrown if
    * this method is called and the number of components successfully parsed
    * does not match the number of components of the base function.
+   * @param vars The vars used by this operation.
+   * @param expression The expression used by this operation.
+   * @param constants The constants used by this operation.
+   * @param time_dependent The time dependent.
    */
   void
   initialize(const std::string &vars,
@@ -343,6 +354,8 @@ public:
    * one component (i.e., the function is scalar), you should state the
    * component you want to have evaluated; it defaults to zero, i.e., the first
    * component.
+   * @param p The point at which to evaluate the function.
+   * @param component The component to evaluate.
    */
   virtual double
   value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -371,30 +384,20 @@ public:
                  << ") is not equal to the number of expressions (" << arg2
                  << ").");
 
-  /** @} */
-};
-
-
-template <int dim>
-std::string
-FunctionParser<dim>::default_variable_names()
-{
-  switch (dim)
-    {
-      case 1:
-        return "x";
-      case 2:
-        return "x,y";
-      case 3:
-        return "x,y,z";
-      default:
-        DEAL_II_NOT_IMPLEMENTED();
-    }
-  return "";
-}
-
-
-
-DEAL_II_NAMESPACE_CLOSE
-
-#endif
+  /**
+   *  @} */
+  ****mplate<int dim> *d::string                   *
+     nctionParser<dim>::default_variable_names() *
+    *switch (dim) *
+  {
+  *case 1:
+    *return "x";
+  *case 2:
+    *return "x,y";
+  *case 3:
+    *return "x,y,z";
+    *default : *DEAL_II_NOT_IMPLEMENTED();
+    *
+  }
+  *return "";
+  *****AL_II_NAMESPACE_CLOSE **ndif * /

--- a/include/deal.II/base/function_restriction.h
+++ b/include/deal.II/base/function_restriction.h
@@ -54,6 +54,10 @@ namespace Functions
      *
      * A pointer to the incoming function is stored internally, so the function
      * must have a longer lifetime than the created restriction.
+     * @param function The function object.
+     * @param direction The coordinate direction to which this operation
+     * refers.
+     * @param coordinate_value The coordinate value.
      */
     CoordinateRestriction(const Function<dim + 1> &function,
                           const unsigned int       direction,
@@ -114,6 +118,9 @@ namespace Functions
      *
      * A pointer to the incoming function is stored internally, so the function
      * must have a longer lifetime than the created restriction.
+     * @param function The function object.
+     * @param open_direction The open direction.
+     * @param point The point at which to evaluate the function.
      */
     PointRestriction(const Function<dim + 1> &function,
                      const unsigned int       open_direction,
@@ -158,6 +165,9 @@ namespace internal
    * convention given by the function coordinate_to_one_dim_higher. Thus, the
    * order of coordinates on the lower-dimensional point are not preserved:
    * $\{(z, x), 1, y \}$ creates the point $(x, y, z)$.
+   * @param point The point at which to evaluate the function.
+   * @param component_in_dim_plus_1 The component in dim plus 1.
+   * @param coordinate_value The coordinate value.
    */
   template <int dim>
   Point<dim + 1>

--- a/include/deal.II/base/function_signed_distance.h
+++ b/include/deal.II/base/function_signed_distance.h
@@ -48,6 +48,8 @@ namespace Functions
     public:
       /**
        * Constructor, takes the center and radius of the sphere.
+       * @param center The point associated with this operation.
+       * @param radius The radius used by this operation.
        */
       Sphere(const Point<dim> &center = Point<dim>(), const double radius = 1);
 
@@ -58,6 +60,8 @@ namespace Functions
       /**
        * @copydoc Function::gradient()
        *
+       * @param point The point at which to evaluate the function.
+       * @param component The component to evaluate.
        * @note The gradient is singular at the center of the sphere. If the
        * incoming @p point is too close to the center, a floating-point
        * exception may be thrown or entries in the gradient may be +inf/-inf
@@ -71,6 +75,8 @@ namespace Functions
       /**
        * @copydoc Function::hessian()
        *
+       * @param point The point at which to evaluate the function.
+       * @param component The component to evaluate.
        * @note The Hessian is singular at the center of the sphere. If the
        * incoming @p point is too close to the center, a floating-point
        * exception may be thrown or entries in the Hessian may be +inf/-inf
@@ -104,6 +110,8 @@ namespace Functions
     public:
       /**
        * Constructor, takes a point in the plane and the plane normal.
+       * @param point The point at which to evaluate the function.
+       * @param normal The tensor argument supplied to this operation.
        */
       Plane(const Point<dim> &point, const Tensor<1, dim> &normal);
 
@@ -162,6 +170,7 @@ namespace Functions
       /**
        * Calculates the gradient of the signed distance function via the normal
        * of the closest point on the ellipsoid.
+       * @param component The component to evaluate.
        */
       Tensor<1, dim>
       gradient(const Point<dim> &,
@@ -249,6 +258,8 @@ namespace Functions
        * The signed distance is negative for points inside the rectangle, zero
        * for points on the rectangle and positive for points outside the
        * rectangle.
+       * @param p The point at which to evaluate the function.
+       * @param component The component to evaluate.
        */
       double
       value(const Point<dim>  &p,
@@ -298,6 +309,8 @@ namespace Functions
        * The signed distance is negative for points inside the disk, zero
        * for points on the disk and positive for points outside the
        * disk.
+       * @param p The point at which to evaluate the function.
+       * @param component The component to evaluate.
        */
       double
       value(const Point<dim>  &p,
@@ -372,6 +385,8 @@ namespace Functions
       /**
        * @copydoc Function::gradient()
        *
+       * @param point The point at which to evaluate the function.
+       * @param component The component to evaluate.
        * @note The gradient is singular on the cylinder axis.
        */
       Tensor<1, dim>

--- a/include/deal.II/base/function_spherical.h
+++ b/include/deal.II/base/function_spherical.h
@@ -51,6 +51,8 @@ namespace Functions
      * Note that components of this function are treated as entirely separate
      * quantities -- not as the components of a vector that will be
      * re-interpreted in a different coordinate system.
+     * @param center The point associated with this operation.
+     * @param n_components The number of components.
      */
     Spherical(const Point<dim>  &center       = Point<dim>(),
               const unsigned int n_components = 1);
@@ -60,6 +62,8 @@ namespace Functions
      *
      * This function converts the given point to spherical coordinates,
      * calls svalue() with it, and returns the result.
+     * @param point The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim>  &point,
@@ -71,6 +75,8 @@ namespace Functions
      * This function converts the given point to spherical coordinates,
      * calls sgradient() with it, and converts the result into Cartesian
      * coordinates.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual Tensor<1, dim>
     gradient(const Point<dim>  &p,
@@ -82,6 +88,8 @@ namespace Functions
      * This function converts the given point to spherical coordinates,
      * calls sgradient and shessian() with it, and converts the result into
      * Cartesian coordinates.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual SymmetricTensor<2, dim>
     hessian(const Point<dim>  &p,

--- a/include/deal.II/base/function_time.h
+++ b/include/deal.II/base/function_time.h
@@ -71,6 +71,7 @@ public:
   /**
    * Constructor. May take an initial value for the time variable, which
    * defaults to zero.
+   * @param initial_time The initial time.
    */
   FunctionTime(const Number initial_time = Number(0.0));
 
@@ -87,12 +88,14 @@ public:
 
   /**
    * Set the time to <tt>new_time</tt>, overwriting the old value.
+   * @param new_time The new time.
    */
   virtual void
   set_time(const Number new_time);
 
   /**
    * Advance the time by the given time step <tt>delta_t</tt>.
+   * @param delta_t The delta t.
    */
   virtual void
   advance_time(const Number delta_t);

--- a/include/deal.II/base/function_tools.h
+++ b/include/deal.II/base/function_tools.h
@@ -56,6 +56,11 @@ namespace FunctionTools
    * If the function has more than 1 component the @p component parameter can
    * be used to specify which function component the bounds should be computed
    * for.
+   * @param function The function object.
+   * @param box The box used by this operation.
+   * @param value_bounds The object in which to store the value bounds.
+   * @param gradient_bounds The object in which to store the gradient bounds.
+   * @param component The component to evaluate.
    */
   template <int dim>
   void

--- a/include/deal.II/base/geometric_utilities.h
+++ b/include/deal.II/base/geometric_utilities.h
@@ -50,6 +50,7 @@ namespace GeometricUtilities
      * @f}
      *
      * The use of this function is demonstrated in step-75.
+     * @param point The point at which to evaluate the function.
      */
     template <int dim>
     std::array<double, dim>
@@ -67,6 +68,7 @@ namespace GeometricUtilities
      *  y &= r\, \sin(\theta) \, \sin(\phi) \\
      *  z &= r\, \cos(\phi)
      * @f}
+     * @param scoord The scoord used by this operation.
      */
     template <std::size_t dim>
     Point<dim>

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -452,6 +452,7 @@ public:
   /**
    * Constructor. Initialize the object with the given argument representing a
    * vertex, line, etc.
+   * @param object The object used by this operation.
    */
   GeometryPrimitive(const Object object);
 
@@ -459,6 +460,7 @@ public:
    * Constructor. Initialize the object with an integer that should represent
    * the dimensionality of the geometric object in question. This will usually
    * be a number between zero (a vertex) and three (a hexahedron).
+   * @param object_dimension The object dimension.
    */
   GeometryPrimitive(const unsigned int object_dimension);
 
@@ -798,6 +800,7 @@ public:
   /**
    * Constructor. Take and store a value indicating a particular refinement
    * from the list of possible refinements specified in the base class.
+   * @param refinement_case The refinement case.
    */
   constexpr RefinementCase(
     const typename RefinementPossibilities<dim>::Possibilities refinement_case);
@@ -806,6 +809,7 @@ public:
    * Constructor. Take and store a value indicating a particular refinement as
    * a bit field. To avoid implicit conversions to and from integral values,
    * this constructor is marked as explicit.
+   * @param refinement_case The refinement case.
    */
   constexpr explicit RefinementCase(const std::uint8_t refinement_case);
 
@@ -826,6 +830,7 @@ public:
   /**
    * Return the union of the refinement flags represented by the current
    * object and the one given as argument.
+   * @param r The value on which this function operates.
    */
   constexpr RefinementCase
   operator|(const RefinementCase &r) const;
@@ -833,6 +838,7 @@ public:
   /**
    * Return the intersection of the refinement flags represented by the
    * current object and the one given as argument.
+   * @param r The value on which this function operates.
    */
   constexpr RefinementCase
   operator&(const RefinementCase &r) const;
@@ -852,6 +858,7 @@ public:
    * Return the flag that corresponds to cutting a cell along the axis given
    * as argument. For example, if <code>i=0</code> then the returned value is
    * <tt>RefinementPossibilities<dim>::cut_x</tt>.
+   * @param i The index of the entry.
    */
   static constexpr RefinementCase
   cut_axis(const unsigned int i);
@@ -1168,6 +1175,7 @@ namespace internal
      * Constructor. Take and store a value indicating a particular subface
      * possibility in the list of possible situations specified in the base
      * class.
+     * @param subface_possibility The subface possibility.
      */
     SubfaceCase(const typename SubfacePossibilities<dim>::Possibilities
                   subface_possibility);
@@ -1285,6 +1293,7 @@ struct GeometryInfo<0>
    * Return the number of children of a cell (or face) refined with
    * <tt>ref_case</tt>. Since we are concerned here with points, the number of
    * children is equal to one.
+   * @param refinement_case The refinement case.
    */
   static unsigned int
   n_children(const RefinementCase<0> &refinement_case);
@@ -1337,6 +1346,11 @@ struct GeometryInfo<0>
    *
    * Of course, since this class is for the case `dim==0`, this function
    * is not implemented.
+   * @param face The local face index to which the query refers.
+   * @param vertex The local vertex index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   face_to_cell_vertices(const unsigned int face,
@@ -1358,6 +1372,11 @@ struct GeometryInfo<0>
    *
    * Of course, since this class is for the case `dim==0`, this function
    * is not implemented.
+   * @param face The local face index to which the query refers.
+   * @param line The local line index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   face_to_cell_lines(const unsigned int face,
@@ -2137,6 +2156,7 @@ struct GeometryInfo
   /**
    * Return the number of children of a cell (or face) refined with
    * <tt>ref_case</tt>.
+   * @param refinement_case The refinement case.
    */
   static unsigned int
   n_children(const RefinementCase<dim> &refinement_case);
@@ -2144,6 +2164,7 @@ struct GeometryInfo
   /**
    * Return the number of subfaces of a face refined according to
    * internal::SubfaceCase @p face_ref_case.
+   * @param subface_case The subface case.
    */
   static unsigned int
   n_subfaces(const internal::SubfaceCase<dim> &subface_case);
@@ -2156,6 +2177,8 @@ struct GeometryInfo
    *
    * E.g. for internal::SubfaceCase::cut_xy the ratio is 1/4 for each of the
    * subfaces.
+   * @param subface_case The subface case.
+   * @param subface_no The subface no.
    */
   static double
   subface_ratio(const internal::SubfaceCase<dim> &subface_case,
@@ -2165,6 +2188,11 @@ struct GeometryInfo
    * Given a cell refined with the <code>RefinementCase</code> @p
    * cell_refinement_case return the <code>SubfaceCase</code> of the @p
    * face_no th face.
+   * @param cell_refinement_case The cell refinement case.
+   * @param face_no The face no.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static RefinementCase<dim - 1>
   face_refinement_case(const RefinementCase<dim> &cell_refinement_case,
@@ -2177,6 +2205,11 @@ struct GeometryInfo
    * Given the SubfaceCase @p face_refinement_case of the @p face_no th face,
    * return the smallest RefinementCase of the cell, which corresponds to that
    * refinement of the face.
+   * @param face_refinement_case The face refinement case.
+   * @param face_no The face no.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static RefinementCase<dim>
   min_cell_refinement_case_for_face_refinement(
@@ -2189,6 +2222,8 @@ struct GeometryInfo
   /**
    * Given a cell refined with the RefinementCase @p cell_refinement_case
    * return the RefinementCase of the @p line_no th face.
+   * @param cell_refinement_case The cell refinement case.
+   * @param line_no The line no.
    */
   static RefinementCase<1>
   line_refinement_case(const RefinementCase<dim> &cell_refinement_case,
@@ -2197,6 +2232,7 @@ struct GeometryInfo
   /**
    * Return the minimal / smallest RefinementCase of the cell, which ensures
    * refinement of line @p line_no.
+   * @param line_no The line no.
    */
   static RefinementCase<dim>
   min_cell_refinement_case_for_line_refinement(const unsigned int line_no);
@@ -2246,6 +2282,13 @@ struct GeometryInfo
    * RefinementCase of the face, <tt>face_ref_case</tt>, might have an
    * influence on which child is behind which given subface, thus this is an
    * additional argument, defaulting to isotropic refinement of the face.
+   * @param ref_case The ref case.
+   * @param face The local face index to which the query refers.
+   * @param subface The subface used by this operation.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
+   * @param face_refinement_case The face refinement case.
    */
   static unsigned int
   child_cell_on_face(const RefinementCase<dim>     &ref_case,
@@ -2269,6 +2312,8 @@ struct GeometryInfo
    *
    * For <tt>dim=2</tt> this call is simply passed down to the
    * face_to_cell_vertices() function.
+   * @param line The local line index to which the query refers.
+   * @param vertex The local vertex index to which the query refers.
    */
   static unsigned int
   line_to_cell_vertices(const unsigned int line, const unsigned int vertex);
@@ -2292,6 +2337,11 @@ struct GeometryInfo
    * cell, this call is passed down to the child_cell_on_face() function.
    * Hence this function is simply a wrapper of child_cell_on_face() giving it
    * a suggestive name.
+   * @param face The local face index to which the query refers.
+   * @param vertex The local vertex index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   face_to_cell_vertices(const unsigned int face,
@@ -2310,6 +2360,11 @@ struct GeometryInfo
    * the standard and non-standard orientation. <tt>face_orientation</tt>
    * defaults to <tt>true</tt>, <tt>face_flip</tt> and <tt>face_rotation</tt>
    * default to <tt>false</tt> (standard orientation) and has no effect in 2d.
+   * @param face The local face index to which the query refers.
+   * @param line The local line index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   face_to_cell_lines(const unsigned int face,
@@ -2326,6 +2381,10 @@ struct GeometryInfo
    * describes a face in standard orientation.
    *
    * This function is only implemented in 3d.
+   * @param vertex The local vertex index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   standard_to_real_face_vertex(const unsigned int vertex,
@@ -2341,6 +2400,10 @@ struct GeometryInfo
    * describes a face in standard orientation.
    *
    * This function is only implemented in 3d.
+   * @param vertex The local vertex index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   real_to_standard_face_vertex(const unsigned int vertex,
@@ -2356,6 +2419,10 @@ struct GeometryInfo
    * describes a face in standard orientation.
    *
    * This function is only implemented in 3d.
+   * @param line The local line index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   standard_to_real_face_line(const unsigned int line,
@@ -2367,6 +2434,8 @@ struct GeometryInfo
    * Map the vertex index @p vertex of a line in standard orientation to one of a
    * face with arbitrary @p line_orientation. The value of this flag default to
    * <tt>true</tt>.
+   * @param vertex The local vertex index to which the query refers.
+   * @param line_orientation The line orientation.
    */
   static unsigned int
   standard_to_real_line_vertex(const unsigned int vertex,
@@ -2376,6 +2445,7 @@ struct GeometryInfo
    * Decompose the vertex index in a quad into a pair of a line index and a
    * vertex index within this line.
    *
+   * @param vertex The local vertex index to which the query refers.
    * @note Which line is selected is not of importance (and not exposed on
    *   purpose).
    */
@@ -2386,6 +2456,7 @@ struct GeometryInfo
    * Decompose the vertex index in a hex into a pair of a quad index and a
    * vertex index within this quad.
    *
+   * @param vertex The local vertex index to which the query refers.
    * @note Which quad is selected is not of importance (and not exposed on
    *   purpose).
    */
@@ -2396,6 +2467,7 @@ struct GeometryInfo
    * Decompose the line index in a hex into a pair of a quad index and a line
    * index within this quad.
    *
+   * @param line The local line index to which the query refers.
    * @note Which quad is selected is not of importance (and not exposed on
    *   purpose).
    */
@@ -2410,6 +2482,10 @@ struct GeometryInfo
    * standard orientation.
    *
    * This function is only implemented in 3d.
+   * @param line The local line index to which the query refers.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   static unsigned int
   real_to_standard_face_line(const unsigned int line,
@@ -2421,6 +2497,7 @@ struct GeometryInfo
    * Return the position of the @p ith vertex on the unit cell. The order of
    * vertices is the canonical one in deal.II, as described in the general
    * documentation of this class.
+   * @param vertex The local vertex index to which the query refers.
    */
   static Point<dim>
   unit_cell_vertex(const unsigned int vertex);
@@ -2433,6 +2510,7 @@ struct GeometryInfo
    *
    * The order of child cells is described the general documentation of this
    * class.
+   * @param p The point at which to evaluate the function.
    */
   static unsigned int
   child_cell_from_point(const Point<dim> &p);
@@ -2443,6 +2521,9 @@ struct GeometryInfo
    * Neither original nor returned coordinates need actually be inside the
    * cell, we simply perform a scale-and-shift operation with a shift that
    * depends on the number of the child.
+   * @param p The point at which to evaluate the function.
+   * @param child_index The child index.
+   * @param refine_case The refine case.
    */
   static Point<dim>
   cell_to_child_coordinates(const Point<dim>         &p,
@@ -2454,6 +2535,9 @@ struct GeometryInfo
    * The reverse function to the one above: take a point in the coordinate
    * system of the child, and transform it to the coordinate system of the
    * parent cell.
+   * @param p The point at which to evaluate the function.
+   * @param child_index The child index.
+   * @param refine_case The refine case.
    */
   static Point<dim>
   child_to_cell_coordinates(const Point<dim>         &p,
@@ -2464,6 +2548,7 @@ struct GeometryInfo
   /**
    * Return true if the given point is inside the unit cell of the present
    * space dimension.
+   * @param p The point at which to evaluate the function.
    */
   static bool
   is_inside_unit_cell(const Point<dim> &p);
@@ -2478,6 +2563,8 @@ struct GeometryInfo
    *
    * The tolerance parameter may be less than zero, indicating that the point
    * should be safely inside the cell.
+   * @param p The point at which to evaluate the function.
+   * @param eps The eps used by this operation.
    */
   static bool
   is_inside_unit_cell(const Point<dim> &p, const double eps);
@@ -2485,6 +2572,7 @@ struct GeometryInfo
   /**
    * Projects a given point onto the unit cell, i.e. each coordinate outside
    * [0..1] is modified to lie within that interval.
+   * @param p The point at which to evaluate the function.
    */
   template <typename Number = double>
   static Point<dim, Number>
@@ -2494,6 +2582,7 @@ struct GeometryInfo
    * Return the infinity norm of the vector between a given point @p p
    * outside the unit cell to the closest unit cell boundary. For points
    * inside the cell, this is defined as zero.
+   * @param p The point at which to evaluate the function.
    */
   static double
   distance_to_unit_cell(const Point<dim> &p);
@@ -2501,6 +2590,8 @@ struct GeometryInfo
   /**
    * Compute the value of the $i$-th $d$-linear (i.e. (bi-,tri-)linear) shape
    * function at location $\xi$.
+   * @param xi The point associated with this operation.
+   * @param i The index of the entry.
    */
   static double
   d_linear_shape_function(const Point<dim> &xi, const unsigned int i);
@@ -2508,6 +2599,8 @@ struct GeometryInfo
   /**
    * Compute the gradient of the $i$-th $d$-linear (i.e. (bi-,tri-)linear)
    * shape function at location $\xi$.
+   * @param xi The point associated with this operation.
+   * @param i The index of the entry.
    */
   static Tensor<1, dim>
   d_linear_shape_function_gradient(const Point<dim> &xi, const unsigned int i);

--- a/include/deal.II/base/graph_coloring.h
+++ b/include/deal.II/base/graph_coloring.h
@@ -326,6 +326,7 @@ namespace GraphColoring
      * odd) zone. Consequently, we can combine colors from all even and all
      * odd zones. This function tries to create colors of similar number of
      * elements.
+     * @param partition_coloring The partition coloring.
      */
     template <typename Iterator>
     std::vector<std::vector<Iterator>>
@@ -579,6 +580,8 @@ namespace GraphColoring
    * SparsityTools::color_sparsity_pattern, is an alternate method for
    * coloring using graph connections represented by SparsityPattern.
    * For further details, refer to SparsityTools::color_sparsity_pattern.
+   * @param sparsity_pattern The sparsity pattern.
+   * @param color_indices The object in which to store the color indices.
    */
   unsigned int
   color_sparsity_pattern(const SparsityPattern     &sparsity_pattern,

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -367,6 +367,7 @@ namespace HDF5
      * href="https://support.hdfgroup.org/HDF5/doc/UG/HDF5_Users_Guide-Responsive%20HTML5/index.html#t=HDF5_Users_Guide%2FDatatypes%2FHDF5_Datatypes.htm%23TOC_6_10_Data_Transferbc-26&rhtocid=6.5_2">Data
      * Transfer: Datatype Conversion and Selection</a>  section in the HDF5
      * User's Guide.
+     * @param attr_name The attr name.
      */
     template <typename T>
     T
@@ -383,6 +384,8 @@ namespace HDF5
      * href="https://support.hdfgroup.org/HDF5/doc/UG/HDF5_Users_Guide-Responsive%20HTML5/index.html#t=HDF5_Users_Guide%2FDatatypes%2FHDF5_Datatypes.htm%23TOC_6_10_Data_Transferbc-26&rhtocid=6.5_2">Data
      * Transfer: Datatype Conversion and Selection</a>  section in the HDF5
      * User's Guide.
+     * @param attr_name The attr name.
+     * @param value The value associated with the function.
      */
     template <typename T>
     void
@@ -497,6 +500,7 @@ namespace HDF5
      * href="https://support.hdfgroup.org/HDF5/doc/UG/HDF5_Users_Guide-Responsive%20HTML5/index.html#t=HDF5_Users_Guide%2FDatatypes%2FHDF5_Datatypes.htm%23TOC_6_10_Data_Transferbc-26&rhtocid=6.5_2">Data
      * Transfer: Datatype Conversion and Selection</a>  section in the HDF5
      * User's Guide.
+     * @param coordinates The coordinates used by this operation.
      */
     template <typename Container>
     Container
@@ -573,6 +577,12 @@ namespace HDF5
      * `Vector<std::complex<double>>`, `FullMatrix<float>`,
      * `FullMatrix<double>`, `FullMatrix<std::complex<float>>` or
      * `FullMatrix<std::complex<double>>`.
+     * @param data_dimensions The data dimensions.
+     * @param offset The offset into the underlying storage or file at which
+     * the operation starts.
+     * @param stride The stride used by this operation.
+     * @param count The number of elements to process.
+     * @param block The block used by this operation.
      */
     template <typename Container>
     Container
@@ -614,6 +624,8 @@ namespace HDF5
      * `Vector<std::complex<double>>`, `FullMatrix<float>`,
      * `FullMatrix<double>`, `FullMatrix<std::complex<float>>` or
      * `FullMatrix<std::complex<double>>`.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename Container>
     void
@@ -646,6 +658,9 @@ namespace HDF5
      * href="https://support.hdfgroup.org/HDF5/doc/UG/HDF5_Users_Guide-Responsive%20HTML5/index.html#t=HDF5_Users_Guide%2FDatatypes%2FHDF5_Datatypes.htm%23TOC_6_10_Data_Transferbc-26&rhtocid=6.5_2">Data
      * Transfer: Datatype Conversion and Selection</a>  section in the HDF5
      * User's Guide.
+     * @param data The data values to read from or write to the current
+     * object.
+     * @param coordinates The coordinates used by this operation.
      */
     template <typename Container>
     void
@@ -716,6 +731,14 @@ namespace HDF5
      * `Vector<std::complex<double>>`, `FullMatrix<float>`,
      * `FullMatrix<double>`, `FullMatrix<std::complex<float>>` or
      * `FullMatrix<std::complex<double>>`.
+     * @param data The data values to read from or write to the current
+     * object.
+     * @param data_dimensions The data dimensions.
+     * @param offset The offset into the underlying storage or file at which
+     * the operation starts.
+     * @param stride The stride used by this operation.
+     * @param count The number of elements to process.
+     * @param block The block used by this operation.
      */
     template <typename Container>
     void
@@ -768,6 +791,7 @@ namespace HDF5
 
     /**
      * This function sets the boolean query_io_mode.
+     * @param new_query_io_mode The new query io mode.
      */
     void
     set_query_io_mode(const bool new_query_io_mode);
@@ -1013,18 +1037,24 @@ namespace HDF5
   public:
     /**
      * Opens a sub-group of the current Group or File.
+     * @param name The name associated with the object being created or
+     * queried.
      */
     Group
     open_group(const std::string &name) const;
 
     /**
      * Creates a sub-group in the current Group or File.
+     * @param name The name associated with the object being created or
+     * queried.
      */
     Group
     create_group(const std::string &name) const;
 
     /**
      * Opens a dataset.
+     * @param name The name associated with the object being created or
+     * queried.
      */
     DataSet
     open_dataset(const std::string &name) const;
@@ -1038,6 +1068,9 @@ namespace HDF5
      * href="https://support.hdfgroup.org/HDF5/doc/UG/HDF5_Users_Guide-Responsive%20HTML5/index.html#t=HDF5_Users_Guide%2FDatatypes%2FHDF5_Datatypes.htm%23TOC_6_10_Data_Transferbc-26&rhtocid=6.5_2">Data
      * Transfer: Datatype Conversion and Selection</a>  section in the HDF5
      * User's Guide.
+     * @param name The name associated with the object being created or
+     * queried.
+     * @param dimensions The dimensions used by this operation.
      */
     template <typename number>
     DataSet
@@ -1061,6 +1094,10 @@ namespace HDF5
      * `Vector<std::complex<double>>`, `FullMatrix<float>`,
      * `FullMatrix<double>`, `FullMatrix<std::complex<float>>` or
      * `FullMatrix<std::complex<double>>`.
+     * @param name The name associated with the object being created or
+     * queried.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename Container>
     void
@@ -1092,6 +1129,9 @@ namespace HDF5
      * Creates or opens an HDF5 file for serial operations. This call does not
      * require MPI support. It creates or opens an HDF5 file depending on the
      * value of @p mode.
+     * @param name The name associated with the object being created or
+     * queried.
+     * @param mode The mode used by this operation.
      */
     File(const std::string &name, const FileAccessMode mode);
 
@@ -1101,6 +1141,10 @@ namespace HDF5
      * HDF5 file depending on the value of @p mode. @p mpi_communicator
      * defines the processes that participate in this call; `MPI_COMM_WORLD` is
      * a common value for the MPI communicator.
+     * @param name The name associated with the object being created or
+     * queried.
+     * @param mode The mode used by this operation.
+     * @param mpi_communicator The MPI communicator.
      */
     File(const std::string   &name,
          const FileAccessMode mode,
@@ -1145,6 +1189,8 @@ namespace HDF5
      * one-dimensional array that specifies the size of each dimension of the
      * container, see:
      * https://support.hdfgroup.org/HDF5/doc1.8/RM/RM_H5S.html#Dataspace-CreateSimple
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename number>
     std::vector<hsize_t>
@@ -1153,6 +1199,8 @@ namespace HDF5
     /**
      * Return the dimensions of `data`. For a Vector this function returns
      * `std::vector<hsize_t>{vector_size}`.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename number>
     std::vector<hsize_t>
@@ -1161,6 +1209,8 @@ namespace HDF5
     /**
      * Return the dimensions of `data`. For a FullMatrix the function returns
      * `std::vector<hsize_t>{rows, columns}`.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename number>
     std::vector<hsize_t>
@@ -1169,6 +1219,8 @@ namespace HDF5
     /**
      * This function returns the total size of the container. For a std::vector
      * the function returns `int(vector_size)`.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename number>
     unsigned int
@@ -1177,6 +1229,8 @@ namespace HDF5
     /**
      * This function returns the total size of the container. For a Vector the
      * function returns `int(vector_size)`.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename number>
     unsigned int
@@ -1185,6 +1239,8 @@ namespace HDF5
     /**
      * This function returns the total size of the container. For a FullMatrix
      * the function returns `int(rows*columns)`.
+     * @param data The data values to read from or write to the current
+     * object.
      */
     template <typename number>
     unsigned int
@@ -1207,6 +1263,7 @@ namespace HDF5
      *
      * A FullMatrix can store only data of HDF5 datasets with rank 2. The size
      * of the FullMatrix will be FullMatrix(dim_0,dim_2)
+     * @param dimensions The dimensions used by this operation.
      */
     template <typename Container>
     std::enable_if_t<
@@ -1216,6 +1273,7 @@ namespace HDF5
 
     /**
      * Same as above.
+     * @param dimensions The dimensions used by this operation.
      */
     template <typename Container>
     std::enable_if_t<
@@ -1225,6 +1283,7 @@ namespace HDF5
 
     /**
      * Same as above.
+     * @param dimensions The dimensions used by this operation.
      */
     template <typename Container>
     std::enable_if_t<
@@ -1237,6 +1296,8 @@ namespace HDF5
      * operations of DataSet. A property list has to be created for the MPI
      * driver. For the serial driver the default H5P_DEFAULT can be used. In
      * addition H5Pset_dxpl_mpio is used to set the MPI mode to collective.
+     * @param plist The plist used by this operation.
+     * @param mpi Whether to mpi.
      */
     inline void
     set_plist(hid_t &plist, const bool mpi);
@@ -1248,6 +1309,12 @@ namespace HDF5
      * query_io_mode is True then H5Pget_mpio_actual_io_mode and
      * H5Pget_mpio_no_collective_cause are used to check if the operation has
      * been collective.
+     * @param plist The plist used by this operation.
+     * @param io_mode The object in which to store the io mode.
+     * @param local_no_collective_cause The object in which to store the local no collective cause.
+     * @param global_no_collective_cause The object in which to store the global no collective cause.
+     * @param mpi Whether to mpi.
+     * @param query_io_mode The query io mode.
      */
     inline void
     release_plist(hid_t                     &plist,
@@ -1259,6 +1326,7 @@ namespace HDF5
 
     /**
      * Convert a HDF5 no_collective_cause code to a human readable string.
+     * @param no_collective_cause The no collective cause.
      */
     inline std::string
     no_collective_cause_to_string(const std::uint32_t no_collective_cause);

--- a/include/deal.II/base/incremental_function.h
+++ b/include/deal.II/base/incremental_function.h
@@ -63,6 +63,7 @@ namespace Functions
     /**
      * Constructor which wraps a given function @p base.
      *
+     * @param base The base used by this operation.
      * @note This class stores a non-constant reference to @p base
      * and will call <code>base.set_time()</code> during evaluation
      * in order to evaluate the @p base class at any arbitrary time.
@@ -78,6 +79,8 @@ namespace Functions
      * Unless there is only one component (i.e. the function is scalar), you
      * should state the component you want to have evaluated. By default, the
      * value of the first component is computed.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual RangeNumberType
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -87,6 +90,8 @@ namespace Functions
      *
      * It is required that the @p values vector have the correct size before
      * this function is called.
+     * @param p The point at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value(const Point<dim>        &p,
@@ -96,6 +101,7 @@ namespace Functions
      * Set the time decrement.
      *
      * It is expected that this value be positive.
+     * @param delta_t The delta t.
      */
     void
     set_decrement(const time_type delta_t);

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -111,6 +111,7 @@ public:
 
   /**
    * Constructor that also sets the overall size of the index range.
+   * @param size The number of entries in the object to create or resize.
    */
   explicit IndexSet(const size_type size);
 
@@ -128,12 +129,14 @@ public:
   /**
    * Move constructor. Create a new IndexSet by transferring the internal data
    * of the input set.
+   * @param is The is used by this operation.
    */
   IndexSet(IndexSet &&is) noexcept;
 
   /**
    * Move assignment operator. Transfer the internal data of the input set into
    * the current one.
+   * @param is The is used by this operation.
    */
   IndexSet &
   operator=(IndexSet &&is) noexcept;
@@ -141,6 +144,7 @@ public:
 #ifdef DEAL_II_TRILINOS_WITH_TPETRA
   /**
    * Constructor from a Trilinos Teuchos::RCP<Tpetra::Map>.
+   * @param map The map used by this operation.
    */
   template <typename NodeType>
   explicit IndexSet(
@@ -151,6 +155,7 @@ public:
 #ifdef DEAL_II_TRILINOS_WITH_EPETRA
   /**
    * Constructor from a Trilinos Epetra_BlockMap.
+   * @param map The map used by this operation.
    */
   explicit IndexSet(const Epetra_BlockMap &map);
 #endif // DEAL_II_WITH_TRILINOS
@@ -167,6 +172,7 @@ public:
    *
    * This function can only be called if the index set does not yet contain
    * any elements.  This can be achieved by calling clear(), for example.
+   * @param size The number of entries in the object to create or resize.
    */
   void
   set_size(const size_type size);
@@ -197,6 +203,7 @@ public:
    * add_indices() function below. It is considerably more efficient,
    * particularly if the indices to be added are stored in an array
    * that is already sorted.
+   * @param index The index of the entry.
    */
   void
   add_index(const size_type index);
@@ -243,12 +250,16 @@ public:
    * This function will generate an exception if any of the (possibly shifted)
    * indices of the @p other index set lie outside the range
    * <code>[0,size())</code> represented by the current object.
+   * @param other The object to copy or move from.
+   * @param offset The offset into the underlying storage or file at which the
+   * operation starts.
    */
   void
   add_indices(const IndexSet &other, const size_type offset = 0);
 
   /**
    * Return whether the specified index is an element of the index set.
+   * @param index The index of the entry.
    */
   bool
   is_element(const size_type index) const;
@@ -280,6 +291,7 @@ public:
    * at the index one larger than the last one stored on process $p$.
    * In case there is only one MPI process, this just means that the IndexSet
    * is complete.
+   * @param communicator The MPI communicator.
    */
   bool
   is_ascending_and_one_to_one(const MPI_Comm communicator) const;
@@ -294,6 +306,7 @@ public:
    * Return the global index of the local index with number @p local_index
    * stored in this index set. @p local_index obviously needs to be less than
    * n_elements().
+   * @param local_index The local index.
    */
   size_type
   nth_index_in_set(const size_type local_index) const;
@@ -303,6 +316,7 @@ public:
    * global_index is. @p global_index needs to be less than the size(). This
    * function returns numbers::invalid_dof_index if the index @p global_index is not actually
    * a member of this index set, i.e. if `is_element(global_index)` is false.
+   * @param global_index The global index.
    */
   size_type
   index_within_set(const size_type global_index) const;
@@ -352,6 +366,7 @@ public:
    * On the other hand, the comparison against an empty object makes
    * sense to ensure, for example, that an IndexSet object has been
    * initialized.
+   * @param is The is used by this operation.
    */
   bool
   operator==(const IndexSet &is) const;
@@ -369,6 +384,7 @@ public:
    * On the other hand, the comparison against an empty object makes
    * sense to ensure, for example, that an IndexSet object has been
    * initialized.
+   * @param is The is used by this operation.
    */
   bool
   operator!=(const IndexSet &is) const;
@@ -378,6 +394,7 @@ public:
    * i.e. a set of indices that are elements of both index sets. The two index
    * sets must have the same size (though of course they do not have to have
    * the same number of indices).
+   * @param is The is used by this operation.
    */
   IndexSet
   operator&(const IndexSet &is) const;
@@ -397,6 +414,8 @@ public:
    *
    * A more general function of the same name, taking a mask instead
    * of just an interval to define the view, is below.
+   * @param begin The begin of the range.
+   * @param end The end of the range.
    */
   IndexSet
   get_view(const size_type begin, const size_type end) const;
@@ -445,6 +464,7 @@ public:
    * freedom as well as all indices of $T$ degrees of freedom. The
    * resulting view is an index set of size $N_u+N_T$ that contains
    * the indices of the locally owned $u$ and $T$ degrees of freedom.
+   * @param mask The mask used by this operation.
    */
   IndexSet
   get_view(const IndexSet &mask) const;
@@ -453,6 +473,7 @@ public:
    * Split the set indices represented by this object into blocks given by the
    * @p n_indices_per_block structure. The sum of its entries must match the
    * global size of the current object.
+   * @param n_indices_per_block The number of indices per block.
    */
   std::vector<IndexSet>
   split_by_block(
@@ -463,6 +484,7 @@ public:
    * if $x$ is the current object and $o$ the argument, then we compute $x
    * \leftarrow x \backslash o$.
    *
+   * @param other The object to copy or move from.
    * @pre The sizes of the two index spaces need to be equal, i.e., the
    *   condition `this->size() == other.size()` has to be true.
    */
@@ -484,6 +506,7 @@ public:
    * each row one by one and reindexing the entries of the matrix in consecutive
    * order. A one in the matrix then corresponds to an entry in the reindexed
    * IndexSet that is returned by this function.
+   * @param other The object to copy or move from.
    */
   IndexSet
   tensor_product(const IndexSet &other) const;
@@ -534,6 +557,7 @@ public:
    * one to elements of the vector. Specifically, this is the case for classes
    * Vector, BlockVector, but also std::vector@<bool@>, std::vector@<int@>,
    * and std::vector@<double@>.
+   * @param vector The vector used by this operation.
    */
   template <typename VectorType>
   void
@@ -545,6 +569,7 @@ public:
    * function returns `true` if the two sets are the same, that is, it
    * considers the "subset" comparison typically used in set theory,
    * rather than the "strict subset" comparison.
+   * @param other The object to copy or move from.
    */
   bool
   is_subset_of(const IndexSet &other) const;
@@ -552,6 +577,7 @@ public:
   /**
    * Output a text representation of this IndexSet to the given stream. Used
    * for testing.
+   * @param out The output stream to which data is written.
    */
   template <typename StreamType>
   void
@@ -560,6 +586,7 @@ public:
   /**
    * Write the IndexSet into a text based file format, that can be read in
    * again using the read() function.
+   * @param out The output stream to which data is written.
    */
   void
   write(std::ostream &out) const;
@@ -567,6 +594,7 @@ public:
   /**
    * Construct the IndexSet from a text based representation given by the
    * stream @p in written by the write() function.
+   * @param in The input data or stream from which values are read.
    */
   void
   read(std::istream &in);
@@ -574,6 +602,7 @@ public:
   /**
    * Write the IndexSet into a binary, compact representation, that can be
    * read in again using the block_read() function.
+   * @param out The output stream to which data is written.
    */
   void
   block_write(std::ostream &out) const;
@@ -581,6 +610,7 @@ public:
   /**
    * Construct the IndexSet from a binary representation given by the stream
    * @p in written by the write_block() function.
+   * @param in The input data or stream from which values are read.
    */
   void
   block_read(std::istream &in);
@@ -613,6 +643,8 @@ public:
    * that correspond to degrees of freedom located on ghost cells. Another
    * application of this method is to select a subset of the elements of a
    * vector, e.g. for extracting only certain solution components.
+   * @param communicator The MPI communicator.
+   * @param overlapping Whether to overlapping.
    */
   Epetra_Map
   make_trilinos_map(const MPI_Comm communicator = MPI_COMM_WORLD,
@@ -679,11 +711,14 @@ public:
     /**
      * Construct a valid accessor given an IndexSet and the index @p range_idx
      * of the range to point to.
+     * @param idxset The idxset used by this operation.
+     * @param range_idx The range idx.
      */
     IntervalAccessor(const IndexSet *idxset, const size_type range_idx);
 
     /**
      * Construct an invalid accessor for the IndexSet.
+     * @param idxset The idxset used by this operation.
      */
     explicit IntervalAccessor(const IndexSet *idxset);
 
@@ -769,11 +804,14 @@ public:
     /**
      * Construct a valid iterator pointing to the interval with index @p
      * range_idx.
+     * @param idxset The idxset used by this operation.
+     * @param range_idx The range idx.
      */
     IntervalIterator(const IndexSet *idxset, const size_type range_idx);
 
     /**
      * Construct an invalid iterator (used as end()).
+     * @param idxset The idxset used by this operation.
      */
     explicit IntervalIterator(const IndexSet *idxset);
 
@@ -784,11 +822,13 @@ public:
 
     /**
      * Copy constructor from @p other iterator.
+     * @param other The object to copy or move from.
      */
     IntervalIterator(const IntervalIterator &other) = default;
 
     /**
      * Assignment of another iterator.
+     * @param other The object to copy or move from.
      */
     IntervalIterator &
     operator=(const IntervalIterator &other) = default;
@@ -840,6 +880,7 @@ public:
      * distance is given by how many times one has to apply operator++ to the
      * current iterator to get the argument (for a positive return value), or
      * operator-- (for a negative return value).
+     * @param p The point at which to evaluate the function.
      */
     int
     operator-(const IntervalIterator &p) const;
@@ -872,6 +913,9 @@ public:
     /**
      * Construct an iterator pointing to the global index @p index in the
      * interval @p range_idx
+     * @param idxset The idxset used by this operation.
+     * @param range_idx The range idx.
+     * @param index The index of the entry.
      */
     ElementIterator(const IndexSet *idxset,
                     const size_type range_idx,
@@ -879,6 +923,7 @@ public:
 
     /**
      * Construct an iterator pointing to the end of the IndexSet.
+     * @param idxset The idxset used by this operation.
      */
     explicit ElementIterator(const IndexSet *idxset);
 
@@ -932,6 +977,7 @@ public:
      * it_right to get the left operand @p it_left (for a positive return
      * value), or to @p it_left to get the @p it_right (for a negative return
      * value).
+     * @param p The point at which to evaluate the function.
      */
     std::ptrdiff_t
     operator-(const ElementIterator &p) const;
@@ -988,6 +1034,7 @@ public:
    *
    * If there is no element in this IndexSet at or behind @p global_index,
    * this method will return end().
+   * @param global_index The global index.
    */
   ElementIterator
   at(const size_type global_index) const;
@@ -1206,6 +1253,7 @@ private:
  * @endcode
  *
  * @relatesalso IndexSet
+ * @param N The n used by this operation.
  */
 inline IndexSet
 complete_index_set(const IndexSet::size_type N)

--- a/include/deal.II/base/init_finalize.h
+++ b/include/deal.II/base/init_finalize.h
@@ -74,6 +74,8 @@ enum class InitializeLibrary
 /**
  * Global operator which returns an object in which all bits are set which are
  * either set in the first or the second argument.
+ * @param f1 The first callback to combine.
+ * @param f2 The second callback to combine.
  */
 inline InitializeLibrary
 operator|(const InitializeLibrary f1, const InitializeLibrary f2)
@@ -87,6 +89,8 @@ operator|(const InitializeLibrary f1, const InitializeLibrary f2)
 /**
  * Global operator which returns an object in which all bits are set that are
  * set both in the first and second argument.
+ * @param f1 The first callback to combine.
+ * @param f2 The second callback to combine.
  */
 inline InitializeLibrary
 operator&(const InitializeLibrary f1, const InitializeLibrary f2)
@@ -107,6 +111,10 @@ public:
   /**
    * Initialize deal.II and the requested external libraries.
    *
+   * @param argc The argc used by this operation.
+   * @param argv The argv used by this operation.
+   * @param libraries The libraries used by this operation.
+   * @param max_num_threads The max num threads.
    * @note This function calls MultithreadInfo::set_thread_limit() with
    * either @p max_num_threads or, following the discussion above, a
    * number of threads equal to the number of cores allocated to this MPI
@@ -171,12 +179,14 @@ public:
    *   MPI_IBarrier(comm, &request);
    * }
    * @endcode
+   * @param request The request used by this operation.
    */
   static void
   register_request(MPI_Request &request);
 
   /**
    * Unregister a request previously added using register_request().
+   * @param request The request used by this operation.
    */
   static void
   unregister_request(MPI_Request &request);

--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -287,6 +287,8 @@ private:
 /**
  * Create an object of type IteratorRange given the beginning and
  * end iterator.
+ * @param begin The begin of the range.
+ * @param end The end of the range.
  */
 template <typename BaseIterator>
 IteratorRange<BaseIterator>

--- a/include/deal.II/base/job_identifier.h
+++ b/include/deal.II/base/job_identifier.h
@@ -53,6 +53,7 @@ public:
    * <tt>file</tt>. For example, this function can be called from a
    * user program with argument <tt>__FILE__</tt> to create an
    * identifier for the program being run.
+   * @param filename The file name.
    */
   static std::string
   base_name(const std::string &filename);

--- a/include/deal.II/base/lazy.h
+++ b/include/deal.II/base/lazy.h
@@ -142,6 +142,7 @@ public:
    * Copy constructor. If the `other` object contains an initialized
    * value, then that value will be copied into the current object. If the
    * `other` object is uninitialized, then the current object will be as well.
+   * @param other The object to copy or move from.
    */
   Lazy(const Lazy &other);
 
@@ -151,6 +152,7 @@ public:
    * value, then that value will be moved into the current object, and the
    * `other` object will end up being empty (as if default initialized). If the
    * `other` object is uninitialized, then the current object will be as well.
+   * @param other The object to copy or move from.
    */
   Lazy(Lazy &&other) noexcept;
 
@@ -161,6 +163,7 @@ public:
    * `other` object is uninitialized, then the current object will be as well.
    *
    * Any content of the current object is lost in the assignment.
+   * @param other The object to copy or move from.
    */
   Lazy &
   operator=(const Lazy &other);
@@ -173,6 +176,7 @@ public:
    * `other` object is uninitialized, then the current object will be as well.
    *
    * Any content of the current object is lost in the move assignment.
+   * @param other The object to copy or move from.
    */
   Lazy &
   operator=(Lazy &&other) noexcept;

--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -175,6 +175,8 @@ public:
 
   /**
    * Copy operator.
+   * @param it The iterator associated with the range processed by this
+   * operation.
    */
   DerivedIterator &
   operator=(const DerivedIterator &it);
@@ -205,24 +207,28 @@ public:
 
   /**
    * Return an iterator that is @p n entries ahead of the current one.
+   * @param n The n used by this operation.
    */
   DerivedIterator
   operator+(const difference_type n) const;
 
   /**
    * Return an iterator that is @p n entries behind the current one.
+   * @param n The n used by this operation.
    */
   DerivedIterator
   operator-(const difference_type n) const;
 
   /**
    * Increment the iterator position by @p n.
+   * @param n The n used by this operation.
    */
   DerivedIterator &
   operator+=(const difference_type n);
 
   /**
    * Decrement the iterator position by @p n.
+   * @param n The n used by this operation.
    */
   DerivedIterator &
   operator-=(const difference_type n);
@@ -232,6 +238,7 @@ public:
    * distance is given by how many times one has to apply operator++() to the
    * current iterator to get the argument (for a positive return value), or
    * operator--() (for a negative return value).
+   * @param p The point at which to evaluate the function.
    */
   difference_type
   operator-(const DerivedIterator &p) const;
@@ -251,6 +258,7 @@ public:
   /**
    * Comparison operator. Returns <code>true</code> if both iterators point to
    * the same entry in the same container.
+   * @param right The right-hand operand.
    */
   template <typename OtherIterator>
   std::enable_if_t<std::is_convertible_v<OtherIterator, DerivedIterator>, bool>
@@ -262,6 +270,7 @@ public:
 
   /**
    * Opposite of operator==().
+   * @param right The right-hand operand.
    */
   template <typename OtherIterator>
   std::enable_if_t<std::is_convertible_v<OtherIterator, DerivedIterator>, bool>

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -101,12 +101,15 @@ public:
     /**
      * Set a new prefix for @p deallog, which will be removed when the
      * variable is destroyed.
+     * @param text The text used by this operation.
      */
     Prefix(const std::string &text);
 
     /**
      * Set a new prefix for the given stream, which will be removed when the
      * variable is destroyed.
+     * @param text The text used by this operation.
+     * @param stream The stream used by this operation.
      */
     Prefix(const std::string &text, LogStream &stream);
 
@@ -203,6 +206,7 @@ public:
    * the end of the code block, at the nearest @p return statement, or
    * because an intermediate function call results in an exception that
    * is not immediately caught.
+   * @param text The text used by this operation.
    */
   void
   push(const std::string &text);
@@ -224,6 +228,7 @@ public:
    * example usage of this method.
    *
    * The previous value of this parameter is returned.
+   * @param n The n used by this operation.
    */
   unsigned int
   depth_console(const unsigned int n);
@@ -236,6 +241,7 @@ public:
    * file.
    *
    * The previous value of this parameter is returned.
+   * @param n The n used by this operation.
    */
   unsigned int
   depth_file(const unsigned int n);
@@ -243,6 +249,7 @@ public:
 
   /**
    * Log the thread id.
+   * @param flag Whether to flag.
    */
   bool
   log_thread_id(const bool flag);
@@ -252,6 +259,7 @@ public:
    * Set the precision for the underlying stream and returns the previous
    * stream precision. This function mimics
    * http://www.cplusplus.com/reference/ios/ios_base/precision/
+   * @param prec The prec used by this operation.
    */
   std::streamsize
   precision(const std::streamsize prec);
@@ -261,6 +269,7 @@ public:
    * Set the width for the underlying stream and returns the previous stream
    * width. This function mimics
    * http://www.cplusplus.com/reference/ios/ios_base/width/
+   * @param wide The wide used by this operation.
    */
   std::streamsize
   width(const std::streamsize wide);
@@ -270,6 +279,7 @@ public:
    * set the flags for the underlying stream and returns the previous stream
    * flags. This function mimics
    * http://www.cplusplus.com/reference/ios/ios_base/flags/
+   * @param f The function object.
    */
   std::ios::fmtflags
   flags(const std::ios::fmtflags f);

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -87,6 +87,7 @@ namespace MemoryConsumption
    * Calculate the memory consumption of a fundamental type. See
    * EnableIfScalar for a discussion on how this restriction (SFINAE) is
    * implemented.
+   * @param t The time associated with the evaluation.
    */
   template <typename T>
   inline std::enable_if_t<std::is_fundamental_v<T>, std::size_t>
@@ -97,6 +98,7 @@ namespace MemoryConsumption
    * specialization (past this one) is available for the type <tt>T</tt>, then
    * this function returns the member function
    * <tt>t.memory_consumption()</tt>'s value.
+   * @param t The time associated with the evaluation.
    */
   template <typename T>
   inline std::enable_if_t<!(std::is_fundamental_v<T> || std::is_pointer_v<T>),
@@ -108,6 +110,7 @@ namespace MemoryConsumption
    * value does not include the size of the pointer. This function only
    * measures up to (and including) the NUL byte; the underlying buffer may be
    * larger.
+   * @param string The string used by this operation.
    */
   inline std::size_t
   memory_consumption(const char *string);
@@ -131,6 +134,7 @@ namespace MemoryConsumption
   /**
    * Determine an estimate of the amount of memory in bytes consumed by a
    * <tt>std::string</tt> variable.
+   * @param s The value on which this function operates.
    */
   inline std::size_t
   memory_consumption(const std::string &s);
@@ -161,6 +165,7 @@ namespace MemoryConsumption
    * For the most commonly used vectors, there are special functions that
    * compute the size without a loop. This also applies for the special case
    * of vectors of bools.
+   * @param v The value on which this function operates.
    */
   template <typename T>
   inline std::size_t
@@ -185,6 +190,7 @@ namespace MemoryConsumption
    * possible to also compute the memory consumption of arrays of vectors,
    * arrays of strings, etc, where the individual elements may have vastly
    * different sizes.
+   * @param v The value on which this function operates.
    */
   template <typename T, std::size_t N>
   inline std::size_t
@@ -208,6 +214,7 @@ namespace MemoryConsumption
    *
    * This is a special case, as the bools are not stored one-by-one, but as a
    * bit field.
+   * @param v The value on which this function operates.
    */
   inline std::size_t
   memory_consumption(const std::vector<bool> &v);
@@ -215,6 +222,7 @@ namespace MemoryConsumption
   /**
    * Determine an estimate of the amount of memory in bytes consumed by a pair
    * of values.
+   * @param p The point at which to evaluate the function.
    */
   template <typename A, typename B>
   inline std::size_t
@@ -223,6 +231,7 @@ namespace MemoryConsumption
   /**
    * Determine an estimate of the amount of memory in bytes consumed by a
    * value wrapped in a std::optional.
+   * @param o The value on which this function operates.
    */
   template <typename A>
   inline std::size_t

--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -45,6 +45,8 @@ namespace MemorySpace
     /**
      * Copy the class member values to @p begin.
      * If the data is on the @ref GlossDevice "device" it is moved to the host.
+     * @param begin The begin of the range.
+     * @param n_elements The number of elements.
      */
     void
     copy_to(T *begin, const std::size_t n_elements);
@@ -52,6 +54,8 @@ namespace MemorySpace
     /**
      * Copy the data in @p begin to the class member values.
      * The pointer @p begin must be on the host.
+     * @param begin The begin of the range.
+     * @param n_elements The number of elements.
      */
     void
     copy_from(const T *begin, const std::size_t n_elements);
@@ -93,6 +97,8 @@ namespace MemorySpace
 
   /**
    * Swap function similar to std::swap.
+   * @param u The value on which this function operates.
+   * @param v The value on which this function operates.
    */
   template <typename T, typename MemorySpace>
   inline void
@@ -164,6 +170,8 @@ namespace MemorySpace
 
   /**
    * Swap function similar to std::swap.
+   * @param u The value on which this function operates.
+   * @param v The value on which this function operates.
    */
   template <typename T, typename MemorySpace>
   inline void

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -75,12 +75,15 @@ public:
   /**
    * Constructor. Same as above but without arguments to be forwarded to the
    * constructor of the underlying object.
+   * @param minlevel The minlevel used by this operation.
+   * @param maxlevel The maxlevel used by this operation.
    */
   MGLevelObject(const unsigned int minlevel = 0,
                 const unsigned int maxlevel = 0);
 
   /**
    * Access object on level @p level.
+   * @param level The level used by this operation.
    */
   Object &
   operator[](const unsigned int level);
@@ -90,6 +93,7 @@ public:
    *
    * This function can be called on a @p const object, and
    * consequently returns a @p const reference.
+   * @param level The level used by this operation.
    */
   const Object &
   operator[](const unsigned int level) const;
@@ -124,6 +128,7 @@ public:
    * This clearly requires that the objects stored on each level allow for
    * this operation. This is, in particular, true for vectors and matrices
    * if @p d is zero, thereby zeroing out all vector or matrix entries.
+   * @param d The scalar value to assign.
    */
   MGLevelObject<Object> &
   operator=(const double d);
@@ -173,6 +178,7 @@ public:
    * </code>
    * This means this function can accept a lambda, a std::function, or a plain
    * function pointer.
+   * @param action The action used by this operation.
    */
   template <typename ActionFunctionObjectType>
   void

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -85,6 +85,9 @@ namespace Utilities
    * For example, a @p total_size of 11 with 3 processes will result
    * in the IndexSets { [0,4), [4,8), [8,11)] }, and this function will
    * return the @p my_partition_id 's IndexSet.
+   * @param my_partition_id The my partition id.
+   * @param n_partitions The number of partitions.
+   * @param total_size The total size.
    */
   IndexSet
   create_evenly_distributed_partitioning(
@@ -138,6 +141,7 @@ namespace Utilities
      * is not using MPI at all, or is using MPI but has been started with
      * only one MPI process), then the communicator necessarily involves
      * only one process and the function returns 1.
+     * @param mpi_communicator The MPI communicator.
      */
     unsigned int
     n_mpi_processes(const MPI_Comm mpi_communicator);
@@ -149,6 +153,7 @@ namespace Utilities
      * @ref GlossMPICommunicator "communicator".
      * This will be a unique value for each process between zero and (less
      * than) the number of all processes (given by get_n_mpi_processes()).
+     * @param mpi_communicator The MPI communicator.
      */
     unsigned int
     this_mpi_process(const MPI_Comm mpi_communicator);
@@ -156,6 +161,8 @@ namespace Utilities
     /**
      * Return a vector of the ranks (within @p comm_large) of a subset of
      * processes specified by @p comm_small.
+     * @param comm_large The comm large.
+     * @param comm_small The comm small.
      */
     std::vector<unsigned int>
     mpi_processes_within_communicator(const MPI_Comm comm_large,
@@ -226,6 +233,7 @@ namespace Utilities
      *
      * This function is equivalent to calling
      * <code>MPI_Comm_dup(mpi_communicator, &return_value);</code>.
+     * @param mpi_communicator The MPI communicator.
      */
     MPI_Comm
     duplicate_communicator(const MPI_Comm mpi_communicator);
@@ -238,6 +246,7 @@ namespace Utilities
      * The argument is passed by reference and will be invalidated and set to
      * the MPI null handle. This function is equivalent to calling
      * <code>MPI_Comm_free(&mpi_communicator);</code>.
+     * @param mpi_communicator The MPI communicator.
      */
     void
     free_communicator(MPI_Comm mpi_communicator);
@@ -259,6 +268,7 @@ namespace Utilities
     public:
       /**
        * Create a duplicate of the given @p communicator.
+       * @param communicator The MPI communicator.
        */
       explicit DuplicatedCommunicator(const MPI_Comm communicator)
         : comm(duplicate_communicator(communicator))
@@ -344,6 +354,7 @@ namespace Utilities
       public:
         /**
          * Constructor. Blocks until it can acquire the lock.
+         * @param comm The MPI communicator.
          */
         explicit ScopedLock(CollectiveMutex &mutex, const MPI_Comm comm)
           : mutex(mutex)
@@ -386,6 +397,7 @@ namespace Utilities
        *
        * This is a collective call that needs to be executed by all processors
        * in the communicator.
+       * @param comm The MPI communicator.
        */
       void
       lock(const MPI_Comm comm);
@@ -395,6 +407,7 @@ namespace Utilities
        *
        * This is a collective call that needs to be executed by all processors
        * in the communicator.
+       * @param comm The MPI communicator.
        */
       void
       unlock(const MPI_Comm comm);
@@ -466,6 +479,8 @@ namespace Utilities
       /**
        * Constructor. Take both the wait and clean-up functions mentioned
        * in the class documentation as arguments.
+       * @param wait_operation The object in which to store the wait operation.
+       * @param get_and_cleanup_operation The object in which to store the get and cleanup operation.
        */
       template <typename W, typename G>
       Future(W &&wait_operation, G &&get_and_cleanup_operation);
@@ -578,6 +593,8 @@ namespace Utilities
      * @p locally_owned_size across the MPI communicator.  Each process will
      * store contiguous subset of indices, and the index set on process p+1
      * starts at the index one larger than the last one stored on process p.
+     * @param comm The MPI communicator.
+     * @param locally_owned_size The locally owned size.
      */
     std::vector<IndexSet>
     create_ascending_partitioning(
@@ -590,6 +607,8 @@ namespace Utilities
      * MPI communicator @p comm.
      * Uses @p comm to determine number of partitions and processor ID to call the
      * @p create_evenly_distributed_partitioning() function above.
+     * @param comm The MPI communicator.
+     * @param total_size The total size.
      */
     IndexSet
     create_evenly_distributed_partitioning(
@@ -632,6 +651,7 @@ namespace Utilities
      * by passing
      * 1 as the @p count.
      *
+     * @param n_bytes The number of bytes.
      * @note The function does not just return an object of type `MPI_Datatype`
      *   because such objects need to be destroyed by a call to `MPI_Type_free`
      *   and it is easy to forget to do so (thereby creating a resource leak).
@@ -679,6 +699,8 @@ namespace Utilities
      * <code>MPI_Allreduce</code> function, i.e. all processors receive the
      * result of this operation.
      *
+     * @param t The time associated with the evaluation.
+     * @param mpi_communicator The MPI communicator.
      * @note Sometimes, not all processors need a result and in that case one
      * would call the <code>MPI_Reduce</code> function instead of the
      * <code>MPI_Allreduce</code> function. The latter is at most twice as
@@ -701,6 +723,9 @@ namespace Utilities
      * one of them having a const type qualifier and the other not.
      *
      * Input and output arrays may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param sums The sums used by this operation.
      */
     template <typename T, typename U>
     void
@@ -714,6 +739,9 @@ namespace Utilities
      * processor.
      *
      * Input and output arrays may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param sums The sums used by this operation.
      */
     template <typename T>
     void
@@ -725,6 +753,8 @@ namespace Utilities
      * Perform an MPI sum of the entries of a symmetric tensor.
      *
      * @relatesalso SymmetricTensor
+     * @param local The tensor argument supplied to this operation.
+     * @param mpi_communicator The MPI communicator.
      */
     template <int rank, int dim, typename Number>
     SymmetricTensor<rank, dim, Number>
@@ -735,6 +765,8 @@ namespace Utilities
      * Perform an MPI sum of the entries of a tensor.
      *
      * @relatesalso Tensor
+     * @param local The tensor argument supplied to this operation.
+     * @param mpi_communicator The MPI communicator.
      */
     template <int rank, int dim, typename Number>
     Tensor<rank, dim, Number>
@@ -744,6 +776,9 @@ namespace Utilities
     /**
      * Perform an MPI sum of the entries of a SparseMatrix.
      *
+     * @param local The local used by this operation.
+     * @param mpi_communicator The MPI communicator.
+     * @param global The global used by this operation.
      * @note @p local and @p global should have the same sparsity
      * pattern and it should be the same for all MPI processes.
      *
@@ -764,6 +799,8 @@ namespace Utilities
      * <code>MPI_Allreduce</code> function, i.e. all processors receive the
      * result of this operation.
      *
+     * @param t The time associated with the evaluation.
+     * @param mpi_communicator The MPI communicator.
      * @note Sometimes, not all processors need a result and in that case one
      * would call the <code>MPI_Reduce</code> function instead of the
      * <code>MPI_Allreduce</code> function. The latter is at most twice as
@@ -786,6 +823,9 @@ namespace Utilities
      * one of them having a const type qualifier and the other not.
      *
      * Input and output vectors may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param maxima The maxima used by this operation.
      */
     template <typename T, typename U>
     void
@@ -799,6 +839,9 @@ namespace Utilities
      * processor.
      *
      * Input and output arrays may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param maxima The maxima used by this operation.
      */
     template <typename T>
     void
@@ -815,6 +858,8 @@ namespace Utilities
      * <code>MPI_Allreduce</code> function, i.e. all processors receive the
      * result of this operation.
      *
+     * @param t The time associated with the evaluation.
+     * @param mpi_communicator The MPI communicator.
      * @note Sometimes, not all processors need a result and in that case one
      * would call the <code>MPI_Reduce</code> function instead of the
      * <code>MPI_Allreduce</code> function. The latter is at most twice as
@@ -837,6 +882,9 @@ namespace Utilities
      * one of them having a const type qualifier and the other not.
      *
      * Input and output arrays may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param minima The minima used by this operation.
      */
     template <typename T, typename U>
     void
@@ -850,6 +898,9 @@ namespace Utilities
      * processor.
      *
      * Input and output arrays may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param minima The minima used by this operation.
      */
     template <typename T>
     void
@@ -873,6 +924,8 @@ namespace Utilities
      * <code>MPI_Allreduce</code> function, i.e., all processors receive the
      * result of this operation.
      *
+     * @param t The time associated with the evaluation.
+     * @param mpi_communicator The MPI communicator.
      * @note Sometimes, not all processors need a result and in that case one
      * would call the <code>MPI_Reduce</code> function instead of the
      * <code>MPI_Allreduce</code> function. The latter is at most twice as
@@ -894,6 +947,9 @@ namespace Utilities
      *
      * Input and output arrays may be the same.
      *
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param results The results used by this operation.
      * @note Depending on your standard library, this function may not work with
      *   specializations of `std::vector` for the data type `bool`. In that
      *   case, use a different container or data type.
@@ -910,6 +966,9 @@ namespace Utilities
      * arrays from each processor.
      *
      * Input and output arrays may be the same.
+     * @param values The values associated with the function.
+     * @param mpi_communicator The MPI communicator.
+     * @param results The results used by this operation.
      */
     template <typename T>
     void
@@ -929,6 +988,8 @@ namespace Utilities
      * <code>MPI_Allreduce</code> function, i.e., all processors receive the
      * result of this operation.
      *
+     * @param t The time associated with the evaluation.
+     * @param mpi_communicator The MPI communicator.
      * @note Sometimes, not all processors need a result and in that case one
      * would call the <code>MPI_Reduce</code> function instead of the
      * <code>MPI_Allreduce</code> function. The latter is at most twice as
@@ -1007,6 +1068,8 @@ namespace Utilities
      * @p mpi_communicator. Each processor's value is given in @p my_value and
      * the result will be returned. The result is available on all machines.
      *
+     * @param my_value The my value.
+     * @param mpi_communicator The MPI communicator.
      * @note Sometimes, not all processors need a result and in that case one
      * would call the <code>MPI_Reduce</code> function instead of the
      * <code>MPI_Allreduce</code> function. The latter is at most twice as
@@ -1024,6 +1087,8 @@ namespace Utilities
      * @ref GlossMPICommunicator "communicator"
      * @p mpi_communicator for each entry of the vector.
      *
+     * @param my_value The my value.
+     * @param mpi_communicator The MPI communicator.
      * @note This function performs a single reduction sweep.
      *
      * @pre Size of the input vector has to be the same on all processes.
@@ -1040,6 +1105,9 @@ namespace Utilities
      * @ref GlossMPICommunicator "communicator"
      * @p mpi_communicator for each entry of the ArrayView.
      *
+     * @param my_values The my values.
+     * @param result The result used by this operation.
+     * @param mpi_communicator The MPI communicator.
      * @note This function performs a single reduction sweep.
      *
      * @pre Size of the input ArrayView has to be the same on all processes
@@ -1326,6 +1394,10 @@ namespace Utilities
      *
      * In contrast to all_reduce, the result will be only available on a
      * single rank. On all other processes, the returned value is undefined.
+     * @param local_value The local value.
+     * @param comm The MPI communicator.
+     * @param combiner The combiner used by this operation.
+     * @param root_process The root process.
      */
     template <typename T>
     [[nodiscard]] T
@@ -1345,6 +1417,8 @@ namespace Utilities
      *
      * This function is only available if `T` is a type natively supported
      * by MPI.
+     * @param value The value associated with the function.
+     * @param comm The MPI communicator.
      */
     template <typename T, typename = std::enable_if_t<is_mpi_type<T> == true>>
     [[nodiscard]] std::pair<T, T>
@@ -1359,6 +1433,9 @@ namespace Utilities
      * by a broadcast step) but due to the user-specified binary operation also
      * general object types, including ones that store variable amounts of data,
      * can be handled.
+     * @param local_value The local value.
+     * @param comm The MPI communicator.
+     * @param combiner The combiner used by this operation.
      */
     template <typename T>
     [[nodiscard]] T
@@ -1386,6 +1463,10 @@ namespace Utilities
      * not just those natively supported by MPI. The only restriction
      * on the type is that it needs to be possible to call
      * Utilities::pack() and Utilities::unpack() on the object.
+     * @param object The object used by this operation.
+     * @param communicator The MPI communicator.
+     * @param target_rank The target rank.
+     * @param mpi_tag The mpi tag.
      */
     template <typename T>
     Future<void>
@@ -1410,6 +1491,9 @@ namespace Utilities
      * Unlike `MPI_Irecv`, the object to be received may be of any
      * type on which one can call Utilities::pack() and Utilities::unpack(),
      * not just those natively supported by MPI.
+     * @param communicator The MPI communicator.
+     * @param source_rank The source rank.
+     * @param mpi_tag The mpi tag.
      */
     template <typename T>
     Future<T>
@@ -1475,6 +1559,9 @@ namespace Utilities
      * for each rank that has requested indices owned by the current rank
      * those indices that have been queried. The values of the map are
      * therefore all index sets describing subsets of the owned set of indices.
+     * @param owned_indices The owned indices.
+     * @param indices_to_look_up The indices to look up.
+     * @param comm The MPI communicator.
      */
     std::pair<std::vector<unsigned int>, std::map<unsigned int, IndexSet>>
     compute_index_owner_and_requesters(const IndexSet &owned_indices,
@@ -1485,6 +1572,9 @@ namespace Utilities
      * Compute the union of the input vectors @p vec of all processes in the
      *   MPI communicator @p comm.
      *
+     * @param vec The vectorized operand whose entries are combined element-
+     * wise with the current object.
+     * @param comm The MPI communicator.
      * @note This is a @ref GlossCollectiveOperation "collective operation". The result will available on all
      *   processes.
      */
@@ -1494,6 +1584,8 @@ namespace Utilities
 
     /**
      * The same as above but for std::set.
+     * @param set The set used by this operation.
+     * @param comm The MPI communicator.
      */
     template <typename T>
     std::set<T>
@@ -1677,6 +1769,7 @@ namespace Utilities
      * objects of such a type, or a pointer to an object of such a
      * type. The compiler will produce an error if this requirement is
      * not satisfied.
+     * @param nullptr The nullptr used by this operation.
      */
     template <typename T>
     inline const MPI_Datatype mpi_type_id_for_type =

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -261,6 +261,8 @@ namespace Utilities
          *   providing a corresponding object to this function,
          *   use the other run() function in this class that takes function
          *   objects as arguments.
+         * @param process The process used by this operation.
+         * @param comm The MPI communicator.
          */
         DEAL_II_DEPRECATED
         std::vector<unsigned int>
@@ -338,6 +340,11 @@ namespace Utilities
 
         /**
          * @copydoc Interface::run()
+         * @param targets The targets used by this operation.
+         * @param create_request The create request.
+         * @param answer_request The answer request.
+         * @param process_answer The process answer.
+         * @param comm The MPI communicator.
          */
         virtual std::vector<unsigned int>
         run(
@@ -592,6 +599,11 @@ namespace Utilities
 
         /**
          * @copydoc Interface::run()
+         * @param targets The targets used by this operation.
+         * @param create_request The create request.
+         * @param answer_request The answer request.
+         * @param process_answer The process answer.
+         * @param comm The MPI communicator.
          */
         virtual std::vector<unsigned int>
         run(
@@ -811,6 +823,11 @@ namespace Utilities
 
         /**
          * @copydoc Interface::run()
+         * @param targets The targets used by this operation.
+         * @param create_request The create request.
+         * @param answer_request The answer request.
+         * @param process_answer The process answer.
+         * @param comm The MPI communicator.
          */
         virtual std::vector<unsigned int>
         run(
@@ -944,6 +961,11 @@ namespace Utilities
         /**
          * @copydoc Interface::run()
          *
+         * @param targets The targets used by this operation.
+         * @param create_request The create request.
+         * @param answer_request The answer request.
+         * @param process_answer The process answer.
+         * @param comm The MPI communicator.
          * @note The function call is delegated to another ConsensusAlgorithms::Interface implementation.
          */
         virtual std::vector<unsigned int>
@@ -1303,6 +1325,7 @@ namespace Utilities
         /**
          * Return whether a vector of targets (MPI ranks) has only unique
          * elements.
+         * @param targets The targets used by this operation.
          */
         inline bool
         has_unique_elements(const std::vector<unsigned int> &targets)
@@ -1318,6 +1341,8 @@ namespace Utilities
 
         /**
          * Handle exceptions inside the ConsensusAlgorithm::run() functions.
+         * @param exception The exception used by this operation.
+         * @param comm The MPI communicator.
          */
         inline void
         handle_exception(std::exception_ptr &&exception, const MPI_Comm comm)

--- a/include/deal.II/base/mpi_large_count.h
+++ b/include/deal.II/base/mpi_large_count.h
@@ -59,6 +59,11 @@ namespace Utilities
        * Create a contiguous type of (possibly large) @p count.
        *
        * See the MPI 4.x standard for details.
+       * @param count The number of entries described by @p datatype.
+       * @param oldtype The MPI datatype that describes one entry of the
+       * original buffer.
+       * @param newtype The MPI datatype object that stores the newly created
+       * derived type.
        */
       inline int
       Type_contiguous_c(MPI_Count     count,
@@ -146,6 +151,14 @@ namespace Utilities
        * Send a package to rank @p dest with a (possibly large) @p count.
        *
        * See the MPI 4.x standard for details.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param dest The destination MPI rank.
+       * @param tag The MPI message tag.
+       * @param comm The MPI communicator.
        */
       inline int
       Send_c(const void  *buf,
@@ -185,6 +198,16 @@ namespace Utilities
        * Receive a package from rank @p source with a (possibly large) @p count.
        *
        * See the MPI 4.x standard for details.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param source The source MPI rank from which data is received.
+       * @param tag The MPI message tag.
+       * @param comm The MPI communicator.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       inline int
       Recv_c(void        *buf,
@@ -227,6 +250,13 @@ namespace Utilities
        * the process with rank "root" to all other processes.
        *
        * See the MPI 4.x standard for details.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param root_mpi_rank The root mpi rank.
+       * @param comm The MPI communicator.
        */
       inline int
       Bcast_c(void        *buf,
@@ -265,6 +295,16 @@ namespace Utilities
        * Write a possibly large @p count of data at the location @p offset.
        *
        * See the MPI 4.x standard for details.
+       * @param fh The MPI file handle on which the operation acts.
+       * @param offset The offset into the underlying storage or file at which
+       * the operation starts.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       inline int
       File_write_at_c(MPI_File     fh,
@@ -301,6 +341,16 @@ namespace Utilities
        * location @p offset.
        *
        * See the MPI 4.x standard for details.
+       * @param fh The MPI file handle on which the operation acts.
+       * @param offset The offset into the underlying storage or file at which
+       * the operation starts.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       inline int
       File_write_at_all_c(MPI_File     fh,
@@ -337,6 +387,14 @@ namespace Utilities
        * Collectively write a possibly large @p count of data in order.
        *
        * See the MPI 4.x standard for details.
+       * @param fh The MPI file handle on which the operation acts.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       inline int
       File_write_ordered_c(MPI_File     fh,
@@ -372,6 +430,16 @@ namespace Utilities
        * location @p offset.
        *
        * See the MPI 4.x standard for details.
+       * @param fh The MPI file handle on which the operation acts.
+       * @param offset The offset into the underlying storage or file at which
+       * the operation starts.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       inline int
       File_read_at_c(MPI_File     fh,
@@ -408,6 +476,16 @@ namespace Utilities
        * location @p offset.
        *
        * See the MPI 4.x standard for details.
+       * @param fh The MPI file handle on which the operation acts.
+       * @param offset The offset into the underlying storage or file at which
+       * the operation starts.
+       * @param buf The address of the buffer that is sent, received, read, or
+       * written.
+       * @param count The number of entries described by @p datatype.
+       * @param datatype The MPI datatype that describes one entry of the
+       * buffer.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       inline int
       File_read_at_all_c(MPI_File     fh,

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -56,6 +56,9 @@ namespace Utilities
        * Constructor. Set up point-to-point communication pattern based on the
        * IndexSets arguments @p indexset_locally_owned and @p indexset_ghost for the MPI
        * communicator @p communicator.
+       * @param indexset_locally_owned The indexset locally owned.
+       * @param indexset_ghost The indexset ghost.
+       * @param communicator The MPI communicator.
        */
       NoncontiguousPartitioner(const IndexSet &indexset_locally_owned,
                                const IndexSet &indexset_ghost,
@@ -69,6 +72,9 @@ namespace Utilities
        * update_values_finish(). It is allowed to include entries with the
        * value numbers::invalid_dof_index which do not take part of the index
        * exchange but are present in the data vectors as padding.
+       * @param indices_locally_owned The indices locally owned.
+       * @param indices_ghost The indices ghost.
+       * @param communicator The MPI communicator.
        */
       NoncontiguousPartitioner(
         const std::vector<types::global_dof_index> &indices_locally_owned,
@@ -87,6 +93,9 @@ namespace Utilities
        * @p n_components_templated has to be set to `0` in this case. Either
        * @p n_components_templated or @p n_components can be set.
        *
+       * @param locally_owned_array The locally owned array.
+       * @param ghost_array The ghost array.
+       * @param n_components The number of components.
        * @pre The vectors only have to provide a method begin(), which allows
        *   to access their raw data.
        *
@@ -113,6 +122,12 @@ namespace Utilities
        * function, the user can provide the temporary data structures to be
        * used.
        *
+       * @param communication_channel The communication channel.
+       * @param locally_owned_array The locally owned array.
+       * @param temporary_storage The temporary storage.
+       * @param ghost_array The ghost array.
+       * @param requests The requests used by this operation.
+       * @param n_components The number of components.
        * @pre The size of the @p temporary_storage vector has to be at least
        *   temporary_storage_size. The reason for this is that this vector is
        *   used as buffer for both sending and receiving data.
@@ -134,6 +149,11 @@ namespace Utilities
        * Start update: Data is packed, non-blocking send and receives
        * are started.
        *
+       * @param communication_channel The communication channel.
+       * @param locally_owned_array The locally owned array.
+       * @param temporary_storage The temporary storage.
+       * @param requests The requests used by this operation.
+       * @param n_components The number of components.
        * @note In contrast to the function
        *   Utilities::MPI::Partitioner::export_to_ghosted_array_start, the user
        *   does not pass a reference to the destination vector, since the data
@@ -160,6 +180,10 @@ namespace Utilities
        * received. Once data from any process is received it is processed and
        * placed at the right position of the vector @p dst.
        *
+       * @param temporary_storage The temporary storage.
+       * @param ghost_array The ghost array.
+       * @param requests The requests used by this operation.
+       * @param n_components The number of components.
        * @note In contrast to the function
        *   Utilities::MPI::Partitioner::export_to_ghosted_array_finish, the user
        *   also has to pass a reference to the buffer @p temporary_storage,
@@ -181,6 +205,9 @@ namespace Utilities
        * Similar to the above functions but for importing vector entries
        * from @p ghost_array to @p locally_owned_storage.
        *
+       * @param vector_operation The vector operation.
+       * @param ghost_array The ghost array.
+       * @param locally_owned_storage The locally owned storage.
        * @note In contrast to the functions in
        *   Utilities::MPI::Partitioner, this function expects that
        *   locally_owned_storage is empty.
@@ -197,6 +224,12 @@ namespace Utilities
        * users can provide temporaty arrays. This function calls
        * import_from_ghosted_array_start() and
        * import_from_ghosted_array_finish() in sequence.
+       * @param vector_operation The vector operation.
+       * @param communication_channel The communication channel.
+       * @param ghost_array The ghost array.
+       * @param temporary_storage The temporary storage.
+       * @param locally_owned_storage The locally owned storage.
+       * @param requests The requests used by this operation.
        */
       template <typename Number>
       void
@@ -210,6 +243,11 @@ namespace Utilities
       /**
        * Start update for importig values: Data is packed, non-blocking send
        * and receives are started.
+       * @param vector_operation The vector operation.
+       * @param communication_channel The communication channel.
+       * @param ghost_array The ghost array.
+       * @param temporary_storage The temporary storage.
+       * @param requests The requests used by this operation.
        */
       template <typename Number>
       void
@@ -225,6 +263,10 @@ namespace Utilities
        * been sent and received. Once data from any process is received it is
        * processed and placed at the right position of the vector
        * @p locally_owned_storage.
+       * @param vector_operation The vector operation.
+       * @param temporary_storage The temporary storage.
+       * @param locally_owned_storage The locally owned storage.
+       * @param requests The requests used by this operation.
        */
       template <typename Number>
       void
@@ -270,6 +312,9 @@ namespace Utilities
        * Initialize the inner data structures using explicit sets of
        * indices. See the documentation of the other reinit() function for
        * what the function does.
+       * @param locally_owned_indices The locally owned indices.
+       * @param ghost_indices The ghost indices.
+       * @param communicator The MPI communicator.
        */
       void
       reinit(const std::vector<types::global_dof_index> &locally_owned_indices,

--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -90,6 +90,10 @@ namespace Utilities
       public:
         /**
          *  Constructor.
+         * @param tolerance The tolerance used by this operation.
+         * @param enforce_unique_mapping The enforce unique mapping.
+         * @param rtree_level The rtree level.
+         * @param marked_vertices The marked vertices.
          */
         AdditionalData(
           const double       tolerance                              = 1e-6,
@@ -169,6 +173,9 @@ namespace Utilities
        * a list of points @p points and mesh description (@p tria and @p
        * mapping).
        *
+       * @param points The points at which to evaluate the function.
+       * @param tria The tria used by this operation.
+       * @param mapping The mapping used by this operation.
        * @warning This is a collective call that needs to be executed by all
        *   processors in the communicator.
        *
@@ -184,6 +191,8 @@ namespace Utilities
        * Set up internal data structures and communication pattern based on
        * an existing Cache and a list of points @p points.
        *
+       * @param cache The cache used by this operation.
+       * @param points The points at which to evaluate the function.
        * @warning This is a collective call that needs to be executed by all
        *   processors in the communicator.
        *
@@ -202,6 +211,10 @@ namespace Utilities
        * Having it as a separate function makes it possible to set up the class
        * if it is known in which cells corresponding reference points are
        * located (e.g. if intersections of cells are known).
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param tria The tria used by this operation.
+       * @param mapping The mapping used by this operation.
        */
       void
       reinit(const GridTools::internal::
@@ -253,12 +266,14 @@ namespace Utilities
 
         /**
          * Return active cell iterator of the processed cell @p cell.
+         * @param cell The cell on which the operation is performed.
          */
         typename Triangulation<dim, spacedim>::active_cell_iterator
         get_active_cell_iterator(const unsigned int cell) const;
 
         /**
          * Return unit points of the processed cell @p cell.
+         * @param cell The cell on which the operation is performed.
          */
         ArrayView<const Point<dim>>
         get_unit_points(const unsigned int cell) const;
@@ -272,6 +287,9 @@ namespace Utilities
          * For more than one component, the returned ArrayView has one entry for
          * each component for each data point and all components for each point
          * are stored consecutively.
+         * @param cell The cell on which the operation is performed.
+         * @param values The values associated with the function.
+         * @param n_components The number of components.
          */
         template <typename DataType>
         ArrayView<DataType>
@@ -317,6 +335,11 @@ namespace Utilities
        * @p buffer is a temporary buffer than can be used to avoid extra
        * allocations.
        *
+       * @param output The output iterator or object that receives the
+       * computed results.
+       * @param buffer The buffer used by this operation.
+       * @param evaluation_function The evaluation function.
+       * @param sort_data The sort data.
        * @note If the map of points to cells is not a
        *   one-to-one relation (is_map_unique()==false), the result needs to be
        *   processed with the help of get_point_ptrs(). This
@@ -348,6 +371,8 @@ namespace Utilities
       /**
        * Same as above but with the result provided as return value and
        * without external allocation of a user-provided buffer.
+       * @param evaluation_function The evaluation function.
+       * @param sort_data The sort data.
        */
       template <typename DataType, unsigned int n_components = 1>
       std::vector<DataType>
@@ -361,6 +386,10 @@ namespace Utilities
        * makes the data at the points, provided by @p input, available in the
        * function @p evaluation_function.
        *
+       * @param input The input data or stream from which values are read.
+       * @param buffer The buffer used by this operation.
+       * @param evaluation_function The evaluation function.
+       * @param sort_data The sort data.
        * @warning This is a collective call that needs to be executed by all
        *   processors in the communicator.
        *
@@ -385,6 +414,9 @@ namespace Utilities
       /**
        * Same as above but without external allocation of a user-provided
        * buffer.
+       * @param input The input data or stream from which values are read.
+       * @param evaluation_function The evaluation function.
+       * @param sort_data The sort data.
        */
       template <typename DataType, unsigned int n_components = 1>
       void
@@ -418,6 +450,7 @@ namespace Utilities
 
       /**
        * Return if point @p i could be found in the domain.
+       * @param i The index of the entry.
        */
       bool
       point_found(const unsigned int i) const;
@@ -580,6 +613,13 @@ namespace Utilities
 #ifdef DEAL_II_WITH_MPI
       /**
        * Pack @p data and send it via MPI_Isend.
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param rank The rank used by this operation.
+       * @param tag The MPI message tag.
+       * @param comm The MPI communicator.
+       * @param buffers The buffers used by this operation.
+       * @param requests The requests used by this operation.
        */
       template <typename T>
       std::enable_if_t<Utilities::MPI::is_mpi_type<T> == false, void>
@@ -610,6 +650,12 @@ namespace Utilities
       /**
        * Above function specialized for data types supported by MPI
        * so that one can skip packing.
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param rank The rank used by this operation.
+       * @param tag The MPI message tag.
+       * @param comm The MPI communicator.
+       * @param requests The requests used by this operation.
        */
       template <typename T>
       std::enable_if_t<Utilities::MPI::is_mpi_type<T> == true, void>
@@ -637,6 +683,13 @@ namespace Utilities
       /**
        * Above function specialized for Tenors objects. The underlying data type
        * might be supported by MPI so that one can skip packing.
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param rank The rank used by this operation.
+       * @param tag The MPI message tag.
+       * @param comm The MPI communicator.
+       * @param buffers The buffers used by this operation.
+       * @param requests The requests used by this operation.
        */
       template <int rank_, int dim, typename T>
       std::enable_if_t<Utilities::MPI::is_mpi_type<T> == true, void>
@@ -656,6 +709,12 @@ namespace Utilities
 
       /**
        * Receive message, unpack it, and store the result in @p data.
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param comm The MPI communicator.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
+       * @param buffer The buffer used by this operation.
        */
       template <typename T>
       std::enable_if_t<Utilities::MPI::is_mpi_type<T> == false, void>
@@ -691,6 +750,11 @@ namespace Utilities
       /**
        * Above function specialized for data types supported by MPI
        * so that one can skip unpacking.
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param comm The MPI communicator.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
        */
       template <typename T>
       std::enable_if_t<Utilities::MPI::is_mpi_type<T> == true, void>
@@ -714,6 +778,12 @@ namespace Utilities
       /**
        * Above function specialized for Tensor objects. The underlying data type
        * might be supported by MPI so that one can skip unpacking.
+       * @param data The data values to read from or write to the current
+       * object.
+       * @param comm The MPI communicator.
+       * @param status The MPI status object that receives information about
+       * the completed operation.
+       * @param buffer The buffer used by this operation.
        */
       template <int rank_, int dim, typename T>
       std::enable_if_t<Utilities::MPI::is_mpi_type<T> == true, void>

--- a/include/deal.II/base/mu_parser_internal.h
+++ b/include/deal.II/base/mu_parser_internal.h
@@ -163,6 +163,10 @@ namespace internal
        * Initialize the internal state of the object. This is the same as the
        * inheriting class method - see FunctionParser::initialize() for more
        * information.
+       * @param vars The vars used by this operation.
+       * @param expressions The expressions used by this operation.
+       * @param constants The constants used by this operation.
+       * @param time_dependent The time dependent.
        */
       virtual void
       initialize(const std::string                   &vars,
@@ -179,6 +183,9 @@ namespace internal
 
       /**
        * Compute the value of a single component.
+       * @param p The point at which to evaluate the function.
+       * @param time The time associated with the evaluation.
+       * @param component The component to evaluate.
        */
       Number
       do_value(const Point<dim> &p,
@@ -187,6 +194,9 @@ namespace internal
 
       /**
        * Compute the values of all components.
+       * @param p The point at which to evaluate the function.
+       * @param time The time associated with the evaluation.
+       * @param values The object in which to store the computed values.
        */
       void
       do_all_values(const Point<dim>  &p,

--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -99,6 +99,7 @@ public:
    * executed by Utilities::MPI::MPI_InitFinalize. Use the appropriate
    * argument of the constructor of Utilities::MPI::MPI_InitFinalize if you
    * have an MPI based code.
+   * @param max_threads The max threads.
    */
   static void
   set_thread_limit(

--- a/include/deal.II/base/mutable_bind.h
+++ b/include/deal.II/base/mutable_bind.h
@@ -88,6 +88,8 @@ namespace Utilities
     /**
      * Construct a MutableBind object specifying the function, and
      * each arguments separately.
+     * @param function The function object.
+     * @param arguments The arguments used by this operation.
      */
     template <typename FunctionType>
     MutableBind(FunctionType function, FunctionArgs &&...arguments);
@@ -95,6 +97,8 @@ namespace Utilities
     /**
      * Construct a MutableBind object specifying the function, and
      * the arguments as a tuple.
+     * @param function The function object.
+     * @param arguments The arguments used by this operation.
      */
     template <typename FunctionType>
     MutableBind(FunctionType function, TupleType &&arguments);
@@ -102,6 +106,7 @@ namespace Utilities
     /**
      * Construct a MutableBind object specifying only the function. By default,
      * the arguments are left to their default constructor values.
+     * @param function The function object.
      */
     template <typename FunctionType>
     MutableBind(FunctionType function);
@@ -116,6 +121,7 @@ namespace Utilities
     /**
      * Set the arguments to use in @p function, for next time
      * operator()() is called, using move semantic.
+     * @param arguments The arguments used by this operation.
      */
     void
     set_arguments(TupleType &&arguments);
@@ -123,6 +129,7 @@ namespace Utilities
     /**
      * Set the arguments to use in @p function, for next time
      * operator()() is called, using move semantic.
+     * @param arguments The arguments used by this operation.
      */
     void
     set_arguments(FunctionArgs &&...arguments);
@@ -178,6 +185,8 @@ namespace Utilities
    * bound.parse_arguments("3: 4.0");
    * bound(); // will execute my_function(3, 4.0);
    * @endcode
+   * @param function The function object.
+   * @param arguments The arguments used by this operation.
    */
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
@@ -186,6 +195,7 @@ namespace Utilities
 
   /**
    * Same as above, using a std::function object.
+   * @param arguments The arguments used by this operation.
    */
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
@@ -201,6 +211,7 @@ namespace Utilities
    * object, then the arguments passed to the function object will be
    * initialized with the values coming from each of the arguments' default
    * constructors.
+   * @param function The function object.
    */
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -267,18 +267,21 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * other words, if you give a very large number of type <code>long
    * double</code>, this function may return <code>false</code> even if the
    * number is finite with respect to type <code>long double</code>.
+   * @param x The value whose finiteness is to be tested.
    */
   bool is_finite(const double x);
 
   /**
    * Return @p true if real and imaginary parts of the given complex number
    * are finite.
+   * @param x The value whose finiteness is to be tested.
    */
   bool is_finite(const std::complex<double> &x);
 
   /**
    * Return @p true if real and imaginary parts of the given complex number
    * are finite.
+   * @param x The value whose finiteness is to be tested.
    */
   bool is_finite(const std::complex<float> &x);
 
@@ -289,6 +292,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * Again may not work correctly if real or imaginary parts are very large
    * numbers that are infinite in terms of <code>double</code>, but finite
    * with respect to <code>long double</code>.
+   * @param x The value whose finiteness is to be tested.
    */
   bool is_finite(const std::complex<long double> &x);
 
@@ -299,6 +303,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note This function expects that @p value_2 is castable to the type
    * of @p value_1.
    */
@@ -313,6 +319,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note This function expects that @p value_2 is castable to the type
    * of @p value_1.
    */
@@ -326,6 +334,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * For intricate data types (e.g. some automatically differentiable numbers),
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
+   * @param value The value associated with the function.
    */
   template <typename Number>
   constexpr DEAL_II_HOST_DEVICE bool value_is_zero(const Number &value);
@@ -337,6 +346,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note This function expects that @p value_2 is castable to the type
    * of @p value_1.
    */
@@ -350,6 +361,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note This function expects that @p value_2 is castable to the type
    * of @p value_1.
    */
@@ -366,6 +379,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note This function expects that @p value_2 is castable to the type
    * of @p value_1.
    */
@@ -379,6 +394,8 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note This function expects that @p value_2 is castable to the type
    * of @p value_1.
    */
@@ -422,6 +439,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
      * template is selected if number is not a complex data type, this
      * function simply returns the given number.
      *
+     * @param x The value on which this function operates.
      * @note This function can also be used in @ref GlossDevice "device" code.
      */
     static constexpr DEAL_II_HOST_DEVICE const number &
@@ -432,6 +450,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
      * general template is chosen for types not equal to std::complex, this
      * function simply returns the square of the given number.
      *
+     * @param x The value on which this function operates.
      * @note If the template type can be used in @ref GlossDevice "device" code, the same holds true
      * for this function.
      */
@@ -440,6 +459,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
     /**
      * Return the absolute value of a number.
+     * @param x The value on which this function operates.
      */
     static DEAL_II_HOST_DEVICE real_type
     abs(const number &x);
@@ -475,6 +495,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
     /**
      * Return the complex-conjugate of the given number.
+     * @param x The value on which this function operates.
      */
     static constexpr std::complex<number>
     conjugate(const std::complex<number> &x);
@@ -484,6 +505,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
      * specialization of the general template is chosen for types equal to
      * std::complex, this function returns the product of a number and its
      * complex conjugate.
+     * @param x The value on which this function operates.
      */
     static constexpr real_type
     abs_square(const std::complex<number> &x);
@@ -491,6 +513,7 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
 
     /**
      * Return the absolute value of a complex number.
+     * @param x The complex value whose finiteness is to be tested.
      */
     static real_type
     abs(const std::complex<number> &x);
@@ -761,6 +784,8 @@ namespace numbers
    * returns only whether the scalar values stored by the input values are
    * equal.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note When ADOL-C is compiled with the "advanced branching" feature, then
    * this specialization is only intended for use in assertions and
    * other code paths that do not affect the end result of a computation.
@@ -781,6 +806,8 @@ namespace numbers
    * returns only whether the scalar values stored by the input values are
    * equal.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note When ADOL-C is compiled with the "advanced branching" feature, then
    * this specialization is only intended for use in assertions and
    * other code paths that do not affect the end result of a computation.
@@ -816,6 +843,8 @@ namespace numbers
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note When ADOL-C is compiled with the "advanced branching" feature, then
    * this specialization is only intended for use in assertions and
    * other code paths that do not affect the end result of a computation.
@@ -837,6 +866,8 @@ namespace numbers
    * this function returns the result of the comparison of scalar values stored
    * by the input arguments.
    *
+   * @param value_1 The value 1.
+   * @param value_2 The value 2.
    * @note When ADOL-C is compiled with the "advanced branching" feature, then
    * this specialization is only intended for use in assertions and
    * other code paths that do not affect the end result of a computation.

--- a/include/deal.II/base/observer_pointer.h
+++ b/include/deal.II/base/observer_pointer.h
@@ -120,11 +120,13 @@ public:
   /**
    * Copy constructor for ObserverPointer. We do not copy the object subscribed
    * to from <tt>tt</tt>, but subscribe ourselves to it again.
+   * @param other The object to copy or move from.
    */
   ObserverPointer(const ObserverPointer<T, P> &other);
 
   /**
    * Move constructor for ObserverPointer.
+   * @param other The object to copy or move from.
    */
   ObserverPointer(ObserverPointer<T, P> &&other) noexcept;
 
@@ -136,6 +138,8 @@ public:
    * The <tt>id</tt> is used in the call to
    * EnableObserverPointer::subscribe(id) and by ~ObserverPointer()
    * in the call to EnableObserverPointer::unsubscribe().
+   * @param t The time associated with the evaluation.
+   * @param id The id used by this operation.
    */
   ObserverPointer(T *t, const std::string &id);
 
@@ -144,6 +148,7 @@ public:
    * not a null pointer, the constructor subscribes to the given object to
    * lock it, i.e. to prevent its destruction before the end of its use. The
    * id of this pointer is set to the name of the class P.
+   * @param t The time associated with the evaluation.
    */
   ObserverPointer(T *t);
 
@@ -157,6 +162,7 @@ public:
    * new object automatically and unsubscribes to an old one if it exists. It
    * will not try to subscribe to a null-pointer, but still delete the old
    * subscription.
+   * @param tt The tt used by this operation.
    */
   ObserverPointer<T, P> &
   operator=(T *tt);
@@ -172,12 +178,14 @@ public:
   /**
    * Assignment operator for ObserverPointer. The pointer subscribes to the new
    * object automatically and unsubscribes to an old one if it exists.
+   * @param other The object to copy or move from.
    */
   ObserverPointer<T, P> &
   operator=(const ObserverPointer<T, P> &other);
 
   /**
    * Move assignment operator for ObserverPointer.
+   * @param other The object to copy or move from.
    */
   ObserverPointer<T, P> &
   operator=(ObserverPointer<T, P> &&other) noexcept;
@@ -242,6 +250,8 @@ public:
    *
    * Note that we indeed need a reference of a pointer, as we want to change
    * the pointer variable which we are given.
+   * @param ptr A pointer to the first element of the memory region on which
+   * this operation acts.
    */
   void
   swap(T *&ptr);
@@ -677,6 +687,8 @@ swap(ObserverPointer<T, P> &t1, ObserverPointer<T, Q> &t2)
  *
  * Note that we indeed need a reference of a pointer, as we want to change the
  * pointer variable which we are given.
+ * @param t1 The first object to compare.
+ * @param t2 The second object to compare.
  */
 template <typename T, typename P>
 inline void
@@ -693,6 +705,8 @@ swap(ObserverPointer<T, P> &t1, T *&t2)
  *
  * Note that we indeed need a reference of a pointer, as we want to change the
  * pointer variable which we are given.
+ * @param t1 The first object to compare.
+ * @param t2 The second object to compare.
  */
 template <typename T, typename P>
 inline void

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -82,6 +82,11 @@ namespace parallel
 #ifdef DEAL_II_WITH_TASKFLOW
     /**
      * Internal function to do a parallel_for using taskflow
+     * @param x_begin The x begin.
+     * @param x_end The x end.
+     * @param functor The callable object to apply to each item or subrange.
+     * @param grainsize The minimum number of items assigned to one chunk of
+     * work.
      */
     template <typename Iterator, typename Functor>
     void
@@ -121,6 +126,11 @@ namespace parallel
 #ifdef DEAL_II_WITH_TBB
     /**
      * Encapsulate tbb::parallel_for.
+     * @param x_begin The x begin.
+     * @param x_end The x end.
+     * @param functor The callable object to apply to each item or subrange.
+     * @param grainsize The minimum number of items assigned to one chunk of
+     * work.
      */
     template <typename Iterator, typename Functor>
     void
@@ -138,6 +148,13 @@ namespace parallel
 
     /**
      * Encapsulate tbb::parallel_for when an affinite_partitioner is provided.
+     * @param x_begin The x begin.
+     * @param x_end The x end.
+     * @param functor The callable object to apply to each item or subrange.
+     * @param grainsize The minimum number of items assigned to one chunk of
+     * work.
+     * @param partitioner The TBB affinity partitioner used to preserve
+     * thread-to-data affinity across repeated calls.
      */
     template <typename Iterator, typename Functor>
     void
@@ -156,6 +173,9 @@ namespace parallel
 
     /**
      * Just execute things sequentially.
+     * @param x_begin The x begin.
+     * @param x_end The x end.
+     * @param functor The callable object to apply to each item or subrange.
      */
     template <typename Iterator, typename Functor>
     void
@@ -198,6 +218,13 @@ namespace parallel
    *    std::assignable_from<decltype(*std::declval<OutputIterator>()),
    *    std::invoke_result_t<Function,
    * decltype(*std::declval<InputIterator>())>>)}
+   * @param begin_in The begin in.
+   * @param end_in The end in.
+   * @param out The output iterator or object that receives the computed
+   * results.
+   * @param function The function object.
+   * @param grainsize The minimum number of items assigned to one chunk of
+   * work.
    */
   template <typename InputIterator, typename OutputIterator, typename Function>
   DEAL_II_CXX20_REQUIRES(
@@ -281,6 +308,15 @@ namespace parallel
    *    std::invoke_result_t<Function,
    * decltype(*std::declval<InputIterator1>()),
    *    decltype(*std::declval<InputIterator2>())>>)}
+   * @param begin_in1 The begin in1.
+   * @param end_in1 The end in1.
+   * @param in2 The beginning of the additional input range processed together
+   * with the first range.
+   * @param out The output iterator or object that receives the computed
+   * results.
+   * @param function The function object.
+   * @param grainsize The minimum number of items assigned to one chunk of
+   * work.
    */
   template <typename InputIterator1,
             typename InputIterator2,
@@ -376,6 +412,17 @@ namespace parallel
    * decltype(*std::declval<InputIterator1>()),
    *    decltype(*std::declval<InputIterator2>()),
    *    decltype(*std::declval<InputIterator3>())>>)}
+   * @param begin_in1 The begin in1.
+   * @param end_in1 The end in1.
+   * @param in2 The beginning of the additional input range processed together
+   * with the first range.
+   * @param in3 The beginning of the additional input range processed together
+   * with the first range.
+   * @param out The output iterator or object that receives the computed
+   * results.
+   * @param function The function object.
+   * @param grainsize The minimum number of items assigned to one chunk of
+   * work.
    */
   template <typename InputIterator1,
             typename InputIterator2,
@@ -457,6 +504,8 @@ namespace parallel
      * end.
      *
      * @dealiiConceptRequires{(std::invocable<Function, Iterator, Iterator>)}
+     * @param range The range of iterators processed by this operation.
+     * @param f The function object.
      */
     template <typename Iterator, typename Function>
     DEAL_II_CXX20_REQUIRES((std::invocable<Function, Iterator, Iterator>))
@@ -539,6 +588,11 @@ namespace parallel
    * topic.
    *
    * @dealiiConceptRequires{(std::invocable<Function, Iterator, Iterator>)}
+   * @param begin The begin of the range.
+   * @param end The end of the range.
+   * @param f The function object.
+   * @param grainsize The minimum number of items assigned to one chunk of
+   * work.
    */
   template <typename Iterator, typename Function>
   DEAL_II_CXX20_REQUIRES((std::invocable<Function, Iterator, Iterator>))
@@ -687,6 +741,9 @@ namespace parallel
      * because it any operation that changes the data of a derived class will
      * inherently not be thread-safe when several threads work with the same
      * data simultaneously.
+     * @param begin The begin of the range.
+     * @param end The end of the range.
+     * @param minimum_parallel_grain_size The minimum parallel grain size.
      */
     void
     apply_parallel(const std::size_t begin,
@@ -752,6 +809,11 @@ namespace parallel
    * multithreading. Otherwise, it may be called on subsets of the given
    * range, with results from the individual subranges accumulated internally.
    *
+   * @param f The function object.
+   * @param begin The begin of the range.
+   * @param end The end of the range.
+   * @param grainsize The minimum number of items assigned to one chunk of
+   * work.
    * @warning If ResultType is a floating point type, then accumulation is not
    * an associative operation. In other words, if the given function object is
    * called three times on three subranges, returning values $a,b,c$, then the
@@ -844,6 +906,7 @@ namespace parallel
        * After using the partitioner in a tbb loop through
        * acquire_one_partitioner(), this call makes the partitioner available
        * again.
+       * @param p The point at which to evaluate the function.
        */
       void
       release_one_partitioner(

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -362,6 +362,7 @@ public:
    * a section name is specified, then this is used to scope the
    * parameters in the given section, otherwise a pretty printed
    * version of the derived class is used.
+   * @param section_name The section name.
    */
   ParameterAcceptor(const std::string &section_name = "");
 
@@ -445,6 +446,7 @@ public:
    * Derived classes can use this method to declare their parameters.
    * ParameterAcceptor::initialize() calls it for each derived class. The
    * default implementation is empty.
+   * @param prm The prm used by this operation.
    */
   virtual void
   declare_parameters(ParameterHandler &prm);
@@ -461,6 +463,7 @@ public:
    * Derived classes can use this method to parse their parameters.
    * ParameterAcceptor::initialize() calls it for each derived class. The
    * default implementation is empty.
+   * @param prm The prm used by this operation.
    */
   virtual void
   parse_parameters(ParameterHandler &prm);
@@ -480,6 +483,7 @@ public:
    * Parse the given ParameterHandler. This function enters the
    * subsection returned by get_section_name() for each derived class,
    * and parses all parameters that were added using add_parameter().
+   * @param prm The prm used by this operation.
    */
   static void
   parse_all_parameters(ParameterHandler &prm = ParameterAcceptor::prm);
@@ -489,6 +493,7 @@ public:
    * parameters.This function enters the subsection returned by
    * get_section_name() for each derived class, and declares all parameters
    * that were added using add_parameter().
+   * @param prm The prm used by this operation.
    */
   static void
   declare_all_parameters(ParameterHandler &prm = ParameterAcceptor::prm);
@@ -516,6 +521,12 @@ public:
    *
    * See the documentation of ParameterHandler::add_parameter() for more
    * information.
+   * @param entry The parameter entry that is declared, queried, or
+   * documented.
+   * @param parameter The parameter used by this operation.
+   * @param documentation The text used to document the parameter or object.
+   * @param prm_ The object in which to store the prm .
+   * @param pattern The pattern that valid parameter values must satisfy.
    */
   template <typename ParameterType>
   void
@@ -581,6 +592,7 @@ public:
    *   end
    * end
    * @endcode
+   * @param subsection The subsection used by this operation.
    */
   void
   enter_subsection(const std::string &subsection);
@@ -594,6 +606,7 @@ public:
 
   /**
    * Make sure we enter the right subsection of the given parameter.
+   * @param prm The prm used by this operation.
    */
   void
   enter_my_subsection(ParameterHandler &prm);
@@ -601,6 +614,7 @@ public:
   /**
    * This function undoes what the enter_my_subsection() function did. It only
    * makes sense if enter_my_subsection() was called on `prm` before this one.
+   * @param prm The prm used by this operation.
    */
   void
   leave_my_subsection(ParameterHandler &prm);
@@ -624,13 +638,10 @@ private:
   static std::set<ParameterAcceptor *, internal::ParameterAcceptorCompare>
     class_list;
 
-  /** The id of this specific class instance. */
-  const unsigned int acceptor_id;
-
   /**
-   * Separator between sections.
-   */
-  static const char sep = '/';
+   *  The id of this specific class instance. */
+  *const unsigned int acceptor_id;
+  **Separator between sections.*/ static const char sep = '/';
 
 protected:
   /** The subsection name for this class. */
@@ -699,6 +710,8 @@ public:
    * Default constructor. The argument `section_name` is forwarded to the
    * constructor of the ParameterAcceptor class, while all other arguments
    * are passed to the SourceClass constructor.
+   * @param section_name The section name.
+   * @param args The args used by this operation.
    */
   template <typename... Args>
   ParameterAcceptorProxy(const std::string &section_name, Args... args);
@@ -706,6 +719,7 @@ public:
   /**
    * Overloads the ParameterAcceptor::declare_parameters function, by calling
    * @p SourceClass::declare_parameters with @p prm as an argument.
+   * @param prm The prm used by this operation.
    */
   virtual void
   declare_parameters(ParameterHandler &prm) override;
@@ -713,6 +727,7 @@ public:
   /**
    * Overloads the ParameterAcceptor::parse_parameters function, by calling
    * @p SourceClass::parse_parameters with @p prm as an argument.
+   * @param prm The prm used by this operation.
    */
   virtual void
   parse_parameters(ParameterHandler &prm) override;

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1009,6 +1009,10 @@ public:
    * function was called. No further processing of the input stream
    * occurs, that is everything that comes after the parameter whose
    * value does not satisfy its pattern is ignored.
+   * @param input The input data or stream from which values are read.
+   * @param filename The file name.
+   * @param last_line The last line.
+   * @param skip_undefined The skip undefined.
    */
   virtual void
   parse_input(std::istream      &input,
@@ -1036,6 +1040,10 @@ public:
    * also set `assert_mandatory_entries_are_found=true`. For example, this
    * ensures that parameters with typos in the input file will not be skipped,
    * while such mistakes would otherwise remain unrecognized.
+   * @param filename The file name.
+   * @param last_line The last line.
+   * @param skip_undefined The skip undefined.
+   * @param assert_mandatory_entries_are_found The assert mandatory entries are found.
    */
   virtual void
   parse_input(const std::string &filename,
@@ -1050,6 +1058,9 @@ public:
    * The function in essence reads the entire file into a stream and
    * then calls the other parse_input() function with that stream. See
    * there for more information.
+   * @param s The value on which this function operates.
+   * @param last_line The last line.
+   * @param skip_undefined The skip undefined.
    */
   virtual void
   parse_input_from_string(const std::string &s,
@@ -1062,6 +1073,8 @@ public:
    * using the XML output style and then modified by hand as necessary, or from
    * a file written using this method and then modified by the graphical
    * parameter GUI (see the general documentation of this class).
+   * @param input The input data or stream from which values are read.
+   * @param skip_undefined The skip undefined.
    */
   virtual void
   parse_input_from_xml(std::istream &input, const bool skip_undefined = false);
@@ -1072,6 +1085,8 @@ public:
    * using the JSON output style and then modified by hand as necessary, or from
    * a separate program that knows how to write JSON format for ParameterHandler
    * input.
+   * @param input The input data or stream from which values are read.
+   * @param skip_undefined The skip undefined.
    */
   virtual void
   parse_input_from_json(std::istream &input, const bool skip_undefined = false);
@@ -1105,6 +1120,12 @@ public:
    * successfully can be queried by the functions get_entries_wrongly_not_set()
    * and assert_that_entries_have_been_set().
    *
+   * @param entry The parameter entry that is declared, queried, or
+   * documented.
+   * @param default_value The default value.
+   * @param pattern The pattern that valid parameter values must satisfy.
+   * @param documentation The text used to document the parameter or object.
+   * @param has_to_be_set The has to be set.
    * @note An entry can be declared more than once without generating an
    * error, for example to override an earlier default value.
    */
@@ -1164,6 +1185,9 @@ public:
    * It is valid to add multiple actions to the same parameter. They will
    * in that case be executed in the same order in which they were added.
    *
+   * @param entry The parameter entry that is declared, queried, or
+   * documented.
+   * @param execute_action The execute action.
    * @note Actions may modify all sorts of variables in their scope. The
    *  only thing an action should not modify is the ParameterHandler object
    *  it is attached to. In other words, it is not allowed to enter or
@@ -1201,6 +1225,12 @@ public:
    * one of the methods provided by this class. Whether a parameter has been set
    * successfully can be queried by the functions get_entries_wrongly_not_set()
    * and assert_that_entries_have_been_set().
+   * @param entry The parameter entry that is declared, queried, or
+   * documented.
+   * @param parameter The parameter used by this operation.
+   * @param documentation The text used to document the parameter or object.
+   * @param pattern The pattern that valid parameter values must satisfy.
+   * @param has_to_be_set The has to be set.
    */
   template <typename ParameterType>
   void
@@ -1261,6 +1291,8 @@ public:
 
   /**
    * Enter a subsection. If it does not yet exist, create it if requested.
+   * @param subsection The subsection used by this operation.
+   * @param create_path_if_needed The create path if needed.
    */
   void
   enter_subsection(const std::string &subsection,
@@ -1276,6 +1308,7 @@ public:
    * Check whether a subsection or a subsection path exists in current tree.
    * The input parameter @p sub_path is assumed to be relative to the
    * currently selected path.
+   * @param sub_path The sub path.
    */
   bool
   subsection_path_exists(const std::vector<std::string> &sub_path) const;
@@ -1296,6 +1329,7 @@ public:
    * Given the name of an entry as argument, the function computes a full path
    * into the parameter tree using the current subsection. The path elements are
    * separated by the path_separator, which is a '.'.
+   * @param name The name under which the parameter is declared.
    */
   std::string
   get_current_full_path(const std::string &name) const;
@@ -1304,6 +1338,8 @@ public:
    * This function computes a full path into the parameter tree given a path
    * from the current subsection and the name of an entry. The path elements are
    * separated by the path_separator, which is a '.'.
+   * @param sub_path The sub path.
+   * @param name The name under which the parameter is declared.
    */
   std::string
   get_current_full_path(const std::vector<std::string> &sub_path,
@@ -1313,6 +1349,7 @@ public:
    * Return value of entry @p entry_string.  If the entry was changed,
    * then the changed value is returned, otherwise the default value. If the
    * value of an undeclared entry is required, an @p Assert will fail.
+   * @param entry_string The entry string.
    */
   std::string
   get(const std::string &entry_string) const;
@@ -1326,6 +1363,8 @@ public:
    * subsection. The first string in @p entry_subsection_path must be the name
    * of a subsection of the current section, and each next string must be the
    * name of a subsection of the one before it.
+   * @param entry_subsection_path The entry subsection path.
+   * @param entry_string The entry string.
    */
   std::string
   get(const std::vector<std::string> &entry_subsection_path,
@@ -1335,6 +1374,7 @@ public:
    * Return value of entry @p entry_string as <code>long int</code>. (A long
    * int is chosen so that even very large unsigned values can be returned by
    * this function).
+   * @param entry_string The entry string.
    */
   long int
   get_integer(const std::string &entry_string) const;
@@ -1346,6 +1386,8 @@ public:
    * If @p entry_subsection_path is non-empty, the value will be gotten
    * from the subsection represented by that path instead of the current
    * subsection.
+   * @param entry_subsection_path The entry subsection path.
+   * @param entry_string The entry string.
    */
   long int
   get_integer(const std::vector<std::string> &entry_subsection_path,
@@ -1353,6 +1395,7 @@ public:
 
   /**
    * Return value of entry @p entry_name as @p double.
+   * @param entry_name The entry name.
    */
   double
   get_double(const std::string &entry_name) const;
@@ -1362,6 +1405,8 @@ public:
    * If @p entry_subsection_path is non-empty, the value will be gotten
    * from the subsection represented by that path instead of the current
    * subsection.
+   * @param entry_subsection_path The entry subsection path.
+   * @param entry_string The entry string.
    */
   double
   get_double(const std::vector<std::string> &entry_subsection_path,
@@ -1370,6 +1415,7 @@ public:
    * Return value of entry @p entry_name as @p bool. The entry may
    * be "true" or "yes" for @p true, "false" or "no" for @p false
    * respectively.
+   * @param entry_name The entry name.
    */
   bool
   get_bool(const std::string &entry_name) const;
@@ -1381,6 +1427,8 @@ public:
    * If @p entry_subsection_path is non-empty, the value will be gotten
    * from the subsection represented by that path instead of the current
    * subsection.
+   * @param entry_subsection_path The entry subsection path.
+   * @param entry_string The entry string.
    */
   bool
   get_bool(const std::vector<std::string> &entry_subsection_path,
@@ -1394,6 +1442,8 @@ public:
    *
    * The function throws an exception of type ExcValueDoesNotMatchPattern if
    * the new value does not conform to the pattern for this entry.
+   * @param entry_name The entry name.
+   * @param new_value The new value.
    */
   void
   set(const std::string &entry_name, const std::string &new_value);
@@ -1407,6 +1457,8 @@ public:
    *
    * The function throws an exception of type ExcValueDoesNotMatchPattern if
    * the new value does not conform to the pattern for this entry.
+   * @param entry_name The entry name.
+   * @param new_value The new value.
    */
   void
   set(const std::string &entry_name, const char *new_value);
@@ -1419,6 +1471,8 @@ public:
    *
    * The function throws an exception of type ExcValueDoesNotMatchPattern if
    * the new value does not conform to the pattern for this entry.
+   * @param entry_name The entry name.
+   * @param new_value The new value.
    */
   void
   set(const std::string &entry_name, const long int new_value);
@@ -1435,6 +1489,8 @@ public:
    *
    * The function throws an exception of type ExcValueDoesNotMatchPattern if
    * the new value does not conform to the pattern for this entry.
+   * @param entry_name The entry name.
+   * @param new_value The new value.
    */
   void
   set(const std::string &entry_name, const double new_value);
@@ -1447,6 +1503,8 @@ public:
    *
    * The function throws an exception of type ExcValueDoesNotMatchPattern if
    * the new value does not conform to the pattern for this entry.
+   * @param entry_name The entry name.
+   * @param new_value The new value.
    */
   void
   set(const std::string &entry_name, const bool new_value);
@@ -1522,6 +1580,8 @@ public:
    * \printindex[prmindex]
    * \printindex[prmindexfull]
    * @endcode
+   * @param out The output stream to which data is written.
+   * @param style The style in which parameter information is formatted.
    */
   std::ostream &
   print_parameters(std::ostream &out, const OutputStyle style) const;
@@ -1563,6 +1623,8 @@ public:
    * to <tt>KeepDeclarationOrder</tt>: in this case entries are printed in the
    * same order as they have been declared.
    *
+   * @param out The output stream to which data is written.
+   * @param style The style in which parameter information is formatted.
    * @note All style settings in @p style not related to the ordering are
    *   ignored.
    */
@@ -1581,6 +1643,8 @@ public:
    * to <tt>KeepDeclarationOrder</tt>: in this case entries are printed in the
    * same order as they have been declared.
    *
+   * @param out The output stream to which data is written.
+   * @param style The style in which parameter information is formatted.
    * @note All style settings in @p style not related to the ordering are
    *   ignored.
    *
@@ -1633,6 +1697,7 @@ public:
 
   /**
    * Test for equality.
+   * @param prm2 The prm2 used by this operation.
    */
   bool
   operator==(const ParameterHandler &prm2) const;
@@ -1696,6 +1761,8 @@ public:
                  << "> does not match the given pattern <" << arg2 << ">.");
   /**
    * Exception
+   * @param ExcAlreadyAtTopLevel The exc already at top level used by this
+   * operation.
    */
   DeclExceptionMsg(
     ExcAlreadyAtTopLevel,
@@ -1774,6 +1841,8 @@ public:
    * Exception for when an XML file cannot be read at all. This happens when
    * there is no top-level XML element called "ParameterHandler" or when there
    * are multiple top level elements.
+   * @param ExcInvalidXMLParameterFile The exc invalid xmlparameter file used
+   * by this operation.
    */
   DeclExceptionMsg(ExcInvalidXMLParameterFile,
                    "The provided file could not be parsed as a "
@@ -1863,6 +1932,10 @@ private:
    * parsing a parameter file, for example to obtain only the spatial dimension
    * of the problem. By default all entries and subsections are expected to be
    * declared.
+   * @param line The local line index to which the query refers.
+   * @param input_filename The input filename.
+   * @param current_line_n The current line n.
+   * @param skip_undefined The skip undefined.
    */
   void
   scan_line(std::string        line,
@@ -1880,6 +1953,11 @@ private:
    * argument indicates how many spaces the output should be indented,
    * so that subsections properly nest inside the output of higher
    * sections.
+   * @param tree The tree used by this operation.
+   * @param target_subsection_path The target subsection path.
+   * @param style The style in which parameter information is formatted.
+   * @param indent_level The indent level.
+   * @param out The output stream to which data is written.
    */
   void
   recursively_print_parameters(
@@ -1898,6 +1976,8 @@ private:
  * if it did not then the result of the bit-or <tt>operator |</tt> would be an
  * integer which would in turn trigger a compiler warning when we tried to
  * assign it to an object of type ParameterHandler::OutputStyle.
+ * @param f1 The first callback to combine.
+ * @param f2 The second callback to combine.
  */
 inline ParameterHandler::OutputStyle
 operator|(const ParameterHandler::OutputStyle f1,
@@ -2141,12 +2221,14 @@ public:
     /**
      * <tt>create_new</tt> must provide a clean object, either by creating a
      * new one or by cleaning an old one.
+     * @param run_no The run no.
      */
     virtual void
     create_new(const unsigned int run_no) = 0;
 
     /**
      * Get the parameters and run any necessary action.
+     * @param prm The prm used by this operation.
      */
     virtual void
     run(ParameterHandler &prm) = 0;
@@ -2179,6 +2261,10 @@ public:
    * of the problem. By default all entries and subsections are expected to be
    * declared.
    *
+   * @param input The input data or stream from which values are read.
+   * @param filename The file name.
+   * @param last_line The last line.
+   * @param skip_undefined The skip undefined.
    * @note This is the only overload of the three <tt>parse_input</tt>
    * functions implemented by ParameterHandler overridden with new behavior by
    * this class. This is because the other two <tt>parse_input</tt> functions
@@ -2201,6 +2287,7 @@ public:
 
   /**
    * run the central loop.
+   * @param uc The uc used by this operation.
    */
   void
   loop(UserClass &uc);
@@ -2247,6 +2334,10 @@ private:
      * Construct an object with given subsection path, name and value. The
      * splitting up into the different variants is done later by
      * <tt>split_different_values</tt>.
+     * @param Path The file name.
+     * @param Name The name associated with the object being created or
+     * queried.
+     * @param Value The value associated with the function.
      */
     Entry(const std::vector<std::string> &Path,
           const std::string              &Name,

--- a/include/deal.II/base/parsed_convergence_table.h
+++ b/include/deal.II/base/parsed_convergence_table.h
@@ -246,6 +246,7 @@ public:
    * Attach all the parameters in this class to entries of the parameter
    * handler @p prm. Whenever the content of @p prm changes, the parameters
    * of this class will be updated.
+   * @param prm The prm used by this operation.
    */
   void
   add_parameters(ParameterHandler &prm);
@@ -260,6 +261,11 @@ public:
    * When it is a vector function, an assertion is triggered if the number of
    * components does not coincide with the number of components of the
    * underlying finite element space.
+   * @param vspace The vspace used by this operation.
+   * @param solution The solution used by this operation.
+   * @param exact The exact used by this operation.
+   * @param weight The weights used in the quadrature rule or linear
+   * combination.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -270,6 +276,12 @@ public:
 
   /**
    * Same as above, with a different mapping.
+   * @param mapping The mapping used by this operation.
+   * @param vspace The vspace used by this operation.
+   * @param solution The solution used by this operation.
+   * @param exact The exact used by this operation.
+   * @param weight The weights used in the quadrature rule or linear
+   * combination.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -352,6 +364,8 @@ public:
 
   /**
    * Difference between two solutions in the same vector space.
+   * @param weight The weights used in the quadrature rule or linear
+   * combination.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -362,6 +376,9 @@ public:
 
   /**
    * Same as above, with a non default mapping.
+   * @param mapping The mapping used by this operation.
+   * @param weight The weights used in the quadrature rule or linear
+   * combination.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -375,6 +392,7 @@ public:
    * Write the error table to the @p out stream (in text format), and
    * (possibly) to the file stream specified in the parameters (with the format
    * deduced from the file name extension).
+   * @param out The output stream to which data is written.
    */
   void
   output_table(std::ostream &out);

--- a/include/deal.II/base/parsed_function.h
+++ b/include/deal.II/base/parsed_function.h
@@ -85,6 +85,8 @@ namespace Functions
      * @p n_components components (defaults to 1). The parameter @p h is used
      * to initialize the AutoDerivativeFunction class from which this class is
      * derived.
+     * @param n_components The number of components.
+     * @param h The h used by this operation.
      */
     ParsedFunction(const unsigned int n_components = 1, const double h = 1e-8);
 
@@ -105,6 +107,9 @@ namespace Functions
      *  set Variable names      = x,y,t
      *
      *  @endcode
+     * @param prm The prm used by this operation.
+     * @param n_components The number of components.
+     * @param input_expr The input expr.
      */
     static void
     declare_parameters(ParameterHandler  &prm,
@@ -181,6 +186,7 @@ namespace Functions
      *
      * The time variable can be set according to specifications in the
      * FunctionTime base class.
+     * @param prm The prm used by this operation.
      */
     void
     parse_parameters(ParameterHandler &prm);
@@ -188,6 +194,8 @@ namespace Functions
     /**
      * Return all components of a vector-valued function at the given point @p
      * p.
+     * @param p The point at which to evaluate the function.
+     * @param values The object in which to store the computed values.
      */
     virtual void
     vector_value(const Point<dim> &p, Vector<double> &values) const override;
@@ -197,6 +205,8 @@ namespace Functions
      * only one component (i.e. the function is scalar), you should state the
      * component you want to have evaluated; it defaults to zero, i.e. the
      * first component.
+     * @param p The point at which to evaluate the function.
+     * @param component The component to evaluate.
      */
     virtual double
     value(const Point<dim> &p, const unsigned int component = 0) const override;
@@ -206,6 +216,7 @@ namespace Functions
      *
      * We need to overwrite this to set the time also in the accessor
      * FunctionParser<dim>.
+     * @param newtime The newtime used by this operation.
      */
     virtual void
     set_time(const double newtime) override;

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -207,6 +207,7 @@ namespace Utilities
       /**
        * Constructor with size argument. Creates an MPI_COMM_SELF structure
        * where there is no real parallel layout.
+       * @param size The number of entries in the object to create or resize.
        */
       Partitioner(const unsigned int size);
 
@@ -218,6 +219,9 @@ namespace Utilities
        * and one-to-one fashion, i.e., the indices of process $p$ sit exactly
        * between the indices of the processes $p-1$ and $p+1$, respectively.
        *
+       * @param local_size The local size.
+       * @param ghost_size The ghost size.
+       * @param communicator The MPI communicator.
        * @note Setting the @p ghost_size variable to an appropriate value
        *   provides memory space for the ghost data in a vector's memory
        *   allocation as and allows access to it via local_element(). However,
@@ -234,6 +238,9 @@ namespace Utilities
        * describing the locally owned range and another one for describing
        * ghost indices that are owned by other processors, but that we need to
        * have read or write access to.
+       * @param locally_owned_indices The locally owned indices.
+       * @param ghost_indices_in The ghost indices in.
+       * @param communicator_in The communicator in.
        */
       Partitioner(const IndexSet &locally_owned_indices,
                   const IndexSet &ghost_indices_in,
@@ -245,6 +252,8 @@ namespace Utilities
        * describing the locally owned range. It allows to set the ghost
        * indices at a later time. Apart from this, it is similar to the other
        * constructor with two index sets.
+       * @param locally_owned_indices The locally owned indices.
+       * @param communicator_in The communicator in.
        */
       Partitioner(const IndexSet &locally_owned_indices,
                   const MPI_Comm  communicator_in);
@@ -269,6 +278,7 @@ namespace Utilities
 
       /**
        * Set the locally owned indices. Used in the constructor.
+       * @param locally_owned_indices The locally owned indices.
        */
       void
       set_owned_indices(const IndexSet &locally_owned_indices);
@@ -282,6 +292,8 @@ namespace Utilities
        * useful if a distributed vector is based on that larger ghost index
        * set but only a tighter subset should be communicated according to
        * @p ghost_indices.
+       * @param ghost_indices The ghost indices.
+       * @param larger_ghost_index_set The larger ghost index set.
        */
       void
       set_ghost_indices(const IndexSet &ghost_indices,
@@ -322,6 +334,7 @@ namespace Utilities
       /**
        * Return true if the given global index is in the local range of this
        * processor.
+       * @param global_index The global index.
        */
       bool
       in_local_range(const types::global_dof_index global_index) const;
@@ -335,6 +348,7 @@ namespace Utilities
        * between 0 and locally_owned_size() - 1, and the local index for
        * ghosts is between locally_owned_size() and locally_owned_size() +
        * n_ghost_indices() - 1.
+       * @param global_index The global index.
        */
       unsigned int
       global_to_local(const types::global_dof_index global_index) const;
@@ -346,6 +360,7 @@ namespace Utilities
        * and locally_owned_size() - 1, and the local index for ghosts must be
        * between locally_owned_size() and locally_owned_size() +
        * n_ghost_indices() - 1.
+       * @param local_index The local index.
        */
       types::global_dof_index
       local_to_global(const unsigned int local_index) const;
@@ -354,6 +369,7 @@ namespace Utilities
        * Return whether the given global index is a ghost index on the
        * present processor. Returns false for indices that are owned locally
        * and for indices not present at all.
+       * @param global_index The global index.
        */
       bool
       is_ghost_entry(const types::global_dof_index global_index) const;
@@ -431,6 +447,7 @@ namespace Utilities
        * only, i.e., if only some processors decide that the partitioning is
        * not compatible, only these processors will return @p false, whereas
        * the other processors will return @p true.
+       * @param part The part used by this operation.
        */
       bool
       is_compatible(const Partitioner &part) const;
@@ -450,6 +467,7 @@ namespace Utilities
        * This method performs global communication, so make sure to use it
        * only in a context where all processors call it the same number of
        * times.
+       * @param part The part used by this operation.
        */
       bool
       is_globally_compatible(const Partitioner &part) const;

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -88,6 +88,7 @@ namespace Patterns
 
     /**
      * Return <tt>true</tt> if the given string matches the pattern.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const = 0;
@@ -119,6 +120,7 @@ namespace Patterns
 
     /**
      * Return a string describing the pattern.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const = 0;
@@ -156,6 +158,7 @@ namespace Patterns
 
   /**
    * Return pointer to the correct derived class based on description.
+   * @param description The text used to document the parameter or object.
    */
   std::unique_ptr<PatternBase>
   pattern_factory(const std::string &description);
@@ -166,6 +169,8 @@ namespace Patterns
      * Escape the string @p input for the specified @p style so that characters
      * will appear as intended. For example, characters like _ can not be
      * written as is in LateX and have to be escaped as \_.
+     * @param input The input data or stream from which values are read.
+     * @param style The style in which parameter information is formatted.
      */
     std::string
     escape(const std::string &input, const PatternBase::OutputStyle style);
@@ -216,6 +221,8 @@ namespace Patterns
      * is inclusive of both bounds values, i.e., the @p upper_bound is
      * an allowed value, rather than indicating a half-open value as
      * is often done in other contexts.
+     * @param lower_bound The lower bound.
+     * @param upper_bound The upper bound.
      */
     Integer(const int lower_bound = min_int_value,
             const int upper_bound = max_int_value);
@@ -223,6 +230,7 @@ namespace Patterns
     /**
      * Return <tt>true</tt> if the string is an integer and its value is
      * within the specified range.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -231,6 +239,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. If bounds were specified to the constructor, then include them
      * into this description.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -247,6 +256,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Integer>
     create(const std::string &description);
@@ -312,6 +322,8 @@ namespace Patterns
      * lower bound, then the entire set of double precision numbers is
      * implied. The default values are chosen such that no bounds are
      * enforced on parameters.
+     * @param lower_bound The lower bound.
+     * @param upper_bound The upper bound.
      */
     Double(const double lower_bound = min_double_value,
            const double upper_bound = max_double_value);
@@ -319,6 +331,7 @@ namespace Patterns
     /**
      * Return <tt>true</tt> if the string is a number and its value is within
      * the specified range.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -327,6 +340,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. If bounds were specified to the constructor, then include them
      * into this description.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -345,6 +359,7 @@ namespace Patterns
      * description() on an existing object), or @p nullptr otherwise. Ownership
      * of the returned object is transferred to the caller of this function,
      * which should be freed using @p delete.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Double>
     create(const std::string &description);
@@ -387,12 +402,14 @@ namespace Patterns
     /**
      * Constructor. Take the given parameter as the specification of valid
      * strings.
+     * @param seq The seq used by this operation.
      */
     Selection(const std::string &seq);
 
     /**
      * Return <tt>true</tt> if the string is an element of the description
      * list passed to the constructor.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -401,6 +418,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the list of valid strings passed to the
      * constructor.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -424,6 +442,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Selection>
     create(const std::string &description);
@@ -466,6 +485,10 @@ namespace Patterns
      * The three other arguments can be used to denote minimal and maximal
      * allowable lengths of the list, and the string that is used as a
      * separator between elements of the list.
+     * @param base_pattern The base pattern.
+     * @param min_elements The min elements.
+     * @param max_elements The max elements.
+     * @param separator The separator used by this operation.
      */
     List(const PatternBase &base_pattern,
          const unsigned int min_elements = 0,
@@ -487,12 +510,14 @@ namespace Patterns
 
     /**
      * Copy constructor.
+     * @param other The object to copy or move from.
      */
     List(const List &other);
 
     /**
      * Return <tt>true</tt> if the string is a comma-separated list of strings
      * each of which match the pattern given to the constructor.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -500,6 +525,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -516,6 +542,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<List>
     create(const std::string &description);
@@ -600,6 +627,12 @@ namespace Patterns
      * The four other arguments can be used to denote minimal and maximal
      * allowable lengths of the list as well as the separators used to delimit
      * pairs of the map and the symbol used to separate keys and values.
+     * @param key_pattern The key pattern.
+     * @param value_pattern The value pattern.
+     * @param min_elements The min elements.
+     * @param max_elements The max elements.
+     * @param separator The separator used by this operation.
+     * @param key_value_separator The key value separator.
      */
     Map(const PatternBase &key_pattern,
         const PatternBase &value_pattern,
@@ -610,12 +643,14 @@ namespace Patterns
 
     /**
      * Copy constructor.
+     * @param other The object to copy or move from.
      */
     Map(const Map &other);
 
     /**
      * Return <tt>true</tt> if the string is a comma-separated list of strings
      * each of which match the pattern given to the constructor.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -623,6 +658,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -639,6 +675,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Map>
     create(const std::string &description);
@@ -788,6 +825,8 @@ namespace Patterns
      * Constructor. Same as above, specialized for const char *. This is
      * necessary to avoid compilers errors due to the variadic constructors
      * provided below.
+     * @param patterns The patterns used by this operation.
+     * @param separator The separator used by this operation.
      */
     Tuple(const std::vector<std::unique_ptr<PatternBase>> &patterns,
           const char                                      *separator);
@@ -809,6 +848,8 @@ namespace Patterns
      *
      * Since we support a pure variadic templates version, without this
      * specialization, the compiler will fail with cryptic errors.
+     * @param separator The separator used by this operation.
+     * @param patterns The patterns used by this operation.
      */
     template <class... PatternTypes>
     Tuple(const char *separator, const PatternTypes &...patterns);
@@ -823,12 +864,14 @@ namespace Patterns
 
     /**
      * Copy constructor.
+     * @param other The object to copy or move from.
      */
     Tuple(const Tuple &other);
 
     /**
      * Return <tt>true</tt> if the string is a list of strings
      * each of which matches the patterns given to the constructor.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -836,6 +879,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -852,6 +896,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Tuple>
     create(const std::string &description);
@@ -865,6 +910,7 @@ namespace Patterns
 
     /**
      * Return a reference to the i-th pattern in the tuple.
+     * @param i The index of the entry.
      */
     const PatternBase &
     get_pattern(const unsigned int i) const;
@@ -908,12 +954,14 @@ namespace Patterns
   public:
     /**
      * Constructor. @p seq is a list of valid options separated by "|".
+     * @param seq The seq used by this operation.
      */
     MultipleSelection(const std::string &seq);
 
     /**
      * Return <tt>true</tt> if the string is an element of the description
      * list passed to the constructor.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -922,6 +970,7 @@ namespace Patterns
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the list of valid strings passed to the
      * constructor.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -938,6 +987,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<MultipleSelection>
     create(const std::string &description);
@@ -991,6 +1041,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -1007,6 +1058,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Bool>
     create(const std::string &description);
@@ -1033,6 +1085,7 @@ namespace Patterns
     /**
      * Return <tt>true</tt> if the string matches its constraints, i.e.
      * always.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -1040,6 +1093,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Anything]"</tt>.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -1056,6 +1110,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<Anything>
     create(const std::string &description);
@@ -1104,12 +1159,14 @@ namespace Patterns
     /**
      * Constructor.  The type of the file can be specified by choosing the
      * flag.
+     * @param type The type used by this operation.
      */
     FileName(const FileType type = input);
 
     /**
      * Return <tt>true</tt> if the string matches its constraints, i.e.
      * always.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -1117,6 +1174,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Filename]"</tt>.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -1138,6 +1196,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<FileName>
     create(const std::string &description);
@@ -1173,6 +1232,7 @@ namespace Patterns
     /**
      * Return <tt>true</tt> if the string matches its constraints, i.e.
      * always.
+     * @param test_string The test string.
      */
     virtual bool
     match(const std::string &test_string) const override;
@@ -1180,6 +1240,7 @@ namespace Patterns
     /**
      * Return a description of the pattern that valid strings are expected to
      * match. Here, this is the string <tt>"[Filename]"</tt>.
+     * @param style The style in which parameter information is formatted.
      */
     virtual std::string
     description(const OutputStyle style = Machine) const override;
@@ -1196,6 +1257,7 @@ namespace Patterns
      * Create a new object if the start of description matches
      * description_init.  Ownership of that object is transferred to the
      * caller of this function.
+     * @param description The text used to document the parameter or object.
      */
     static std::unique_ptr<DirectoryName>
     create(const std::string &description);
@@ -1321,6 +1383,8 @@ namespace Patterns
        * deleted, it is implemented and available in the specializations of the
        * Convert
        * class template for particular kinds of template arguments @p T.
+       * @param s The value on which this function operates.
+       * @param p The point at which to evaluate the function.
        */
       static std::string
       to_string(const T                     &s,
@@ -1335,6 +1399,8 @@ namespace Patterns
        * deleted, it is implemented and available in the specializations of the
        * Convert
        * class template for particular kinds of template arguments @p T.
+       * @param s The value on which this function operates.
+       * @param p The point at which to evaluate the function.
        */
       static T
       to_value(const std::string           &s,
@@ -1359,6 +1425,7 @@ namespace Patterns
      * See the documentation of the class Patterns::Tools::Convert, and of the
      * helper class Patterns::Tools::RankInfo for details on the way separators
      * are selected when outputting STL container types.
+     * @param t The time associated with the evaluation.
      */
     template <typename T>
     std::string
@@ -1388,6 +1455,8 @@ namespace Patterns
      * Notice that the current content of variable @p t is ignored. Its type is
      * used to infer how to interpret the string. If the string is successfully
      * parsed, then @p t will be set to the parsed content of @p s.
+     * @param s The value on which this function operates.
+     * @param t The time associated with the evaluation.
      */
     template <typename T>
     void
@@ -1406,76 +1475,70 @@ namespace Patterns
                    std::string,
                    << "The string \"" << arg1
                    << "\" does not match the pattern \"" << arg2 << "\"");
-    /** @} */
-  } // namespace Tools
-} // namespace Patterns
-
-
-// ---------------------- inline and template functions --------------------
-namespace Patterns
-{
-  template <class... PatternTypes>
-  Tuple::Tuple(const char *separator, const PatternTypes &...ps)
-    : // forward to the version with std::string argument
-    Tuple(std::string(separator), ps...)
-  {}
-
-
-
-  template <class... PatternTypes>
-  Tuple::Tuple(const std::string &separator, const PatternTypes &...ps)
-    : separator(separator)
-  {
-    static_assert(is_base_of_all<PatternBase, PatternTypes...>::value,
-                  "Not all of the input arguments of this function "
-                  "are derived from PatternBase");
-    static_assert(sizeof...(ps) > 0,
-                  "The number of PatternTypes must be greater than zero!");
-    const auto pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
-    for (const auto p : pattern_pointers)
-      patterns.push_back(p->clone());
-  }
-
-
-
-  template <class... PatternTypes>
-  Tuple::Tuple(const PatternTypes &...ps)
-    : // forward to the version with the separator argument
-    Tuple(":", ps...)
-  {}
-
-
-
-  namespace Tools
-  {
-    namespace internal
+    /**
+     *  @} */
+    * // namespace Tools
+      *namespace Patterns ** *
+      -- -- -- -- -- -- -- -- -- -- -inline
+                                      and template functions-- -- -- -- -- -- -- -- -- --*space
+                                        Patterns **
+                                          mplate<class... PatternTypes> *
+                                          ple::Tuple(
+                                            const char *separator,
+                                            const PatternTypes &...ps) *
+      : // forward to the version with std::string argument
+        *Tuple(std::string(separator), ps...) *
+        ****mplate<class... PatternTypes> *ple::Tuple(
+          const std::string &separator,
+          const PatternTypes &...ps) *
+      : separator(separator) *
+        *static_assert(is_base_of_all<PatternBase, PatternTypes...>::value,
+                       *"Not all of the input arguments of this function " *
+                         "are derived from PatternBase");
+    *static_assert(sizeof...(ps) > 0,
+                   *"The number of PatternTypes must be greater than zero!");
+    *const auto pattern_pointers = {(static_cast<const PatternBase *>(&ps))...};
+    *for (const auto p : pattern_pointers) * patterns.push_back(p->clone());
+    *****mplate<class... PatternTypes> *
+        ple::Tuple(const PatternTypes &...ps) *
+      : // forward to the version with the separator argument
+        *Tuple(":", ps...) *
+        ****mespace Tools **namespace internal *
     {
-      /**
-       * Store information about the rank types of the given class.
-       *
-       * A class has Rank equal to the number of different separators
-       * that are required to uniquely identify its element(s) in a string.
-       *
-       * This class is used to detect whether the class T is compatible
-       * with a Patterns::List pattern or with a Patterns::Map pattern.
-       *
-       * Objects like Point() or std::complex<double> are vector-likes, and
-       * have vector_rank 1. Elementary types, like `int`, `unsigned int`,
-       * `double`, etc. have vector_rank 0. `std::vector`, `std::list` and in
-       * general containers have rank equal to 1 + vector_rank of the contained
-       * type. Similarly for map types.
-       *
-       * A class with list_rank::value = 0 is either elementary or a
-       * map. A class with map_rank::value = 0 is either a List compatible
-       * class, or an elementary type.
-       *
-       * Elementary types are not compatible with Patterns::List, but non
-       * elementary types, like Point(), or std::complex<double>, are compatible
-       * with the List type. Adding more compatible types is a matter of adding
-       * a specialization of this struct for the given type.
-       */
-      template <class T, class Enable = void>
-      struct RankInfo
+      * /**
+         *    * Store information about the rank types of the given class.
+         *    *
+         *    * A class has Rank equal to the number of different separators
+         *    * that are required to uniquely identify its element(s) in a
+         * string.
+         *    *
+         *    * This class is used to detect whether the class T is compatible
+         *    * with a Patterns::List pattern or with a Patterns::Map pattern.
+         *    *
+         *    * Objects like Point() or std::complex<double> are vector-likes,
+         * and
+         *    * have vector_rank 1. Elementary types, like `int`, `unsigned
+         * int`,
+         *    * `double`, etc. have vector_rank 0. `std::vector`, `std::list`
+         * and in
+         *    * general containers have rank equal to 1 + vector_rank of the
+         * contained
+         *    * type. Similarly for map types.
+         *    *
+         *    * A class with list_rank::value = 0 is either elementary or a
+         *    * map. A class with map_rank::value = 0 is either a List
+         * compatible
+         *    * class, or an elementary type.
+         *    *
+         *    * Elementary types are not compatible with Patterns::List, but non
+         *    * elementary types, like Point(), or std::complex<double>, are
+         * compatible
+         *    * with the List type. Adding more compatible types is a matter of
+         * adding
+         *    * a specialization of this struct for the given type.
+         */
+        template <class T, class Enable = void>
+        struct RankInfo
       {
         static constexpr int list_rank = 0;
         static constexpr int map_rank  = 0;
@@ -2207,6 +2270,8 @@ namespace Patterns
 
       /**
        * Convert a string to a value, using the given pattern, or a default one.
+       * @param s The value on which this function operates.
+       * @param pattern The pattern that valid parameter values must satisfy.
        */
       static T
       to_value(const std::string           &s,

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -131,6 +131,7 @@ public:
    * <tt>dim!=1</tt> as it would leave some components of the point
    * coordinates uninitialized.
    *
+   * @param x The value on which this function operates.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr explicit DEAL_II_HOST_DEVICE
@@ -143,6 +144,8 @@ public:
    * coordinates uninitialized (if dim>2) or would not use some arguments (if
    * dim<2).
    *
+   * @param x The value on which this function operates.
+   * @param y The value on which this function operates.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE
@@ -155,6 +158,9 @@ public:
    * point coordinates uninitialized (if dim>3) or would not use some
    * arguments (if dim<3).
    *
+   * @param x The value on which this function operates.
+   * @param y The value on which this function operates.
+   * @param z The value on which this function operates.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE
@@ -162,6 +168,7 @@ public:
 
   /**
    * Convert a boost::geometry::point to a dealii::Point.
+   * @param boost_pt The boost pt.
    */
   template <std::size_t dummy_dim,
             std::enable_if_t<(dim == dummy_dim) && (dummy_dim != 0), int> = 0>
@@ -174,6 +181,7 @@ public:
    * that is zero in all coordinates except for a single 1 in the <tt>i</tt>th
    * coordinate.
    *
+   * @param i The index of the entry.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   static constexpr DEAL_II_HOST_DEVICE Point<dim, Number>
@@ -182,6 +190,7 @@ public:
   /**
    * Read access to the <tt>index</tt>th coordinate.
    *
+   * @param index The index of the entry.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE Number
@@ -190,6 +199,7 @@ public:
   /**
    * Read and write access to the <tt>index</tt>th coordinate.
    *
+   * @param index The index of the entry.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE Number &
@@ -199,6 +209,7 @@ public:
    * Assignment operator from Tensor<1, dim, Number> with different underlying
    * scalar type. This obviously requires that the @p OtherNumber type is
    * convertible to @p Number.
+   * @param p The point at which to evaluate the function.
    */
   template <typename OtherNumber>
   constexpr Point<dim, Number> &
@@ -260,6 +271,7 @@ public:
   /**
    * Multiply the current point by a factor.
    *
+   * @param OtherNumber The other number used by this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    *
    * @relatesalso EnableIfScalar
@@ -274,6 +286,7 @@ public:
   /**
    * Divide the current point by a factor.
    *
+   * @param OtherNumber The other number used by this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -286,6 +299,7 @@ public:
   /**
    * Return the scalar product of the vectors representing two points.
    *
+   * @param p The point at which to evaluate the function.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE Number
@@ -312,6 +326,7 @@ public:
    * <tt>p</tt>, i.e. the $l_2$ norm of the difference between the
    * vectors representing the two points.
    *
+   * @param p The point at which to evaluate the function.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   DEAL_II_HOST_DEVICE typename numbers::NumberTraits<Number>::real_type
@@ -321,6 +336,7 @@ public:
    * Return the squared Euclidean distance of <tt>this</tt> point to the point
    * <tt>p</tt>.
    *
+   * @param p The point at which to evaluate the function.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE
@@ -653,6 +669,8 @@ inline void Point<dim, Number>::serialize(Archive &ar, const unsigned int)
 /**
  * Global operator scaling a point vector by a scalar.
  *
+ * @param factor The scalar factor by which all entries are scaled.
+ * @param p The point at which to evaluate the function.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relates Point
@@ -695,6 +713,8 @@ operator<<(std::ostream &out, const Point<dim, Number> &p)
  * @relatesalso Point
  *
  * @dealiiConceptRequires{dim >= 0}
+ * @param in The input data or stream from which values are read.
+ * @param p The point at which to evaluate the function.
  */
 template <int dim, typename Number>
 DEAL_II_CXX20_REQUIRES(dim >= 0)

--- a/include/deal.II/base/polynomial.h
+++ b/include/deal.II/base/polynomial.h
@@ -88,6 +88,7 @@ namespace Polynomials
 
     /**
      * Constructor creating a zero polynomial of degree @p n.
+     * @param n The n used by this operation.
      */
     Polynomial(const unsigned int n);
 
@@ -104,6 +105,8 @@ namespace Polynomials
      * where $j=0,\ldots,n-1$ where $n$ is the number of support points and the
      * degree of the polynomials is $n-1$. The second argument of this
      * constructor, $j$, then selects which of these polynomials you want.
+     * @param lagrange_support_points The lagrange support points.
+     * @param j The index of the entry.
      */
     Polynomial(const std::vector<Point<1>> &lagrange_support_points,
                const unsigned int           j);
@@ -121,6 +124,7 @@ namespace Polynomials
      * polynomial is in the product form of roots, the evaluation is
      * based on products of the form (x - x_i), whereas the Horner
      * scheme is used for polynomials in the coefficient form.
+     * @param x The value on which this function operates.
      */
     number
     value(const number x) const;
@@ -134,6 +138,8 @@ namespace Polynomials
      * This function uses the Horner scheme for numerical stability of the
      * evaluation for polynomials in the coefficient form or the product of
      * terms involving the roots if that representation is used.
+     * @param x The value on which this function operates.
+     * @param values The object in which to store the computed values.
      */
     void
     value(const number x, std::vector<number> &values) const;
@@ -155,6 +161,9 @@ namespace Polynomials
      * operations such as additions or multiplication with the type
      * `number` of the polynomial, and must be convertible from
      * `number` by `operator=`.
+     * @param x The value on which this function operates.
+     * @param n_derivatives The number of derivatives.
+     * @param values The values associated with the function.
      */
     template <typename Number2>
     void
@@ -197,6 +206,7 @@ namespace Polynomials
      * polynomial <i>q</i>, such that <i>q(x) = p(t)</i>.
      *
      * The operation is performed in place.
+     * @param factor The scalar factor by which all entries are scaled.
      */
     void
     scale(const number factor);
@@ -215,6 +225,8 @@ namespace Polynomials
      *
      * The operation is performed in place, i.e. the coefficients of the
      * present object are changed.
+     * @param offset The offset into the underlying storage or file at which
+     * the operation starts.
      */
     template <typename number2>
     void
@@ -235,36 +247,42 @@ namespace Polynomials
 
     /**
      * Multiply with a scalar.
+     * @param s The operand supplied to this operation.
      */
     Polynomial<number> &
     operator*=(const double s);
 
     /**
      * Multiply with another polynomial.
+     * @param p The point at which to evaluate the function.
      */
     Polynomial<number> &
     operator*=(const Polynomial<number> &p);
 
     /**
      * Add a second polynomial.
+     * @param p The point at which to evaluate the function.
      */
     Polynomial<number> &
     operator+=(const Polynomial<number> &p);
 
     /**
      * Subtract a second polynomial.
+     * @param p The point at which to evaluate the function.
      */
     Polynomial<number> &
     operator-=(const Polynomial<number> &p);
 
     /**
      * Test for equality of two polynomials.
+     * @param p The point at which to evaluate the function.
      */
     bool
     operator==(const Polynomial<number> &p) const;
 
     /**
      * Print coefficients.
+     * @param out The output stream to which data is written.
      */
     void
     print(std::ostream &out) const;
@@ -353,6 +371,8 @@ namespace Polynomials
     /**
      * Constructor, taking the degree of the monomial and an optional
      * coefficient as arguments.
+     * @param n The n used by this operation.
+     * @param coefficient The coefficient used by this operation.
      */
     Monomial(const unsigned int n, const double coefficient = 1.);
 
@@ -361,6 +381,7 @@ namespace Polynomials
      * <tt>degree</tt>, which then spans the full space of polynomials up to
      * the given degree. This function may be used to initialize the
      * TensorProductPolynomials and PolynomialSpace classes.
+     * @param degree The polynomial degree.
      */
     static std::vector<Polynomial<number>>
     generate_complete_basis(const unsigned int degree);
@@ -400,6 +421,8 @@ namespace Polynomials
      * Constructor. Takes the degree <tt>n</tt> of the Lagrangian polynomial
      * and the index <tt>support_point</tt> of the support point. Fills the
      * <tt>coefficients</tt> of the base class Polynomial.
+     * @param n The n used by this operation.
+     * @param support_point The support point.
      */
     LagrangeEquidistant(const unsigned int n, const unsigned int support_point);
 
@@ -410,6 +433,7 @@ namespace Polynomials
      * the same degree but support point running from zero to <tt>degree</tt>.
      * This function may be used to initialize the TensorProductPolynomials
      * and PolynomialSpace classes.
+     * @param degree The polynomial degree.
      */
     static std::vector<Polynomial<double>>
     generate_complete_basis(const unsigned int degree);
@@ -432,6 +456,7 @@ namespace Polynomials
    * Lagrange polynomials for interpolation of these points. The number of
    * polynomials is equal to the number of points and the maximum degree is
    * one less.
+   * @param points The points at which to evaluate the function.
    */
   std::vector<Polynomial<double>>
   generate_complete_Lagrange_basis(const std::vector<Point<1>> &points);
@@ -456,6 +481,7 @@ namespace Polynomials
   public:
     /**
      * Constructor for polynomial of degree <tt>p</tt>.
+     * @param p The point at which to evaluate the function.
      */
     Legendre(const unsigned int p);
 
@@ -464,6 +490,7 @@ namespace Polynomials
      * <tt>degree</tt>, which then spans the full space of polynomials up to
      * the given degree. This function may be used to initialize the
      * TensorProductPolynomials and PolynomialSpace classes.
+     * @param degree The polynomial degree.
      */
     static std::vector<Polynomial<double>>
     generate_complete_basis(const unsigned int degree);
@@ -494,12 +521,14 @@ namespace Polynomials
     /**
      * Constructor for polynomial of degree <tt>p</tt>. There is an exception
      * for <tt>p==0</tt>, see the general documentation.
+     * @param p The point at which to evaluate the function.
      */
     Lobatto(const unsigned int p = 0);
 
     /**
      * Return the polynomials with index <tt>0</tt> up to <tt>degree</tt>.
      * There is an exception for <tt>p==0</tt>, see the general documentation.
+     * @param p The point at which to evaluate the function.
      */
     static std::vector<Polynomial<double>>
     generate_complete_basis(const unsigned int p);
@@ -557,6 +586,7 @@ namespace Polynomials
     /**
      * Constructor for polynomial of degree <tt>p</tt>. There is an exception
      * for <tt>p==0</tt>, see the general documentation.
+     * @param p The point at which to evaluate the function.
      */
     Hierarchical(const unsigned int p);
 
@@ -569,6 +599,7 @@ namespace Polynomials
      *
      * This function may be used to initialize the TensorProductPolynomials,
      * AnisotropicPolynomials, and PolynomialSpace classes.
+     * @param degree The polynomial degree.
      */
     static std::vector<Polynomial<double>>
     generate_complete_basis(const unsigned int degree);
@@ -640,6 +671,7 @@ namespace Polynomials
     /**
      * Constructor for polynomial with index <tt>p</tt>. See the class
      * documentation on the definition of the sequence of polynomials.
+     * @param p The point at which to evaluate the function.
      */
     HermiteInterpolation(const unsigned int p);
 
@@ -647,6 +679,7 @@ namespace Polynomials
      * Return the polynomials with index <tt>0</tt> up to <tt>p+1</tt> in a
      * space of degree up to <tt>p</tt>. Here, <tt>p</tt> has to be at least
      * 3.
+     * @param p The point at which to evaluate the function.
      */
     static std::vector<Polynomial<double>>
     generate_complete_basis(const unsigned int p);
@@ -761,6 +794,8 @@ namespace Polynomials
     /**
      * Constructor for the polynomial with index <tt>index</tt> within the set
      * up polynomials of degree @p degree.
+     * @param degree The polynomial degree.
+     * @param index The index of the entry.
      */
     HermiteLikeInterpolation(const unsigned int degree,
                              const unsigned int index);
@@ -768,6 +803,7 @@ namespace Polynomials
     /**
      * Return the polynomials with index <tt>0</tt> up to <tt>degree+1</tt> in
      * a space of degree up to <tt>degree</tt>.
+     * @param degree The polynomial degree.
      */
     static std::vector<Polynomial<double>>
     generate_complete_basis(const unsigned int degree);
@@ -826,6 +862,9 @@ namespace Polynomials
    * beta equal to zero (Legendre case), one (Gauss-Lobatto case) as well as
    * two, so be careful when using it for other values as the Newton iteration
    * might or might not converge.
+   * @param degree The polynomial degree.
+   * @param alpha The alpha used by this operation.
+   * @param beta The beta used by this operation.
    */
   template <typename Number>
   std::vector<Number>

--- a/include/deal.II/base/polynomial_space.h
+++ b/include/deal.II/base/polynomial_space.h
@@ -113,6 +113,7 @@ public:
 
   /**
    * Prints the list of the indices to <tt>out</tt>.
+   * @param out The output stream to which data is written.
    */
   template <typename StreamType>
   void
@@ -121,6 +122,7 @@ public:
   /**
    * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==n()</tt>. Stores a copy of <tt>renumber</tt>.
+   * @param renumber The renumber used by this operation.
    */
   void
   set_numbering(const std::vector<unsigned int> &renumber);
@@ -137,6 +139,12 @@ public:
    * If you need values or derivatives of all polynomials then use this
    * function, rather than using any of the compute_value(), compute_grad() or
    * compute_grad_grad() functions, see below, in a loop over all polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -151,6 +159,8 @@ public:
    * <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -161,6 +171,8 @@ public:
    *
    * Consider using evaluate() instead.
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @tparam order The order of the derivative.
    */
   template <int order>
@@ -169,6 +181,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -176,6 +190,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -183,6 +199,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -190,6 +208,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -200,6 +220,8 @@ public:
    * <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -209,6 +231,8 @@ public:
    * at unit point <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -218,6 +242,7 @@ public:
    * class. Here, if <tt>N</tt> is the number of one-dimensional polynomials
    * given, then the result of this function is <i>N</i> in 1d,
    * <i>N(N+1)/2</i> in 2d, and <i>N(N+1)(N+2)/6</i> in 3d.
+   * @param n The n used by this operation.
    */
   static unsigned int
   n_polynomials(const unsigned int n);

--- a/include/deal.II/base/polynomials_abf.h
+++ b/include/deal.II/base/polynomials_abf.h
@@ -66,6 +66,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -85,6 +91,7 @@ public:
    * Return the number of polynomials in the space <tt>RT(degree)</tt> without
    * requiring to build an object of PolynomialsABF. This is required by the
    * FiniteElement classes.
+   * @param degree The polynomial degree.
    */
   static unsigned int
   n_polynomials(const unsigned int degree);

--- a/include/deal.II/base/polynomials_adini.h
+++ b/include/deal.II/base/polynomials_adini.h
@@ -58,6 +58,12 @@ public:
    * If you need values or derivatives of all polynomials then use this
    * function, rather than using any of the compute_value(), compute_grad() or
    * compute_grad_grad() functions, see below, in a loop over all polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -71,12 +77,16 @@ public:
    * Compute the value of the <tt>i</tt>th polynomial at <tt>unit_point</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -84,6 +94,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -91,6 +103,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -98,6 +112,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -108,6 +124,8 @@ public:
    * <tt>unit_point</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -117,6 +135,8 @@ public:
    * at <tt>unit_point</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;

--- a/include/deal.II/base/polynomials_barycentric.h
+++ b/include/deal.II/base/polynomials_barycentric.h
@@ -102,12 +102,15 @@ public:
 
   /**
    * Constructor for a monomial.
+   * @param powers The powers used by this operation.
+   * @param coefficient The coefficient used by this operation.
    */
   BarycentricPolynomial(const TableIndices<dim + 1> &powers,
                         const Number                 coefficient);
 
   /**
    * Return the specified monomial.
+   * @param d The value on which this function operates.
    */
   static BarycentricPolynomial<dim, Number>
   monomial(const unsigned int d);
@@ -117,6 +120,7 @@ public:
    * For example, the first P6 basis function is printed as
    * <code>-1 * t0^1 + 2 * t0^2</code>, where <code>t0</code> is the first
    * barycentric variable, <code>t1</code> is the second, etc.
+   * @param out The output stream to which data is written.
    */
   void
   print(std::ostream &out) const;
@@ -135,6 +139,7 @@ public:
 
   /**
    * Add a scalar.
+   * @param a The operand supplied to this operation.
    */
   template <typename Number2>
   BarycentricPolynomial<dim, Number>
@@ -142,6 +147,7 @@ public:
 
   /**
    * Subtract a scalar.
+   * @param a The operand supplied to this operation.
    */
   template <typename Number2>
   BarycentricPolynomial<dim, Number>
@@ -149,6 +155,7 @@ public:
 
   /**
    * Multiply by a scalar.
+   * @param a The operand supplied to this operation.
    */
   template <typename Number2>
   BarycentricPolynomial<dim, Number>
@@ -156,6 +163,7 @@ public:
 
   /**
    * Divide by a scalar.
+   * @param a The operand supplied to this operation.
    */
   template <typename Number2>
   BarycentricPolynomial<dim, Number>
@@ -163,36 +171,42 @@ public:
 
   /**
    * Add another barycentric polynomial.
+   * @param augend The augend used by this operation.
    */
   BarycentricPolynomial<dim, Number>
   operator+(const BarycentricPolynomial<dim, Number> &augend) const;
 
   /**
    * Subtract another barycentric polynomial.
+   * @param augend The augend used by this operation.
    */
   BarycentricPolynomial<dim, Number>
   operator-(const BarycentricPolynomial<dim, Number> &augend) const;
 
   /**
    * Multiply by another barycentric polynomial.
+   * @param multiplicand The multiplicand used by this operation.
    */
   BarycentricPolynomial<dim, Number>
   operator*(const BarycentricPolynomial<dim, Number> &multiplicand) const;
 
   /**
    * Differentiate in barycentric coordinates.
+   * @param coordinate The coordinate used by this operation.
    */
   BarycentricPolynomial<dim, Number>
   barycentric_derivative(const unsigned int coordinate) const;
 
   /**
    * Differentiate in Cartesian coordinates.
+   * @param coordinate The coordinate used by this operation.
    */
   BarycentricPolynomial<dim, Number>
   derivative(const unsigned int coordinate) const;
 
   /**
    * Evaluate the polynomial.
+   * @param point The point at which to evaluate the function.
    */
   Number
   value(const Point<dim> &point) const;
@@ -261,12 +275,14 @@ public:
 
   /**
    * Get the standard Lagrange basis for a specified degree.
+   * @param degree The polynomial degree.
    */
   static BarycentricPolynomials<dim>
   get_fe_p_basis(const unsigned int degree);
 
   /**
    * Constructor taking the polynomial @p degree as input.
+   * @param polynomials The polynomials used by this operation.
    */
   BarycentricPolynomials(
     const std::vector<BarycentricPolynomial<dim>> &polynomials);
@@ -281,12 +297,19 @@ public:
 
   /**
    * Access operator.
+   * @param i The index of the entry.
    */
   const BarycentricPolynomial<dim> &
   operator[](const std::size_t i) const;
 
   /**
    * @copydoc ScalarPolynomialsBase::evaluate()
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -298,12 +321,16 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_value()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -311,6 +338,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -318,6 +347,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -325,6 +356,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -332,12 +365,16 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_grad()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_grad_grad()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -372,6 +409,8 @@ protected:
 
 /**
  * Multiply a BarycentricPolynomial by a constant.
+ * @param a The operand supplied to this operation.
+ * @param bp The bp used by this operation.
  */
 template <int dim, typename Number1, typename Number2>
 BarycentricPolynomial<dim, Number1>
@@ -382,6 +421,8 @@ operator*(const Number2 &a, const BarycentricPolynomial<dim, Number1> &bp)
 
 /**
  * Add a constant to a BarycentricPolynomial.
+ * @param a The operand supplied to this operation.
+ * @param bp The bp used by this operation.
  */
 template <int dim, typename Number1, typename Number2>
 BarycentricPolynomial<dim, Number1>
@@ -392,6 +433,8 @@ operator+(const Number2 &a, const BarycentricPolynomial<dim, Number1> &bp)
 
 /**
  * Subtract a BarycentricPolynomial from a constant.
+ * @param a The operand supplied to this operation.
+ * @param bp The bp used by this operation.
  */
 template <int dim, typename Number1, typename Number2>
 BarycentricPolynomial<dim, Number1>

--- a/include/deal.II/base/polynomials_bdm.h
+++ b/include/deal.II/base/polynomials_bdm.h
@@ -112,6 +112,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -131,6 +137,7 @@ public:
    * Return the number of polynomials in the space <tt>BDM(degree)</tt>
    * without requiring to build an object of PolynomialsBDM. This is required
    * by the FiniteElement classes.
+   * @param degree The polynomial degree.
    */
   static unsigned int
   n_polynomials(const unsigned int degree);

--- a/include/deal.II/base/polynomials_bernardi_raugel.h
+++ b/include/deal.II/base/polynomials_bernardi_raugel.h
@@ -103,6 +103,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -116,6 +122,7 @@ public:
    * Return the number of polynomials in the space <tt>BR(degree)</tt> without
    * requiring to build an object of PolynomialsBernardiRaugel. This is
    * required by the FiniteElement classes.
+   * @param k The index of the entry.
    */
   static unsigned int
   n_polynomials(const unsigned int k);

--- a/include/deal.II/base/polynomials_integrated_legendre_sz.h
+++ b/include/deal.II/base/polynomials_integrated_legendre_sz.h
@@ -46,12 +46,14 @@ class IntegratedLegendreSZ : public Polynomials::Polynomial<double>
 public:
   /**
    * Constructor generating the coefficients of the polynomials at degree p.
+   * @param p The point at which to evaluate the function.
    */
   IntegratedLegendreSZ(const unsigned int p);
 
   /**
    * Return the complete set of Integrated Legendre polynomials up to the
    * given degree.
+   * @param degree The polynomial degree.
    */
   static std::vector<Polynomials::Polynomial<double>>
   generate_complete_basis(const unsigned int degree);

--- a/include/deal.II/base/polynomials_nedelec.h
+++ b/include/deal.II/base/polynomials_nedelec.h
@@ -63,6 +63,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -82,6 +88,7 @@ public:
    * Return the number of polynomials in the space <tt>N(degree)</tt> without
    * requiring to build an object of PolynomialsNedelec. This is required by
    * the FiniteElement classes.
+   * @param degree The polynomial degree.
    */
   static unsigned int
   n_polynomials(const unsigned int degree);

--- a/include/deal.II/base/polynomials_p.h
+++ b/include/deal.II/base/polynomials_p.h
@@ -11,19 +11,19 @@
 // -----------------------------------------------------------------------------
 
 #ifndef dealii_polynomials_P_h
-#define dealii_polynomials_P_h
+#  define dealii_polynomials_P_h
 
 
-#include <deal.II/base/config.h>
+#  include <deal.II/base/config.h>
 
-#include <deal.II/base/exceptions.h>
-#include <deal.II/base/point.h>
-#include <deal.II/base/polynomial.h>
-#include <deal.II/base/polynomial_space.h>
-#include <deal.II/base/tensor.h>
+#  include <deal.II/base/exceptions.h>
+#  include <deal.II/base/point.h>
+#  include <deal.II/base/polynomial.h>
+#  include <deal.II/base/polynomial_space.h>
+#  include <deal.II/base/tensor.h>
 
-#include <memory>
-#include <vector>
+#  include <memory>
+#  include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 /**
@@ -70,6 +70,7 @@ public:
    * gives the degrees i,j,k in the x,y,z directions.
    *
    * In 1d and 2d, obviously only i and i,j are returned.
+   * @param n The n used by this operation.
    */
   std::array<unsigned int, dim>
   directional_degrees(unsigned int n) const;
@@ -94,23 +95,20 @@ private:
   const unsigned int p;
 };
 
-/** @} */
-
-template <int dim>
-inline unsigned int
-PolynomialsP<dim>::degree() const
+/**
+ *  @} */
+**template <int dim>
+ *inline unsigned int *
+ PolynomialsP<dim>::degree() const *
 {
-  return p;
+  *return p;
+  *
 }
-
-
-template <int dim>
-inline std::array<unsigned int, dim>
-PolynomialsP<dim>::directional_degrees(unsigned int n) const
+***template <int dim>
+  *inline std::array<unsigned int, dim> *
+  PolynomialsP<dim>::directional_degrees(unsigned int n) const *
 {
-  return this->compute_index(n);
+  *return this->compute_index(n);
+  *
 }
-
-DEAL_II_NAMESPACE_CLOSE
-
-#endif
+**DEAL_II_NAMESPACE_CLOSE **#endif * /

--- a/include/deal.II/base/polynomials_piecewise.h
+++ b/include/deal.II/base/polynomials_piecewise.h
@@ -71,6 +71,10 @@ namespace Polynomials
      *
      * If the number of intervals is one, the piecewise polynomial behaves
      * exactly like a usual polynomial.
+     * @param coefficients_on_interval The coefficients on interval.
+     * @param n_intervals The number of intervals.
+     * @param interval The interval used by this operation.
+     * @param spans_next_interval The spans next interval.
      */
     PiecewisePolynomial(const Polynomial<number> &coefficients_on_interval,
                         const unsigned int        n_intervals,
@@ -82,6 +86,8 @@ namespace Polynomials
      * subset of the unit interval. It uses a polynomial description that is
      * scaled to the size of the subinterval compared to the unit interval.
      * The subintervals are bounded by the adjacent points in @p points.
+     * @param points The points at which to evaluate the function.
+     * @param index The index of the entry.
      */
     PiecewisePolynomial(const std::vector<Point<1, number>> &points,
                         const unsigned int                   index);
@@ -91,6 +97,7 @@ namespace Polynomials
      * underlying polynomial. The polynomial evaluates to zero when outside of
      * the given interval (and possible the next one to the right when it
      * spans over that range).
+     * @param x The value on which this function operates.
      */
     number
     value(const number x) const;
@@ -108,6 +115,8 @@ namespace Polynomials
      * jumps of gradients on the element boundary), but it is the user's
      * responsibility to avoid evaluation at these points when it does not
      * make sense.
+     * @param x The value on which this function operates.
+     * @param values The object in which to store the computed values.
      */
     void
     value(const number x, std::vector<number> &values) const;
@@ -126,6 +135,9 @@ namespace Polynomials
      * jumps of gradients on the element boundary), but it is the user's
      * responsibility to avoid evaluation at these points when it does not
      * make sense.
+     * @param x The value on which this function operates.
+     * @param n_derivatives The number of derivatives.
+     * @param values The values associated with the function.
      */
     void
     value(const number       x,
@@ -204,6 +216,8 @@ namespace Polynomials
    * Generates a complete Lagrange basis on a subdivision of the unit interval
    * in smaller intervals for a given degree on the subintervals and number of
    * intervals.
+   * @param n_subdivisions The number of subdivisions.
+   * @param base_degree The base degree.
    */
   std::vector<PiecewisePolynomial<double>>
   generate_complete_Lagrange_basis_on_subdivisions(
@@ -213,6 +227,7 @@ namespace Polynomials
   /**
    * Generates a complete linear basis on a subdivision of the unit interval
    * in smaller intervals for a given vector of points.
+   * @param points The points at which to evaluate the function.
    */
   std::vector<PiecewisePolynomial<double>>
   generate_complete_linear_basis_on_subdivisions(

--- a/include/deal.II/base/polynomials_rannacher_turek.h
+++ b/include/deal.II/base/polynomials_rannacher_turek.h
@@ -52,6 +52,8 @@ public:
 
   /**
    * Value of basis function @p i at @p p.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -60,6 +62,8 @@ public:
    * <tt>order</tt>-th of basis function @p i at @p p.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   template <int order>
   Tensor<order, dim>
@@ -67,6 +71,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -74,6 +80,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -81,6 +89,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -88,6 +98,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -95,12 +107,16 @@ public:
 
   /**
    * Gradient of basis function @p i at @p p.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
 
   /**
    * Gradient of gradient of basis function @p i at @p p.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -110,6 +126,12 @@ public:
    *
    * Size of the vectors must be either equal to the number of polynomials or
    * zero. A size of zero means that we are not computing the vector entries.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,

--- a/include/deal.II/base/polynomials_raviart_thomas.h
+++ b/include/deal.II/base/polynomials_raviart_thomas.h
@@ -63,6 +63,7 @@ public:
    * Variant of the n_polynomials() function taking only a single argument
    * `degree`, assuming `degree + 1` in the normal direction and `degree` in
    * the tangential directions.
+   * @param degree The polynomial degree.
    */
   static unsigned int
   n_polynomials(const unsigned int degree);
@@ -73,6 +74,7 @@ public:
   /**
    * Compute the lexicographic to hierarchic numbering underlying this class,
    * computed as a free function.
+   * @param degree The polynomial degree.
    */
   static std::vector<unsigned int>
   get_lexicographic_numbering(const unsigned int degree);

--- a/include/deal.II/base/polynomials_rt_bubbles.h
+++ b/include/deal.II/base/polynomials_rt_bubbles.h
@@ -91,6 +91,7 @@ public:
   /**
    * Constructor. Creates all basis functions for RT_bubbles polynomials of
    * given degree using the lexicographic order from FE_RaviartThomas.
+   * @param k The index of the entry.
    */
   PolynomialsRT_Bubbles(const unsigned int k);
 
@@ -100,6 +101,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -119,6 +126,7 @@ public:
    * Return the number of polynomials in the space <tt>RT_Bubbles(degree)</tt>
    * without requiring to build an object of PolynomialsRT-Bubbles. This is
    * required by the FiniteElement classes.
+   * @param degree The polynomial degree.
    */
   static unsigned int
   n_polynomials(const unsigned int degree);

--- a/include/deal.II/base/polynomials_vector_anisotropic.h
+++ b/include/deal.II/base/polynomials_vector_anisotropic.h
@@ -49,6 +49,9 @@ public:
    * Constructor. Creates all basis functions for anisotropic vector-valued
    * polynomials of given degrees in normal and tangential directions,
    * respectively.
+   * @param degree_normal The degree normal.
+   * @param degree_tangential The degree tangential.
+   * @param polynomial_ordering The polynomial ordering.
    */
   PolynomialsVectorAnisotropic(
     const unsigned int               degree_normal,
@@ -57,6 +60,7 @@ public:
 
   /**
    * Copy constructor.
+   * @param other The object to copy or move from.
    */
   PolynomialsVectorAnisotropic(const PolynomialsVectorAnisotropic &other) =
     default;
@@ -68,6 +72,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>. In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -88,6 +98,8 @@ public:
    * Return the number of polynomials in the space without requiring to
    * build an object of PolynomialsVectorAnisotropic. This is required by the
    * FiniteElement classes.
+   * @param normal_degree The normal degree.
+   * @param tangential_degree The tangential degree.
    */
   static unsigned int
   n_polynomials(const unsigned int normal_degree,

--- a/include/deal.II/base/polynomials_wedge.h
+++ b/include/deal.II/base/polynomials_wedge.h
@@ -34,6 +34,7 @@ namespace internal
   /**
    * Return the support points of a wedge in a way that can also be compiled
    * for dim==1 and dim==2.
+   * @param degree The polynomial degree.
    */
   template <int dim>
   std::vector<Point<dim>>

--- a/include/deal.II/base/process_grid.h
+++ b/include/deal.II/base/process_grid.h
@@ -65,6 +65,9 @@ namespace Utilities
        * The product of rows and columns should be less or equal to the total
        * number of cores
        * in the @p mpi_communicator.
+       * @param mpi_communicator The MPI communicator.
+       * @param n_rows The number of rows.
+       * @param n_columns The number of columns.
        */
       ProcessGrid(const MPI_Comm     mpi_communicator,
                   const unsigned int n_rows,
@@ -86,6 +89,11 @@ namespace Utilities
        * For example, a square matrix $640x640$ with the block size $32$
        * and the @p mpi_communicator with 11 cores will result in the $3x3$
        * process grid.
+       * @param mpi_communicator The MPI communicator.
+       * @param n_rows_matrix The number of rows matrix.
+       * @param n_columns_matrix The number of columns matrix.
+       * @param row_block_size The row block size.
+       * @param column_block_size The column block size.
        */
       ProcessGrid(const MPI_Comm     mpi_communicator,
                   const unsigned int n_rows_matrix,
@@ -130,6 +138,8 @@ namespace Utilities
        * Send @p count values stored consequently starting at @p value from
        * the process with rank zero to processes which
        * are not in the process grid.
+       * @param value The value associated with the function.
+       * @param count The number of elements to process.
        */
       template <typename NumberType>
       void

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -80,6 +80,10 @@ public:
    *
    * @deprecated Use the version of this function which takes a
    * combined_orientation argument instead.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param q_points The object in which to store the q points.
    */
   DEAL_II_DEPRECATED_WITH_COMMENT(
     "Use the version of this function which takes a combined_orientation "
@@ -97,6 +101,9 @@ public:
    *
    * @deprecated Use the version of this function which takes a
    * combined_orientation argument instead.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
    */
   DEAL_II_DEPRECATED_WITH_COMMENT(
     "Use the version of this function which takes a combined_orientation "
@@ -114,6 +121,12 @@ public:
    *
    * @deprecated Use the version of project_to_face() which takes a
    * combined_orientation argument instead.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
    */
   DEAL_II_DEPRECATED_WITH_COMMENT(
     "Use the version of project_to_face() which takes a combined_orientation "
@@ -130,6 +143,10 @@ public:
    * Compute the cell quadrature formula corresponding to using
    * <tt>quadrature</tt> on face <tt>face_no</tt>. For further details, see
    * the general doc for this class.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param combined_orientation The combined orientation.
    */
   static Quadrature<dim>
   project_to_face(const ReferenceCell<dim>          &reference_cell,
@@ -143,6 +160,12 @@ public:
    * corresponding to RefineCase::Type <tt>ref_case</tt>. The last argument is
    * only used in 3d.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param subface_no The subface no.
+   * @param q_points The object in which to store the q points.
+   * @param ref_case The ref case.
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
@@ -167,6 +190,11 @@ public:
    * <tt>face_no</tt> with RefinementCase<dim-1> <tt>ref_case</tt>. The last
    * argument is only used in 3d.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param subface_no The subface no.
+   * @param ref_case The ref case.
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
@@ -194,6 +222,14 @@ public:
    * <tt>face_no</tt> with SubfaceCase<dim> <tt>ref_case</tt>. The last
    * argument is only used in 3d.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param subface_no The subface no.
+   * @param face_orientation The face orientation.
+   * @param face_flip The face flip.
+   * @param face_rotation The face rotation.
+   * @param ref_case The ref case.
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    *
@@ -219,6 +255,12 @@ public:
    * <tt>face_no</tt> with RefinementCase<dim-1> <tt>ref_case</tt>. The last
    * argument is only used in 3d.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param face_no The face no.
+   * @param subface_no The subface no.
+   * @param combined_orientation The combined orientation.
+   * @param ref_case The ref case.
    * @note Only the points are transformed. The quadrature weights are the
    * same as those of the original rule.
    */
@@ -243,6 +285,8 @@ public:
    * to a single face and use it as a quadrature on this face, as is done in
    * FEFaceValues.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
    * @note This function creates ReferenceCell::n_face_orientations() sets of
    * quadrature points for each face which are indexed (by combined orientation
    * and face number) by a DataSetDescriptor.
@@ -254,6 +298,8 @@ public:
   /**
    * Like the above function, applying the same face quadrature
    * formula on all faces.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
    */
   static Quadrature<dim>
   project_to_all_faces(const ReferenceCell<dim>  &reference_cell,
@@ -271,6 +317,8 @@ public:
    * This in particular allows us to extract a subset of points corresponding
    * to a single subface and use it as a quadrature on this face, as is done
    * in FESubfaceValues.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
    */
   static Quadrature<dim>
   project_to_all_subfaces(const ReferenceCell<dim> &reference_cell,
@@ -286,6 +334,9 @@ public:
    * fraction of the cell, the weights of the resulting object are divided by
    * GeometryInfo<dim>::children_per_cell.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param child_no The child no.
    * @warning This function is only implemented for hypercube elements.
    */
   static Quadrature<dim>
@@ -302,6 +353,8 @@ public:
    * The child numbering is the same as the children would be numbered upon
    * refinement of the cell.
    *
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
    * @warning This function is only implemented for hypercube elements.
    */
   static Quadrature<dim>
@@ -311,6 +364,10 @@ public:
   /**
    * Project the one dimensional rule <tt>quadrature</tt> to the straight line
    * connecting the points <tt>p1</tt> and <tt>p2</tt>.
+   * @param reference_cell The reference cell.
+   * @param quadrature The quadrature formula used by this operation.
+   * @param p1 The point associated with this operation.
+   * @param p2 The point associated with this operation.
    */
   static Quadrature<dim>
   project_to_line(const ReferenceCell<dim> &reference_cell,
@@ -360,6 +417,12 @@ public:
      *
      * @deprecated Use the version of this function which takes a
      * combined_orientation argument instead.
+     * @param reference_cell The reference cell.
+     * @param face_no The face no.
+     * @param face_orientation The face orientation.
+     * @param face_flip The face flip.
+     * @param face_rotation The face rotation.
+     * @param n_quadrature_points The number of quadrature points.
      */
     DEAL_II_DEPRECATED_WITH_COMMENT(
       "Use the version of this function which takes a combined_orientation "
@@ -379,6 +442,10 @@ public:
      * @p n_quadrature_points is the number of quadrature points the
      * lower-dimensional face quadrature formula (the one that has been
      * projected onto the faces) has.
+     * @param reference_cell The reference cell.
+     * @param face_no The face no.
+     * @param combined_orientation The combined orientation.
+     * @param n_quadrature_points The number of quadrature points.
      */
     static DataSetDescriptor
     face(const ReferenceCell<dim>          &reference_cell,
@@ -393,6 +460,12 @@ public:
      *
      * @deprecated Use the version of this function which takes a
      * combined_orientation argument instead.
+     * @param reference_cell The reference cell.
+     * @param face_no The face no.
+     * @param face_orientation The face orientation.
+     * @param face_flip The face flip.
+     * @param face_rotation The face rotation.
+     * @param quadrature The quadrature formula used by this operation.
      */
     DEAL_II_DEPRECATED_WITH_COMMENT(
       "Use the version of this function which takes a combined_orientation "
@@ -410,6 +483,10 @@ public:
      * taking into account the possibility of different quadrature rules being
      * used on each face.
      *
+     * @param reference_cell The reference cell.
+     * @param face_no The face no.
+     * @param combined_orientation The combined orientation.
+     * @param quadrature The quadrature formula used by this operation.
      */
     static DataSetDescriptor
     face(const ReferenceCell<dim>          &reference_cell,
@@ -431,6 +508,14 @@ public:
      *
      * @deprecated Use the version of this function which takes a
      * combined_orientation argument instead.
+     * @param reference_cell The reference cell.
+     * @param face_no The face no.
+     * @param subface_no The subface no.
+     * @param face_orientation The face orientation.
+     * @param face_flip The face flip.
+     * @param face_rotation The face rotation.
+     * @param n_quadrature_points The number of quadrature points.
+     * @param ref_case The ref case.
      */
     DEAL_II_DEPRECATED_WITH_COMMENT(
       "Use the version of this function which takes a combined_orientation "
@@ -457,6 +542,12 @@ public:
      * projected onto the faces) has.
      *
      * Through the last argument anisotropic refinement can be respected.
+     * @param reference_cell The reference cell.
+     * @param face_no The face no.
+     * @param subface_no The subface no.
+     * @param combined_orientation The combined orientation.
+     * @param n_quadrature_points The number of quadrature points.
+     * @param ref_case The ref case.
      */
     static DataSetDescriptor
     subface(const ReferenceCell<dim>          &reference_cell,
@@ -489,65 +580,51 @@ public:
   };
 };
 
-/** @} */
-
-
-// -------------------  inline and template functions ----------------
-
-
-
-template <int dim>
-inline QProjector<dim>::DataSetDescriptor::DataSetDescriptor(
-  const unsigned int dataset_offset)
-  : dataset_offset(dataset_offset)
-{}
-
-
-template <int dim>
-inline QProjector<dim>::DataSetDescriptor::DataSetDescriptor()
-  : dataset_offset(numbers::invalid_unsigned_int)
-{}
-
-
-
-template <int dim>
-typename QProjector<dim>::DataSetDescriptor
-QProjector<dim>::DataSetDescriptor::cell()
+/**
+ *  @} */
+*** // -------------------  inline and template functions ----------------
+  ****template <int dim>
+     *inline QProjector<dim>::DataSetDescriptor::DataSetDescriptor(
+         *const unsigned int dataset_offset) *
+  : dataset_offset(dataset_offset) * {} *
+    **template <int dim>
+     *inline QProjector<dim>::DataSetDescriptor::DataSetDescriptor() *
+  : dataset_offset(numbers::invalid_unsigned_int) *
+    {} *
+    ***template <int dim>
+      *typename QProjector<dim>::DataSetDescriptor
+        *QProjector<dim>::DataSetDescriptor::cell() *
 {
-  return 0;
+  *return 0;
+  *
 }
-
-
-
-template <int dim>
-inline QProjector<dim>::DataSetDescriptor::operator unsigned int() const
+****template <int dim>
+   *inline QProjector<dim>::DataSetDescriptor::operator unsigned int() const *
 {
-  return dataset_offset;
+  *return dataset_offset;
+  *
 }
-
-
-
-template <int dim>
-Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
-  const ReferenceCell<dim>  &reference_cell,
-  const Quadrature<dim - 1> &quadrature)
+****template <int dim>
+   *Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
+       *const ReferenceCell<dim> &reference_cell,
+         *const Quadrature<dim - 1> &quadrature) *
 {
-  return project_to_all_faces(reference_cell,
-                              hp::QCollection<dim - 1>(quadrature));
+  *return project_to_all_faces(reference_cell,
+                               *hp::QCollection<dim - 1>(quadrature));
+  *
 }
-
-
+*
 /* -------------- declaration of explicit specializations ------------- */
 
 #ifndef DOXYGEN
 
 
-template <>
-void
-QProjector<1>::project_to_face(const ReferenceCell<1> &reference_cell,
-                               const Quadrature<0> &,
-                               const unsigned int,
-                               std::vector<Point<1>> &);
+  template <>
+  void
+  QProjector<1>::project_to_face(const ReferenceCell<1> &reference_cell,
+                                 const Quadrature<0> &,
+                                 const unsigned int,
+                                 std::vector<Point<1>> &);
 template <>
 void
 QProjector<2>::project_to_face(const ReferenceCell<2> &reference_cell,

--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -161,11 +161,13 @@ public:
    *
    * If dim == 0, the resulting quadrature formula will be a single Point<0>
    * having unit weight.
+   * @param quadrature_1d The quadrature 1d.
    */
   explicit Quadrature(const Quadrature<dim != 1 ? 1 : 0> &quadrature_1d);
 
   /**
    * Copy constructor.
+   * @param q The quadrature formula used by this operation.
    */
   Quadrature(const Quadrature<dim> &q);
 
@@ -179,6 +181,9 @@ public:
    * Construct a quadrature formula from given vectors of quadrature points
    * (which should really be in the unit cell) and the corresponding weights.
    * You will want to have the weights sum up to one, but this is not checked.
+   * @param points The points at which to evaluate the function.
+   * @param weights The weights used in the quadrature rule or linear
+   * combination.
    */
   Quadrature(const std::vector<Point<dim>> &points,
              const std::vector<double>     &weights);
@@ -187,6 +192,9 @@ public:
    * Construct a quadrature formula from given vectors of quadrature points
    * (which should really be in the unit cell) and the corresponding weights,
    * moving the points and weights into the present object.
+   * @param points The points at which to evaluate the function.
+   * @param weights The weights used in the quadrature rule or linear
+   * combination.
    */
   Quadrature(std::vector<Point<dim>> &&points, std::vector<double> &&weights);
 
@@ -196,12 +204,14 @@ public:
    * perform integrations, but rather to be used with FEValues objects in
    * order to find the position of some points (the quadrature points in this
    * object) on the transformed cell in real space.
+   * @param points The points at which to evaluate the function.
    */
   Quadrature(const std::vector<Point<dim>> &points);
 
   /**
    * Constructor for a one-point quadrature. Sets the weight of this point to
    * one.
+   * @param point The point at which to evaluate the function.
    */
   Quadrature(const Point<dim> &point);
 
@@ -226,6 +236,7 @@ public:
 
   /**
    * Test for equality of two quadratures.
+   * @param p The point at which to evaluate the function.
    */
   bool
   operator==(const Quadrature<dim> &p) const;
@@ -237,6 +248,9 @@ public:
    * to actually perform integrations, but rather to be used with FEValues
    * objects in order to find the position of some points (the quadrature
    * points in this object) on the transformed cell in real space.
+   * @param points The points at which to evaluate the function.
+   * @param weights The weights used in the quadrature rule or linear
+   * combination.
    */
   void
   initialize(const ArrayView<const Point<dim>> &points,
@@ -256,6 +270,7 @@ public:
 
   /**
    * Return the <tt>i</tt>th quadrature point.
+   * @param i The index of the entry.
    */
   const Point<dim> &
   point(const unsigned int i) const;
@@ -268,6 +283,7 @@ public:
 
   /**
    * Return the weight of the <tt>i</tt>th quadrature point.
+   * @param i The index of the entry.
    */
   double
   weight(const unsigned int i) const;
@@ -389,16 +405,22 @@ public:
   /**
    * Constructor for a one-dimensional formula. This one just copies the given
    * quadrature rule.
+   * @param qx The qx used by this operation.
    */
   QAnisotropic(const Quadrature<1> &qx);
 
   /**
    * Constructor for a two-dimensional formula.
+   * @param qx The qx used by this operation.
+   * @param qy The qy used by this operation.
    */
   QAnisotropic(const Quadrature<1> &qx, const Quadrature<1> &qy);
 
   /**
    * Constructor for a three-dimensional formula.
+   * @param qx The qx used by this operation.
+   * @param qy The qy used by this operation.
+   * @param qz The qz used by this operation.
    */
   QAnisotropic(const Quadrature<1> &qx,
                const Quadrature<1> &qy,
@@ -438,6 +460,8 @@ public:
    * in each direction. The result is a tensor product quadrature formula
    * defined on the unit hypercube (i.e., the line segment, unit square, or
    * unit cube in 1d, 2d, and 3d respectively).
+   * @param base_quadrature The base quadrature.
+   * @param n_copies The number of copies.
    */
   QIterated(const Quadrature<1> &base_quadrature, const unsigned int n_copies);
 
@@ -450,6 +474,8 @@ public:
    * defined on the unit hypercube (i.e., the line segment, unit square, or
    * unit cube in 1d, 2d, and 3d respectively).
    *
+   * @param base_quadrature The base quadrature.
+   * @param intervals The point associated with this operation.
    * @note We require that `intervals.front() == 0` and `interval.back() == 1`.
    */
   QIterated(const Quadrature<1>         &base_quadrature,
@@ -457,6 +483,8 @@ public:
 
   /**
    * Exception
+   * @param ExcInvalidQuadratureFormula The exc invalid quadrature formula
+   * used by this operation.
    */
   DeclExceptionMsg(ExcInvalidQuadratureFormula,
                    "The quadrature formula you provided cannot be used "

--- a/include/deal.II/base/quadrature_lib.h
+++ b/include/deal.II/base/quadrature_lib.h
@@ -40,6 +40,7 @@ public:
   /**
    * Generate a formula with <tt>n</tt> quadrature points (in each space
    * direction), exact for polynomials of degree <tt>2n-1</tt>.
+   * @param n The n used by this operation.
    */
   QGauss(const unsigned int n);
 };
@@ -97,6 +98,8 @@ public:
    * direction).
    * <tt>ep</tt> defines whether the left/lower/front endpoint(s) (default)
    * or the right/upper/back endpoint(s) are part of the quadrature points.
+   * @param n The n used by this operation.
+   * @param end_point The end point.
    */
   QGaussRadau(const unsigned int n,
               const EndPoint     end_point = QGaussRadau::EndPoint::left);
@@ -140,6 +143,7 @@ public:
   /**
    * Generate a formula with <tt>n</tt> quadrature points (in each space
    * direction).
+   * @param n The n used by this operation.
    */
   QGaussLobatto(const unsigned int n);
 };
@@ -240,6 +244,8 @@ class QGaussLog : public Quadrature<dim>
 public:
   /**
    * Generate a formula with <tt>n</tt> quadrature points
+   * @param n The n used by this operation.
+   * @param revert Whether to revert.
    */
   QGaussLog(const unsigned int n, const bool revert = false);
 
@@ -305,6 +311,10 @@ public:
    * singularity, the scale factor inside the logarithmic function and a flag
    * that decides whether the singularity is left inside the quadrature
    * formula or it is factored out, to be included in the integrand.
+   * @param n The n used by this operation.
+   * @param x0 The point associated with this operation.
+   * @param alpha The alpha used by this operation.
+   * @param factor_out_singular_weight The factor out singular weight.
    */
   QGaussLogR(const unsigned int n,
              const Point<dim>  &x0                         = Point<dim>(),
@@ -385,6 +395,9 @@ public:
    *   integral += f(singular_quad_noR.point(i))*singular_quad_noR.weight(i)/R;
    * }
    * @endcode
+   * @param n The n used by this operation.
+   * @param singularity The point associated with this operation.
+   * @param factor_out_singular_weight The factor out singular weight.
    */
   QGaussOneOverR(const unsigned int n,
                  const Point<dim>  &singularity,
@@ -422,6 +435,9 @@ public:
    *   integral += f(singular_quad_noR.point(i))*singular_quad_noR.weight(i)/R;
    * }
    * @endcode
+   * @param n The n used by this operation.
+   * @param vertex_index The vertex index.
+   * @param factor_out_singular_weight The factor out singular weight.
    */
   QGaussOneOverR(const unsigned int n,
                  const unsigned int vertex_index,
@@ -455,6 +471,7 @@ public:
   /**
    * The constructor takes an arbitrary quadrature formula @p quad and sorts
    * its points and weights according to ascending weights.
+   * @param quad The quad used by this operation.
    */
   QSorted(const Quadrature<dim> &quad);
 
@@ -531,12 +548,16 @@ public:
    * argument. The quadrature formula will be mapped using Telles' rule. Make
    * sure that the order of the quadrature rule is appropriate for the
    * singularity in question.
+   * @param base_quad The base quad.
+   * @param singularity The point associated with this operation.
    */
   QTelles(const Quadrature<1> &base_quad, const Point<dim> &singularity);
   /**
    * A variant of above constructor that takes as parameters the order @p n
    * and location of a singularity. A Gauss Legendre quadrature of order n
    * will be used
+   * @param n The n used by this operation.
+   * @param singularity The point associated with this operation.
    */
   QTelles(const unsigned int n, const Point<dim> &singularity);
 };
@@ -905,6 +926,7 @@ public:
   /**
    * Constructor taking the number of quadrature points in 1d direction
    * @p n_points_1d.
+   * @param n_points_1D The number of points 1d.
    */
   explicit QGaussSimplex(const unsigned int n_points_1D);
 };
@@ -949,6 +971,8 @@ public:
    * @p n_points_1d and boolean indicating whether the rule should be order
    * $2 n - 1$ or $2 n$: see the general documentation of this class for more
    * information.
+   * @param n_points_1D The number of points 1d.
+   * @param use_odd_order The use odd order.
    */
   explicit QWitherdenVincentSimplex(const unsigned int n_points_1D,
                                     const bool         use_odd_order = true);
@@ -980,6 +1004,7 @@ public:
    * Users specify a number `n_points_1d` as an indication of what polynomial
    * degree to be integrated exactly. For details, see the comments of
    * QGaussSimplex.
+   * @param n_points_1D The number of points 1d.
    */
   explicit QGaussWedge(const unsigned int n_points_1D);
 };
@@ -995,6 +1020,7 @@ public:
    * Users specify a number `n_points_1d` as an indication of what polynomial
    * degree to be integrated exactly. For details, see the comments of
    * QGaussSimplex.
+   * @param n_points_1D The number of points 1d.
    */
   explicit QGaussPyramid(const unsigned int n_points_1D);
 };

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -81,6 +81,8 @@ public:
    * After the data is initialized, it can be modified using the get_data()
    * function.
    *
+   * @param cell The cell on which the operation is performed.
+   * @param number_of_data_points_per_cell The number of data points per cell.
    * @note Subsequent calls of this function with the same @p cell will not
    * alter the objects associated with it. In order to remove the stored data,
    * use the erase() function.
@@ -105,6 +107,9 @@ public:
    * Same as above but for a range of iterators starting at @p cell_start
    * until, but not including, @p cell_end for all locally owned cells, i.e.
    * for which `cell->is_locally_owned()==true` .
+   * @param cell_start The cell start.
+   * @param cell_end The cell end.
+   * @param number_of_data_points_per_cell The number of data points per cell.
    */
   template <typename T = DataType>
   void
@@ -118,6 +123,7 @@ public:
    * If no data is attached to the @p cell, this function will not do anything
    * and returns false.
    *
+   * @param cell The cell on which the operation is performed.
    * @note This function will also check that there are no
    * outstanding references to the data stored on this cell. That is to say,
    * that the only references to the stored data are that made by this class.
@@ -140,6 +146,7 @@ public:
    * This allows flexibility if class @p T is not the same as @p DataType on a
    * cell-by-cell basis.
    *
+   * @param cell The cell on which the operation is performed.
    * @pre The type @p T needs to match the class provided to initialize() .
    *
    * @pre @p cell must be from the same Triangulation that is used to
@@ -158,6 +165,7 @@ public:
    * This allows flexibility if class @p T is not the same as @p DataType on a
    * cell-by-cell basis.
    *
+   * @param cell The cell on which the operation is performed.
    * @pre The type @p T needs to match the class provided to initialize() .
    *
    * @pre @p cell must be from the same Triangulation that is used to
@@ -179,6 +187,7 @@ public:
    * This allows flexibility if class @p T is not the same as @p DataType on a
    * cell-by-cell basis.
    *
+   * @param cell The cell on which the operation is performed.
    * @pre The type @p T needs to match the class provided to initialize().
    * @pre @p cell must be from the same Triangulation that is used to
    * initialize() the cell data.
@@ -199,6 +208,7 @@ public:
    * This allows flexibility if class @p T is not the same as @p DataType on a
    * cell-by-cell basis.
    *
+   * @param cell The cell on which the operation is performed.
    * @pre The type @p T needs to match the class provided to initialize().
    * @pre @p cell must be from the same Triangulation that is used to
    * initialize() the cell data.
@@ -299,6 +309,7 @@ public:
    * This vector will contain all scalar and/or Tensorial data local to each
    * quadrature point.
    *
+   * @param values The object in which to store the computed values.
    * @note  The function will be called with @p values of size number_of_values().
    * The implementation may still have an assert to check that it is indeed the
    * case.
@@ -310,6 +321,7 @@ public:
    * The opposite of the above, namely
    * unpack a vector @p values into the data stored in this class.
    *
+   * @param values The values associated with the function.
    * @note  The function will be called with @p values of size number_of_values().
    * The implementation may still have an assert to check that it is indeed the
    * case.
@@ -452,6 +464,9 @@ namespace parallel
        * rule @p mass_quadrature used to integrate its local @ref GlossMassMatrix "mass matrix" and
        * finally the quadrature rule @p data_quadrature which is used to store @p DataType.
        *
+       * @param projection_fe The projection fe.
+       * @param mass_quadrature The mass quadrature.
+       * @param data_quadrature The data quadrature.
        * @pre @p projection_fe has to be scalar-valued.
        *
        * @note Since this class does projection on cell-by-cell basis,
@@ -466,6 +481,8 @@ namespace parallel
        * @p data_storage represents the cell data which should be transferred
        * and it should be initialized for each locally owned active cell.
        *
+       * @param tria The tria used by this operation.
+       * @param data_storage The object in which to store the data storage.
        * @note Although CellDataStorage class allows storing on different cells
        * different objects derived from the base class, here we assume that
        * @p data_storage contains objects of the same type, more specifically

--- a/include/deal.II/base/quadrature_selector.h
+++ b/include/deal.II/base/quadrature_selector.h
@@ -42,6 +42,8 @@ public:
    * Constructor. Takes the name of the quadrature rule (one of "gauss",
    * "milne", "weddle", etc) and, if it is "gauss", the number of quadrature
    * points in each coordinate direction.
+   * @param s The value on which this function operates.
+   * @param order The order used by this operation.
    */
   QuadratureSelector(const std::string &s, const unsigned int order = 0);
 
@@ -85,11 +87,15 @@ public:
                  std::string,
                  << arg1 << " is not a valid name for a quadrature rule.");
   /** @} */
+
 private:
   /**
    * This static function creates a quadrature object according to the name
    * given as a string, and the appropriate order (if the name is "gauss"). It
    * is called from the constructor.
+   *
+   * @param s The quadrature selector string.
+   * @param order The quadrature order.
    */
   static Quadrature<dim>
   create_quadrature(const std::string &s, const unsigned int order);

--- a/include/deal.II/base/scalar_polynomials_base.h
+++ b/include/deal.II/base/scalar_polynomials_base.h
@@ -63,6 +63,8 @@ public:
   /**
    * Constructor. This takes the degree of the space, @p deg from the finite element
    * class, and @p n, the number of polynomials for the space.
+   * @param deg The deg used by this operation.
+   * @param n_polynomials The number of polynomials.
    */
   ScalarPolynomialsBase(const unsigned int deg,
                         const unsigned int n_polynomials);
@@ -94,6 +96,12 @@ public:
    * function, rather than using any of the <tt>compute_value</tt>,
    * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
    * in a loop over all tensor product polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   virtual void
   evaluate(const Point<dim>            &unit_point,
@@ -108,6 +116,8 @@ public:
    * <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual double
   compute_value(const unsigned int i, const Point<dim> &p) const = 0;
@@ -118,6 +128,8 @@ public:
    *
    * Consider using evaluate() instead.
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @tparam order The order of the derivative.
    */
   template <int order>
@@ -129,6 +141,8 @@ public:
    * at unit point <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i, const Point<dim> &p) const = 0;
@@ -138,6 +152,8 @@ public:
    * at unit point <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i, const Point<dim> &p) const = 0;
@@ -147,6 +163,8 @@ public:
    * at unit point <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i, const Point<dim> &p) const = 0;
@@ -156,6 +174,8 @@ public:
    * at unit point <tt>p</tt>.
    *
    * Consider using evaluate() instead.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i, const Point<dim> &p) const = 0;

--- a/include/deal.II/base/scalar_polynomials_vandermonde_base.h
+++ b/include/deal.II/base/scalar_polynomials_vandermonde_base.h
@@ -44,6 +44,8 @@ public:
   /**
    * Constructor. This takes the degree @p degree of the space and the number
    * of polynomials @p n.
+   * @param degree The polynomial degree.
+   * @param n_dofs The number of dofs.
    */
   ScalarPolynomialsVandermondeBase(const unsigned int degree,
                                    const unsigned int n_dofs);
@@ -57,6 +59,12 @@ public:
   /**
    * @copydoc ScalarPolynomialsBase::evaluate()
    *
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    * @note Currently, only the vectors @p values and @p grads are filled.
    */
   void
@@ -69,6 +77,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_value()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -76,6 +86,8 @@ public:
   /**
    * @copydoc ScalarPolynomialsBase::compute_derivative()
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @note Currently, only implemented for first derivative.
    */
   template <int order>
@@ -84,6 +96,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -92,6 +106,8 @@ public:
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @note Not implemented yet.
    */
   Tensor<2, dim>
@@ -101,6 +117,8 @@ public:
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @note Not implemented yet.
    */
   Tensor<3, dim>
@@ -110,6 +128,8 @@ public:
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @note Not implemented yet.
    */
   Tensor<4, dim>
@@ -118,6 +138,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_grad()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -125,6 +147,8 @@ public:
   /**
    * @copydoc ScalarPolynomialsBase::compute_grad_grad()
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @note Not implemented yet.
    */
   Tensor<2, dim>

--- a/include/deal.II/base/scope_exit.h
+++ b/include/deal.II/base/scope_exit.h
@@ -134,6 +134,7 @@ public:
   /**
    * Constructor. Takes a function object that is to be executed at the
    * place where the current object goes out of scope as argument.
+   * @param exit_function The exit function.
    */
   explicit ScopeExit(const std::function<void()> &exit_function);
 

--- a/include/deal.II/base/symbolic_function.h
+++ b/include/deal.II/base/symbolic_function.h
@@ -212,6 +212,7 @@ namespace Functions
      * by calling update_user_substitution_map(), and that you provide all the
      * additional function arguments of your function using the method
      * set_additional_function_arguments().
+     * @param expressions The expressions used by this operation.
      */
     SymbolicFunction(const std::string &expressions);
 
@@ -221,6 +222,7 @@ namespace Functions
      *
      * Notice that this method will trigger a recomputation of the
      * gradients, Hessians, and Laplacians of each component.
+     * @param substitutions The substitutions used by this operation.
      */
     void
     update_user_substitution_map(
@@ -240,6 +242,7 @@ namespace Functions
      * arguments than simply the coordinates and time. If you want to compute
      * the total derivative w.r.t. to complicated symbolic expressions, you
      * should call update_user_substitution_map() instead.
+     * @param arguments The arguments used by this operation.
      */
     void
     set_additional_function_arguments(
@@ -311,6 +314,7 @@ namespace Functions
     /**
      * Print the stored arguments and function expression, as it would be
      * evaluated when calling the method value().
+     * @param out The output stream to which data is written.
      */
     template <typename StreamType>
     StreamType &

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -311,6 +311,9 @@ namespace internal
      * <tt>position-1</tt> are taken from previous_indices, and new_index is
      * put at position <tt>position</tt>. The remaining indices remain in
      * invalid state.
+     * @param previous_indices The previous indices.
+     * @param new_index The new index.
+     * @param position The position of the entry to access.
      */
     DEAL_II_HOST_DEVICE
     DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE TableIndices<2>
@@ -333,6 +336,9 @@ namespace internal
      * <tt>position-1</tt> are taken from previous_indices, and new_index is
      * put at position <tt>position</tt>. The remaining indices remain in
      * invalid state.
+     * @param previous_indices The previous indices.
+     * @param new_index The new index.
+     * @param position The position of the entry to access.
      */
     DEAL_II_HOST_DEVICE
     DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE TableIndices<4>
@@ -584,6 +590,7 @@ namespace internal
     public:
       /**
        * Index operator.
+       * @param i The index of the entry.
        */
       DEAL_II_HOST_DEVICE
       constexpr Accessor<rank, dim, constness, P - 1, Number>
@@ -591,6 +598,7 @@ namespace internal
 
       /**
        * Index operator.
+       * @param i The index of the entry.
        */
       DEAL_II_HOST_DEVICE
       constexpr Accessor<rank, dim, constness, P - 1, Number>
@@ -825,6 +833,7 @@ public:
    *
    * Because we check for symmetry via a non-constexpr function call, you will
    * have to use the symmetrize() function in constexpr contexts instead.
+   * @param t The time associated with the evaluation.
    */
   template <typename OtherNumber>
   explicit DEAL_II_HOST_DEVICE
@@ -852,6 +861,7 @@ public:
    * Copy constructor from tensors with different underlying scalar type. This
    * obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
+   * @param initializer The tensor argument supplied to this operation.
    */
   template <typename OtherNumber>
   DEAL_II_HOST_DEVICE constexpr explicit SymmetricTensor(
@@ -862,6 +872,7 @@ public:
    * type.
    * This obviously requires that the @p OtherNumber type is convertible to
    * @p Number.
+   * @param rhs The right-hand-side operand.
    */
   template <typename OtherNumber>
   DEAL_II_HOST_DEVICE constexpr SymmetricTensor &
@@ -872,6 +883,7 @@ public:
    * exactly it means to assign a scalar value to a tensor, zero is the only
    * value allowed for <tt>d</tt>, allowing the intuitive notation
    * $\mathbf A = 0$ to reset all elements of the tensor to zero.
+   * @param d The scalar value to assign.
    */
   DEAL_II_HOST_DEVICE
   constexpr SymmetricTensor &
@@ -915,6 +927,7 @@ public:
   /**
    * Scale the tensor by <tt>factor</tt>, i.e. multiply all components by
    * <tt>factor</tt>.
+   * @param factor The scalar factor by which all entries are scaled.
    */
   template <typename OtherNumber>
   DEAL_II_HOST_DEVICE constexpr SymmetricTensor &
@@ -922,6 +935,7 @@ public:
 
   /**
    * Scale the tensor by <tt>1/factor</tt>.
+   * @param factor The scalar divisor by which all entries are divided.
    */
   template <typename OtherNumber>
   DEAL_II_HOST_DEVICE constexpr SymmetricTensor &
@@ -972,6 +986,7 @@ public:
    * value, they write it into the first argument to the function in the same
    * way as the corresponding functions for the Tensor class do things.
    *
+   * @param s The operand supplied to this operation.
    * @note The origin of the difference in how `operator*()` is implemented between
    *   Tensor and SymmetricTensor is that for the former, the product between
    *   two Tensor objects of same rank and dimension results in another Tensor
@@ -995,6 +1010,7 @@ public:
   /**
    * Contraction over the last two indices of the present object with the first
    * two indices of the rank-4 symmetric tensor given as argument.
+   * @param s The operand supplied to this operation.
    */
   template <typename OtherNumber>
   DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR
@@ -1004,6 +1020,7 @@ public:
 
   /**
    * Return a read-write reference to the indicated element.
+   * @param indices The multi-index that identifies the tensor entry to access.
    */
   DEAL_II_HOST_DEVICE
   constexpr Number &
@@ -1011,6 +1028,7 @@ public:
 
   /**
    * Return a @p const reference to the value referred to by the argument.
+   * @param indices The multi-index that identifies the tensor entry to access.
    */
   DEAL_II_HOST_DEVICE
   constexpr const Number &
@@ -1019,6 +1037,7 @@ public:
   /**
    * Access the elements of a row of this symmetric tensor. This function is
    * called for constant tensors.
+   * @param row The row index to access.
    */
   DEAL_II_HOST_DEVICE
   constexpr internal::SymmetricTensorAccessors::
@@ -1028,6 +1047,7 @@ public:
   /**
    * Access the elements of a row of this symmetric tensor. This function is
    * called for non-constant tensors.
+   * @param row The row index to access.
    */
   DEAL_II_HOST_DEVICE
   constexpr internal::SymmetricTensorAccessors::
@@ -1038,6 +1058,8 @@ public:
    * Return a @p const reference to the value referred to by the argument.
    *
    * Exactly the same as operator().
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   DEAL_II_HOST_DEVICE
   constexpr const Number &
@@ -1047,6 +1069,8 @@ public:
    * Return a read-write reference to the indicated element.
    *
    * Exactly the same as operator().
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   DEAL_II_HOST_DEVICE
   constexpr Number &
@@ -1057,6 +1081,7 @@ public:
    * <tt>s.access_raw_entry(unrolled_index)</tt> does the same as
    * <tt>s[s.unrolled_to_component_indices(unrolled_index)]</tt>, but more
    * efficiently.
+   * @param unrolled_index The unrolled index.
    */
   DEAL_II_HOST_DEVICE
   constexpr const Number &
@@ -1067,6 +1092,7 @@ public:
    * <tt>s.access_raw_entry(unrolled_index)</tt> does the same as
    * <tt>s[s.unrolled_to_component_indices(unrolled_index)]</tt>, but more
    * efficiently.
+   * @param unrolled_index The unrolled index.
    */
   DEAL_II_HOST_DEVICE
   constexpr Number &
@@ -1091,6 +1117,8 @@ public:
    * symmetric tensors, this function returns which index within the range
    * <code>[0,n_independent_components)</code> the given entry in a symmetric
    * tensor has.
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   static DEAL_II_HOST_DEVICE constexpr unsigned int
   component_to_unrolled_index(const TableIndices<rank_> &indices);
@@ -1099,6 +1127,7 @@ public:
    * The opposite of the previous function: given an index $i$ in the unrolled
    * form of the tensor, return what set of indices $(k,l)$ (for rank-2
    * tensors) or $(k,l,m,n)$ (for rank-4 tensors) corresponds to it.
+   * @param i The index of the entry.
    */
   static DEAL_II_HOST_DEVICE constexpr TableIndices<rank_>
   unrolled_to_component_indices(const unsigned int i);
@@ -1846,6 +1875,8 @@ namespace internal
 {
   /**
    * Perform the double contraction between two rank-2 symmetric tensors.
+   * @param data The data values to read from or write to the current object.
+   * @param sdata The sdata used by this operation.
    */
   template <int dim, typename Number, typename OtherNumber = Number>
   DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
@@ -1888,6 +1919,8 @@ namespace internal
   /**
    * Perform the double contraction between a rank-4 and a rank-2
    * symmetric tensor.
+   * @param data The data values to read from or write to the current object.
+   * @param sdata The sdata used by this operation.
    */
   template <int dim, typename Number, typename OtherNumber = Number>
   DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
@@ -1918,6 +1951,8 @@ namespace internal
   /**
    * Perform the double contraction between a rank-2 and a rank-4
    * symmetric tensor.
+   * @param data The data values to read from or write to the current object.
+   * @param sdata The sdata used by this operation.
    */
   template <int dim, typename Number, typename OtherNumber = Number>
   DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
@@ -1963,6 +1998,8 @@ namespace internal
 
   /**
    * Perform the double contraction between two rank-4 symmetric tensors.
+   * @param data The data values to read from or write to the current object.
+   * @param sdata The sdata used by this operation.
    */
   template <int dim, typename Number, typename OtherNumber = Number>
   DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
@@ -2648,6 +2685,8 @@ SymmetricTensor<rank_, dim, Number>::serialize(Archive &ar, const unsigned int)
  * creation of a temporary variable.
  *
  * @relatesalso SymmetricTensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -2673,6 +2712,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * creation of a temporary variable.
  *
  * @relatesalso SymmetricTensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -2693,6 +2734,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * operation.
  *
  * @relatesalso SymmetricTensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -2710,6 +2753,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * operation.
  *
  * @relatesalso SymmetricTensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -2727,6 +2772,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * operation.
  *
  * @relatesalso SymmetricTensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -2744,6 +2791,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * operation.
  *
  * @relatesalso SymmetricTensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -2795,6 +2844,7 @@ determinant(const SymmetricTensor<2, dim, Number> &t)
  * \f]
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR DEAL_II_ALWAYS_INLINE Number
@@ -2826,6 +2876,7 @@ trace(const SymmetricTensor<2, dim, Number> &d)
  * \f]
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr Number
@@ -2872,6 +2923,7 @@ second_invariant(const SymmetricTensor<2, 1, Number> &)
  * invariant are the same; the determinant is the third invariant.)
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <typename Number>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE Number
@@ -2889,6 +2941,7 @@ second_invariant(const SymmetricTensor<2, 2, Number> &t)
  * \left[ (\text{tr} \mathbf A)^2 - \text{tr} (\mathbf{A}^2) \right]$.
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <typename Number>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE Number
@@ -2906,6 +2959,7 @@ second_invariant(const SymmetricTensor<2, 3, Number> &t)
  * eigenvalue.
  *
  * @relatesalso SymmetricTensor
+ * @param T The time associated with the evaluation.
  */
 template <typename Number>
 std::array<Number, 1>
@@ -2925,6 +2979,7 @@ eigenvalues(const SymmetricTensor<2, 1, Number> &T);
  * $\lambda_1, \lambda_2 = \frac{1}{2} \left[ \text{tr} \mathbf{T} \pm
  * \sqrt{(\text{tr} \mathbf{T})^2 - 4 \det \mathbf{T}} \right]$.
  *
+ * @param T The time associated with the evaluation.
  * @warning The algorithm employed here determines the eigenvalues by
  * computing the roots of the characteristic polynomial. In the case that there
  * exists a common root (the eigenvalues are equal), the computation is
@@ -2953,6 +3008,7 @@ eigenvalues(const SymmetricTensor<2, 2, Number> &T);
  * \left[\text{tr}(\mathbf{T}^2) - (\text{tr}\mathbf T)^2\right] -
  * \det \mathbf T$.
  *
+ * @param T The time associated with the evaluation.
  * @warning The algorithm employed here determines the eigenvalues by
  * computing the roots of the characteristic polynomial. In the case that there
  * exists a common root (the eigenvalues are equal), the computation is
@@ -3093,6 +3149,7 @@ namespace internal
 // of this global enumeration into the documentation
 // See https://stackoverflow.com/a/1717984
 /** @file */
+
 /**
  * An enumeration for the algorithm to be employed when performing
  * the computation of normalized eigenvectors and their corresponding
@@ -3145,6 +3202,8 @@ enum struct SymmetricTensorEigenvectorMethod
  * presented in @cite Kopp2008.
  *
  * @relatesalso SymmetricTensor
+ * @param T The time associated with the evaluation.
+ * @param method The numerical method to use.
  */
 template <int dim, typename Number>
 std::array<std::pair<Number, Tensor<1, dim, Number>>, dim>
@@ -3161,6 +3220,7 @@ eigenvectors(const SymmetricTensor<2, dim, Number> &T,
  * class.
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <int rank_, int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -3276,6 +3336,7 @@ DEAL_II_HOST_DEVICE DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
 /**
  * Invert a symmetric rank-2 tensor.
  *
+ * @param t The time associated with the evaluation.
  * @note If a tensor is not invertible, then the result is unspecified, but will
  * likely contain the results of a division by zero or a very small number at
  * the very least.
@@ -3302,6 +3363,7 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * the very least.
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr SymmetricTensor<4, dim, Number>
@@ -3333,6 +3395,8 @@ invert(const SymmetricTensor<4, dim, Number> &t)
  * of a symmetric tensor ($\mathbf I : \mathbf B = \text{tr} \mathbf B$).
  *
  * @relatesalso SymmetricTensor
+ * @param t1 The first object to compare.
+ * @param t2 The second object to compare.
  */
 template <int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr inline SymmetricTensor<4, dim, Number>
@@ -3565,6 +3629,7 @@ positive_negative_projectors(
  * as a symmetric rank-2 tensor. This is the version for general dimensions.
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -3655,6 +3720,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * type as is used to store the elements of the symmetric tensor.
  *
  * @relatesalso SymmetricTensor
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  */
 template <int rank_, int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -3674,6 +3741,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * type as is used to store the elements of the symmetric tensor.
  *
  * @relatesalso SymmetricTensor
+ * @param factor The scalar factor by which all entries are scaled.
+ * @param t The time associated with the evaluation.
  */
 template <int rank_, int dim, typename Number>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -3709,6 +3778,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * input tensor by the scalar factor.
  *
  * @relates SymmetricTensor
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<
@@ -3738,6 +3809,8 @@ operator*(const SymmetricTensor<rank_, dim, Number> &t,
  * information about template arguments and the return type.
  *
  * @relates SymmetricTensor
+ * @param factor The scalar factor by which all entries are scaled.
+ * @param t The time associated with the evaluation.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<
@@ -3758,6 +3831,8 @@ operator*(const Number                                   &factor,
  * Division of a symmetric tensor of general rank by a scalar.
  *
  * @relates SymmetricTensor
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  */
 template <int rank_, int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline SymmetricTensor<
@@ -3781,6 +3856,8 @@ operator/(const SymmetricTensor<rank_, dim, Number> &t,
  * right.
  *
  * @relates SymmetricTensor
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  */
 template <int rank_, int dim>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -3799,6 +3876,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * left.
  *
  * @relates SymmetricTensor
+ * @param factor The scalar factor by which all entries are scaled.
+ * @param t The time associated with the evaluation.
  */
 template <int rank_, int dim>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -3816,6 +3895,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * Division of a symmetric tensor of general rank by a scalar.
  *
  * @relates SymmetricTensor
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  */
 template <int rank_, int dim>
 DEAL_II_HOST_DEVICE constexpr inline SymmetricTensor<rank_, dim>
@@ -3834,6 +3915,8 @@ operator/(const SymmetricTensor<rank_, dim> &t, const double factor)
  * <code>SymmetricTensor::operator*()</code>.
  *
  * @relates SymmetricTensor
+ * @param t1 The first object to compare.
+ * @param t2 The second object to compare.
  */
 template <int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -3856,6 +3939,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * $(\mathbf A \cdot\mathbf B)_{ij}=\sum_k A_{ik}B_{kj}$.
  *
  * @relates SymmetricTensor
+ * @param t1 The first object to compare.
+ * @param t2 The second object to compare.
  */
 template <int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
@@ -3883,6 +3968,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * $(\mathbf A \cdot\mathbf B)_{ij}=\sum_k A_{ik}B_{kj}$.
  *
  * @relates SymmetricTensor
+ * @param t1 The first object to compare.
+ * @param t2 The second object to compare.
  */
 template <int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
@@ -3907,6 +3994,9 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  * with the general Tensor class.
  *
  * @relates SymmetricTensor
+ * @param tmp The tensor argument supplied to this operation.
+ * @param t The time associated with the evaluation.
+ * @param s The value on which this function operates.
  */
 template <typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE void
@@ -3933,6 +4023,9 @@ double_contract(
  * with the general Tensor class.
  *
  * @relates SymmetricTensor
+ * @param tmp The tensor argument supplied to this operation.
+ * @param s The value on which this function operates.
+ * @param t The time associated with the evaluation.
  */
 template <typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline void
@@ -3959,6 +4052,9 @@ double_contract(
  * with the general Tensor class.
  *
  * @relates SymmetricTensor
+ * @param tmp The tensor argument supplied to this operation.
+ * @param t The time associated with the evaluation.
+ * @param s The value on which this function operates.
  */
 template <typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline void
@@ -3990,6 +4086,9 @@ double_contract(
  * with the general Tensor class.
  *
  * @relates SymmetricTensor
+ * @param tmp The tensor argument supplied to this operation.
+ * @param s The value on which this function operates.
+ * @param t The time associated with the evaluation.
  */
 template <typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline void
@@ -4021,6 +4120,9 @@ double_contract(
  * with the general Tensor class.
  *
  * @relates SymmetricTensor
+ * @param tmp The tensor argument supplied to this operation.
+ * @param t The time associated with the evaluation.
+ * @param s The value on which this function operates.
  */
 template <typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline void
@@ -4053,6 +4155,9 @@ double_contract(
  * with the general Tensor class.
  *
  * @relates SymmetricTensor
+ * @param tmp The tensor argument supplied to this operation.
+ * @param s The value on which this function operates.
+ * @param t The time associated with the evaluation.
  */
 template <typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr inline void
@@ -4077,6 +4182,8 @@ double_contract(
  * (i.e., a vector). The result is a rank-1 tensor (i.e., a vector).
  *
  * @relates SymmetricTensor
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  */
 template <int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr Tensor<
@@ -4102,6 +4209,8 @@ operator*(const SymmetricTensor<2, dim, Number> &src1,
  * (i.e., a matrix). The result is a rank-1 tensor (i.e., a vector).
  *
  * @relates SymmetricTensor
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  */
 template <int dim, typename Number, typename OtherNumber>
 DEAL_II_HOST_DEVICE constexpr Tensor<
@@ -4129,6 +4238,8 @@ operator*(const Tensor<1, dim, Number>               &src1,
  *     \text{right}_{k, j_1,\ldots,j_{r2}}
  * @f]
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @note As one operand is a Tensor, the multiplication operator only performs a
  * contraction over a single pair of indices. This is in contrast to the
  * multiplication operator for SymmetricTensor, which does the double
@@ -4165,6 +4276,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
  *     \text{right}_{k, j_1,\ldots,j_{r2}}
  * @f]
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @note As one operand is a Tensor, the multiplication operator only performs a
  * contraction over a single pair of indices. This is in contrast to the
  * multiplication operator for SymmetricTensor, which does the double

--- a/include/deal.II/base/synchronous_iterator.h
+++ b/include/deal.II/base/synchronous_iterator.h
@@ -48,6 +48,7 @@ struct SynchronousIterators
 {
   /**
    * Constructor.
+   * @param i The index of the entry.
    */
   SynchronousIterators(const Iterators &i);
 
@@ -133,6 +134,8 @@ operator<(const SynchronousIterators<Iterators> &a,
  * the first element is sufficient.
  *
  * @relatesalso SynchronousIterators
+ * @param a The operand supplied to this operation.
+ * @param b The operand supplied to this operation.
  */
 template <typename Iterators>
 inline std::size_t
@@ -149,6 +152,8 @@ operator-(const SynchronousIterators<Iterators> &a,
  * Advance a tuple of iterators by $n$.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
+ * @param n The n used by this operation.
  */
 template <typename I1, typename I2>
 inline void
@@ -162,6 +167,8 @@ advance(std::tuple<I1, I2> &t, const unsigned int n)
  * Advance a tuple of iterators by $n$.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
+ * @param n The n used by this operation.
  */
 template <typename I1, typename I2, typename I3>
 inline void
@@ -176,6 +183,8 @@ advance(std::tuple<I1, I2, I3> &t, const unsigned int n)
  * Advance a tuple of iterators by $n$.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
+ * @param n The n used by this operation.
  */
 template <typename I1, typename I2, typename I3, typename I4>
 inline void
@@ -191,6 +200,7 @@ advance(std::tuple<I1, I2, I3, I4> &t, const unsigned int n)
  * Reverse a tuple of iterators by 1.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
  */
 template <typename I1, typename I2>
 inline void
@@ -204,6 +214,7 @@ prev(std::tuple<I1, I2> &t)
  * Reverse a tuple of iterators by 1.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
  */
 template <typename I1, typename I2, typename I3>
 inline void
@@ -218,6 +229,7 @@ prev(std::tuple<I1, I2, I3> &t)
  * Reverse a tuple of iterators by 1.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
  */
 template <typename I1, typename I2, typename I3, typename I4>
 inline void
@@ -233,6 +245,7 @@ prev(std::tuple<I1, I2, I3, I4> &t)
  * Advance a tuple of iterators by 1.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
  */
 template <typename I1, typename I2>
 inline void
@@ -246,6 +259,7 @@ advance_by_one(std::tuple<I1, I2> &t)
  * Advance a tuple of iterators by 1.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
  */
 template <typename I1, typename I2, typename I3>
 inline void
@@ -260,6 +274,7 @@ advance_by_one(std::tuple<I1, I2, I3> &t)
  * Advance a tuple of iterators by 1.
  *
  * @relatesalso SynchronousIterators
+ * @param t The time associated with the evaluation.
  */
 template <typename I1, typename I2, typename I3, typename I4>
 inline void
@@ -275,6 +290,8 @@ advance_by_one(std::tuple<I1, I2, I3, I4> &t)
  * Advance the elements of this iterator by $n$.
  *
  * @relatesalso SynchronousIterators
+ * @param a The operand supplied to this operation.
+ * @param n The n used by this operation.
  */
 template <typename Iterators>
 inline SynchronousIterators<Iterators>
@@ -289,6 +306,7 @@ operator+(const SynchronousIterators<Iterators> &a, const std::size_t n)
  * Advance the elements of this iterator by 1 (pre-increment).
  *
  * @relatesalso SynchronousIterators
+ * @param a The operand supplied to this operation.
  */
 template <typename Iterators>
 inline SynchronousIterators<Iterators> &
@@ -302,6 +320,7 @@ operator++(SynchronousIterators<Iterators> &a)
  * Reverse the elements of this iterator by 1 (pre-decrement).
  *
  * @relatesalso SynchronousIterators
+ * @param a The operand supplied to this operation.
  */
 template <typename Iterators>
 inline SynchronousIterators<Iterators> &
@@ -315,6 +334,7 @@ operator--(SynchronousIterators<Iterators> &a)
  * Advance the elements of this iterator by 1 (post-increment).
  *
  * @relatesalso SynchronousIterators
+ * @param a The operand supplied to this operation.
  */
 template <typename Iterators>
 inline SynchronousIterators<Iterators>
@@ -330,6 +350,8 @@ operator++(SynchronousIterators<Iterators> &a, int)
  * comparing only the first element is sufficient.
  *
  * @relatesalso SynchronousIterators
+ * @param a The operand supplied to this operation.
+ * @param b The operand supplied to this operation.
  */
 template <typename Iterators>
 inline bool

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -181,11 +181,13 @@ namespace internal
        *
        * Using this constructor is risky if accessors are stored longer than
        * the table it points to. Don't do this.
+       * @param a The value on which this function operates.
        */
       Accessor(const Accessor &a);
 
       /**
        * Index operator. Performs a range check.
+       * @param i The index of the entry.
        */
       Accessor<N, T, C, P - 1>
       operator[](const size_type i) const;
@@ -278,11 +280,13 @@ namespace internal
        *
        * Using this constructor is risky if accessors are stored longer than
        * the table it points to. Don't do this.
+       * @param a The value on which this function operates.
        */
       Accessor(const Accessor &a);
 
       /**
        * Index operator. Performs a range check.
+       * @param size_type The size type.
        */
       reference
       operator[](const size_type) const;
@@ -454,6 +458,7 @@ public:
   /**
    * Constructor. Initialize the array with the given dimensions in each index
    * component.
+   * @param sizes The sizes used by this operation.
    */
   explicit TableBase(const TableIndices<N> &sizes);
 
@@ -461,6 +466,10 @@ public:
    * Constructor. Initialize the array with the given dimensions in each index
    * component, and then initialize the elements of the table using the second
    * and third argument by calling fill(entries,C_style_indexing).
+   * @param sizes The sizes used by this operation.
+   * @param entries The iterator associated with the range processed by this
+   * operation.
+   * @param C_style_indexing The c style indexing.
    */
   template <typename InputIterator>
   TableBase(const TableIndices<N> &sizes,
@@ -469,18 +478,21 @@ public:
 
   /**
    * Copy constructor. Performs a deep copy.
+   * @param src The src used by this operation.
    */
   TableBase(const TableBase<N, T> &src);
 
   /**
    * Copy constructor. Performs a deep copy from a table object storing some
    * other data type.
+   * @param src The src used by this operation.
    */
   template <typename T2>
   TableBase(const TableBase<N, T2> &src);
 
   /**
    * Move constructor. Transfers the contents of another Table.
+   * @param src The src used by this operation.
    */
   TableBase(TableBase<N, T> &&src) noexcept;
 
@@ -496,6 +508,7 @@ public:
    * We can't use the other, templatized version since if we don't declare
    * this one, the compiler will happily generate a predefined copy operator
    * which is not what we want.
+   * @param src The src used by this operation.
    */
   TableBase<N, T> &
   operator=(const TableBase<N, T> &src);
@@ -506,6 +519,7 @@ public:
    *
    * This function requires that the type <tt>T2</tt> is convertible to
    * <tt>T</tt>.
+   * @param src The src used by this operation.
    */
   template <typename T2>
   TableBase<N, T> &
@@ -514,12 +528,14 @@ public:
   /**
    * Move assignment operator. Transfer all elements of <tt>src</tt> into the
    * table.
+   * @param src The src used by this operation.
    */
   TableBase<N, T> &
   operator=(TableBase<N, T> &&src) noexcept;
 
   /**
    * Test for equality of two tables.
+   * @param T2 The second object to compare.
    */
   bool
   operator==(const TableBase<N, T> &T2) const;
@@ -538,6 +554,8 @@ public:
    * is set to @p false, all elements of the table are set to a
    * default constructed object for the element type. Otherwise the
    * memory is left in an uninitialized or otherwise undefined state.
+   * @param new_size The new size.
+   * @param omit_default_initialization The omit default initialization.
    */
   void
   reinit(const TableIndices<N> &new_size,
@@ -551,6 +569,7 @@ public:
 
   /**
    * Size of the table in direction <tt>i</tt>.
+   * @param i The index of the entry.
    */
   size_type
   size(const unsigned int i) const;
@@ -617,12 +636,14 @@ public:
 
   /**
    * Fill all table entries with the same value.
+   * @param value The value associated with the function.
    */
   void
   fill(const T &value);
 
   /**
    * Return a read-write reference to the indicated element.
+   * @param indices The multi-index that identifies the table entry to access.
    */
   typename AlignedVector<T>::reference
   operator()(const TableIndices<N> &indices);
@@ -633,6 +654,7 @@ public:
    * We return the requested value as a constant reference rather than by
    * value since this object may hold data types that may be large, and we
    * don't know here whether copying is expensive or not.
+   * @param indices The multi-index that identifies the table entry to access.
    */
   typename AlignedVector<T>::const_reference
   operator()(const TableIndices<N> &indices) const;
@@ -676,6 +698,8 @@ public:
    * process may also result in a modification of elements visible on other
    * processes, assuming they are located within one shared memory node.
    *
+   * @param communicator The MPI communicator.
+   * @param root_process The root process.
    * @note The use of shared memory between MPI processes requires
    *   that the detected MPI installation supports the necessary operations.
    *   This is the case for MPI 3.0 and higher.
@@ -736,6 +760,7 @@ public:
    * standard containers. Also, there is a global function <tt>swap(u,v)</tt>
    * that simply calls <tt>u.swap(v)</tt>, again in analogy to standard
    * functions.
+   * @param v The value on which this function operates.
    */
   void
   swap(TableBase<N, T> &v) noexcept;
@@ -843,6 +868,7 @@ public:
 
   /**
    * Constructor. Pass down the given dimension to the base class.
+   * @param size The number of entries in the object to create or resize.
    */
   explicit Table(const size_type size);
 
@@ -891,6 +917,7 @@ public:
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-only reference.
+   * @param i The index of the entry.
    */
   typename AlignedVector<T>::const_reference
   operator[](const size_type i) const;
@@ -898,6 +925,7 @@ public:
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-write reference.
+   * @param i The index of the entry.
    */
   typename AlignedVector<T>::reference
   operator[](const size_type i);
@@ -905,6 +933,7 @@ public:
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-only reference.
+   * @param i The index of the entry.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i) const;
@@ -912,6 +941,7 @@ public:
   /**
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-write reference.
+   * @param i The index of the entry.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i);
@@ -1004,6 +1034,7 @@ namespace MatrixTableIterators
 
     /**
      * Constructor setting up the end iterator.
+     * @param table The table used by this operation.
      */
     AccessorBase(const container_pointer_type table);
 
@@ -1014,6 +1045,8 @@ namespace MatrixTableIterators
 
     /**
      * Constructor taking an array index.
+     * @param table The table used by this operation.
+     * @param linear_index The linear index.
      */
     AccessorBase(const container_pointer_type table,
                  const std::ptrdiff_t         linear_index);
@@ -1201,16 +1234,21 @@ namespace MatrixTableIterators
 
     /**
      * Constructor from an accessor.
+     * @param accessor The accessor used by this operation.
      */
     Iterator(const Accessor<TableType, Constness, storage_order> &accessor);
 
     /**
      * Constructor. Create the end iterator for a table.
+     * @param object The object used by this operation.
      */
     Iterator(const container_pointer_type object);
 
     /**
      * Constructor for a particular table entry.
+     * @param object The object used by this operation.
+     * @param row The row index to access.
+     * @param column The column used by this operation.
      */
     Iterator(const container_pointer_type object,
              const size_type              row,
@@ -1218,11 +1256,14 @@ namespace MatrixTableIterators
 
     /**
      * Copy constructor from a non-const iterator.
+     * @param i The index of the entry.
      */
     Iterator(const Iterator<TableType, false, storage_order> &i);
 
     /**
      * Constructor for an entry with a particular linear index.
+     * @param container The container used by this operation.
+     * @param linear_index The linear index.
      */
     Iterator(const container_pointer_type container,
              const std::ptrdiff_t         linear_index);
@@ -1288,6 +1329,8 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
    */
   Table(const size_type size1, const size_type size2);
 
@@ -1339,6 +1382,9 @@ public:
    * Reinitialize the object. This function is mostly here for compatibility
    * with the earlier <tt>vector2d</tt> class. Passes down to the base class
    * by converting the arguments to the data type requested by the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param omit_default_initialization The omit default initialization.
    */
   void
   reinit(const size_type size1,
@@ -1352,6 +1398,7 @@ public:
    * this two-dimensional table. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<2, T, true, 1>
   operator[](const size_type i) const;
@@ -1361,6 +1408,7 @@ public:
    * this two-dimensional table. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<2, T, false, 1>
   operator[](const size_type i);
@@ -1370,6 +1418,8 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i, const size_type j) const;
@@ -1379,6 +1429,8 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i, const size_type j);
@@ -1497,6 +1549,9 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param size3 The size of the table in the third dimension.
    */
   Table(const size_type size1, const size_type size2, const size_type size3);
 
@@ -1550,6 +1605,10 @@ public:
   /**
    * Reinitialize the object. Passes down to the base class
    * by converting the arguments to the data type requested by the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param size3 The size of the table in the third dimension.
+   * @param omit_default_initialization The omit default initialization.
    */
   void
   reinit(const size_type size1,
@@ -1565,6 +1624,7 @@ public:
    * performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<3, T, true, 2>
   operator[](const size_type i) const;
@@ -1575,6 +1635,7 @@ public:
    * checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<3, T, false, 2>
   operator[](const size_type i);
@@ -1584,6 +1645,9 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i, const size_type j, const size_type k) const;
@@ -1594,6 +1658,9 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i, const size_type j, const size_type k);
@@ -1631,6 +1698,10 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param size3 The size of the table in the third dimension.
+   * @param size4 The size of the table in the fourth dimension.
    */
   Table(const size_type size1,
         const size_type size2,
@@ -1643,6 +1714,7 @@ public:
    * are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<4, T, true, 3>
   operator[](const size_type i) const;
@@ -1653,6 +1725,7 @@ public:
    * are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<4, T, false, 3>
   operator[](const size_type i);
@@ -1662,6 +1735,10 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i,
@@ -1675,6 +1752,10 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i,
@@ -1716,6 +1797,11 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param size3 The size of the table in the third dimension.
+   * @param size4 The size of the table in the fourth dimension.
+   * @param size5 The size of the table in the fifth dimension.
    */
   Table(const size_type size1,
         const size_type size2,
@@ -1729,6 +1815,7 @@ public:
    * performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<5, T, true, 4>
   operator[](const size_type i) const;
@@ -1739,6 +1826,7 @@ public:
    * performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<5, T, false, 4>
   operator[](const size_type i);
@@ -1748,6 +1836,11 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
+   * @param m The index in the fifth dimension.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i,
@@ -1761,6 +1854,11 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
+   * @param m The index in the fifth dimension.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i,
@@ -1802,6 +1900,12 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param size3 The size of the table in the third dimension.
+   * @param size4 The size of the table in the fourth dimension.
+   * @param size5 The size of the table in the fifth dimension.
+   * @param size6 The size of the table in the sixth dimension.
    */
   Table(const size_type size1,
         const size_type size2,
@@ -1816,6 +1920,7 @@ public:
    * performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<6, T, true, 5>
   operator[](const size_type i) const;
@@ -1826,6 +1931,7 @@ public:
    * performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<6, T, false, 5>
   operator[](const size_type i);
@@ -1835,6 +1941,12 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
+   * @param m The index in the fifth dimension.
+   * @param n The index in the sixth dimension.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i,
@@ -1849,6 +1961,12 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
+   * @param m The index in the fifth dimension.
+   * @param n The index in the sixth dimension.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i,
@@ -1890,6 +2008,13 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param size3 The size of the table in the third dimension.
+   * @param size4 The size of the table in the fourth dimension.
+   * @param size5 The size of the table in the fifth dimension.
+   * @param size6 The size of the table in the sixth dimension.
+   * @param size7 The size of the table in the seventh dimension.
    */
   Table(const size_type size1,
         const size_type size2,
@@ -1905,6 +2030,7 @@ public:
    * performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<7, T, true, 6>
   operator[](const size_type i) const;
@@ -1915,6 +2041,7 @@ public:
    * performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
    */
   dealii::internal::TableBaseAccessors::Accessor<7, T, false, 6>
   operator[](const size_type i);
@@ -1924,6 +2051,13 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
+   * @param m The index in the fifth dimension.
+   * @param n The index in the sixth dimension.
+   * @param o The index in the seventh dimension.
    */
   typename AlignedVector<T>::const_reference
   operator()(const size_type i,
@@ -1939,6 +2073,13 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
+   * @param k The index of the entry.
+   * @param l The index in the fourth dimension.
+   * @param m The index in the fifth dimension.
+   * @param n The index in the sixth dimension.
+   * @param o The index in the seventh dimension.
    */
   typename AlignedVector<T>::reference
   operator()(const size_type i,
@@ -2016,6 +2157,8 @@ public:
 
   /**
    * Constructor. Pass down the given dimensions to the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
    */
   TransposeTable(const size_type size1, const size_type size2);
 
@@ -2023,6 +2166,9 @@ public:
    * Reinitialize the object. This function is mostly here for compatibility
    * with the earlier <tt>vector2d</tt> class. Passes down to the base class
    * by converting the arguments to the data type requested by the base class.
+   * @param size1 The size of the table in the first dimension.
+   * @param size2 The size of the table in the second dimension.
+   * @param omit_default_initialization The omit default initialization.
    */
   void
   reinit(const size_type size1,
@@ -2034,6 +2180,8 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function only allows read access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
    */
   const_reference
   operator()(const size_type i, const size_type j) const;
@@ -2043,6 +2191,8 @@ public:
    * the same time. Range checks are performed.
    *
    * This version of the function allows read-write access.
+   * @param i The index of the entry.
+   * @param j The index of the entry.
    */
   reference
   operator()(const size_type i, const size_type j);
@@ -3708,6 +3858,8 @@ Table<7, T>::operator()(const size_type i,
  * Global function @p swap which overloads the default implementation of the
  * C++ standard library which uses a temporary object. The function simply
  * exchanges the data of the two tables.
+ * @param u The value on which this function operates.
+ * @param v The value on which this function operates.
  */
 template <int N, typename T>
 inline void

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -59,6 +59,7 @@ namespace internal
     /**
      * Constructor. Initialize this table element with the value
      * <code>t</code>.
+     * @param t The time associated with the evaluation.
      */
     template <typename T>
     explicit TableEntry(const T &t);
@@ -88,6 +89,8 @@ namespace internal
      * formatting. The value is cached as a string internally in cached_value.
      * The cache needs to be invalidated with this routine if the formatting
      * of the column changes.
+     * @param scientific Whether to scientific.
+     * @param precision The precision used by this operation.
      */
     void
     cache_string(bool scientific, unsigned int precision) const;
@@ -395,6 +398,7 @@ public:
    * possible for small programs, but may not be feasible for
    * large code bases in which parts of the code base are only
    * executed based on run-time parameters.)
+   * @param key The key used by this operation.
    */
   void
   declare_column(const std::string &key);
@@ -404,6 +408,8 @@ public:
    * the value of type <tt>T</tt> to the column. Values of type <tt>T</tt>
    * must be convertible to one of <code>int, unsigned int, double,
    * std::uint64_t, std::string</code> or a compiler error will result.
+   * @param key The key used by this operation.
+   * @param value The value associated with the function.
    */
   template <typename T>
   void
@@ -428,6 +434,7 @@ public:
   /**
    * Switch auto-fill mode on or off. See the general documentation of this
    * class for a description of what auto-fill mode does.
+   * @param state Whether to state.
    */
   void
   set_auto_fill_mode(const bool state);
@@ -443,6 +450,8 @@ public:
    * Concerning the order of the columns, the supercolumn replaces the first
    * column that is added to the supercolumn. Within the supercolumn the order
    * of output follows the order the columns are added to the supercolumn.
+   * @param key The key used by this operation.
+   * @param superkey The superkey used by this operation.
    */
   void
   add_column_to_supercolumn(const std::string &key,
@@ -463,6 +472,7 @@ public:
    * five columns and then call one of the <tt>write_*</tt> functions, then
    * call this function with the next five columns and again <tt>write_*</tt>,
    * and so on.
+   * @param new_order The new order.
    */
   void
   set_column_order(const std::vector<std::string> &new_order);
@@ -471,6 +481,8 @@ public:
    * Set the <tt>precision</tt> e.g. double or float variables are written
    * with. <tt>precision</tt> is the same as in calling
    * <tt>out<<setprecision(precision)</tt>.
+   * @param key The key used by this operation.
+   * @param precision The precision used by this operation.
    */
   void
   set_precision(const std::string &key, const unsigned int precision);
@@ -478,6 +490,8 @@ public:
   /**
    * Set the <tt>scientific_flag</tt>. True means scientific, false means
    * fixed point notation.
+   * @param key The key used by this operation.
+   * @param scientific Whether to scientific.
    */
   void
   set_scientific(const std::string &key, const bool scientific);
@@ -486,18 +500,22 @@ public:
    * Set the caption of the column <tt>key</tt> for tex output. You may want
    * to chose this different from <tt>key</tt>, if it contains formulas or
    * similar constructs.
+   * @param key The key used by this operation.
+   * @param tex_caption The tex caption.
    */
   void
   set_tex_caption(const std::string &key, const std::string &tex_caption);
 
   /**
    * Set the tex caption of the entire <tt>table</tt> for tex output.
+   * @param table_caption The table caption.
    */
   void
   set_tex_table_caption(const std::string &table_caption);
 
   /**
    * Set the label of this <tt>table</tt> for tex output.
+   * @param table_label The table label.
    */
   void
   set_tex_table_label(const std::string &table_label);
@@ -506,6 +524,8 @@ public:
    * Set the caption the supercolumn <tt>superkey</tt> for tex output.
    * You may want to chose this different from <tt>superkey</tt>, if it
    * contains formulas or similar constructs.
+   * @param superkey The superkey used by this operation.
+   * @param tex_supercaption The tex supercaption.
    */
   void
   set_tex_supercaption(const std::string &superkey,
@@ -516,6 +536,8 @@ public:
    * <tt>l</tt>, or <tt>p{3cm}</tt>. The default is <tt>c</tt>. Also if this
    * function is not called for a column, the default is preset to be
    * <tt>c</tt>.
+   * @param key The key used by this operation.
+   * @param format The format used by this operation.
    */
   void
   set_tex_format(const std::string &key, const std::string &format = "c");
@@ -530,6 +552,8 @@ public:
    *
    * The second argument indicates how column keys are to be displayed. See
    * the description of TextOutputFormat for more information.
+   * @param out The output stream to which data is written.
+   * @param format The format used by this operation.
    */
   void
   write_text(std::ostream          &out,
@@ -541,6 +565,8 @@ public:
    * <code>\\end{document}</code> are used. In this way the file can be
    * included into an existing tex file using a command like
    * <code>\\input{table_file}</code>.
+   * @param file The file name or path associated with the operation.
+   * @param with_header The with header.
    */
   void
   write_tex(std::ostream &file, const bool with_header = true) const;
@@ -630,12 +656,14 @@ protected:
 
     /**
      * Constructor.
+     * @param tex_caption The tex caption.
      */
     explicit Column(const std::string &tex_caption);
 
     /**
      * Pad this column with default constructed elements to the number of rows
      * given by the argument.
+     * @param length The length used by this operation.
      */
     void
     pad_column_below(const unsigned int length);
@@ -738,6 +766,7 @@ protected:
    *
    * This function implicitly checks the consistency of the data. The result
    * is returned in <tt>sel_columns</tt>.
+   * @param sel_columns The object in which to store the sel columns.
    */
   void
   get_selected_columns(std::vector<std::string> &sel_columns) const;

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -58,30 +58,36 @@ public:
    * the number of arguments given is different from the number of the
    * indices this class stores (i.e., the template argument `N` of
    * this class), or if any of the arguments is not of some integer type.
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   template <typename... T>
   constexpr TableIndices(const T... indices);
 
   /**
    * Read-only access the value of the <tt>i</tt>th index.
+   * @param i The index of the entry.
    */
   constexpr std::size_t
   operator[](const unsigned int i) const;
 
   /**
    * Write access the value of the <tt>i</tt>th index.
+   * @param i The index of the entry.
    */
   constexpr std::size_t &
   operator[](const unsigned int i);
 
   /**
    * Compare two index fields for equality.
+   * @param other The object to copy or move from.
    */
   constexpr bool
   operator==(const TableIndices<N> &other) const;
 
   /**
    * Compare two index fields for inequality.
+   * @param other The object to copy or move from.
    */
   constexpr bool
   operator!=(const TableIndices<N> &other) const;

--- a/include/deal.II/base/task_result.h
+++ b/include/deal.II/base/task_result.h
@@ -96,6 +96,7 @@ namespace Threads
     /**
      * A constructor that takes a Task object and initializes the
      * current object to be the result of that task.
+     * @param task The task used by this operation.
      */
     TaskResult(const Task<T> &task)
       : result_is_available(false)
@@ -254,6 +255,7 @@ namespace Threads
      * is working on data that is changing as it is working, with obviously
      * unpredictable results.)
      *
+     * @param t The time associated with the evaluation.
      * @note As mentioned above, it is a considered a bug to assign a task to
      *   a TaskResult object that already has a task running. That means that
      *   you will get in trouble if multiple threads (or multiple tasks running

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -352,6 +352,8 @@ struct PointerComparison
   /**
    * Comparison function for pointers of the same type. Returns @p true if the
    * two pointers are equal.
+   * @param p1 The p1 used by this operation.
+   * @param p2 The p2 used by this operation.
    */
   template <typename T>
   static bool
@@ -665,6 +667,7 @@ namespace concepts
    * in one contiguous array in which we access all elements via a pointer to
    * the first element plus an offset. In contrast, linked lists, maps, and
    * similar objects are typically not stored as contiguous containers.
+   * @param c The container object whose interface is checked.
    */
   template <typename C>
   concept is_contiguous_container = requires(C &c) {
@@ -1003,6 +1006,13 @@ namespace concepts
    * interface to serve as a vector in vector-space operations -- principally
    * what is required to run iterative solvers: things such as norms, dot
    * products, etc.
+   * @param U The vector object on which the required operations are tested.
+   * @param V An additional vector object used as an input operand.
+   * @param W A third vector object used in multi-vector operations.
+   * @param a A scalar coefficient used in scaling and axpy-like operations.
+   * @param b A second scalar coefficient used in linear combinations.
+   * @param s The scalar weight used in `sadd()`-style operations.
+   * @param operation The compression operation passed to `compress()`.
    */
   template <typename VectorType>
   concept is_vector_space_vector = requires(VectorType                      U,
@@ -1095,6 +1105,9 @@ namespace concepts
    * a `VectorType` object as input and produce another `VectorType`
    * as output (both objects being taken as arguments to the `vmult()`
    * function).
+   * @param A The matrix or linear operator whose interface is being tested.
+   * @param dst The destination vector into which `vmult()` writes the result.
+   * @param src The source vector that is multiplied by @p A.
    */
   template <typename MatrixType, typename VectorType>
   concept is_linear_operator_on =
@@ -1110,6 +1123,10 @@ namespace concepts
    * take a `VectorType` object as input and produce another `VectorType`
    * as output (both objects being taken as arguments to the `vmult()`
    * function).
+   * @param A The matrix or linear operator whose transpose interface is being
+   * tested.
+   * @param dst The destination vector into which `Tvmult()` writes the result.
+   * @param src The source vector that is multiplied by the transpose of @p A.
    */
   template <typename MatrixType, typename VectorType>
   concept is_transpose_linear_operator_on =

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -152,6 +152,7 @@ public:
    * obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
    *
+   * @param initializer The tensor argument supplied to this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -161,6 +162,7 @@ public:
   /**
    * Constructor, where the data is copied from a C-style array.
    *
+   * @param initializer The initializer used by this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -170,12 +172,14 @@ public:
 #ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
   /**
    * Copy constructor
+   * @param other The object to copy or move from.
    */
   constexpr DEAL_II_HOST_DEVICE
   Tensor(const Tensor<0, dim, Number> &other);
 
   /**
    * Move constructor
+   * @param other The object to copy or move from.
    */
   constexpr DEAL_II_HOST_DEVICE
   Tensor(Tensor<0, dim, Number> &&other) noexcept;
@@ -208,6 +212,7 @@ public:
    * obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
    *
+   * @param rhs The right-hand-side operand.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -221,6 +226,7 @@ public:
    * copy constructor for Sacado::Rad::ADvar types automatically.
    * See https://github.com/dealii/dealii/pull/5865.
    *
+   * @param rhs The right-hand-side operand.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE Tensor &
@@ -230,6 +236,7 @@ public:
 #ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
   /**
    * Move assignment operator
+   * @param other The object to copy or move from.
    */
   constexpr DEAL_II_HOST_DEVICE Tensor<0, dim, Number> &
   operator=(Tensor<0, dim, Number> &&other) noexcept;
@@ -239,6 +246,7 @@ public:
    * This operator assigns a scalar to a tensor. This obviously requires
    * that the @p OtherNumber type is convertible to @p Number.
    *
+   * @param d The scalar value to assign.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -249,6 +257,7 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param d The scalar value to assign.
    */
   template <typename OtherNumber>
   constexpr DEAL_II_HOST_DEVICE Tensor &
@@ -256,6 +265,7 @@ public:
 
   /**
    * Test for equality of two tensors.
+   * @param rhs The right-hand-side operand.
    */
   template <typename OtherNumber>
   constexpr bool
@@ -263,6 +273,7 @@ public:
 
   /**
    * Test for inequality of two tensors.
+   * @param rhs The right-hand-side operand.
    */
   template <typename OtherNumber>
   constexpr bool
@@ -271,6 +282,7 @@ public:
   /**
    * Add another scalar.
    *
+   * @param rhs The right-hand-side operand.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -280,6 +292,7 @@ public:
   /**
    * Subtract another scalar.
    *
+   * @param rhs The right-hand-side operand.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -289,6 +302,7 @@ public:
   /**
    * Multiply the scalar with a <tt>factor</tt>.
    *
+   * @param factor The scalar factor by which all entries are scaled.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -298,6 +312,7 @@ public:
   /**
    * Divide the scalar by <tt>factor</tt>.
    *
+   * @param factor The scalar divisor by which all entries are divided.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -531,6 +546,7 @@ public:
   /**
    * A constructor where the data is copied from a C-style array.
    *
+   * @param initializer The initializer used by this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE explicit Tensor(const array_type &initializer);
@@ -545,6 +561,7 @@ public:
    * This constructor obviously requires that the @p ElementType type is
    * either equal to @p Number, or is convertible to @p Number.
    *
+   * @param initializer The initializer used by this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename ElementType, typename MemorySpace>
@@ -556,6 +573,7 @@ public:
    * obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
    *
+   * @param initializer The tensor argument supplied to this operation.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -564,6 +582,7 @@ public:
 
   /**
    * Constructor that converts from a "tensor of tensors".
+   * @param initializer The tensor argument supplied to this operation.
    */
   template <typename OtherNumber>
   constexpr Tensor(
@@ -591,6 +610,7 @@ public:
   /**
    * Read-Write access operator.
    *
+   * @param i The index of the entry.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE value_type &
@@ -599,6 +619,7 @@ public:
   /**
    * Read-only access operator.
    *
+   * @param i The index of the entry.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   constexpr DEAL_II_HOST_DEVICE const value_type &
@@ -606,12 +627,16 @@ public:
 
   /**
    * Read access using TableIndices <tt>indices</tt>
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   constexpr const Number &
   operator[](const TableIndices<rank_> &indices) const;
 
   /**
    * Read and write access using TableIndices <tt>indices</tt>
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   constexpr Number &
   operator[](const TableIndices<rank_> &indices);
@@ -649,6 +674,7 @@ public:
    * This obviously requires that the @p OtherNumber type is convertible to @p
    * Number.
    *
+   * @param rhs The right-hand-side operand.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -660,6 +686,7 @@ public:
    * exactly it means to assign a scalar value to a tensor, zero is the only
    * value allowed for <tt>d</tt>, allowing the intuitive notation
    * <tt>t=0</tt> to reset all elements of the tensor to zero.
+   * @param d The scalar value to assign.
    */
   constexpr DEAL_II_HOST_DEVICE Tensor &
   operator=(const Number &d) &;
@@ -668,6 +695,7 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param d The scalar value to assign.
    */
   constexpr DEAL_II_HOST_DEVICE Tensor &
   operator=(const Number &d) && = delete;
@@ -722,6 +750,7 @@ public:
    * Scale the tensor by <tt>factor</tt>, i.e. multiply all components by
    * <tt>factor</tt>.
    *
+   * @param factor The scalar factor by which all entries are scaled.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -731,6 +760,7 @@ public:
   /**
    * Scale the vector by <tt>1/factor</tt>.
    *
+   * @param factor The scalar divisor by which all entries are divided.
    * @note This function can also be used in @ref GlossDevice "device" code.
    */
   template <typename OtherNumber>
@@ -798,6 +828,8 @@ public:
   /**
    * Return an unrolled index in the range $[0,\text{dim}^{\text{rank}}-1]$
    * for the element of the tensor indexed by the argument to the function.
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    */
   static constexpr DEAL_II_HOST_DEVICE unsigned int
   component_to_unrolled_index(const TableIndices<rank_> &indices);
@@ -806,6 +838,7 @@ public:
    * Opposite of  component_to_unrolled_index: For an index in the range
    * $[0, \text{dim}^{\text{rank}}-1]$, return which set of indices it would
    * correspond to.
+   * @param i The index of the entry.
    */
   static constexpr DEAL_II_HOST_DEVICE TableIndices<rank_>
   unrolled_to_component_indices(const unsigned int i);
@@ -1960,6 +1993,8 @@ operator<<(std::ostream &out, const Tensor<0, dim, Number> &p)
  * This function unwraps the underlying @p Number stored in the Tensor and
  * multiplies @p object with it.
  *
+ * @param object The object used by this operation.
+ * @param t The time associated with the evaluation.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -1980,6 +2015,8 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
  * This function unwraps the underlying @p Number stored in the Tensor and
  * multiplies @p object with it.
  *
+ * @param t The time associated with the evaluation.
+ * @param object The object used by this operation.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2000,6 +2037,8 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
  * OtherNumber that are stored within the Tensor and multiplies them. It
  * returns an unwrapped number of product type.
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2018,6 +2057,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
 /**
  * Division of a tensor of rank 0 by a scalar number.
  *
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2037,6 +2078,8 @@ DEAL_II_HOST_DEVICE constexpr DEAL_II_ALWAYS_INLINE
 /**
  * Add two tensors of rank 0.
  *
+ * @param p The point at which to evaluate the function.
+ * @param q The quadrature formula used by this operation.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2054,6 +2097,8 @@ constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
 /**
  * Subtract two tensors of rank 0.
  *
+ * @param p The point at which to evaluate the function.
+ * @param q The quadrature formula used by this operation.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2076,6 +2121,8 @@ constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE
  * number, a complex floating point number, etc.) is allowed, see the
  * documentation of EnableIfScalar for details.
  *
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2102,6 +2149,8 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
  * number, a complex floating point number, etc.) is allowed, see the
  * documentation of EnableIfScalar for details.
  *
+ * @param factor The scalar factor by which all entries are scaled.
+ * @param t The time associated with the evaluation.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2125,6 +2174,8 @@ DEAL_II_HOST_DEVICE constexpr inline DEAL_II_ALWAYS_INLINE
  * discussion on operator*() above for more information about template
  * arguments and the return type.
  *
+ * @param t The time associated with the evaluation.
+ * @param factor The scalar factor by which all entries are scaled.
  * @note This function can also be used in @ref GlossDevice "device" code.
  *
  * @relatesalso Tensor
@@ -2146,6 +2197,8 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
 /**
  * Addition of two tensors of general rank.
  *
+ * @param p The point at which to evaluate the function.
+ * @param q The quadrature formula used by this operation.
  * @tparam rank The rank of both tensors.
  *
  * @note This function can also be used in @ref GlossDevice "device" code.
@@ -2167,6 +2220,8 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
 /**
  * Subtraction of two tensors of general rank.
  *
+ * @param p The point at which to evaluate the function.
+ * @param q The quadrature formula used by this operation.
  * @tparam rank The rank of both tensors.
  *
  * @note This function can also be used in @ref GlossDevice "device" code.
@@ -2189,6 +2244,8 @@ constexpr DEAL_II_HOST_DEVICE inline DEAL_II_ALWAYS_INLINE
  * multiplication of two scalar values).
  *
  * @relatesalso Tensor
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  */
 template <int dim, typename Number, typename OtherNumber>
 inline constexpr DEAL_II_ALWAYS_INLINE
@@ -2215,6 +2272,8 @@ inline constexpr DEAL_II_ALWAYS_INLINE
  *     \text{right}_{i, j}
  * @f]
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @tparam rank The rank of both tensors.
  *
  * @relatesalso Tensor
@@ -2255,6 +2314,8 @@ inline constexpr DEAL_II_ALWAYS_INLINE
  *     \text{right}_{k, j_1,\ldots,j_{r2}}
  * @f]
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @note For the Tensor class, the multiplication operator only performs a
  * contraction over a single pair of indices. This is in contrast to the
  * multiplication operator for SymmetricTensor, for which the corresponding
@@ -2363,6 +2424,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  *   contract<0, 2>(t1, t2);
  * @endcode
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @note The position of the index is counted from 0, i.e.,
  * $0\le\text{index}_i<\text{range}_i$.
  *
@@ -2436,6 +2499,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  *   double_contract<0, 2, 1, 0>(t1, t2);
  * @endcode
  *
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  * @note The position of the index is counted from 0, i.e.,
  * $0\le\text{index}_i<\text{range}_i$.
  *
@@ -2532,6 +2597,8 @@ constexpr inline
  * @f]
  *
  * @relatesalso Tensor
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
  */
 template <int rank, int dim, typename Number, typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
@@ -2596,6 +2663,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  * @f]
  *
  * @relatesalso Tensor
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  */
 template <int rank_1,
           int rank_2,
@@ -2633,6 +2702,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  * (e.g. from the <tt>dim==2</tt> case in the switch).
  *
  * @relatesalso Tensor
+ * @param src The tensor argument supplied to this operation.
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, Number>
@@ -2657,6 +2727,8 @@ cross_product_2d(const Tensor<1, dim, Number> &src)
  * case in the switch).
  *
  * @relatesalso Tensor
+ * @param src1 The first source tensor involved in the contraction.
+ * @param src2 The second source tensor involved in the contraction.
  */
 template <int dim, typename Number1, typename Number2>
 constexpr inline DEAL_II_ALWAYS_INLINE
@@ -2691,6 +2763,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  * Compute the determinant of a tensor or rank 2.
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
@@ -2719,6 +2792,7 @@ determinant(const Tensor<2, dim, Number> &t)
  * Specialization for dim==1.
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
@@ -2731,6 +2805,7 @@ determinant(const Tensor<2, 1, Number> &t)
  * Specialization for dim==2.
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
@@ -2744,6 +2819,7 @@ determinant(const Tensor<2, 2, Number> &t)
  * Specialization for dim==3.
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
@@ -2765,6 +2841,7 @@ determinant(const Tensor<2, 3, Number> &t)
  * diagonal entries.
  *
  * @relatesalso Tensor
+ * @param d The value on which this function operates.
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
@@ -2866,6 +2943,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE Tensor<2, 3, Number>
  * Return the transpose of the given tensor.
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, Number>
@@ -2894,6 +2972,7 @@ transpose(const Tensor<2, dim, Number> &t)
  * \; .
  * @f]
  *
+ * @param t The time associated with the evaluation.
  * @note This requires that the tensor is invertible.
  *
  * @relatesalso Tensor
@@ -2915,6 +2994,7 @@ adjugate(const Tensor<2, dim, Number> &t)
  *    = \left[ \textrm{adj}\mathbf A \right]^{T} \; .
  * @f]
  *
+ * @param t The time associated with the evaluation.
  * @note This requires that the tensor is invertible.
  *
  * @relatesalso Tensor
@@ -3001,6 +3081,7 @@ project_onto_orthogonal_tensors(const Tensor<2, dim, Number> &A);
  * (maximum of the sums over columns).
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 inline Number
@@ -3027,6 +3108,7 @@ l1_norm(const Tensor<2, dim, Number> &t)
  * (maximum of the sums over rows).
  *
  * @relatesalso Tensor
+ * @param t The time associated with the evaluation.
  */
 template <int dim, typename Number>
 inline Number

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -170,6 +170,7 @@ namespace TensorAccessors
    *  - use the contract function below that contracts the _last_ elements of
    * tensors.
    *
+   * @param t The time associated with the evaluation.
    * @note This function returns an internal class object consisting of an
    * array subscript operator <code>operator[](unsigned int)</code> and an
    * alias <code>value_type</code> describing its return value.
@@ -204,6 +205,9 @@ namespace TensorAccessors
    * @endcode
    * This is equivalent to <code>tensor[0][1][2][3][4] = 42.</code>.
    *
+   * @param t The time associated with the evaluation.
+   * @param indices The multi-index that identifies the tensor entry to
+   * access.
    * @tparam T A tensorial object of rank @p rank. @p T must provide a local
    * alias <code>value_type</code> and an index operator
    * <code>operator[]()</code> that returns a (const or non-const) reference
@@ -257,6 +261,9 @@ namespace TensorAccessors
    * with r = rank_1 + rank_2 - 2 * no_contr, l = rank_1 - no_contr, l1 =
    * rank_1, and c = no_contr.
    *
+   * @param result The result used by this operation.
+   * @param left The left-hand operand.
+   * @param right The right-hand operand.
    * @note The Types @p T1, @p T2, and @p T3 must have rank rank_1 + rank_2 -
    * 2 * no_contr, rank_1, or rank_2, respectively. Obviously, no_contr must
    * be less or equal than rank_1 and rank_2.
@@ -310,6 +317,9 @@ namespace TensorAccessors
    *                           * right[j_0]..[j_];
    * @endcode
    *
+   * @param left The left-hand operand.
+   * @param middle The middle used by this operation.
+   * @param right The right-hand operand.
    * @note The Types @p T2, @p T3, and @p T4 must have rank rank_1, rank_1 +
    * rank_2, and rank_3, respectively. @p T1 must be a scalar type.
    */

--- a/include/deal.II/base/tensor_function.h
+++ b/include/deal.II/base/tensor_function.h
@@ -74,6 +74,7 @@ public:
   /**
    * Constructor. May take an initial value for the time variable, which
    * defaults to zero.
+   * @param initial_time The initial time.
    */
   TensorFunction(const time_type initial_time = time_type(0.0));
 
@@ -86,6 +87,7 @@ public:
 
   /**
    * Return the value of the function at the given point.
+   * @param p The point at which to evaluate the function.
    */
   virtual value_type
   value(const Point<dim> &p) const;
@@ -94,6 +96,8 @@ public:
    * Set <tt>values</tt> to the point values of the function at the
    * <tt>points</tt>.  It is assumed that <tt>values</tt> already has the
    * right size, i.e.  the same size as the <tt>points</tt> array.
+   * @param points The points at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   value_list(const std::vector<Point<dim>> &points,
@@ -101,6 +105,7 @@ public:
 
   /**
    * Return the gradient of the function at the given point.
+   * @param p The point at which to evaluate the function.
    */
   virtual gradient_type
   gradient(const Point<dim> &p) const;
@@ -109,6 +114,8 @@ public:
    * Set <tt>gradients</tt> to the gradients of the function at the
    * <tt>points</tt>.  It is assumed that <tt>values</tt> already has the
    * right size, i.e.  the same size as the <tt>points</tt> array.
+   * @param points The points at which to evaluate the function.
+   * @param gradients The object in which to store the computed gradients.
    */
   virtual void
   gradient_list(const std::vector<Point<dim>> &points,
@@ -138,6 +145,8 @@ public:
    *
    * An initial value for the time variable may be specified, otherwise it
    * defaults to zero.
+   * @param value The value associated with the function.
+   * @param initial_time The initial time.
    */
   ConstantTensorFunction(const dealii::Tensor<rank, dim, Number> &value,
                          const time_type initial_time = 0.0);
@@ -190,6 +199,7 @@ public:
    *
    * An initial value for the time variable may be specified, otherwise it
    * defaults to zero.
+   * @param initial_time The initial time.
    */
   ZeroTensorFunction(const time_type initial_time = 0.0);
 };

--- a/include/deal.II/base/tensor_function_parser.h
+++ b/include/deal.II/base/tensor_function_parser.h
@@ -110,6 +110,7 @@ public:
    * initialized with the initialize() method before you can use it. If an
    * attempt to use this function is made before the initialize() method has
    * been called, then an exception is thrown.
+   * @param initial_time The initial time.
    */
   TensorFunctionParser(const double initial_time = 0.0);
 
@@ -120,6 +121,9 @@ public:
    * then an exception is thrown.
    * Takes a semicolon separated list of expressions (one for each component
    * of the tensor function), an optional comma-separated list of constants.
+   * @param expression The expression used by this operation.
+   * @param constants The constants used by this operation.
+   * @param variable_names The variable names.
    */
   TensorFunctionParser(
     const std::string &expression,
@@ -205,6 +209,10 @@ public:
    * are expected to be separated by a semicolon. An exception is thrown if
    * this method is called and the number of components successfully parsed
    * does not match the number of components of the base function.
+   * @param vars The vars used by this operation.
+   * @param expression The expression used by this operation.
+   * @param constants The constants used by this operation.
+   * @param time_dependent The time dependent.
    */
   void
   initialize(const std::string &vars,
@@ -222,12 +230,15 @@ public:
 
   /**
    * Return the value of the tensor function at the given point.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<rank, dim, Number>
   value(const Point<dim> &p) const override;
 
   /**
    * Return the value of the tensor function at the given point.
+   * @param p The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
    */
   virtual void
   value_list(const std::vector<Point<dim>>          &p,

--- a/include/deal.II/base/tensor_polynomials_base.h
+++ b/include/deal.II/base/tensor_polynomials_base.h
@@ -62,6 +62,8 @@ public:
   /**
    * Constructor. This takes the degree of the space, @p deg from the finite element
    * class, and @p n, the number of polynomials for the space.
+   * @param deg The deg used by this operation.
+   * @param n_polynomials The number of polynomials.
    */
   TensorPolynomialsBase(const unsigned int deg,
                         const unsigned int n_polynomials);
@@ -88,6 +90,12 @@ public:
    *
    * The size of the vectors must either be zero or equal <tt>n()</tt>.  In
    * the first case, the function will not compute these values.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   virtual void
   evaluate(const Point<dim>            &unit_point,

--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -90,6 +90,7 @@ public:
 
   /**
    * Print the list of the indices to <tt>out</tt>.
+   * @param out The output stream to which data is written.
    */
   void
   output_indices(std::ostream &out) const;
@@ -97,6 +98,7 @@ public:
   /**
    * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==n()</tt>.  Stores a copy of <tt>renumber</tt>.
+   * @param renumber The renumber used by this operation.
    */
   void
   set_numbering(const std::vector<unsigned int> &renumber);
@@ -124,6 +126,12 @@ public:
    * use this function, rather than using any of the compute_value(),
    * compute_grad() or compute_grad_grad() functions, see below, in a loop
    * over all tensor product polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -144,6 +152,8 @@ public:
    * several times.  Instead use the evaluate() function with
    * <tt>values.size()==</tt>n() to get the point values of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -160,6 +170,8 @@ public:
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @tparam order The derivative order.
    */
   template <int order>
@@ -168,6 +180,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -175,6 +189,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -182,6 +198,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -189,6 +207,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -205,6 +225,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with
    * <tt>grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -220,6 +242,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with
    * <tt>grad_grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -333,6 +357,7 @@ public:
    *
    * The number of tensor product polynomials is <tt>Nx*Ny*Nz</tt>, or with
    * terms dropped if the number of space dimensions is less than 3.
+   * @param base_polynomials The base polynomials.
    */
   AnisotropicPolynomials(
     const std::vector<std::vector<Polynomials::Polynomial<double>>>
@@ -341,6 +366,7 @@ public:
   /**
    * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==n()</tt>.  Stores a copy of <tt>renumber</tt>.
+   * @param renumber The renumber used by this operation.
    */
   void
   set_numbering(const std::vector<unsigned int> &renumber);
@@ -369,6 +395,12 @@ public:
    * use this function, rather than using any of the <tt>compute_value</tt>,
    * <tt>compute_grad</tt> or <tt>compute_grad_grad</tt> functions, see below,
    * in a loop over all tensor product polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -389,6 +421,8 @@ public:
    * several times.  Instead use the <tt>compute</tt> function, see above,
    * with <tt>values.size()==this->n()</tt> to get the point values of all
    * tensor polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -405,6 +439,8 @@ public:
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @tparam order The derivative order.
    */
   template <int order>
@@ -413,6 +449,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -420,6 +458,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -427,6 +467,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -434,6 +476,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -450,6 +494,8 @@ public:
    * several times.  Instead use the <tt>compute</tt> function, see above,
    * with <tt>grads.size()==this->n()</tt> to get the point value of all
    * tensor polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -465,6 +511,8 @@ public:
    * several times.  Instead use the <tt>compute</tt> function, see above,
    * with <tt>grad_grads.size()==this->n()</tt> to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -515,10 +563,9 @@ private:
     const std::vector<std::vector<Polynomials::Polynomial<double>>> &pols);
 };
 
-/** @} */
-
+/**
+ *  @} */
 #ifndef DOXYGEN
-
 
 /* ---------------- template and inline functions ---------- */
 

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -66,6 +66,7 @@ public:
 
   /**
    * Print the list of <tt>tensor_polys</tt> indices to <tt>out</tt>.
+   * @param out The output stream to which data is written.
    */
   void
   output_indices(std::ostream &out) const;
@@ -74,6 +75,7 @@ public:
    * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==tensor_polys.n()</tt>.  Stores a copy of
    * <tt>renumber</tt>.
+   * @param renumber The renumber used by this operation.
    */
   void
   set_numbering(const std::vector<unsigned int> &renumber);
@@ -101,6 +103,12 @@ public:
    * use this function, rather than using any of the compute_value(),
    * compute_grad() or compute_grad_grad() functions, see below, in a loop
    * over all tensor product polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -121,6 +129,8 @@ public:
    * several times.  Instead use the evaluate() function with
    * <tt>values.size()==</tt>n() to get the point values of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -136,6 +146,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with the
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   template <int order>
   Tensor<order, dim>
@@ -143,6 +155,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -150,6 +164,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -157,6 +173,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -164,6 +182,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -180,6 +200,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with
    * <tt>grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -195,6 +217,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with
    * <tt>grad_grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -238,24 +262,24 @@ private:
   std::vector<unsigned int> index_map_inverse;
 };
 
-/** @} */
-
-
+/**
+ *  @} */
+*
 /* ---------------- template and inline functions ---------- */
 
 #ifndef DOXYGEN
 
-template <int dim>
-template <class Pol>
-inline TensorProductPolynomialsBubbles<dim>::TensorProductPolynomialsBubbles(
-  const std::vector<Pol> &pols)
+  template <int dim>
+  template <class Pol>
+  inline TensorProductPolynomialsBubbles<dim>::TensorProductPolynomialsBubbles(
+    const std::vector<Pol> &pols)
   : ScalarPolynomialsBase<dim>(1,
                                Utilities::fixed_power<dim>(pols.size()) + dim)
-  , tensor_polys(pols)
-  , index_map(tensor_polys.n() +
-              ((tensor_polys.polynomials.size() <= 2) ? 1 : dim))
-  , index_map_inverse(tensor_polys.n() +
-                      ((tensor_polys.polynomials.size() <= 2) ? 1 : dim))
+, tensor_polys(pols)
+, index_map(tensor_polys.n() +
+            ((tensor_polys.polynomials.size() <= 2) ? 1 : dim))
+, index_map_inverse(tensor_polys.n() +
+                    ((tensor_polys.polynomials.size() <= 2) ? 1 : dim))
 {
   const unsigned int q_degree  = tensor_polys.polynomials.size() - 1;
   const unsigned int n_bubbles = ((q_degree <= 1) ? 1 : dim);

--- a/include/deal.II/base/tensor_product_polynomials_const.h
+++ b/include/deal.II/base/tensor_product_polynomials_const.h
@@ -59,6 +59,7 @@ public:
 
   /**
    * Print the list of <tt>tensor_polys</tt> indices to <tt>out</tt>.
+   * @param out The output stream to which data is written.
    */
   void
   output_indices(std::ostream &out) const;
@@ -67,6 +68,7 @@ public:
    * Set the ordering of the polynomials. Requires
    * <tt>renumber.size()==tensor_polys.n()</tt>.  Stores a copy of
    * <tt>renumber</tt>.
+   * @param renumber The renumber used by this operation.
    */
   void
   set_numbering(const std::vector<unsigned int> &renumber);
@@ -94,6 +96,12 @@ public:
    * use this function, rather than using any of the compute_value(),
    * compute_grad() or compute_grad_grad() functions, see below, in a loop
    * over all tensor product polynomials.
+   * @param unit_point The point at which to evaluate the function.
+   * @param values The object in which to store the computed values.
+   * @param grads The object in which to store the computed gradients.
+   * @param grad_grads The object in which to store the computed gradients.
+   * @param third_derivatives The object in which to store the computed third derivatives.
+   * @param fourth_derivatives The object in which to store the computed fourth derivatives.
    */
   void
   evaluate(const Point<dim>            &unit_point,
@@ -114,6 +122,8 @@ public:
    * several times.  Instead use the evaluate() function with
    * <tt>values.size()==</tt>n() to get the point values of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   double
   compute_value(const unsigned int i, const Point<dim> &p) const override;
@@ -130,6 +140,8 @@ public:
    * size of the appropriate parameter set to n() to get the point value of
    * all tensor polynomials all at once and in a much more efficient way.
    *
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    * @tparam order The derivative order.
    */
   template <int order>
@@ -138,6 +150,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_1st_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<1, dim>
   compute_1st_derivative(const unsigned int i,
@@ -145,6 +159,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_2nd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<2, dim>
   compute_2nd_derivative(const unsigned int i,
@@ -152,6 +168,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_3rd_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<3, dim>
   compute_3rd_derivative(const unsigned int i,
@@ -159,6 +177,8 @@ public:
 
   /**
    * @copydoc ScalarPolynomialsBase::compute_4th_derivative()
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   virtual Tensor<4, dim>
   compute_4th_derivative(const unsigned int i,
@@ -175,6 +195,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with
    * <tt>grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<1, dim>
   compute_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -190,6 +212,8 @@ public:
    * several times.  Instead use the evaluate() function, see above, with
    * <tt>grad_grads.size()==</tt>n() to get the point value of all tensor
    * polynomials all at once and in a much more efficient way.
+   * @param i The index of the entry.
+   * @param p The point at which to evaluate the function.
    */
   Tensor<2, dim>
   compute_grad_grad(const unsigned int i, const Point<dim> &p) const override;
@@ -231,21 +255,21 @@ private:
   std::vector<unsigned int> index_map_inverse;
 };
 
-/** @} */
-
-
+/**
+ *  @} */
+*
 /* ---------------- template and inline functions ---------- */
 
 #ifndef DOXYGEN
 
-template <int dim>
-template <class Pol>
-inline TensorProductPolynomialsConst<dim>::TensorProductPolynomialsConst(
-  const std::vector<Pol> &pols)
+  template <int dim>
+  template <class Pol>
+  inline TensorProductPolynomialsConst<dim>::TensorProductPolynomialsConst(
+    const std::vector<Pol> &pols)
   : ScalarPolynomialsBase<dim>(1, Utilities::fixed_power<dim>(pols.size()) + 1)
-  , tensor_polys(pols)
-  , index_map(tensor_polys.n() + 1)
-  , index_map_inverse(tensor_polys.n() + 1)
+, tensor_polys(pols)
+, index_map(tensor_polys.n() + 1)
+, index_map_inverse(tensor_polys.n() + 1)
 {}
 
 

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -122,6 +122,7 @@ namespace Threads
     /**
      * Move constructor. The constructor moves all internal data structures
      * from the argument.
+     * @param t The time associated with the evaluation.
      */
     ThreadLocalStorage(ThreadLocalStorage &&t) noexcept;
 
@@ -129,6 +130,7 @@ namespace Threads
      * A kind of copy constructor. Initializes an internal exemplar by the
      * given object. The exemplar is in turn used to initialize each thread
      * local object instead of invoking the default constructor.
+     * @param t The time associated with the evaluation.
      */
     explicit ThreadLocalStorage(const T &t);
 
@@ -136,17 +138,20 @@ namespace Threads
      * A kind of move constructor. Moves the given object into an internal
      * exemplar. The exemplar is in turn used to initialize each thread
      * local object instead of invoking the default constructor.
+     * @param t The time associated with the evaluation.
      */
     explicit ThreadLocalStorage(T &&t);
 
     /**
      * Copy assignment operator.
+     * @param t The time associated with the evaluation.
      */
     ThreadLocalStorage &
     operator=(const ThreadLocalStorage &t);
 
     /**
      * Move assignment operator.
+     * @param t The time associated with the evaluation.
      */
     ThreadLocalStorage &
     operator=(ThreadLocalStorage &&t) noexcept;
@@ -170,6 +175,7 @@ namespace Threads
     /**
      * Same as above, except that @p exists is set to true if an element was
      * already present for the current thread; false otherwise.
+     * @param exists Whether to exists.
      */
     T &
     get(bool &exists);
@@ -187,6 +193,7 @@ namespace Threads
      * about the object owned by a different thread, that other thread might
      * concurrently be accessing it and that might cause race conditions.
      * To avoid these, the function here returns a copy.
+     * @param id The id used by this operation.
      */
     std::optional<T>
     get_for_thread(const std::thread::id &id) const;

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -73,6 +73,9 @@ namespace Threads
    * A list of subintervals is returned as a vector of pairs of iterators,
    * where each pair denotes the range <code>[begin[i],end[i])</code>.
    *
+   * @param begin The begin of the range.
+   * @param end The end of the range.
+   * @param n_intervals The number of intervals.
    * @ingroup threads
    */
   template <typename ForwardIterator>
@@ -87,6 +90,9 @@ namespace Threads
    * difference that instead of iterators, now values are taken that define
    * the whole interval.
    *
+   * @param begin The begin of the range.
+   * @param end The end of the range.
+   * @param n_intervals The number of intervals.
    * @ingroup threads
    */
   std::vector<std::pair<unsigned int, unsigned int>>
@@ -119,6 +125,7 @@ namespace Threads
      * install a try-catch block, and if an exception of type
      * <code>std::exception</code> is caught, it passes over control to this
      * function, which will then provide some output.
+     * @param exc The exception object that is stored, rethrown, or reported.
      */
     [[noreturn]] void
     handle_std_exception(const std::exception &exc);
@@ -253,6 +260,7 @@ namespace Threads
        * Set the value from the given `std::future` object. If the future
        * object holds an exception, the set will not happen and this function
        * instead throws the exception stored in the future object.
+       * @param v The value on which this function operates.
        */
       inline void
       set_from(std::future<RT> &v)
@@ -323,6 +331,7 @@ namespace Threads
        *  Set the value from the given `std::future` object. If the future
        * object holds an exception, the set will not happen and this function
        * instead throws the exception stored in the future object.
+       * @param v The value on which this function operates.
        */
       inline void
       set_from(std::future<RT &> &v)
@@ -424,6 +433,8 @@ namespace Threads
      *
      * @dealiiConceptRequires{(std::invocable<Function> &&
      *    std::convertible_to<std::invoke_result_t<Function>, RT>)}
+     * @param function The function object.
+     * @param promise The promise used by this operation.
      */
     template <typename RT, typename Function>
     DEAL_II_CXX20_REQUIRES(
@@ -443,6 +454,8 @@ namespace Threads
      * call `std::promise::set_value()` without argument.
      *
      * @dealiiConceptRequires{(std::invocable<Function>)}
+     * @param function The function object.
+     * @param promise The promise used by this operation.
      */
     template <typename Function>
     DEAL_II_CXX20_REQUIRES((std::invocable<Function>))
@@ -495,6 +508,7 @@ namespace Threads
      * only use one thread, then just execute the given function
      * object.
      *
+     * @param function_object The function object.
      * @post Using this constructor automatically makes the task object
      * joinable().
      */
@@ -672,6 +686,7 @@ namespace Threads
      * then calling `t2.return_value()` will return the same object (not just an
      * object with the same value, but in fact the same address!) as
      * calling `t1.return_value()`.
+     * @param other The object to copy or move from.
      */
     Task(const Task &other) = default;
 
@@ -687,6 +702,7 @@ namespace Threads
      * the task, and `t1.return_value()` will result in an error because `t1`
      * no longer refers to a task and consequently does not know anything
      * about a return value.
+     * @param other The object to copy or move from.
      */
     Task(Task &&other) noexcept = default;
 
@@ -702,6 +718,7 @@ namespace Threads
      * then calling `t2.return_value()` will return the same object (not just an
      * object with the same value, but in fact the same address!) as
      * calling `t1.return_value()`.
+     * @param other The object to copy or move from.
      */
     Task &
     operator=(const Task &other) = default;
@@ -719,6 +736,7 @@ namespace Threads
      * the task, and `t1.return_value()` will result in an error because `t1`
      * no longer refers to a task and consequently does not know anything
      * about a return value.
+     * @param other The object to copy or move from.
      */
     Task &
     operator=(Task &&other) noexcept = default;
@@ -850,6 +868,7 @@ namespace Threads
 
     /**
      * Exception
+     * @param ExcNoTask The exc no task used by this operation.
      */
     DeclExceptionMsg(ExcNoTask,
                      "The current object is not associated with a task that "
@@ -1155,6 +1174,7 @@ namespace Threads
    * function object without arguments and returning an object of type RT (or
    * void).
    *
+   * @param function The function object.
    * @note When MultithreadInfo::n_threads() returns 1, i.e., if the
    *   deal.II runtime system has been configured to only use one
    *   thread, then this function just executes the given function
@@ -1200,6 +1220,7 @@ namespace Threads
    * can later retrieve via <code>task.return_value()</code> once the
    * task (i.e., the body of the lambda function) has completed.
    *
+   * @param function_object The function object.
    * @note When MultithreadInfo::n_threads() returns 1, i.e., if the
    *   deal.II runtime system has been configured to only use one
    *   thread, then this function just executes the given function
@@ -1270,6 +1291,8 @@ namespace Threads
    * Overload of the new_task function for non-member or static member
    * functions. See the other functions of same name for more information.
    *
+   * @param fun_ptr The fun ptr.
+   * @param args The args used by this operation.
    * @ingroup threads
    */
   template <typename RT, typename... Args>
@@ -1308,6 +1331,8 @@ namespace Threads
    *
    * See the other functions of same name for more information.
    *
+   * @param fun The fun used by this operation.
+   * @param args The args used by this operation.
    * @note This overload is disabled if the first argument is a
    * pointer or reference to a function, as there is another overload
    * for that case. (Strictly speaking, this overload is disabled if the
@@ -1345,6 +1370,8 @@ namespace Threads
    * Overload of the non-const new_task function. See the other functions of
    * same name for more information.
    *
+   * @param c The value on which this function operates.
+   * @param args The args used by this operation.
    * @ingroup threads
    */
   template <typename RT, typename C, typename... Args>
@@ -1362,6 +1389,8 @@ namespace Threads
    * Overload of the new_task function. See the other functions of same name for
    * more information.
    *
+   * @param c The value on which this function operates.
+   * @param args The args used by this operation.
    * @ingroup threads
    */
   template <typename RT, typename C, typename... Args>
@@ -1394,6 +1423,7 @@ namespace Threads
   public:
     /**
      * Add another task object to the collection.
+     * @param t The time associated with the evaluation.
      */
     TaskGroup &
     operator+=(const Task<RT> &t)

--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -200,6 +200,11 @@ namespace TimeStepping
      * to the implicit problems. The input parameters are the time, $ \tau $,
      * and a vector. The output is the value of function at this point. This
      * function returns the time at the end of the time step.
+     * @param F The function object.
+     * @param J_inverse The j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     virtual double
     evolve_one_time_step(
@@ -240,6 +245,7 @@ namespace TimeStepping
 
     /**
      * Purely virtual method used to initialize the Runge-Kutta method.
+     * @param method The numerical method to use.
      */
     virtual void
     initialize(const runge_kutta_method method) = 0;
@@ -254,6 +260,11 @@ namespace TimeStepping
      * The output is the value of function at this point. This function
      * returns the time at the end of the time step. When using Runge-Kutta
      * methods, @p F and @p J_inverse can only contain one element.
+     * @param F The function object.
+     * @param J_inverse The j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     double
     evolve_one_time_step(
@@ -275,6 +286,11 @@ namespace TimeStepping
      * f}{\partial y} $. The input parameters are the time, $ \tau $, and a
      * vector. The output is the value of function at this point.
      * evolve_one_time_step returns the time at the end of the time step.
+     * @param f The function object.
+     * @param id_minus_tau_J_inverse The id minus tau j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     virtual double
     evolve_one_time_step(
@@ -329,11 +345,13 @@ namespace TimeStepping
 
     /**
      * Constructor. This function calls initialize(runge_kutta_method).
+     * @param method The numerical method to use.
      */
     ExplicitRungeKutta(const runge_kutta_method method);
 
     /**
      * Initialize the explicit Runge-Kutta method.
+     * @param method The numerical method to use.
      */
     void
     initialize(const runge_kutta_method method) override;
@@ -349,6 +367,11 @@ namespace TimeStepping
      * of function at this point. evolve_one_time_step returns the time at the
      * end of the time step.
      *
+     * @param f The function object.
+     * @param id_minus_tau_J_inverse The id minus tau j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      * @note @p id_minus_tau_J_inverse is ignored since the method is explicit.
      */
     double
@@ -367,6 +390,10 @@ namespace TimeStepping
      * required id_minus_tau_J_inverse because it is not used for explicit
      * methods. evolve_one_time_step returns the time at the end of the time
      * step.
+     * @param f The function object.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     double
     evolve_one_time_step(
@@ -433,11 +460,13 @@ namespace TimeStepping
 
     /**
      * Constructor. This function calls initialize(runge_kutta_method).
+     * @param method The numerical method to use.
      */
     LowStorageRungeKutta(const runge_kutta_method method);
 
     /**
      * Initialize the explicit Runge-Kutta method.
+     * @param method The numerical method to use.
      */
     void
     initialize(const runge_kutta_method method) override;
@@ -452,6 +481,11 @@ namespace TimeStepping
      * parameters are the time, $ \tau $, and a vector. The output is the value
      * of function at this point. evolve_one_time_step returns the time at the
      * end of the time step.
+     * @param f The function object.
+     * @param id_minus_tau_J_inverse The id minus tau j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     double
     evolve_one_time_step(
@@ -471,6 +505,12 @@ namespace TimeStepping
      * step. Note that vec_ki holds the evaluation of the differential operator,
      * and vec_ri holds the right-hand side for the differential operator
      * application.
+     * @param f The function object.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param solution The solution used by this operation.
+     * @param vec_ri The object in which to store the vec ri.
+     * @param vec_ki The object in which to store the vec ki.
      */
     double
     evolve_one_time_step(
@@ -486,6 +526,9 @@ namespace TimeStepping
      * Note that here vector @p a is not the conventional definition in terms of a
      * Butcher tableau but merely one of the sub-diagonals. More details can be
      * found in step-67 and the references therein.
+     * @param a The value on which this function operates.
+     * @param b The value on which this function operates.
+     * @param c The value on which this function operates.
      */
     void
     get_coefficients(std::vector<double> &a,
@@ -554,6 +597,9 @@ namespace TimeStepping
      * Constructor. This function calls initialize(runge_kutta_method) and
      * initialize the maximum number of iterations and the tolerance of the
      * Newton solver.
+     * @param method The numerical method to use.
+     * @param max_it The max it.
+     * @param tolerance The tolerance used by this operation.
      */
     ImplicitRungeKutta(const runge_kutta_method method,
                        const unsigned int       max_it    = 100,
@@ -561,6 +607,7 @@ namespace TimeStepping
 
     /**
      * Initialize the implicit Runge-Kutta method.
+     * @param method The numerical method to use.
      */
     void
     initialize(const runge_kutta_method method) override;
@@ -575,6 +622,11 @@ namespace TimeStepping
      * parameters this function receives are the time, $ \tau $, and a vector.
      * The output is the value of function at this point. evolve_one_time_step
      * returns the time at the end of the time step.
+     * @param f The function object.
+     * @param id_minus_tau_J_inverse The id minus tau j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     double
     evolve_one_time_step(
@@ -589,6 +641,8 @@ namespace TimeStepping
     /**
      * Set the maximum number of iterations and the tolerance used by the
      * Newton solver.
+     * @param max_it The max it.
+     * @param tolerance The tolerance used by this operation.
      */
     void
     set_newton_solver_parameters(const unsigned int max_it,
@@ -693,6 +747,13 @@ namespace TimeStepping
     /**
      * Constructor. This function calls initialize(runge_kutta_method) and
      * initialize the parameters needed for time adaptation.
+     * @param method The numerical method to use.
+     * @param coarsen_param The coarsen param.
+     * @param refine_param The refine param.
+     * @param min_delta The min delta.
+     * @param max_delta The max delta.
+     * @param refine_tol The refine tol.
+     * @param coarsen_tol The coarsen tol.
      */
     EmbeddedExplicitRungeKutta(const runge_kutta_method method,
                                const double             coarsen_param = 1.2,
@@ -718,6 +779,7 @@ namespace TimeStepping
 
     /**
      * Initialize the embedded explicit Runge-Kutta method.
+     * @param method The numerical method to use.
      */
     void
     initialize(const runge_kutta_method method) override;
@@ -733,6 +795,11 @@ namespace TimeStepping
      * value of function at this point. evolve_one_time_step returns the time
      * at the end of the time step.
      *
+     * @param f The function object.
+     * @param id_minus_tau_J_inverse The id minus tau j inverse.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      * @note @p id_minus_tau_J_inverse is ignored since the method is explicit.
      */
     double
@@ -751,6 +818,10 @@ namespace TimeStepping
      * required id_minus_tau_J_inverse because it is not used for explicit
      * methods. evolve_one_time_step returns the time at the end of the time
      * step.
+     * @param f The function object.
+     * @param t The time associated with the evaluation.
+     * @param delta_t The delta t.
+     * @param y The value on which this function operates.
      */
     double
     evolve_one_time_step(
@@ -761,6 +832,12 @@ namespace TimeStepping
 
     /**
      * Set the parameters necessary for the time adaptation.
+     * @param coarsen_param The coarsen param.
+     * @param refine_param The refine param.
+     * @param min_delta The min delta.
+     * @param max_delta The max delta.
+     * @param refine_tol The refine tol.
+     * @param coarsen_tol The coarsen tol.
      */
     void
     set_time_adaptation_parameters(const double coarsen_param,

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -142,6 +142,8 @@ public:
    * only performed if Timer::stop() is called before the timer is queried for
    * time duration values.
    *
+   * @param mpi_communicator The MPI communicator.
+   * @param sync_lap_times The sync lap times.
    * @note The timer is stopped before the synchronization over the
    * communicator occurs; the extra cost of the synchronization is not
    * measured.
@@ -169,6 +171,7 @@ public:
   /**
    * Print the data returned by Timer::get_last_lap_wall_time_data() to the
    * given stream.
+   * @param stream The stream used by this operation.
    */
   template <typename StreamType>
   void
@@ -177,6 +180,7 @@ public:
   /**
    * Print the data returned by Timer::get_accumulated_wall_time_data() to the
    * given stream.
+   * @param stream The stream used by this operation.
    */
   template <typename StreamType>
   void
@@ -660,6 +664,8 @@ public:
     /**
      * Enter the given section in the timer. Exit automatically when calling
      * stop() or when the destructor runs.
+     * @param timer_ The object in which to store the timer .
+     * @param section_name The section name.
      */
     Scope(dealii::TimerOutput &timer_, const std::string &section_name);
 
@@ -777,6 +783,9 @@ public:
 
   /**
    * Same as above, but accepts a ConditionalOStream.
+   * @param stream The output stream to which data is written.
+   * @param output_frequency The output frequency.
+   * @param output_type The output type.
    */
   TimerOutput(ConditionalOStream   &stream,
               const OutputFrequency output_frequency,
@@ -791,6 +800,10 @@ public:
    * maximum observed over all processes in the given @p mpi_communicator_timing.
    * This corresponds to the first variant described in this class
    * documentation.
+   * @param mpi_communicator_timing The mpi communicator timing.
+   * @param stream The output stream to which data is written.
+   * @param output_frequency The output frequency.
+   * @param output_type The output type.
    */
   TimerOutput(const MPI_Comm        mpi_communicator_timing,
               std::ostream         &stream,
@@ -799,6 +812,10 @@ public:
 
   /**
    * Same as above but for an ConditionalOStream.
+   * @param mpi_communicator_timing The mpi communicator timing.
+   * @param stream The output stream to which data is written.
+   * @param output_frequency The output frequency.
+   * @param output_type The output type.
    */
   TimerOutput(const MPI_Comm        mpi_communicator_timing,
               ConditionalOStream   &stream,
@@ -814,6 +831,7 @@ public:
   /**
    * Open a section by given a string name of it. In case the name already
    * exists, that section is entered once again and times are accumulated.
+   * @param section_name The section name.
    */
   void
   enter_subsection(const std::string &section_name);
@@ -821,12 +839,14 @@ public:
   /**
    * Leave a section. If no name is given, the last section that was entered
    * is left.
+   * @param section_name The section name.
    */
   void
   leave_subsection(const std::string &section_name = "");
 
   /**
    * Get a map with the collected data of the specified type for each subsection
+   * @param kind The kind used by this operation.
    */
   std::map<std::string, double>
   get_summary_data(const OutputData kind) const;
@@ -860,6 +880,8 @@ public:
    * and the maximum. The value of `quantile` needs to be between 0 (no
    * quantiles are printed besides the minimum and maximum) and 0.5 (when the
    * median is given).
+   * @param mpi_communicator_statistics The mpi communicator statistics.
+   * @param print_quantile The print quantile.
    */
   void
   print_wall_time_statistics(const MPI_Comm mpi_communicator_statistics,

--- a/include/deal.II/base/trilinos_utilities.h
+++ b/include/deal.II/base/trilinos_utilities.h
@@ -111,6 +111,7 @@ namespace Utilities
      * communicators identifies the communication in question, not their
      * relative timing as is the case in a sequential program that just uses a
      * single communicator.
+     * @param communicator The MPI communicator.
      */
     Epetra_Comm *
     duplicate_communicator(const Epetra_Comm &communicator);
@@ -133,6 +134,7 @@ namespace Utilities
      * Epetra_Comm object is still around, it first resets the latter and then
      * destroys the communicator object.
      *
+     * @param communicator The MPI communicator.
      * @note If you call this function on an Epetra_Comm object that is not
      * created by duplicate_communicator(), you are likely doing something
      * quite wrong. Don't do this.
@@ -147,6 +149,7 @@ namespace Utilities
      * is not using MPI at all, or is using MPI but has been started with
      * only one MPI process), then the communicator necessarily involves
      * only one process and the function returns 1.
+     * @param mpi_communicator The MPI communicator.
      */
     unsigned int
     get_n_mpi_processes(const Epetra_Comm &mpi_communicator);
@@ -156,6 +159,7 @@ namespace Utilities
      * described by the given communicator. This will be a unique value for
      * each process between zero and (less than) the number of all processes
      * (given by get_n_mpi_processes()).
+     * @param mpi_communicator The MPI communicator.
      */
     unsigned int
     get_this_mpi_process(const Epetra_Comm &mpi_communicator);
@@ -169,6 +173,8 @@ namespace Utilities
      *
      * This function is typically used with a communicator that has been
      * obtained by the duplicate_communicator() function.
+     * @param map The map used by this operation.
+     * @param comm The MPI communicator.
      */
     Epetra_Map
     duplicate_map(const Epetra_BlockMap &map, const Epetra_Comm &comm);
@@ -195,6 +201,7 @@ namespace Utilities
      * <a
      * href="https://docs.trilinos.org/dev/packages/teuchos/doc/html/classTeuchos_1_1Comm.html">Teuchos::Comm</a>
      * communicator.
+     * @param teuchos_comm The teuchos comm.
      */
     MPI_Comm
     teuchos_comm_to_mpi_comm(

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -81,6 +81,8 @@ namespace Utilities
    * The depth of the Hilbert curve (i.e. the number of bits per dimension) by
    * default is equal to <code>64</code>.
    *
+   * @param points The points at which to evaluate the function.
+   * @param bits_per_dim The bits per dim.
    * @note This function can also handle degenerate cases, e.g. when the bounding
    * box has zero size in one of the dimensions.
    */
@@ -92,6 +94,8 @@ namespace Utilities
 
   /**
    * Same as above, but for points in integer coordinates.
+   * @param points The points at which to evaluate the function.
+   * @param bits_per_dim The bits per dim.
    */
   template <int dim>
   std::vector<std::array<std::uint64_t, dim>>
@@ -110,6 +114,8 @@ namespace Utilities
    * The function is useful in debugging and visualization of indices returned
    * by inverse_Hilbert_space_filling_curve().
    *
+   * @param index The index of the entry.
+   * @param bits_per_dim The bits per dim.
    * @note There is no need to use this function in order to compare indices
    * returned by inverse_Hilbert_space_filling_curve(), as that can easily be
    * done via <code>std::lexicographical_compare()</code>.
@@ -193,6 +199,8 @@ namespace Utilities
    * printed result might show the effects of an overflow upon conversion
    * to `unsigned int`.
    *
+   * @param value The value associated with the function.
+   * @param digits The digits used by this operation.
    * @note The use of this function is discouraged and users should use
    * <code>Utilities::to_string()</code> instead. In its current
    * implementation the function simply calls <code>to_string@<unsigned
@@ -212,6 +220,8 @@ namespace Utilities
    * padded with leading zeros. The result is then the same as if the C++
    * function `std::to_string()` had been called (for integral types),
    * or if `boost::lexical_cast()` had been called (for all other types).
+   * @param value The value associated with the function.
+   * @param digits The digits used by this operation.
    */
   template <typename number>
   std::string
@@ -221,6 +231,7 @@ namespace Utilities
   /**
    * Determine how many digits are needed to represent numbers at most as
    * large as the given number.
+   * @param max_number The max number.
    */
   unsigned int
   needed_digits(const unsigned int max_number);
@@ -232,6 +243,8 @@ namespace Utilities
    * operation, this function reduces the absolute value of a floating point
    * number and always rounds towards zero, since decimal places are simply
    * cut off.
+   * @param number The number used by this operation.
+   * @param n_digits The number of digits.
    */
   template <typename Number>
   Number
@@ -240,6 +253,7 @@ namespace Utilities
   /**
    * Given a string, convert it to an integer. Throw an assertion if that is
    * not possible.
+   * @param s The value on which this function operates.
    */
   int
   string_to_int(const std::string &s);
@@ -254,6 +268,8 @@ namespace Utilities
    * string is usually contracted to "<dim>", instead of "<dim,spacedim>".
    * This function returns a string containing "dim" if dim is equal to
    * spacedim, otherwise it returns "dim,spacedim".
+   * @param dim The dim used by this operation.
+   * @param spacedim The spacedim used by this operation.
    */
   std::string
   dim_string(const int dim, const int spacedim);
@@ -261,6 +277,7 @@ namespace Utilities
   /**
    * Given a list of strings, convert it to a list of integers. Throw an
    * assertion if that is not possible.
+   * @param s The value on which this function operates.
    */
   std::vector<int>
   string_to_int(const std::vector<std::string> &s);
@@ -268,6 +285,7 @@ namespace Utilities
   /**
    * Given a string, convert it to an double. Throw an assertion if that is
    * not possible.
+   * @param s The value on which this function operates.
    */
   double
   string_to_double(const std::string &s);
@@ -276,6 +294,7 @@ namespace Utilities
   /**
    * Given a list of strings, convert it to a list of doubles. Throw an
    * assertion if that is not possible.
+   * @param s The value on which this function operates.
    */
   std::vector<double>
   string_to_double(const std::vector<std::string> &s);
@@ -322,6 +341,8 @@ namespace Utilities
    *   Utilities::split_string_list("      ", ' ');
    * @endcode
    * yields an empty list regardless of the number of spaces in the string.
+   * @param s The value on which this function operates.
+   * @param delimiter The delimiter used by this operation.
    */
   std::vector<std::string>
   split_string_list(const std::string &s, const std::string &delimiter = ",");
@@ -330,6 +351,8 @@ namespace Utilities
   /**
    * Specialization of split_string_list() for the case where the delimiter
    * is a single char.
+   * @param s The value on which this function operates.
+   * @param delimiter The delimiter used by this operation.
    */
   std::vector<std::string>
   split_string_list(const std::string &s, const char delimiter);
@@ -343,6 +366,9 @@ namespace Utilities
    * default value of the delimiter is a space character. If original_text
    * contains newline characters (\n), the string is split at these locations,
    * too.
+   * @param original_text The original text.
+   * @param width The width used by this operation.
+   * @param delimiter The delimiter used by this operation.
    */
   std::vector<std::string>
   break_text_into_lines(const std::string &original_text,
@@ -352,6 +378,8 @@ namespace Utilities
   /**
    * Return true if the given pattern string appears in the first position of
    * the string.
+   * @param name The name associated with the object being created or queried.
+   * @param pattern The pattern that valid parameter values must satisfy.
    */
   bool
   match_at_string_start(const std::string &name, const std::string &pattern);
@@ -363,6 +391,8 @@ namespace Utilities
    *
    * If no integer can be read at the indicated position, return
    * (-1,numbers::invalid_unsigned_int)
+   * @param name The name associated with the object being created or queried.
+   * @param position The position of the entry to access.
    */
   std::pair<int, unsigned int>
   get_integer_at_position(const std::string &name, const unsigned int position);
@@ -370,6 +400,9 @@ namespace Utilities
   /**
    * Return a string with all occurrences of @p from in @p input replaced by
    * @p to.
+   * @param input The input data or stream from which values are read.
+   * @param from The from used by this operation.
+   * @param to The to used by this operation.
    */
   std::string
   replace_in_string(const std::string &input,
@@ -380,6 +413,7 @@ namespace Utilities
    * Return a string with all standard whitespace characters (including
    * '<tt>\\t</tt>', '<tt>\\n</tt>', and '<tt>\\r</tt>') at the beginning and
    * end of @p input removed.
+   * @param input The input data or stream from which values are read.
    */
   std::string
   trim(const std::string &input);
@@ -400,6 +434,8 @@ namespace Utilities
    * random number generator objects every time you want to start from a
    * defined point.
    *
+   * @param a The value on which this function operates.
+   * @param sigma The sigma used by this operation.
    * @note Like the system function rand(), this function produces the same
    * sequence of random numbers every time a program is started. This is an
    * important property for debugging codes, but it makes it impossible to
@@ -450,6 +486,7 @@ namespace Utilities
    * is vastly slower.
    *
    * Use this function as in `fixed_power<dim> (t)` or `fixed_power<7> (t)`.
+   * @param t The time associated with the evaluation.
    */
   template <int N, typename T>
   constexpr T
@@ -461,6 +498,8 @@ namespace Utilities
    * is a positive integer. The @p base must be an arithmetic type
    * (i.e., an integer or floating point type),
    * and the exponent @p iexp must not be negative.
+   * @param base The base used by this operation.
+   * @param iexp The iexp used by this operation.
    */
   template <typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>>>
   constexpr DEAL_II_HOST_DEVICE T
@@ -486,6 +525,11 @@ namespace Utilities
    *
    * This function simply makes the assumption that the sequence is sorted,
    * and we simply don't do the additional check.
+   * @param first The iterator associated with the range processed by this
+   * operation.
+   * @param last The iterator associated with the range processed by this
+   * operation.
+   * @param val The val used by this operation.
    */
   template <typename Iterator, typename T>
   Iterator
@@ -495,6 +539,12 @@ namespace Utilities
    * The same function as above, but taking an argument that is used to
    * compare individual elements of the sequence of objects pointed to by the
    * iterators.
+   * @param first The iterator associated with the range processed by this
+   * operation.
+   * @param last The iterator associated with the range processed by this
+   * operation.
+   * @param val The val used by this operation.
+   * @param comp The component or SIMD lane index to access.
    */
   template <typename Iterator, typename T, typename Comp>
   Iterator
@@ -504,6 +554,7 @@ namespace Utilities
    * Given a permutation vector (i.e. a vector $p_0\ldots p_{N-1}$ where each
    * $p_i\in [0,N)$ and $p_i\neq p_j$ for $i\neq j$), produce the reverse
    * permutation $q_i=N-1-p_i$.
+   * @param permutation The permutation used by this operation.
    */
   template <typename Integer>
   std::vector<Integer>
@@ -513,6 +564,7 @@ namespace Utilities
    * Given a permutation vector (i.e. a vector $p_0\ldots p_{N-1}$ where each
    * $p_i\in [0,N)$ and $p_i\neq p_j$ for $i\neq j$), produce the inverse
    * permutation $q_0\ldots q_{N-1}$ so that $q_{p_i}=p_{q_i}=i$.
+   * @param permutation The permutation used by this operation.
    */
   template <typename Integer>
   std::vector<Integer>
@@ -571,6 +623,9 @@ namespace Utilities
    * types are also special-cased, this covers many of the most common kinds of
    * messages one sends around with MPI or one wants to serialize (the two
    * most common use cases for this function).
+   * @param object The object used by this operation.
+   * @param dest_buffer The object in which to store the dest buffer.
+   * @param allow_compression The allow compression.
    */
   template <typename T>
   std::size_t
@@ -585,6 +640,8 @@ namespace Utilities
    * If the library has been compiled with ZLIB enabled, then the output buffer
    * can be compressed. This can be triggered with the parameter
    * @p allow_compression, and is only of effect if ZLIB is enabled.
+   * @param object The object used by this operation.
+   * @param allow_compression The allow compression.
    */
   template <typename T>
   std::vector<char>
@@ -603,6 +660,8 @@ namespace Utilities
    * read from could have been previously compressed with ZLIB, and
    * is only of effect if ZLIB is enabled.
    *
+   * @param buffer The buffer used by this operation.
+   * @param allow_compression The allow compression.
    * @note Since no arguments to this function depend on the template type
    *  @p T, you must manually specify the template argument when calling
    *  this function.
@@ -632,6 +691,11 @@ namespace Utilities
    * The @p allow_compression parameter denotes if the buffer to
    * read from could have been previously compressed with ZLIB, and
    * is only of effect if ZLIB is enabled.
+   * @param cbegin The iterator associated with the range processed by this
+   * operation.
+   * @param cend The iterator associated with the range processed by this
+   * operation.
+   * @param allow_compression The allow compression.
    */
   template <typename T>
   T
@@ -651,6 +715,8 @@ namespace Utilities
    * read from could have been previously compressed with ZLIB, and
    * is only of effect if ZLIB is enabled.
    *
+   * @param buffer The buffer used by this operation.
+   * @param allow_compression The allow compression.
    * @note This function exists due to a quirk of C++. Specifically,
    *  if you want to pack() or unpack() arrays of objects, then the
    *  following works:
@@ -684,6 +750,11 @@ namespace Utilities
    * The @p allow_compression parameter denotes if the buffer to
    * read from could have been previously compressed with ZLIB, and
    * is only of effect if ZLIB is enabled.
+   * @param cbegin The iterator associated with the range processed by this
+   * operation.
+   * @param cend The iterator associated with the range processed by this
+   * operation.
+   * @param allow_compression The allow compression.
    */
   template <typename T, int N>
   void
@@ -694,6 +765,8 @@ namespace Utilities
 
   /**
    * Check if the bit at position @p n in @p number is set.
+   * @param number The number used by this operation.
+   * @param n The n used by this operation.
    */
   bool
   get_bit(const unsigned char number, const unsigned int n);
@@ -701,6 +774,9 @@ namespace Utilities
 
   /**
    * Set the bit at position @p n in @p number to value @p x.
+   * @param number The number used by this operation.
+   * @param n The n used by this operation.
+   * @param x The value on which this function operates.
    */
   void
   set_bit(unsigned char &number, const unsigned int n, const bool x);
@@ -758,6 +834,7 @@ namespace Utilities
    *     // transferred to 'd'!
    * @endcode
    *
+   * @param p The point at which to evaluate the function.
    * @note This function does not try to convert the `Deleter` objects stored
    *   by `std::unique_ptr` objects. The function therefore only works if the
    *   deleter objects are at their defaults, i.e., if they are of type
@@ -769,6 +846,7 @@ namespace Utilities
 
   /**
    * Return underlying value. Default: return input.
+   * @param p The point at which to evaluate the function.
    */
   template <typename T>
   T &
@@ -776,6 +854,7 @@ namespace Utilities
 
   /**
    * Return underlying value. Specialization for std::shared_ptr<T>.
+   * @param p The point at which to evaluate the function.
    */
   template <typename T>
   T &
@@ -783,6 +862,7 @@ namespace Utilities
 
   /**
    * Return underlying value. Specialization for const std::shared_ptr<T>.
+   * @param p The point at which to evaluate the function.
    */
   template <typename T>
   T &
@@ -790,6 +870,7 @@ namespace Utilities
 
   /**
    * Return underlying value. Specialization for std::unique_ptr<T>.
+   * @param p The point at which to evaluate the function.
    */
   template <typename T>
   T &
@@ -797,6 +878,7 @@ namespace Utilities
 
   /**
    * Return underlying value. Specialization for const std::unique_ptr<T>.
+   * @param p The point at which to evaluate the function.
    */
   template <typename T>
   T &

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -111,6 +111,7 @@ public:
 
   /**
    * Compare for equality.
+   * @param other The object to copy or move from.
    */
   constexpr bool
   operator==(const VectorizedArrayIterator<T> &other) const
@@ -123,6 +124,7 @@ public:
 
   /**
    * Compare for inequality.
+   * @param other The object to copy or move from.
    */
   constexpr bool
   operator!=(const VectorizedArrayIterator<T> &other) const
@@ -174,6 +176,8 @@ public:
   /**
    * This operator advances the iterator by @p offset lanes and returns a
    * reference to <tt>*this</tt>.
+   * @param offset The offset into the underlying storage or file at which the
+   * operation starts.
    */
   constexpr VectorizedArrayIterator<T> &
   operator+=(const std::size_t offset)
@@ -201,6 +205,8 @@ public:
 
   /**
    * Create new iterator, which is shifted by @p offset.
+   * @param offset The offset into the underlying storage or file at which the
+   * operation starts.
    */
   constexpr VectorizedArrayIterator<T>
   operator+(const std::size_t &offset) const
@@ -211,6 +217,7 @@ public:
 
   /**
    * Compute distance between this iterator and iterator @p other.
+   * @param other The object to copy or move from.
    */
   constexpr std::ptrdiff_t
   operator-(const VectorizedArrayIterator<T> &other) const
@@ -260,6 +267,7 @@ public:
    * The initializer list must have at most as many elements as the
    * vector length. Elements not listed in the initializer list are
    * zero-initialized.
+   * @param list The list used by this operation.
    */
   template <typename U>
   constexpr VectorizedArrayBase(const std::initializer_list<U> &list)
@@ -338,6 +346,7 @@ public:
    * This function is inherited by all derived classes and provides
    * the dot product to them unless they override it with their own
    * implementation (presumably using a more efficient approach).
+   * @param v The value on which this function operates.
    */
   auto
   dot_product(const VectorizedArrayType &v) const
@@ -466,6 +475,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const Number scalar)
   {
@@ -488,6 +498,7 @@ public:
 
   /**
    * This function assigns a scalar to the current object.
+   * @param scalar The scalar value to assign to every entry.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -501,6 +512,7 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const Number scalar) && = delete;
@@ -508,6 +520,7 @@ public:
   /**
    * Access operator (only valid with component 0 in the base class without
    * specialization).
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   Number &
@@ -521,6 +534,7 @@ public:
   /**
    * Constant access operator (only valid with component 0 in the base class
    * without specialization).
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const Number &
@@ -533,6 +547,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -544,6 +560,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -555,6 +573,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -566,6 +586,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -580,6 +602,7 @@ public:
    * the given address. The pointer `ptr` needs not be aligned by the amount
    * of bytes in the vectorized array, as opposed to casting a double address
    * to VectorizedArray<double>*.
+   * @param ptr The address of the first value to load from memory.
    */
   template <typename OtherNumber>
   DEAL_II_ALWAYS_INLINE void
@@ -593,6 +616,7 @@ public:
    * size() data items to the given address. The pointer `ptr` needs not be
    * aligned by the amount of bytes in the vectorized array, as opposed to
    * casting a double address to VectorizedArray<double>*.
+   * @param ptr The address of the first value to write to memory.
    */
   template <typename OtherNumber>
   DEAL_II_ALWAYS_INLINE void
@@ -646,6 +670,7 @@ public:
    * Note that streaming stores are only available in the specialized SSE/AVX
    * classes of VectorizedArray of type @p double or @p float, not in the
    * generic base class.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -665,6 +690,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -684,6 +712,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -803,6 +834,7 @@ private:
  * scalar, i.e., broadcasts the scalar to all array elements.
  *
  * @relatesalso VectorizedArray
+ * @param u The value on which this function operates.
  */
 template <typename Number,
           std::size_t width =
@@ -821,6 +853,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  * to all array elements.
  *
  * @relatesalso VectorizedArray
+ * @param u The value on which this function operates.
  */
 template <typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
@@ -848,6 +881,11 @@ make_vectorized_array(const typename VectorizedArrayType::value_type &u)
  * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
  *   out.data[v] = ptrs[v][offset];
  * @endcode
+ * @param out The output iterator or object that receives the computed
+ * results.
+ * @param ptrs The ptrs used by this operation.
+ * @param offset The offset into the underlying storage or file at which the
+ * operation starts.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
@@ -885,6 +923,12 @@ gather(VectorizedArray<Number, width>    &out,
  * This is the inverse operation to vectorized_transpose_and_store().
  *
  * @relatesalso VectorizedArray
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
@@ -909,6 +953,10 @@ vectorized_load_and_transpose(const unsigned int              n_entries,
  * However, this function can also be used if some function returns an array
  * of pointers and no assumption can be made that they belong to the same array,
  * i.e., they can have their origin in different memory allocations.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
@@ -960,6 +1008,13 @@ vectorized_load_and_transpose(const unsigned int                 n_entries,
  * This is the inverse operation to vectorized_load_and_transpose().
  *
  * @relatesalso VectorizedArray
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
@@ -990,6 +1045,11 @@ vectorized_transpose_and_store(const bool                            add_into,
  * However, this function can also be used if some function returns an array
  * of pointers and no assumption can be made that they belong to the same array,
  * i.e., they can have their origin in different memory allocations.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
@@ -1042,6 +1102,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const double scalar)
   {
@@ -1058,6 +1119,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   VectorizedArray &
   operator=(const double x) &
@@ -1070,12 +1132,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   double &
   operator[](const unsigned int comp)
@@ -1085,6 +1149,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   const double &
   operator[](const unsigned int comp) const
@@ -1094,6 +1159,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator+=(const VectorizedArray &vec)
@@ -1104,6 +1171,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator-=(const VectorizedArray &vec)
@@ -1114,6 +1183,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator*=(const VectorizedArray &vec)
@@ -1124,6 +1195,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator/=(const VectorizedArray &vec)
@@ -1136,6 +1209,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 16 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
+   * @param ptr The address of the first value to load from memory.
    */
   void
   load(const double *ptr)
@@ -1157,6 +1231,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 16 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
+   * @param ptr The address of the first value to write to memory.
    */
   void
   store(double *ptr) const
@@ -1175,6 +1250,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 16 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -1197,6 +1273,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   void
   gather(const double *base_ptr, const unsigned int *offsets)
@@ -1216,6 +1295,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   void
   scatter(const unsigned int *offsets, double *base_ptr) const
@@ -1345,6 +1427,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const float scalar)
   {
@@ -1361,6 +1444,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   VectorizedArray &
   operator=(const float x) &
@@ -1373,12 +1457,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   value_type &
   operator[](const unsigned int comp)
@@ -1388,6 +1474,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   const value_type &
   operator[](const unsigned int comp) const
@@ -1397,6 +1484,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator+=(const VectorizedArray &vec)
@@ -1407,6 +1496,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator-=(const VectorizedArray &vec)
@@ -1417,6 +1508,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator*=(const VectorizedArray &vec)
@@ -1427,6 +1520,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   VectorizedArray &
   operator/=(const VectorizedArray &vec)
@@ -1439,6 +1534,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 16 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
+   * @param ptr The address of the first value to load from memory.
    */
   void
   load(const float *ptr)
@@ -1451,6 +1547,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 16 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
+   * @param ptr The address of the first value to write to memory.
    */
   void
   store(float *ptr) const
@@ -1460,6 +1557,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 16 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -1482,6 +1580,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   void
   gather(const float *base_ptr, const unsigned int *offsets)
@@ -1501,6 +1602,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   void
   scatter(const unsigned int *offsets, float *base_ptr) const
@@ -1636,6 +1740,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const double scalar)
   {
@@ -1652,6 +1757,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -1665,12 +1771,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   double &
@@ -1682,6 +1790,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const double &
@@ -1693,6 +1802,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -1708,6 +1819,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -1723,6 +1836,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -1738,6 +1853,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -1755,6 +1872,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 16 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -1777,6 +1895,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 16 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -1796,6 +1915,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 16 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -1818,6 +1938,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -1838,6 +1961,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -1957,6 +2083,12 @@ private:
 
 /**
  * Specialization for double and SSE2.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -1984,6 +2116,10 @@ vectorized_load_and_transpose(const unsigned int          n_entries,
 
 /**
  * Specialization for double and SSE2.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2011,6 +2147,13 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
 
 /**
  * Specialization for double and SSE2.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2063,6 +2206,11 @@ vectorized_transpose_and_store(const bool                        add_into,
 
 /**
  * Specialization for double and SSE2.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2139,6 +2287,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const float scalar)
   {
@@ -2155,6 +2304,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2168,12 +2318,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   float &
@@ -2185,6 +2337,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const float &
@@ -2196,6 +2349,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2211,6 +2366,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2226,6 +2383,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2241,6 +2400,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2258,6 +2419,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 16 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2271,6 +2433,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 16 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2281,6 +2444,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 16 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2303,6 +2467,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2323,6 +2490,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2443,6 +2613,12 @@ private:
 
 /**
  * Specialization for float and SSE2.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2478,6 +2654,10 @@ vectorized_load_and_transpose(const unsigned int         n_entries,
 
 /**
  * Specialization for float and SSE2.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2513,6 +2693,13 @@ vectorized_load_and_transpose(const unsigned int            n_entries,
 
 /**
  * Specialization for float and SSE2.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2576,6 +2763,11 @@ vectorized_transpose_and_store(const bool                       add_into,
 
 /**
  * Specialization for float and SSE2.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -2665,6 +2857,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const double scalar)
   {
@@ -2681,6 +2874,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2694,12 +2888,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   double &
@@ -2711,6 +2907,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const double &
@@ -2722,6 +2919,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2742,6 +2941,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2756,6 +2957,8 @@ public:
   }
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2771,6 +2974,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -2788,6 +2993,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 32 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2808,6 +3014,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 32 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2825,6 +3032,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 32 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -2847,6 +3055,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -2884,6 +3095,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -3022,6 +3236,12 @@ private:
 
 /**
  * Specialization for double and AVX.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3061,6 +3281,10 @@ vectorized_load_and_transpose(const unsigned int          n_entries,
 
 /**
  * Specialization for double and AVX.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3100,6 +3324,13 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
 
 /**
  * Specialization for double and AVX.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3167,6 +3398,11 @@ vectorized_transpose_and_store(const bool                        add_into,
 
 /**
  * Specialization for double and AVX.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3260,6 +3496,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const float scalar)
   {
@@ -3276,6 +3513,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3289,12 +3527,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   float &
@@ -3306,6 +3546,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const float &
@@ -3317,6 +3558,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3337,6 +3580,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3351,6 +3596,8 @@ public:
   }
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3366,6 +3613,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3383,6 +3632,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 32 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -3396,6 +3646,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 32 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -3406,6 +3657,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 32 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -3428,6 +3680,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -3465,6 +3720,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -3603,6 +3861,12 @@ private:
 
 /**
  * Specialization for float and AVX.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3645,6 +3909,10 @@ vectorized_load_and_transpose(const unsigned int         n_entries,
 
 /**
  * Specialization for float and AVX.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3685,6 +3953,13 @@ vectorized_load_and_transpose(const unsigned int            n_entries,
 
 /**
  * Specialization for float and AVX.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3768,6 +4043,11 @@ vectorized_transpose_and_store(const bool                       add_into,
 
 /**
  * Specialization for float and AVX.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -3878,6 +4158,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const double scalar)
   {
@@ -3894,6 +4175,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3908,12 +4190,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const double scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   double &
@@ -3925,6 +4209,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const double &
@@ -3936,6 +4221,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3956,6 +4243,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3970,6 +4259,8 @@ public:
   }
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -3985,6 +4276,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -4002,6 +4295,7 @@ public:
    * Load size() data items from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 64 bytes, as opposed
    * to casting a double address to VectorizedArray<double>*.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4022,6 +4316,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 64 bytes, as opposed to casting a double address to
    * VectorizedArray<double>*.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4039,6 +4334,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 64 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -4061,6 +4357,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4098,6 +4397,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4255,6 +4557,12 @@ private:
 
 /**
  * Specialization for double and AVX-512.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -4300,6 +4608,10 @@ vectorized_load_and_transpose(const unsigned int          n_entries,
 
 /**
  * Specialization for double and AVX-512.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -4339,6 +4651,13 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
 
 /**
  * Specialization for double and AVX-512.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -4422,6 +4741,11 @@ vectorized_transpose_and_store(const bool                        add_into,
 
 /**
  * Specialization for double and AVX-512.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -4525,6 +4849,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const float scalar)
   {
@@ -4541,6 +4866,7 @@ public:
 
   /**
    * This function can be used to set all data fields to a given scalar.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -4554,12 +4880,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const float scalar) && = delete;
 
   /**
    * Access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   float &
@@ -4571,6 +4899,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const float &
@@ -4582,6 +4911,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -4602,6 +4933,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -4616,6 +4949,8 @@ public:
   }
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -4631,6 +4966,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -4648,6 +4985,7 @@ public:
    * Load @p size() from memory into the calling class, starting at
    * the given address. The memory need not be aligned by 64 bytes, as opposed
    * to casting a float address to VectorizedArray<float>*.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4661,6 +4999,7 @@ public:
    * size() to the given address. The memory need not be aligned by
    * 64 bytes, as opposed to casting a float address to
    * VectorizedArray<float>*.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4671,6 +5010,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    * @note Memory must be aligned by 64 bytes.
    */
   DEAL_II_ALWAYS_INLINE
@@ -4693,6 +5033,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   this->operator[](v) = base_ptr[offsets[v]];
    * @endcode
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4730,6 +5073,9 @@ public:
    * for (unsigned int v=0; v<VectorizedArray<Number>::size(); ++v)
    *   base_ptr[offsets[v]] = this->operator[](v);
    * @endcode
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -4888,6 +5234,12 @@ private:
 
 /**
  * Specialization for float and AVX-512.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -4943,6 +5295,10 @@ vectorized_load_and_transpose(const unsigned int          n_entries,
 
 /**
  * Specialization for float and AVX-512.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -4994,6 +5350,13 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
 
 /**
  * Specialization for float and AVX-512.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param offsets The offsets that map local entries to positions in the
+ * underlying storage.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -5108,6 +5471,11 @@ vectorized_transpose_and_store(const bool                        add_into,
 
 /**
  * Specialization for float and AVX-512.
+ * @param add_into The add into.
+ * @param n_entries The number of entries.
+ * @param in The input data or stream from which values are read.
+ * @param out The output iterator or object that receives the computed
+ * results.
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
@@ -5244,6 +5612,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const double scalar)
   {
@@ -5260,6 +5629,7 @@ public:
 
   /**
    * This function assigns a scalar to the current object.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5278,12 +5648,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const double scalar) && = delete;
 
   /**
    * Access operator. The component must be either 0 or 1.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   double &
@@ -5295,6 +5667,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const double &
@@ -5306,6 +5679,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5317,6 +5692,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5328,6 +5705,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5339,6 +5718,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5351,6 +5732,7 @@ public:
   /**
    * Load @p size() from memory into the calling class, starting at
    * the given address.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5362,6 +5744,7 @@ public:
   /**
    * Write the content of the calling class into memory in form of @p
    * size() to the given address.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5372,6 +5755,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5382,6 +5766,9 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::gather()
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5393,6 +5780,9 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::scatter
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5505,6 +5895,7 @@ public:
 
   /**
    * Construct an array with the given scalar broadcast to all lanes.
+   * @param scalar The scalar factor applied to every entry.
    */
   VectorizedArray(const float scalar)
   {
@@ -5521,6 +5912,7 @@ public:
 
   /**
    * This function assigns a scalar to the current object.
+   * @param x The value on which this function operates.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5539,12 +5931,14 @@ public:
    * Assign a scalar to the current object. This overload is used for
    * rvalue references; because it does not make sense to assign
    * something to a temporary, the function is deleted.
+   * @param scalar The scalar value to assign to every entry.
    */
   VectorizedArray &
   operator=(const float scalar) && = delete;
 
   /**
    * Access operator. The component must be between 0 and 3.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   float &
@@ -5556,6 +5950,7 @@ public:
 
   /**
    * Constant access operator.
+   * @param comp The component or SIMD lane index to access.
    */
   DEAL_II_ALWAYS_INLINE
   const float &
@@ -5567,6 +5962,8 @@ public:
 
   /**
    * Element-wise addition of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5578,6 +5975,8 @@ public:
 
   /**
    * Element-wise subtraction of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5589,6 +5988,8 @@ public:
 
   /**
    * Element-wise multiplication of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5600,6 +6001,8 @@ public:
 
   /**
    * Element-wise division of two arrays of numbers.
+   * @param vec The vectorized operand whose entries are combined element-wise
+   * with the current object.
    */
   DEAL_II_ALWAYS_INLINE
   VectorizedArray &
@@ -5612,6 +6015,7 @@ public:
   /**
    * Load @p size() from memory into the calling class, starting at
    * the given address.
+   * @param ptr The address of the first value to load from memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5623,6 +6027,7 @@ public:
   /**
    * Write the content of the calling class into memory in form of @p
    * size() to the given address.
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5633,6 +6038,7 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::streaming_store()
+   * @param ptr The address of the first value to write to memory.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5643,6 +6049,9 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::gather()
+   * @param base_ptr The base ptr.
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5654,6 +6063,9 @@ public:
 
   /**
    * @copydoc VectorizedArray<Number>::scatter
+   * @param offsets The per-lane offsets, measured from @p base_ptr, used in
+   * the gather or scatter operation.
+   * @param base_ptr The base ptr.
    */
   DEAL_II_ALWAYS_INLINE
   void
@@ -5757,6 +6169,8 @@ private:
  * Relational operator == for VectorizedArray
  *
  * @relatesalso VectorizedArray
+ * @param lhs The lhs used by this operation.
+ * @param rhs The right-hand-side operand.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE bool
@@ -5775,6 +6189,8 @@ operator==(const VectorizedArray<Number, width> &lhs,
  * Addition of two vectorized arrays with operator +.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5789,6 +6205,8 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  * Subtraction of two vectorized arrays with operator -.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5803,6 +6221,8 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  * Multiplication of two vectorized arrays with operator *.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5817,6 +6237,8 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  * Division of two vectorized arrays with operator /.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5832,6 +6254,8 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  * size() equal entries) and a vectorized array.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5848,6 +6272,8 @@ operator+(const Number &u, const VectorizedArray<Number, width> &v)
  * that are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -5862,6 +6288,8 @@ operator+(const double u, const VectorizedArray<float, width> &v)
  * with @p size() equal entries).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5877,6 +6305,8 @@ operator+(const VectorizedArray<Number, width> &v, const Number &u)
  * usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -5890,6 +6320,8 @@ operator+(const VectorizedArray<float, width> &v, const double u)
  * array with @p size() equal entries).
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5906,6 +6338,8 @@ operator-(const Number &u, const VectorizedArray<Number, width> &v)
  * are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -5920,6 +6354,8 @@ operator-(const double u, const VectorizedArray<float, width> &v)
  * size() equal entries) from a vectorized array.
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5936,6 +6372,8 @@ operator-(const VectorizedArray<Number, width> &v, const Number &u)
  * that are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -5950,6 +6388,8 @@ operator-(const VectorizedArray<float, width> &v, const double u)
  * size() equal entries) and a vectorized array.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5966,6 +6406,8 @@ operator*(const Number &u, const VectorizedArray<Number, width> &v)
  * that are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -5980,6 +6422,8 @@ operator*(const double u, const VectorizedArray<float, width> &v)
  * array with @p size() equal entries).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -5995,6 +6439,8 @@ operator*(const VectorizedArray<Number, width> &v, const Number &u)
  * are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -6008,6 +6454,8 @@ operator*(const VectorizedArray<float, width> &v, const double u)
  * size() equal entries) and a vectorized array.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -6024,6 +6472,8 @@ operator/(const Number &u, const VectorizedArray<Number, width> &v)
  * that are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
+ * @param v The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -6038,6 +6488,8 @@ operator/(const double u, const VectorizedArray<float, width> &v)
  * array with @p size() equal entries).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -6054,6 +6506,8 @@ operator/(const VectorizedArray<Number, width> &v, const Number &u)
  * are usually double numbers).
  *
  * @relatesalso VectorizedArray
+ * @param v The operand supplied to this operation.
+ * @param u The operand supplied to this operation.
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
@@ -6067,6 +6521,7 @@ operator/(const VectorizedArray<float, width> &v, const double u)
  * Unary operator + on a vectorized array.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -6079,6 +6534,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  * Unary operator - on a vectorized array.
  *
  * @relatesalso VectorizedArray
+ * @param u The operand supplied to this operation.
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
@@ -6195,6 +6651,10 @@ enum class SIMDComparison : int
  * provides overloads for all VectorizedArray<Number> variants as well as
  * generic POD types such as double and float.
  *
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
+ * @param true_value The true value.
+ * @param false_value The false value.
  * @note For this function to work the binary operation has to be encoded
  * via a SIMDComparison template argument @p predicate. Depending on it
  * appropriate low-level machine instructions are generated replacing the
@@ -6240,6 +6700,10 @@ compare_and_apply_mask(const Number &left,
 /**
  * Specialization of above function for the non-vectorized
  * VectorizedArray<Number, 1> variant.
+ * @param left The left-hand operand.
+ * @param right The right-hand operand.
+ * @param true_value The true value.
+ * @param false_value The false value.
  */
 template <SIMDComparison predicate, typename Number>
 DEAL_II_ALWAYS_INLINE inline VectorizedArray<Number, 1>

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -364,6 +364,7 @@ namespace WorkStream
          * Constructor. Take an iterator range, the size of a buffer that can
          * hold items, and the sample additional data object that will be
          * passed to each worker and copier function invocation.
+         * @param chunk_size The chunk size.
          */
         IteratorRangeToItemStream(const Iterator    &begin,
                                   const Iterator    &end,
@@ -725,6 +726,15 @@ namespace WorkStream
        * length is relevant to the parallel pipeline implementation using TBB
        * but not used by taskflow. The parameter is kept here to maintain
        * support for calls to workstream written for TBB.
+       * @param begin The begin of the range.
+       * @param end The end of the range.
+       * @param worker The worker function that computes the per-item or per-
+       * chunk result.
+       * @param copier The copier function that merges a computed result into
+       * the destination object.
+       * @param sample_scratch_data The sample scratch data.
+       * @param sample_copy_data The sample copy data.
+       * @param chunk_size The chunk size.
        */
       template <typename Worker,
                 typename Copier,
@@ -919,6 +929,14 @@ namespace WorkStream
     {
       /**
        * Sequential version without colors.
+       * @param begin The begin of the range.
+       * @param end The end of the range.
+       * @param worker The worker function that computes the per-item or per-
+       * chunk result.
+       * @param copier The copier function that merges a computed result into
+       * the destination object.
+       * @param sample_scratch_data The sample scratch data.
+       * @param sample_copy_data The sample copy data.
        */
       template <typename Worker,
                 typename Copier,
@@ -961,6 +979,13 @@ namespace WorkStream
 
       /**
        * Sequential version with colors
+       * @param colored_iterators The colored iterators.
+       * @param worker The worker function that computes the per-item or per-
+       * chunk result.
+       * @param copier The copier function that merges a computed result into
+       * the destination object.
+       * @param sample_scratch_data The sample scratch data.
+       * @param sample_copy_data The sample copy data.
        */
       template <typename Worker,
                 typename Copier,
@@ -1025,6 +1050,7 @@ namespace WorkStream
       public:
         /**
          * Constructor.
+         * @param sample_copy_data The sample copy data.
          */
         WorkerAndCopier(
           const std::function<void(const Iterator &, ScratchData &, CopyData &)>
@@ -1042,6 +1068,8 @@ namespace WorkStream
         /**
          * The function that calls the worker and the copier functions on a
          * range of items denoted by the two arguments.
+         * @param range The blocked range of iterators to process on this
+         * worker thread.
          */
         void
         operator()(const tbb::blocked_range<
@@ -1167,6 +1195,14 @@ namespace WorkStream
 
       /**
        * The colored run function using TBB.
+       * @param colored_iterators The colored iterators.
+       * @param worker The worker function that computes the per-item or per-
+       * chunk result.
+       * @param copier The copier function that merges a computed result into
+       * the destination object.
+       * @param sample_scratch_data The sample scratch data.
+       * @param sample_copy_data The sample copy data.
+       * @param chunk_size The chunk size.
        */
       template <typename Worker,
                 typename Copier,
@@ -1229,6 +1265,7 @@ namespace WorkStream
       public:
         /**
          * Constructor.
+         * @param sample_copy_data The sample copy data.
          */
         WorkerAndCopier(
           const std::function<void(const Iterator &, ScratchData &, CopyData &)>
@@ -1246,6 +1283,8 @@ namespace WorkStream
         /**
          * The function that calls the worker and the copier functions on a
          * range of items denoted by the two arguments.
+         * @param range The contiguous subrange of iterators to process on this
+         * worker thread.
          */
         void
         operator()(const ArrayView<const Iterator> &range)
@@ -1371,6 +1410,14 @@ namespace WorkStream
 
       /**
        * The colored run function using taskflow.
+       * @param colored_iterators The colored iterators.
+       * @param worker The worker function that computes the per-item or per-
+       * chunk result.
+       * @param copier The copier function that merges a computed result into
+       * the destination object.
+       * @param sample_scratch_data The sample scratch data.
+       * @param sample_copy_data The sample copy data.
+       * @param chunk_size The chunk size.
        */
       template <typename Worker,
                 typename Copier,
@@ -1463,6 +1510,15 @@ namespace WorkStream
    * the input stream that will be worked on by the worker and copier
    * functions one after the other on the same thread.
    *
+   * @param colored_iterators The colored iterators.
+   * @param worker The worker function that computes the per-item or per-chunk
+   * result.
+   * @param copier The copier function that merges a computed result into the
+   * destination object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    * @note If your data objects are large, or their constructors are
    * expensive, it is helpful to keep in mind that <tt>queue_length</tt>
    * copies of the <tt>ScratchData</tt> object and
@@ -1527,6 +1583,16 @@ namespace WorkStream
    * the input stream that will be worked on by the worker and copier
    * functions one after the other on the same thread.
    *
+   * @param begin The begin of the range.
+   * @param end The end of the range.
+   * @param worker The worker function that computes the per-item or per-chunk
+   * result.
+   * @param copier The copier function that merges a computed result into the
+   * destination object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    * @note If your data objects are large, or their constructors are
    * expensive, it is helpful to keep in mind that <tt>queue_length</tt>
    * copies of the <tt>ScratchData</tt> object and
@@ -1645,6 +1711,15 @@ namespace WorkStream
    * functions `IteratorRangeType::begin()` and `IteratorRangeType::end()`,
    * both of which return iterators to elements that form the bounds of the
    * range.
+   * @param iterator_range The iterator range.
+   * @param worker The worker function that computes the per-item or per-chunk
+   * result.
+   * @param copier The copier function that merges a computed result into the
+   * destination object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    */
   template <
     typename Worker,
@@ -1680,6 +1755,15 @@ namespace WorkStream
 
   /**
    * Same as the function above, but for deal.II's IteratorRange.
+   * @param iterator_range The iterator range.
+   * @param worker The worker function that computes the per-item or per-chunk
+   * result.
+   * @param copier The copier function that merges a computed result into the
+   * destination object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    */
   template <typename Worker,
             typename Copier,
@@ -1790,6 +1874,13 @@ namespace WorkStream
    * the input stream that will be worked on by the worker and copier
    * functions one after the other on the same thread.
    *
+   * @param begin The begin of the range.
+   * @param end The end of the range.
+   * @param main_object The object in which to store the main object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    * @note If your data objects are large, or their constructors are
    * expensive, it is helpful to keep in mind that <tt>queue_length</tt>
    * copies of the <tt>ScratchData</tt> object and
@@ -1883,6 +1974,12 @@ namespace WorkStream
    * functions `IteratorRangeType::begin()` and `IteratorRangeType::end()`,
    * both of which return iterators to elements that form the bounds of the
    * range.
+   * @param iterator_range The iterator range.
+   * @param main_object The object in which to store the main object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    */
   template <
     typename MainClass,
@@ -1923,6 +2020,12 @@ namespace WorkStream
 
   /**
    * Same as the function above, but for deal.II's IteratorRange.
+   * @param iterator_range The iterator range.
+   * @param main_object The object in which to store the main object.
+   * @param sample_scratch_data The sample scratch data.
+   * @param sample_copy_data The sample copy data.
+   * @param queue_length The queue length.
+   * @param chunk_size The chunk size.
    */
   template <typename MainClass,
             typename Iterator,


### PR DESCRIPTION
In my continuing evaluation of what one can do with AI, I thought I'd give Copilot a job I really don't want to do myself: Document all of the function arguments where we don't already do that. This patch isn't the first attempt, but required some going around. Not everything is great, some additions are useful, many are more or less tautological. 

I don't propose that we merge this, but I thought I'd post it for discussion and then I'll whittle it down to the ones that I think might actually make sense.