### PR TITLE
doxygen: Escape '&' symbols. Remove trailing whitespaces.

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -1142,7 +1142,7 @@
   author =    {R. Lohner},
   title =     {Edge-Based Compressible Flow Solvers},
   booktitle = {Applied Computational Fluid Dynamics Techniques},
-  publisher = {John Wiley & Sons, Ltd},
+  publisher = {John Wiley \& Sons, Ltd},
   year =      {2008},
   chapter =   {10},
   pages =     {187-200},
@@ -2048,7 +2048,7 @@
   publisher = {Cambridge University Press},
   isbn      = {978-1108420419},
   doi       = {10.1017/9781108333511},
-  url       = {https://www.cambridge.org/highereducation/books/introduction-to-electrodynamics/3AB220820DBB628E5A43D52C4B011ED4#overview} 
+  url       = {https://www.cambridge.org/highereducation/books/introduction-to-electrodynamics/3AB220820DBB628E5A43D52C4B011ED4#overview}
 }
 
 @book{uzunbajakau2024b,
@@ -2167,7 +2167,7 @@ url="https://doi.org/10.1007/978-3-642-22061-6_10"
   url = {http://dx.doi.org/10.1016/j.camwa.2017.06.044},
   DOI = {10.1016/j.camwa.2017.06.044},
   number = {8},
-  journal = {Computers &amp; Mathematics with Applications},
+  journal = {Computers \& Mathematics with Applications},
   publisher = {Elsevier BV},
   author = {Petrides,  Socratis and Demkowicz,  Leszek F.},
   year = {2017},
@@ -2422,7 +2422,7 @@ url="https://doi.org/10.1007/978-3-642-22061-6_10"
    author =    {S. Geevers and W.A. Mulder and J.J.W. van der Vegt},
    title =     {New Higher-Order Mass-Lumped Tetrahedral Elements for Wave Propagation Modelling},
    journal =   {SIAM Journal on Scientific Computing},
-   publisher = {Society for Industrial & Applied Mathematics (SIAM)},
+   publisher = {Society for Industrial \& Applied Mathematics (SIAM)},
    year =      {2018},
    number =    {5},
    volume =    {40},
@@ -2570,8 +2570,8 @@ url="https://doi.org/10.1007/978-3-642-22061-6_10"
 @article{CiarletRiavart1972interpolation,
   author  = {P. Ciarlet and P. Raviart},
   title   = {General Langrange and Hermite interpolation in $\mathbb{R}^{n}$ with applications to finite element methods},
-  journal = {Archive for rational mechanics and analysis}, 
-  volume  = {46}, 
+  journal = {Archive for rational mechanics and analysis},
+  volume  = {46},
   pages   = {177-199},
   year    = {1972}
 }


### PR DESCRIPTION
I've built a LaTeX document to build the bibliography with BibTeX. It only reported issues about the & symbols, which will be fixed with this patch.

Attempt at fixing #19510.