### PR TITLE
KellyErrorEstimator: fix a type.

### DIFF
--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -138,7 +138,7 @@ namespace internal
      * presence of multiple threads where synchronization makes things even
      * slower.
      */
-    Table<3, double> phi;
+    Table<3, number> phi;
 
     /**
      * A vector for the gradients of the finite element function on one cell


### PR DESCRIPTION
This was `number` before the previous patch. Needed by #19806.