### PR TITLE
tests/matrix_free_kokkos/stokes_03 remove redundancy

### DIFF
--- a/tests/matrix_free_kokkos/stokes_03.cc
+++ b/tests/matrix_free_kokkos/stokes_03.cc
@@ -777,9 +777,6 @@ BlockSchurPreconditioner<AInvOperator, SInvOperator, BTOperator, VectorType>::
 
   // first apply the Schur Complement inverse operator.
   {
-    // Zero out output vector, because the Chebychev smoother otherwise
-    // incorrectly uses existing values:
-    dst.block(1) = 0.0;
     S_inverse_operator.vmult(dst.block(1), src.block(1));
     dst.block(1) *= -1.0;
   }


### PR DESCRIPTION
Part of #19782. I can no longer reproduce uninitialized reads and non-determinism even without this statement.