### PR TITLE
inplace_vector_05: make it pass with libc++.

### DIFF
--- a/tests/base/inplace_vector_05.cc
+++ b/tests/base/inplace_vector_05.cc
@@ -96,13 +96,16 @@ test_iterators()
       --i;
     }
 
-  std::sort(vec.begin(), vec.end());
-  print(vec);
-  deallog << std::endl;
+  if constexpr (!std::is_same_v<T, A>)
+    {
+      std::sort(vec.begin(), vec.end());
+      print(vec);
+      deallog << std::endl;
 
-  std::sort(vec.rbegin(), vec.rend());
-  print(vec);
-  deallog << std::endl;
+      std::sort(vec.rbegin(), vec.rend());
+      print(vec);
+      deallog << std::endl;
+    }
 
   print_counts<T>();
   deallog << std::endl;

--- a/tests/base/inplace_vector_05.output
+++ b/tests/base/inplace_vector_05.output
@@ -7,21 +7,7 @@ DEAL:A::A::A(const A&)
 DEAL:A::A::A(const A&)
 DEAL:A::A::A(const A&)
 DEAL:A::size : 3
-DEAL:A::A::A(A&&)
-DEAL:A::A::operator=(A&&)
-DEAL:A::A::~A()
-DEAL:A::A::A(A&&)
-DEAL:A::A::operator=(A&&)
-DEAL:A::A::~A()
-DEAL:A::size : 3
-DEAL:A::A::A(A&&)
-DEAL:A::A::operator=(A&&)
-DEAL:A::A::~A()
-DEAL:A::A::A(A&&)
-DEAL:A::A::operator=(A&&)
-DEAL:A::A::~A()
-DEAL:A::size : 3
-DEAL:A::ctors = 10 dtors = 4
+DEAL:A::ctors = 6 dtors = 0
 DEAL:A::
 DEAL:A::A::~A()
 DEAL:A::A::~A()


### PR DESCRIPTION
Sorting an `inplace_vector` of `A`s does nothing. It looks like libstdc++ set up a temporary buffer but we don't need to record that.