### PR TITLE
utilities_pack_unpack_06: make it pass with newer boost versions.

### DIFF
--- a/tests/base/utilities_pack_unpack_06.cc
+++ b/tests/base/utilities_pack_unpack_06.cc
@@ -123,11 +123,12 @@ check(const double (&array)[N], const Point<dim>(&point))
                                       point_compressed.cend(),
                                       false);
     }
-  catch (const boost::archive::archive_exception &)
+  catch (...)
     {
       deallog << "unpacking compressed point without decompression failed!"
               << std::endl;
     }
+
   try
     {
       double forbidden[N];
@@ -136,7 +137,7 @@ check(const double (&array)[N], const Point<dim>(&point))
                         forbidden,
                         false);
     }
-  catch (const boost::archive::archive_exception &)
+  catch (...)
     {
       deallog << "unpacking compressed array without decompression failed!"
               << std::endl;
@@ -149,11 +150,12 @@ check(const double (&array)[N], const Point<dim>(&point))
                                       point_uncompressed.cend(),
                                       true);
     }
-  catch (const boost::iostreams::gzip_error &)
+  catch (...)
     {
       deallog << "unpacking uncompressed point with decompression failed!"
               << std::endl;
     }
+
   try
     {
       double forbidden[N];
@@ -162,7 +164,7 @@ check(const double (&array)[N], const Point<dim>(&point))
                         forbidden,
                         true);
     }
-  catch (const boost::iostreams::gzip_error &)
+  catch (...)
     {
       deallog << "unpacking uncompressed array with decompression failed!"
               << std::endl;


### PR DESCRIPTION
Different versions of boost throw different exceptions here (either gzip or serialization exceptions). Keep it simple and catch all of them.