### PR TITLE
add more tests and =scalar operator for PETScWrappers::MPI::FullMatrix

### DIFF
--- a/include/deal.II/lac/petsc_full_matrix.h
+++ b/include/deal.II/lac/petsc_full_matrix.h
@@ -73,6 +73,17 @@ namespace PETScWrappers
     void
     reinit(const size_type m, const size_type n);
 
+    /**
+     * This operator assigns a scalar to a matrix. Since this does usually not
+     * make much sense (should we set all matrix entries to this value?),
+     * this operation is only
+     * allowed if the actual value to be assigned is zero. This operator only
+     * exists to allow for the obvious notation <tt>matrix=0</tt>, which sets
+     * all elements of the matrix to zero.
+     */
+    FullMatrix &
+    operator=(const value_type d);
+
 
   private:
     /**
@@ -130,6 +141,17 @@ namespace PETScWrappers
        * Destructor to free the PETSc object.
        */
       ~FullMatrix() override;
+
+      /**
+       * This operator assigns a scalar to a matrix. Since this does usually not
+       * make much sense (should we set all matrix entries to this value?),
+       * this operation is only
+       * allowed if the actual value to be assigned is zero. This operator only
+       * exists to allow for the obvious notation <tt>matrix=0</tt>, which sets
+       * all elements of the matrix to zero.
+       */
+      FullMatrix &
+      operator=(const value_type d);
 
       void
       reinit(const MPI_Comm  communicator,

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -365,12 +365,13 @@ namespace PETScWrappers
 
     /**
      * This operator assigns a scalar to a matrix. Since this does usually not
-     * make much sense (should we set all matrix entries to this value? Only
-     * the nonzero entries of the sparsity pattern?), this operation is only
+     * make much sense (should we set all matrix entries to this value?),
+     * this operation is only
      * allowed if the actual value to be assigned is zero. This operator only
      * exists to allow for the obvious notation <tt>matrix=0</tt>, which sets
-     * all elements of the matrix to zero, but keeps the sparsity pattern
-     * previously used.
+     * all elements of the matrix to zero. For full matrices, all values are set
+     * to zero while for sparse matrices the sparsity pattern is still used, so
+     * only the non-zero entries of the sparsity pattern are set to zero.
      */
     MatrixBase &
     operator=(const value_type d);

--- a/source/lac/petsc_full_matrix.cc
+++ b/source/lac/petsc_full_matrix.cc
@@ -58,6 +58,13 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
+  FullMatrix &
+  FullMatrix::operator=(const value_type d)
+  {
+    MatrixBase::operator=(d);
+    return *this;
+  }
+
 } // namespace PETScWrappers
 
 

--- a/source/lac/petsc_parallel_full_matrix.cc
+++ b/source/lac/petsc_parallel_full_matrix.cc
@@ -87,6 +87,15 @@ namespace PETScWrappers
 
 
 
+    FullMatrix &
+    FullMatrix::operator=(const value_type d)
+    {
+      MatrixBase::operator=(d);
+      return *this;
+    }
+
+
+
     void
     FullMatrix::do_reinit(const MPI_Comm  communicator,
                           const size_type m,

--- a/tests/petsc/deal_solver_full_01.cc
+++ b/tests/petsc/deal_solver_full_01.cc
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// test the CG solver using the PETSc full matrix and vector classes
+
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_qmrs.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/vector_memory.h>
+
+#include <iostream>
+#include <typeinfo>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  deallog << std::setprecision(4);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    SolverControl control(100, 1.e-3);
+
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+    A.compress(VectorOperation::insert);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+    f = 1.;
+
+    GrowingVectorMemory<PETScWrappers::MPI::Vector> mem;
+    SolverCG<PETScWrappers::MPI::Vector>            solver(control, mem);
+    PreconditionIdentity                            preconditioner;
+
+    deallog << "Solver type: " << typeid(solver).name() << std::endl;
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              42,
+                              44);
+  }
+  GrowingVectorMemory<PETScWrappers::MPI::Vector>::release_unused_memory();
+}

--- a/tests/petsc/deal_solver_full_01.output
+++ b/tests/petsc/deal_solver_full_01.output
@@ -1,0 +1,4 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver type: N6dealii8SolverCGINS_13PETScWrappers3MPI6VectorEEE
+DEAL::Solver stopped within 42 - 44 iterations

--- a/tests/petsc/deal_solver_full_02.cc
+++ b/tests/petsc/deal_solver_full_02.cc
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// test the BiCGStab solver using the PETSc full matrix and vector classes
+
+
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_qmrs.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/vector_memory.h>
+
+#include <iostream>
+#include <typeinfo>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  deallog << std::setprecision(4);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    SolverControl control(100, 1.e-10);
+
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+    A.compress(VectorOperation::insert);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+    f = 1.;
+
+    GrowingVectorMemory<PETScWrappers::MPI::Vector> mem;
+    SolverBicgstab<PETScWrappers::MPI::Vector>      solver(control, mem);
+    PreconditionIdentity                            preconditioner;
+    deallog << "Solver type: " << typeid(solver).name() << std::endl;
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              48,
+                              51);
+  }
+  GrowingVectorMemory<PETScWrappers::MPI::Vector>::release_unused_memory();
+}

--- a/tests/petsc/deal_solver_full_02.output
+++ b/tests/petsc/deal_solver_full_02.output
@@ -1,0 +1,4 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver type: N6dealii14SolverBicgstabINS_13PETScWrappers3MPI6VectorEEE
+DEAL::Solver stopped within 48 - 51 iterations

--- a/tests/petsc/deal_solver_full_03.cc
+++ b/tests/petsc/deal_solver_full_03.cc
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// test the GMRES solver using the PETSc full matrix and vector classes
+
+
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_qmrs.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/vector_memory.h>
+
+#include <iostream>
+#include <typeinfo>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  deallog << std::setprecision(4);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    SolverControl control(100, 1.e-3);
+
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+    f = 1.;
+    A.compress(VectorOperation::insert);
+
+    GrowingVectorMemory<PETScWrappers::MPI::Vector>         mem;
+    SolverGMRES<PETScWrappers::MPI::Vector>::AdditionalData data(28);
+    SolverGMRES<PETScWrappers::MPI::Vector> solver(control, mem, data);
+    PreconditionIdentity                    preconditioner;
+    deallog << "Solver type: " << typeid(solver).name() << std::endl;
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              74,
+                              76);
+  }
+  GrowingVectorMemory<PETScWrappers::MPI::Vector>::release_unused_memory();
+}

--- a/tests/petsc/deal_solver_full_03.output
+++ b/tests/petsc/deal_solver_full_03.output
@@ -1,0 +1,4 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver type: N6dealii11SolverGMRESINS_13PETScWrappers3MPI6VectorEEE
+DEAL::Solver stopped within 74 - 76 iterations

--- a/tests/petsc/deal_solver_full_04.cc
+++ b/tests/petsc/deal_solver_full_04.cc
@@ -1,0 +1,74 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// test the MINRES solver using the PETSc full matrix and vector classes
+
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_minres.h>
+#include <deal.II/lac/solver_qmrs.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/vector_memory.h>
+
+#include <iostream>
+#include <typeinfo>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  deallog << std::setprecision(4);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    SolverControl control(100, 1.e-3);
+
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+    f = 1.;
+    A.compress(VectorOperation::insert);
+
+    GrowingVectorMemory<PETScWrappers::MPI::Vector> mem;
+    SolverMinRes<PETScWrappers::MPI::Vector>        solver(control, mem);
+    PreconditionIdentity                            preconditioner;
+    deallog << "Solver type: " << typeid(solver).name() << std::endl;
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              42,
+                              44);
+  }
+  GrowingVectorMemory<PETScWrappers::MPI::Vector>::release_unused_memory();
+}

--- a/tests/petsc/deal_solver_full_04.output
+++ b/tests/petsc/deal_solver_full_04.output
@@ -1,0 +1,4 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver type: N6dealii12SolverMinResINS_13PETScWrappers3MPI6VectorEEE
+DEAL::Solver stopped within 42 - 44 iterations

--- a/tests/petsc/deal_solver_full_05.cc
+++ b/tests/petsc/deal_solver_full_05.cc
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// test the QMRS solver using the PETSc full matrix and vector classes
+
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/precondition.h>
+#include <deal.II/lac/solver_bicgstab.h>
+#include <deal.II/lac/solver_cg.h>
+#include <deal.II/lac/solver_control.h>
+#include <deal.II/lac/solver_gmres.h>
+#include <deal.II/lac/solver_qmrs.h>
+#include <deal.II/lac/solver_richardson.h>
+#include <deal.II/lac/vector_memory.h>
+
+#include <iostream>
+#include <typeinfo>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+  deallog << std::setprecision(4);
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    SolverControl control(100, 1.e-3);
+
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+    f = 1.;
+    A.compress(VectorOperation::insert);
+
+    GrowingVectorMemory<PETScWrappers::MPI::Vector> mem;
+    SolverQMRS<PETScWrappers::MPI::Vector>          solver(control, mem);
+    PreconditionIdentity                            preconditioner;
+    deallog << "Solver type: " << typeid(solver).name() << std::endl;
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              45,
+                              47);
+  }
+  GrowingVectorMemory<PETScWrappers::MPI::Vector>::release_unused_memory();
+}

--- a/tests/petsc/deal_solver_full_05.output
+++ b/tests/petsc/deal_solver_full_05.output
@@ -1,0 +1,4 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver type: N6dealii10SolverQMRSINS_13PETScWrappers3MPI6VectorEEE
+DEAL::Solver stopped within 45 - 47 iterations

--- a/tests/petsc/solver_full_01.cc
+++ b/tests/petsc/solver_full_01.cc
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// test the PETSc Richardson solver for full matrices
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_precondition.h>
+#include <deal.II/lac/petsc_solver.h>
+#include <deal.II/lac/petsc_vector.h>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+
+    f = 1.;
+    u = 0.;
+
+    A.compress(VectorOperation::insert);
+    f.compress(VectorOperation::insert);
+    u.compress(VectorOperation::insert);
+
+    // Richardson is a tricky smoother for the kind of FD matrix we use in
+    // this test. So, simply test that we're able to reduce the residual to
+    // a reasonably small value of 1.e-4.
+    SolverControl control(2500, 1.e-4);
+
+    PETScWrappers::SolverRichardson   solver(control);
+    PETScWrappers::PreconditionJacobi preconditioner(A);
+
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              2295,
+                              2300);
+  }
+}

--- a/tests/petsc/solver_full_01.output
+++ b/tests/petsc/solver_full_01.output
@@ -1,0 +1,3 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver stopped within 2295 - 2300 iterations

--- a/tests/petsc/solver_full_02.cc
+++ b/tests/petsc/solver_full_02.cc
@@ -1,0 +1,66 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2004 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// test the PETSc Chebychev solver for full matrices
+
+#include <deal.II/lac/petsc_full_matrix.h>
+#include <deal.II/lac/petsc_precondition.h>
+#include <deal.II/lac/petsc_solver.h>
+#include <deal.II/lac/petsc_vector.h>
+
+#include "../tests.h"
+
+#include "../testmatrix.h"
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  {
+    const unsigned int size = 32;
+    unsigned int       dim  = (size - 1) * (size - 1);
+
+    deallog << "Size " << size << " Unknowns " << dim << std::endl;
+
+    // Make matrix
+    FDMatrix                  testproblem(size, size);
+    PETScWrappers::FullMatrix A(dim, dim);
+    testproblem.five_point(A);
+
+    IndexSet indices(dim);
+    indices.add_range(0, dim);
+    PETScWrappers::MPI::Vector f(indices, MPI_COMM_WORLD);
+    PETScWrappers::MPI::Vector u(indices, MPI_COMM_WORLD);
+
+    f = 1.;
+    u = 0.;
+
+    A.compress(VectorOperation::insert);
+    f.compress(VectorOperation::insert);
+    u.compress(VectorOperation::insert);
+
+    // Chebychev is a tricky smoother for the kind of FD matrix we use in
+    // this test. So, simply test that we're able to reduce the residual to
+    // a reasonably small value of 1.e-3.
+    SolverControl control(2500, 1.5e-3);
+
+    PETScWrappers::SolverChebychev    solver(control);
+    PETScWrappers::PreconditionJacobi preconditioner(A);
+
+    check_solver_within_range(solver.solve(A, u, f, preconditioner),
+                              control.last_step(),
+                              1050,
+                              1150);
+  }
+}

--- a/tests/petsc/solver_full_02.output
+++ b/tests/petsc/solver_full_02.output
@@ -1,0 +1,3 @@
+
+DEAL::Size 32 Unknowns 961
+DEAL::Solver stopped within 1050 - 1150 iterations


### PR DESCRIPTION
This PR adds a bunch of tests using petsc solvers for standard petsc full matrices. They are essentially just the sparse matrix test, but i swapped out the petsc sparse matrix for the petsc full matrix. This is meant to improve the test coverage. 

Also i added the =scalar operator to the MPI full matrix wrapper. I need it for some larger MPI tests i will add in a future PR to improve the test coverage of the PETScWrappers::MPI::FullMatrix.