### PR TITLE
Prepare some of our examples for use with Tpetra

### DIFF
--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -515,7 +515,15 @@ namespace Step31
     unsigned int timestep_number;
 
     std::shared_ptr<TrilinosWrappers::PreconditionAMG> Amg_preconditioner;
-    std::shared_ptr<TrilinosWrappers::PreconditionIC>  Mp_preconditioner;
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+    using MpPreconditionType = TrilinosWrappers::PreconditionIC;
+#else
+    // IC is not available in Tpetra. Use Jacobi instead, as we do in step-32
+    // TODO: Update the documentation of this step, when we require Tpetra.
+    using MpPreconditionType = TrilinosWrappers::PreconditionJacobi;
+#endif
+    std::shared_ptr<MpPreconditionType> Mp_preconditioner;
 
     bool rebuild_stokes_matrix;
     bool rebuild_temperature_matrices;
@@ -1083,6 +1091,8 @@ namespace Step31
         stokes_constraints.distribute_local_to_global(
           local_matrix, local_dof_indices, stokes_preconditioner_matrix);
       }
+
+    stokes_preconditioner_matrix.compress(VectorOperation::add);
   }
 
 
@@ -1124,12 +1134,19 @@ namespace Step31
 
     Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
 
-    const FEValuesExtractors::Vector     velocity_components(0);
+    const FEValuesExtractors::Vector velocity_components(0);
+
+    TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+    // constant modes and higher order element parameters are not available in
+    // MueLu, which is the AMG package used in Tpetra.
     const std::vector<std::vector<bool>> constant_modes =
       DoFTools::extract_constant_modes(
         stokes_dof_handler, stokes_fe.component_mask(velocity_components));
-    TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
-    amg_data.constant_modes = constant_modes;
+    amg_data.constant_modes        = constant_modes;
+    amg_data.higher_order_elements = true;
+#endif
 
     // Next, we set some more options of the AMG preconditioner. In
     // particular, we need to tell the AMG setup that we use quadratic basis
@@ -1161,13 +1178,12 @@ namespace Step31
     // around since we do not have to care about destroying the previously
     // used object.
     amg_data.elliptic              = true;
-    amg_data.higher_order_elements = true;
     amg_data.smoother_sweeps       = 2;
     amg_data.aggregation_threshold = 0.02;
     Amg_preconditioner->initialize(stokes_preconditioner_matrix.block(0, 0),
                                    amg_data);
 
-    Mp_preconditioner = std::make_shared<TrilinosWrappers::PreconditionIC>();
+    Mp_preconditioner = std::make_shared<MpPreconditionType>();
     Mp_preconditioner->initialize(stokes_preconditioner_matrix.block(1, 1));
 
     std::cout << std::endl;
@@ -1359,6 +1375,9 @@ namespace Step31
                                                         stokes_rhs);
       }
 
+    stokes_matrix.compress(VectorOperation::add);
+    stokes_rhs.compress(VectorOperation::add);
+
     rebuild_stokes_matrix = false;
 
     std::cout << std::endl;
@@ -1456,6 +1475,8 @@ namespace Step31
           temperature_stiffness_matrix);
       }
 
+    temperature_mass_matrix.compress(VectorOperation::add);
+    temperature_stiffness_matrix.compress(VectorOperation::add);
     rebuild_temperature_matrices = false;
   }
 
@@ -1698,13 +1719,13 @@ namespace Step31
 
     {
       const LinearSolvers::InverseMatrix<TrilinosWrappers::SparseMatrix,
-                                         TrilinosWrappers::PreconditionIC>
+                                         MpPreconditionType>
         mp_inverse(stokes_preconditioner_matrix.block(1, 1),
                    *Mp_preconditioner);
 
       const LinearSolvers::BlockSchurPreconditioner<
         TrilinosWrappers::PreconditionAMG,
-        TrilinosWrappers::PreconditionIC>
+        MpPreconditionType>
         preconditioner(stokes_matrix, mp_inverse, *Amg_preconditioner);
 
       SolverControl solver_control(stokes_matrix.m(),
@@ -1785,7 +1806,7 @@ namespace Step31
                                    1e-8 * temperature_rhs.l2_norm());
       SolverCG<TrilinosWrappers::MPI::Vector> cg(solver_control);
 
-      TrilinosWrappers::PreconditionIC preconditioner;
+      MpPreconditionType preconditioner;
       preconditioner.initialize(temperature_matrix);
 
       cg.solve(temperature_matrix,

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -261,7 +261,7 @@ namespace Step32
         if (do_solve_A == true)
           {
             SolverControl solver_control(5000, utmp.l2_norm() * 1e-2);
-            TrilinosWrappers::SolverCG solver(solver_control);
+            SolverCG<TrilinosWrappers::MPI::Vector> solver(solver_control);
             solver.solve(stokes_matrix->block(0, 0),
                          dst.block(0),
                          utmp,
@@ -2163,19 +2163,25 @@ namespace Step32
 
     assemble_stokes_preconditioner();
 
-    const FEValuesExtractors::Vector     velocity_components(0);
-    const std::vector<std::vector<bool>> constant_modes =
-      DoFTools::extract_constant_modes(
-        stokes_dof_handler, stokes_fe.component_mask(velocity_components));
+    const FEValuesExtractors::Vector velocity_components(0);
 
     Mp_preconditioner =
       std::make_shared<TrilinosWrappers::PreconditionJacobi>();
     Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
 
     TrilinosWrappers::PreconditionAMG::AdditionalData Amg_data;
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+    // constant modes and higher order element parameters are not available in
+    // MueLu, which is the AMG package used in Tpetra.
+    const std::vector<std::vector<bool>> constant_modes =
+      DoFTools::extract_constant_modes(
+        stokes_dof_handler, stokes_fe.component_mask(velocity_components));
     Amg_data.constant_modes        = constant_modes;
-    Amg_data.elliptic              = true;
     Amg_data.higher_order_elements = true;
+#endif
+
+    Amg_data.elliptic              = true;
     Amg_data.smoother_sweeps       = 2;
     Amg_data.aggregation_threshold = 0.02;
 

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -308,6 +308,9 @@ namespace Step41
                                                system_rhs,
                                                true);
       }
+
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
   }
 
 
@@ -368,6 +371,8 @@ namespace Step41
                                                local_dof_indices,
                                                mass_matrix);
       }
+
+    mass_matrix.compress(VectorOperation::add);
   }
 
 

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1638,13 +1638,18 @@ namespace Step42
     {
       TimerOutput::Scope t(computing_timer, "Solve: setup preconditioner");
 
+      TrilinosWrappers::PreconditionAMG::AdditionalData additional_data;
+
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+      // the parameter constant_modes and n_cycles are not available in
+      // MueLu, which is the AMG package used with Tpetra containers.
       const std::vector<std::vector<bool>> constant_modes =
         DoFTools::extract_constant_modes(dof_handler);
+      additional_data.constant_modes = constant_modes;
+      additional_data.n_cycles       = 1;
+#endif
 
-      TrilinosWrappers::PreconditionAMG::AdditionalData additional_data;
-      additional_data.constant_modes        = constant_modes;
       additional_data.elliptic              = true;
-      additional_data.n_cycles              = 1;
       additional_data.w_cycle               = false;
       additional_data.output_details        = false;
       additional_data.smoother_sweeps       = 2;

--- a/include/deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h
+++ b/include/deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h
@@ -83,6 +83,9 @@ namespace LinearAlgebra::TpetraWrappers
 
   template <typename Number, typename MemorySpace>
   class PreconditionBlockSSOR;
+
+  template <typename Number, typename MemorySpace>
+  class PreconditionAMGMueLu;
 } // namespace LinearAlgebra::TpetraWrappers
 #  endif
 
@@ -155,6 +158,8 @@ namespace TrilinosWrappers
     PreconditionBlockSOR<double, MemorySpace::Host>;
   using PreconditionBlockSSOR = ::dealii::LinearAlgebra::TpetraWrappers::
     PreconditionBlockSSOR<double, MemorySpace::Host>;
+  using PreconditionAMG = ::dealii::LinearAlgebra::TpetraWrappers::
+    PreconditionAMGMueLu<double, MemorySpace::Host>;
 #  else
   class PreconditionBase;
   class PreconditionIdentity;
@@ -171,6 +176,7 @@ namespace TrilinosWrappers
   class PreconditionBlockJacobi;
   class PreconditionBlockSOR;
   class PreconditionBlockSSOR;
+  class PreconditionAMG;
 #  endif
 } // namespace TrilinosWrappers
 


### PR DESCRIPTION
A first set of patches that improve the compatibility of our steps with Tpetra classes. This does not cover all trilinos examples, but with these changes steps 31, 41, and 42 run successfully with Trilinos 17 and Tpetra. Step-32 requires #19403 or a different use of the sparsity pattern classes.

Changes in this PR:
- remove AMG parameters that are currently not provided by MueLu
- replace the incomplete Cholesky preconditioner in step-31 by Jacobi (IC is not offered as a preconditioner as far as I can see, and we use Jacobi in step-32 already, which solves the same system). this requires updates to the documentation of the step when we require trilinos-17 and remove the Epetra support.
- always call compress after assembling (Epetra didnt need that for serial computations, Tpetra does)
- use the deal.II solvers instead of the Trilinos solvers in step-32 (since one of my recent PRs the deal.II solvers have an alias in the Trilinos namespace already, so I could leave this out of this PR, it would work either way)
- limit step-31, and 42 to a single thread for now. Surprisingly calling things like `vector->getGlobalLength()` seems to be not thread-safe by default, because it internally creates and destroys reference-counted pointers. One solution can be to compile Trilinos with `Teuchos_ENABLE_THREAD_SAFE=ON`, which resolves the issue (I got this idea from the discussion in https://github.com/trilinos/Trilinos/issues/11921). However, since we currently do not guarantee this, it seems necessary to disable the multi-threading. I am unsure what a clean fix here would look like. Use the preprocessor to check if Trilinos is compiled thread-safe and only then enable multi-threading?