### PR TITLE
Use a single implementation for vectorized transpose functions

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -851,9 +851,9 @@ make_vectorized_array(const typename VectorizedArrayType::value_type &u)
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
-gather(VectorizedArray<Number, width>    &out,
-       const std::array<Number *, width> &ptrs,
-       const unsigned int                 offset)
+gather(VectorizedArray<Number, width>          &out,
+       const std::array<const Number *, width> &ptrs,
+       const unsigned int                       offset)
 {
   for (unsigned int v = 0; v < width; ++v)
     out.data[v] = ptrs[v][offset];
@@ -912,9 +912,9 @@ vectorized_load_and_transpose(const unsigned int              n_entries,
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int                 n_entries,
-                              const std::array<Number *, width> &in,
-                              VectorizedArray<Number, width>    *out)
+vectorized_load_and_transpose(const unsigned int n_entries,
+                              const std::array<const Number *, width> &in,
+                              VectorizedArray<Number, width>          *out)
 {
   for (unsigned int i = 0; i < n_entries; ++i)
     for (unsigned int v = 0; v < VectorizedArray<Number, width>::size(); ++v)
@@ -996,7 +996,7 @@ inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                            add_into,
                                const unsigned int                    n_entries,
                                const VectorizedArray<Number, width> *in,
-                               std::array<Number *, width>          &out)
+                               const std::array<Number *, width>    &out)
 {
   if (add_into)
     for (unsigned int i = 0; i < n_entries; ++i)
@@ -1960,39 +1960,10 @@ private:
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int          n_entries,
-                              const double               *in,
-                              const unsigned int         *offsets,
-                              VectorizedArray<double, 2> *out)
+vectorized_load_and_transpose(const unsigned int                   n_entries,
+                              const std::array<const double *, 2> &in,
+                              VectorizedArray<double, 2>          *out)
 {
-  const unsigned int n_chunks = n_entries / 2;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m128d u0          = _mm_loadu_pd(in + 2 * i + offsets[0]);
-      __m128d u1          = _mm_loadu_pd(in + 2 * i + offsets[1]);
-      out[2 * i + 0].data = _mm_unpacklo_pd(u0, u1);
-      out[2 * i + 1].data = _mm_unpackhi_pd(u0, u1);
-    }
-
-  // remainder loop of work that does not divide by 2
-  for (unsigned int i = 2 * n_chunks; i < n_entries; ++i)
-    for (unsigned int v = 0; v < 2; ++v)
-      out[i][v] = in[offsets[v] + i];
-}
-
-
-
-/**
- * Specialization for double and SSE2.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int             n_entries,
-                              const std::array<double *, 2> &in,
-                              VectorizedArray<double, 2>    *out)
-{
-  // see the comments in the vectorized_load_and_transpose above
-
   const unsigned int n_chunks = n_entries / 2;
   for (unsigned int i = 0; i < n_chunks; ++i)
     {
@@ -2002,6 +1973,7 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
       out[2 * i + 1].data = _mm_unpackhi_pd(u0, u1);
     }
 
+  // remainder loop of work that does not divide by 2
   for (unsigned int i = 2 * n_chunks; i < n_entries; ++i)
     for (unsigned int v = 0; v < 2; ++v)
       out[i][v] = in[v][i];
@@ -2014,49 +1986,14 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_transpose_and_store(const bool                        add_into,
-                               const unsigned int                n_entries,
-                               const VectorizedArray<double, 2> *in,
-                               const unsigned int               *offsets,
-                               double                           *out)
+vectorized_load_and_transpose(const unsigned int          n_entries,
+                              const double               *in,
+                              const unsigned int         *offsets,
+                              VectorizedArray<double, 2> *out)
 {
-  const unsigned int n_chunks = n_entries / 2;
-  if (add_into)
-    {
-      for (unsigned int i = 0; i < n_chunks; ++i)
-        {
-          __m128d u0   = in[2 * i + 0].data;
-          __m128d u1   = in[2 * i + 1].data;
-          __m128d res0 = _mm_unpacklo_pd(u0, u1);
-          __m128d res1 = _mm_unpackhi_pd(u0, u1);
-          _mm_storeu_pd(out + 2 * i + offsets[0],
-                        _mm_add_pd(_mm_loadu_pd(out + 2 * i + offsets[0]),
-                                   res0));
-          _mm_storeu_pd(out + 2 * i + offsets[1],
-                        _mm_add_pd(_mm_loadu_pd(out + 2 * i + offsets[1]),
-                                   res1));
-        }
-      // remainder loop of work that does not divide by 2
-      for (unsigned int i = 2 * n_chunks; i < n_entries; ++i)
-        for (unsigned int v = 0; v < 2; ++v)
-          out[offsets[v] + i] += in[i][v];
-    }
-  else
-    {
-      for (unsigned int i = 0; i < n_chunks; ++i)
-        {
-          __m128d u0   = in[2 * i + 0].data;
-          __m128d u1   = in[2 * i + 1].data;
-          __m128d res0 = _mm_unpacklo_pd(u0, u1);
-          __m128d res1 = _mm_unpackhi_pd(u0, u1);
-          _mm_storeu_pd(out + 2 * i + offsets[0], res0);
-          _mm_storeu_pd(out + 2 * i + offsets[1], res1);
-        }
-      // remainder loop of work that does not divide by 2
-      for (unsigned int i = 2 * n_chunks; i < n_entries; ++i)
-        for (unsigned int v = 0; v < 2; ++v)
-          out[offsets[v] + i] = in[i][v];
-    }
+  vectorized_load_and_transpose(n_entries,
+                                {{in + offsets[0], in + offsets[1]}},
+                                out);
 }
 
 
@@ -2069,10 +2006,8 @@ inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                        add_into,
                                const unsigned int                n_entries,
                                const VectorizedArray<double, 2> *in,
-                               std::array<double *, 2>          &out)
+                               const std::array<double *, 2>    &out)
 {
-  // see the comments in the vectorized_transpose_and_store above
-
   const unsigned int n_chunks = n_entries / 2;
   if (add_into)
     {
@@ -2088,6 +2023,7 @@ vectorized_transpose_and_store(const bool                        add_into,
                         _mm_add_pd(_mm_loadu_pd(out[1] + 2 * i), res1));
         }
 
+      // remainder loop for lengths that do not divide by 2
       for (unsigned int i = 2 * n_chunks; i < n_entries; ++i)
         for (unsigned int v = 0; v < 2; ++v)
           out[v][i] += in[i][v];
@@ -2104,10 +2040,30 @@ vectorized_transpose_and_store(const bool                        add_into,
           _mm_storeu_pd(out[1] + 2 * i, res1);
         }
 
+      // remainder loop for lengths that do not divide by 2
       for (unsigned int i = 2 * n_chunks; i < n_entries; ++i)
         for (unsigned int v = 0; v < 2; ++v)
           out[v][i] = in[i][v];
     }
+}
+
+
+
+/**
+ * Specialization for double and SSE2.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
+vectorized_transpose_and_store(const bool                        add_into,
+                               const unsigned int                n_entries,
+                               const VectorizedArray<double, 2> *in,
+                               const unsigned int               *offsets,
+                               double                           *out)
+{
+  vectorized_transpose_and_store(add_into,
+                                 n_entries,
+                                 in,
+                                 {{out + offsets[0], out + offsets[1]}});
 }
 
 
@@ -2446,47 +2402,10 @@ private:
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int         n_entries,
-                              const float               *in,
-                              const unsigned int        *offsets,
-                              VectorizedArray<float, 4> *out)
+vectorized_load_and_transpose(const unsigned int                  n_entries,
+                              const std::array<const float *, 4> &in,
+                              VectorizedArray<float, 4>          *out)
 {
-  const unsigned int n_chunks = n_entries / 4;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m128 u0           = _mm_loadu_ps(in + 4 * i + offsets[0]);
-      __m128 u1           = _mm_loadu_ps(in + 4 * i + offsets[1]);
-      __m128 u2           = _mm_loadu_ps(in + 4 * i + offsets[2]);
-      __m128 u3           = _mm_loadu_ps(in + 4 * i + offsets[3]);
-      __m128 v0           = _mm_shuffle_ps(u0, u1, 0x44);
-      __m128 v1           = _mm_shuffle_ps(u0, u1, 0xee);
-      __m128 v2           = _mm_shuffle_ps(u2, u3, 0x44);
-      __m128 v3           = _mm_shuffle_ps(u2, u3, 0xee);
-      out[4 * i + 0].data = _mm_shuffle_ps(v0, v2, 0x88);
-      out[4 * i + 1].data = _mm_shuffle_ps(v0, v2, 0xdd);
-      out[4 * i + 2].data = _mm_shuffle_ps(v1, v3, 0x88);
-      out[4 * i + 3].data = _mm_shuffle_ps(v1, v3, 0xdd);
-    }
-
-  // remainder loop of work that does not divide by 4
-  for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-    for (unsigned int v = 0; v < 4; ++v)
-      out[i][v] = in[offsets[v] + i];
-}
-
-
-
-/**
- * Specialization for float and SSE2.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int            n_entries,
-                              const std::array<float *, 4> &in,
-                              VectorizedArray<float, 4>    *out)
-{
-  // see the comments in the vectorized_load_and_transpose above
-
   const unsigned int n_chunks = n_entries / 4;
   for (unsigned int i = 0; i < n_chunks; ++i)
     {
@@ -2504,6 +2423,7 @@ vectorized_load_and_transpose(const unsigned int            n_entries,
       out[4 * i + 3].data = _mm_shuffle_ps(v1, v3, 0xdd);
     }
 
+  // remainder loop for lengths not divisible by 4
   for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
     for (unsigned int v = 0; v < 4; ++v)
       out[i][v] = in[v][i];
@@ -2516,11 +2436,28 @@ vectorized_load_and_transpose(const unsigned int            n_entries,
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
+vectorized_load_and_transpose(const unsigned int         n_entries,
+                              const float               *in,
+                              const unsigned int        *offsets,
+                              VectorizedArray<float, 4> *out)
+{
+  vectorized_load_and_transpose(
+    n_entries,
+    {{in + offsets[0], in + offsets[1], in + offsets[2], in + offsets[3]}},
+    out);
+}
+
+
+
+/**
+ * Specialization for float and SSE2.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                       add_into,
                                const unsigned int               n_entries,
                                const VectorizedArray<float, 4> *in,
-                               const unsigned int              *offsets,
-                               float                           *out)
+                               const std::array<float *, 4>    &out)
 {
   const unsigned int n_chunks = n_entries / 4;
   for (unsigned int i = 0; i < n_chunks; ++i)
@@ -2543,67 +2480,6 @@ vectorized_transpose_and_store(const bool                       add_into,
       // pointers
       if (add_into)
         {
-          u0 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[0]), u0);
-          _mm_storeu_ps(out + 4 * i + offsets[0], u0);
-          u1 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[1]), u1);
-          _mm_storeu_ps(out + 4 * i + offsets[1], u1);
-          u2 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[2]), u2);
-          _mm_storeu_ps(out + 4 * i + offsets[2], u2);
-          u3 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[3]), u3);
-          _mm_storeu_ps(out + 4 * i + offsets[3], u3);
-        }
-      else
-        {
-          _mm_storeu_ps(out + 4 * i + offsets[0], u0);
-          _mm_storeu_ps(out + 4 * i + offsets[1], u1);
-          _mm_storeu_ps(out + 4 * i + offsets[2], u2);
-          _mm_storeu_ps(out + 4 * i + offsets[3], u3);
-        }
-    }
-
-  // remainder loop of work that does not divide by 4
-  if (add_into)
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 4; ++v)
-        out[offsets[v] + i] += in[i][v];
-  else
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 4; ++v)
-        out[offsets[v] + i] = in[i][v];
-}
-
-
-
-/**
- * Specialization for float and SSE2.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_transpose_and_store(const bool                       add_into,
-                               const unsigned int               n_entries,
-                               const VectorizedArray<float, 4> *in,
-                               std::array<float *, 4>          &out)
-{
-  // see the comments in the vectorized_transpose_and_store above
-
-  const unsigned int n_chunks = n_entries / 4;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m128 u0 = in[4 * i + 0].data;
-      __m128 u1 = in[4 * i + 1].data;
-      __m128 u2 = in[4 * i + 2].data;
-      __m128 u3 = in[4 * i + 3].data;
-      __m128 t0 = _mm_shuffle_ps(u0, u1, 0x44);
-      __m128 t1 = _mm_shuffle_ps(u0, u1, 0xee);
-      __m128 t2 = _mm_shuffle_ps(u2, u3, 0x44);
-      __m128 t3 = _mm_shuffle_ps(u2, u3, 0xee);
-      u0        = _mm_shuffle_ps(t0, t2, 0x88);
-      u1        = _mm_shuffle_ps(t0, t2, 0xdd);
-      u2        = _mm_shuffle_ps(t1, t3, 0x88);
-      u3        = _mm_shuffle_ps(t1, t3, 0xdd);
-
-      if (add_into)
-        {
           u0 = _mm_add_ps(_mm_loadu_ps(out[0] + 4 * i), u0);
           _mm_storeu_ps(out[0] + 4 * i, u0);
           u1 = _mm_add_ps(_mm_loadu_ps(out[1] + 4 * i), u1);
@@ -2622,6 +2498,7 @@ vectorized_transpose_and_store(const bool                       add_into,
         }
     }
 
+  // remainder loop of work that does not divide by 4
   if (add_into)
     for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
       for (unsigned int v = 0; v < 4; ++v)
@@ -2630,6 +2507,26 @@ vectorized_transpose_and_store(const bool                       add_into,
     for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
       for (unsigned int v = 0; v < 4; ++v)
         out[v][i] = in[i][v];
+}
+
+
+
+/**
+ * Specialization for float and SSE2.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
+vectorized_transpose_and_store(const bool                       add_into,
+                               const unsigned int               n_entries,
+                               const VectorizedArray<float, 4> *in,
+                               const unsigned int              *offsets,
+                               float                           *out)
+{
+  vectorized_transpose_and_store(
+    add_into,
+    n_entries,
+    in,
+    {{out + offsets[0], out + offsets[1], out + offsets[2], out + offsets[3]}});
 }
 
 
@@ -3025,51 +2922,10 @@ private:
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int          n_entries,
-                              const double               *in,
-                              const unsigned int         *offsets,
-                              VectorizedArray<double, 4> *out)
+vectorized_load_and_transpose(const unsigned int                   n_entries,
+                              const std::array<const double *, 4> &in,
+                              VectorizedArray<double, 4>          *out)
 {
-  const unsigned int n_chunks = n_entries / 4;
-  const double      *in0      = in + offsets[0];
-  const double      *in1      = in + offsets[1];
-  const double      *in2      = in + offsets[2];
-  const double      *in3      = in + offsets[3];
-
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m256d u0          = _mm256_loadu_pd(in0 + 4 * i);
-      __m256d u1          = _mm256_loadu_pd(in1 + 4 * i);
-      __m256d u2          = _mm256_loadu_pd(in2 + 4 * i);
-      __m256d u3          = _mm256_loadu_pd(in3 + 4 * i);
-      __m256d t0          = _mm256_permute2f128_pd(u0, u2, 0x20);
-      __m256d t1          = _mm256_permute2f128_pd(u1, u3, 0x20);
-      __m256d t2          = _mm256_permute2f128_pd(u0, u2, 0x31);
-      __m256d t3          = _mm256_permute2f128_pd(u1, u3, 0x31);
-      out[4 * i + 0].data = _mm256_unpacklo_pd(t0, t1);
-      out[4 * i + 1].data = _mm256_unpackhi_pd(t0, t1);
-      out[4 * i + 2].data = _mm256_unpacklo_pd(t2, t3);
-      out[4 * i + 3].data = _mm256_unpackhi_pd(t2, t3);
-    }
-
-  // remainder loop of work that does not divide by 4
-  for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-    out[i].gather(in + i, offsets);
-}
-
-
-
-/**
- * Specialization for double and AVX.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int             n_entries,
-                              const std::array<double *, 4> &in,
-                              VectorizedArray<double, 4>    *out)
-{
-  // see the comments in the vectorized_load_and_transpose above
-
   const unsigned int n_chunks = n_entries / 4;
   const double      *in0      = in[0];
   const double      *in1      = in[1];
@@ -3103,64 +2959,15 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_transpose_and_store(const bool                        add_into,
-                               const unsigned int                n_entries,
-                               const VectorizedArray<double, 4> *in,
-                               const unsigned int               *offsets,
-                               double                           *out)
+vectorized_load_and_transpose(const unsigned int          n_entries,
+                              const double               *in,
+                              const unsigned int         *offsets,
+                              VectorizedArray<double, 4> *out)
 {
-  const unsigned int n_chunks = n_entries / 4;
-  double            *out0     = out + offsets[0];
-  double            *out1     = out + offsets[1];
-  double            *out2     = out + offsets[2];
-  double            *out3     = out + offsets[3];
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m256d u0   = in[4 * i + 0].data;
-      __m256d u1   = in[4 * i + 1].data;
-      __m256d u2   = in[4 * i + 2].data;
-      __m256d u3   = in[4 * i + 3].data;
-      __m256d t0   = _mm256_permute2f128_pd(u0, u2, 0x20);
-      __m256d t1   = _mm256_permute2f128_pd(u1, u3, 0x20);
-      __m256d t2   = _mm256_permute2f128_pd(u0, u2, 0x31);
-      __m256d t3   = _mm256_permute2f128_pd(u1, u3, 0x31);
-      __m256d res0 = _mm256_unpacklo_pd(t0, t1);
-      __m256d res1 = _mm256_unpackhi_pd(t0, t1);
-      __m256d res2 = _mm256_unpacklo_pd(t2, t3);
-      __m256d res3 = _mm256_unpackhi_pd(t2, t3);
-
-      // Cannot use the same store instructions in both paths of the 'if'
-      // because the compiler cannot know that there is no aliasing between
-      // pointers
-      if (add_into)
-        {
-          res0 = _mm256_add_pd(_mm256_loadu_pd(out0 + 4 * i), res0);
-          _mm256_storeu_pd(out0 + 4 * i, res0);
-          res1 = _mm256_add_pd(_mm256_loadu_pd(out1 + 4 * i), res1);
-          _mm256_storeu_pd(out1 + 4 * i, res1);
-          res2 = _mm256_add_pd(_mm256_loadu_pd(out2 + 4 * i), res2);
-          _mm256_storeu_pd(out2 + 4 * i, res2);
-          res3 = _mm256_add_pd(_mm256_loadu_pd(out3 + 4 * i), res3);
-          _mm256_storeu_pd(out3 + 4 * i, res3);
-        }
-      else
-        {
-          _mm256_storeu_pd(out0 + 4 * i, res0);
-          _mm256_storeu_pd(out1 + 4 * i, res1);
-          _mm256_storeu_pd(out2 + 4 * i, res2);
-          _mm256_storeu_pd(out3 + 4 * i, res3);
-        }
-    }
-
-  // remainder loop of work that does not divide by 4
-  if (add_into)
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 4; ++v)
-        out[offsets[v] + i] += in[i][v];
-  else
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 4; ++v)
-        out[offsets[v] + i] = in[i][v];
+  vectorized_load_and_transpose(
+    n_entries,
+    {{in + offsets[0], in + offsets[1], in + offsets[2], in + offsets[3]}},
+    out);
 }
 
 
@@ -3173,10 +2980,8 @@ inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                        add_into,
                                const unsigned int                n_entries,
                                const VectorizedArray<double, 4> *in,
-                               std::array<double *, 4>          &out)
+                               const std::array<double *, 4>    &out)
 {
-  // see the comments in the vectorized_transpose_and_store above
-
   const unsigned int n_chunks = n_entries / 4;
   double            *out0     = out[0];
   double            *out1     = out[1];
@@ -3229,6 +3034,26 @@ vectorized_transpose_and_store(const bool                        add_into,
     for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
       for (unsigned int v = 0; v < 4; ++v)
         out[v][i] = in[i][v];
+}
+
+
+
+/**
+ * Specialization for double and AVX.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
+vectorized_transpose_and_store(const bool                        add_into,
+                               const unsigned int                n_entries,
+                               const VectorizedArray<double, 4> *in,
+                               const unsigned int               *offsets,
+                               double                           *out)
+{
+  vectorized_transpose_and_store(
+    add_into,
+    n_entries,
+    in,
+    {{out + offsets[0], out + offsets[1], out + offsets[2], out + offsets[3]}});
 }
 
 
@@ -3606,57 +3431,15 @@ private:
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int         n_entries,
-                              const float               *in,
-                              const unsigned int        *offsets,
-                              VectorizedArray<float, 8> *out)
+vectorized_load_and_transpose(const unsigned int                  n_entries,
+                              const std::array<const float *, 8> &in,
+                              VectorizedArray<float, 8>          *out)
 {
   const unsigned int n_chunks = n_entries / 4;
   for (unsigned int i = 0; i < n_chunks; ++i)
     {
       // To avoid warnings about uninitialized variables, need to initialize
       // one variable with zero before using it.
-      __m256 t0, t1, t2, t3 = {};
-      t0 = _mm256_insertf128_ps(t3, _mm_loadu_ps(in + 4 * i + offsets[0]), 0);
-      t0 = _mm256_insertf128_ps(t0, _mm_loadu_ps(in + 4 * i + offsets[4]), 1);
-      t1 = _mm256_insertf128_ps(t3, _mm_loadu_ps(in + 4 * i + offsets[1]), 0);
-      t1 = _mm256_insertf128_ps(t1, _mm_loadu_ps(in + 4 * i + offsets[5]), 1);
-      t2 = _mm256_insertf128_ps(t3, _mm_loadu_ps(in + 4 * i + offsets[2]), 0);
-      t2 = _mm256_insertf128_ps(t2, _mm_loadu_ps(in + 4 * i + offsets[6]), 1);
-      t3 = _mm256_insertf128_ps(t3, _mm_loadu_ps(in + 4 * i + offsets[3]), 0);
-      t3 = _mm256_insertf128_ps(t3, _mm_loadu_ps(in + 4 * i + offsets[7]), 1);
-
-      __m256 v0           = _mm256_shuffle_ps(t0, t1, 0x44);
-      __m256 v1           = _mm256_shuffle_ps(t0, t1, 0xee);
-      __m256 v2           = _mm256_shuffle_ps(t2, t3, 0x44);
-      __m256 v3           = _mm256_shuffle_ps(t2, t3, 0xee);
-      out[4 * i + 0].data = _mm256_shuffle_ps(v0, v2, 0x88);
-      out[4 * i + 1].data = _mm256_shuffle_ps(v0, v2, 0xdd);
-      out[4 * i + 2].data = _mm256_shuffle_ps(v1, v3, 0x88);
-      out[4 * i + 3].data = _mm256_shuffle_ps(v1, v3, 0xdd);
-    }
-
-  // remainder loop of work that does not divide by 4
-  for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-    out[i].gather(in + i, offsets);
-}
-
-
-
-/**
- * Specialization for float and AVX.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int            n_entries,
-                              const std::array<float *, 8> &in,
-                              VectorizedArray<float, 8>    *out)
-{
-  // see the comments in the vectorized_load_and_transpose above
-
-  const unsigned int n_chunks = n_entries / 4;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
       __m256 t0, t1, t2, t3 = {};
       t0 = _mm256_insertf128_ps(t3, _mm_loadu_ps(in[0] + 4 * i), 0);
       t0 = _mm256_insertf128_ps(t0, _mm_loadu_ps(in[4] + 4 * i), 1);
@@ -3688,11 +3471,34 @@ vectorized_load_and_transpose(const unsigned int            n_entries,
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
+vectorized_load_and_transpose(const unsigned int         n_entries,
+                              const float               *in,
+                              const unsigned int        *offsets,
+                              VectorizedArray<float, 8> *out)
+{
+  vectorized_load_and_transpose(n_entries,
+                                {{in + offsets[0],
+                                  in + offsets[1],
+                                  in + offsets[2],
+                                  in + offsets[3],
+                                  in + offsets[4],
+                                  in + offsets[5],
+                                  in + offsets[6],
+                                  in + offsets[7]}},
+                                out);
+}
+
+
+
+/**
+ * Specialization for float and AVX.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                       add_into,
                                const unsigned int               n_entries,
                                const VectorizedArray<float, 8> *in,
-                               const unsigned int              *offsets,
-                               float                           *out)
+                               const std::array<float *, 8>    &out)
 {
   const unsigned int n_chunks = n_entries / 4;
   for (unsigned int i = 0; i < n_chunks; ++i)
@@ -3721,87 +3527,6 @@ vectorized_transpose_and_store(const bool                       add_into,
       // Cannot use the same store instructions in both paths of the 'if'
       // because the compiler cannot know that there is no aliasing between
       // pointers
-      if (add_into)
-        {
-          res0 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[0]), res0);
-          _mm_storeu_ps(out + 4 * i + offsets[0], res0);
-          res1 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[1]), res1);
-          _mm_storeu_ps(out + 4 * i + offsets[1], res1);
-          res2 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[2]), res2);
-          _mm_storeu_ps(out + 4 * i + offsets[2], res2);
-          res3 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[3]), res3);
-          _mm_storeu_ps(out + 4 * i + offsets[3], res3);
-          res4 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[4]), res4);
-          _mm_storeu_ps(out + 4 * i + offsets[4], res4);
-          res5 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[5]), res5);
-          _mm_storeu_ps(out + 4 * i + offsets[5], res5);
-          res6 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[6]), res6);
-          _mm_storeu_ps(out + 4 * i + offsets[6], res6);
-          res7 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[7]), res7);
-          _mm_storeu_ps(out + 4 * i + offsets[7], res7);
-        }
-      else
-        {
-          _mm_storeu_ps(out + 4 * i + offsets[0], res0);
-          _mm_storeu_ps(out + 4 * i + offsets[1], res1);
-          _mm_storeu_ps(out + 4 * i + offsets[2], res2);
-          _mm_storeu_ps(out + 4 * i + offsets[3], res3);
-          _mm_storeu_ps(out + 4 * i + offsets[4], res4);
-          _mm_storeu_ps(out + 4 * i + offsets[5], res5);
-          _mm_storeu_ps(out + 4 * i + offsets[6], res6);
-          _mm_storeu_ps(out + 4 * i + offsets[7], res7);
-        }
-    }
-
-  // remainder loop of work that does not divide by 4
-  if (add_into)
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 8; ++v)
-        out[offsets[v] + i] += in[i][v];
-  else
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 8; ++v)
-        out[offsets[v] + i] = in[i][v];
-}
-
-
-
-/**
- * Specialization for float and AVX.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_transpose_and_store(const bool                       add_into,
-                               const unsigned int               n_entries,
-                               const VectorizedArray<float, 8> *in,
-                               std::array<float *, 8>          &out)
-{
-  // see the comments in the vectorized_transpose_and_store above
-
-  const unsigned int n_chunks = n_entries / 4;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m256 u0   = in[4 * i + 0].data;
-      __m256 u1   = in[4 * i + 1].data;
-      __m256 u2   = in[4 * i + 2].data;
-      __m256 u3   = in[4 * i + 3].data;
-      __m256 t0   = _mm256_shuffle_ps(u0, u1, 0x44);
-      __m256 t1   = _mm256_shuffle_ps(u0, u1, 0xee);
-      __m256 t2   = _mm256_shuffle_ps(u2, u3, 0x44);
-      __m256 t3   = _mm256_shuffle_ps(u2, u3, 0xee);
-      u0          = _mm256_shuffle_ps(t0, t2, 0x88);
-      u1          = _mm256_shuffle_ps(t0, t2, 0xdd);
-      u2          = _mm256_shuffle_ps(t1, t3, 0x88);
-      u3          = _mm256_shuffle_ps(t1, t3, 0xdd);
-      __m128 res0 = _mm256_extractf128_ps(u0, 0);
-      __m128 res4 = _mm256_extractf128_ps(u0, 1);
-      __m128 res1 = _mm256_extractf128_ps(u1, 0);
-      __m128 res5 = _mm256_extractf128_ps(u1, 1);
-      __m128 res2 = _mm256_extractf128_ps(u2, 0);
-      __m128 res6 = _mm256_extractf128_ps(u2, 1);
-      __m128 res3 = _mm256_extractf128_ps(u3, 0);
-      __m128 res7 = _mm256_extractf128_ps(u3, 1);
-
       if (add_into)
         {
           res0 = _mm_add_ps(_mm_loadu_ps(out[0] + 4 * i), res0);
@@ -3842,6 +3567,32 @@ vectorized_transpose_and_store(const bool                       add_into,
     for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
       for (unsigned int v = 0; v < 8; ++v)
         out[v][i] = in[i][v];
+}
+
+
+
+/**
+ * Specialization for float and AVX.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
+vectorized_transpose_and_store(const bool                       add_into,
+                               const unsigned int               n_entries,
+                               const VectorizedArray<float, 8> *in,
+                               const unsigned int              *offsets,
+                               float                           *out)
+{
+  vectorized_transpose_and_store(add_into,
+                                 n_entries,
+                                 in,
+                                 {{out + offsets[0],
+                                   out + offsets[1],
+                                   out + offsets[2],
+                                   out + offsets[3],
+                                   out + offsets[4],
+                                   out + offsets[5],
+                                   out + offsets[6],
+                                   out + offsets[7]}});
 }
 
 #  endif
@@ -4258,55 +4009,15 @@ private:
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int          n_entries,
-                              const double               *in,
-                              const unsigned int         *offsets,
-                              VectorizedArray<double, 8> *out)
+vectorized_load_and_transpose(const unsigned int                   n_entries,
+                              const std::array<const double *, 8> &in,
+                              VectorizedArray<double, 8>          *out)
 {
   // do not do full transpose because the code is long and will most
   // likely not pay off because many processors have two load units
   // (for the top 8 instructions) but only 1 permute unit (for the 8
   // shuffle/unpack instructions). rather start the transposition on the
   // vectorized array of half the size with 256 bits
-  const unsigned int n_chunks = n_entries / 4;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m512d t0, t1, t2, t3 = {};
-
-      t0 = _mm512_insertf64x4(t3, _mm256_loadu_pd(in + offsets[0] + 4 * i), 0);
-      t0 = _mm512_insertf64x4(t0, _mm256_loadu_pd(in + offsets[2] + 4 * i), 1);
-      t1 = _mm512_insertf64x4(t3, _mm256_loadu_pd(in + offsets[1] + 4 * i), 0);
-      t1 = _mm512_insertf64x4(t1, _mm256_loadu_pd(in + offsets[3] + 4 * i), 1);
-      t2 = _mm512_insertf64x4(t3, _mm256_loadu_pd(in + offsets[4] + 4 * i), 0);
-      t2 = _mm512_insertf64x4(t2, _mm256_loadu_pd(in + offsets[6] + 4 * i), 1);
-      t3 = _mm512_insertf64x4(t3, _mm256_loadu_pd(in + offsets[5] + 4 * i), 0);
-      t3 = _mm512_insertf64x4(t3, _mm256_loadu_pd(in + offsets[7] + 4 * i), 1);
-
-      __m512d v0          = _mm512_shuffle_f64x2(t0, t2, 0x88);
-      __m512d v1          = _mm512_shuffle_f64x2(t0, t2, 0xdd);
-      __m512d v2          = _mm512_shuffle_f64x2(t1, t3, 0x88);
-      __m512d v3          = _mm512_shuffle_f64x2(t1, t3, 0xdd);
-      out[4 * i + 0].data = _mm512_unpacklo_pd(v0, v2);
-      out[4 * i + 1].data = _mm512_unpackhi_pd(v0, v2);
-      out[4 * i + 2].data = _mm512_unpacklo_pd(v1, v3);
-      out[4 * i + 3].data = _mm512_unpackhi_pd(v1, v3);
-    }
-  // remainder loop of work that does not divide by 4
-  for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-    out[i].gather(in + i, offsets);
-}
-
-
-
-/**
- * Specialization for double and AVX-512.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int             n_entries,
-                              const std::array<double *, 8> &in,
-                              VectorizedArray<double, 8>    *out)
-{
   const unsigned int n_chunks = n_entries / 4;
   for (unsigned int i = 0; i < n_chunks; ++i)
     {
@@ -4342,11 +4053,34 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
+vectorized_load_and_transpose(const unsigned int          n_entries,
+                              const double               *in,
+                              const unsigned int         *offsets,
+                              VectorizedArray<double, 8> *out)
+{
+  vectorized_load_and_transpose(n_entries,
+                                {{in + offsets[0],
+                                  in + offsets[1],
+                                  in + offsets[2],
+                                  in + offsets[3],
+                                  in + offsets[4],
+                                  in + offsets[5],
+                                  in + offsets[6],
+                                  in + offsets[7]}},
+                                out);
+}
+
+
+
+/**
+ * Specialization for double and AVX-512.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                        add_into,
                                const unsigned int                n_entries,
                                const VectorizedArray<double, 8> *in,
-                               const unsigned int               *offsets,
-                               double                           *out)
+                               const std::array<double *, 8>    &out)
 {
   // as for the load, we split the store operations into 256 bit units to
   // better balance between code size, shuffle instructions, and stores
@@ -4375,85 +4109,6 @@ vectorized_transpose_and_store(const bool                        add_into,
       // Cannot use the same store instructions in both paths of the 'if'
       // because the compiler cannot know that there is no aliasing
       // between pointers
-      if (add_into)
-        {
-          res0 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[0]), res0);
-          _mm256_storeu_pd(out + 4 * i + offsets[0], res0);
-          res1 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[1]), res1);
-          _mm256_storeu_pd(out + 4 * i + offsets[1], res1);
-          res2 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[2]), res2);
-          _mm256_storeu_pd(out + 4 * i + offsets[2], res2);
-          res3 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[3]), res3);
-          _mm256_storeu_pd(out + 4 * i + offsets[3], res3);
-          res4 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[4]), res4);
-          _mm256_storeu_pd(out + 4 * i + offsets[4], res4);
-          res5 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[5]), res5);
-          _mm256_storeu_pd(out + 4 * i + offsets[5], res5);
-          res6 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[6]), res6);
-          _mm256_storeu_pd(out + 4 * i + offsets[6], res6);
-          res7 = _mm256_add_pd(_mm256_loadu_pd(out + 4 * i + offsets[7]), res7);
-          _mm256_storeu_pd(out + 4 * i + offsets[7], res7);
-        }
-      else
-        {
-          _mm256_storeu_pd(out + 4 * i + offsets[0], res0);
-          _mm256_storeu_pd(out + 4 * i + offsets[1], res1);
-          _mm256_storeu_pd(out + 4 * i + offsets[2], res2);
-          _mm256_storeu_pd(out + 4 * i + offsets[3], res3);
-          _mm256_storeu_pd(out + 4 * i + offsets[4], res4);
-          _mm256_storeu_pd(out + 4 * i + offsets[5], res5);
-          _mm256_storeu_pd(out + 4 * i + offsets[6], res6);
-          _mm256_storeu_pd(out + 4 * i + offsets[7], res7);
-        }
-    }
-
-  // remainder loop of work that does not divide by 4
-  if (add_into)
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 8; ++v)
-        out[offsets[v] + i] += in[i][v];
-  else
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 8; ++v)
-        out[offsets[v] + i] = in[i][v];
-}
-
-
-
-/**
- * Specialization for double and AVX-512.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_transpose_and_store(const bool                        add_into,
-                               const unsigned int                n_entries,
-                               const VectorizedArray<double, 8> *in,
-                               std::array<double *, 8>          &out)
-{
-  // see the comments in the vectorized_transpose_and_store above
-
-  const unsigned int n_chunks = n_entries / 4;
-  __m512i mask1 = _mm512_set_epi64(0xd, 0xc, 0x5, 0x4, 0x9, 0x8, 0x1, 0x0);
-  __m512i mask2 = _mm512_set_epi64(0xf, 0xe, 0x7, 0x6, 0xb, 0xa, 0x3, 0x2);
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m512d t0   = _mm512_unpacklo_pd(in[i * 4].data, in[i * 4 + 1].data);
-      __m512d t1   = _mm512_unpackhi_pd(in[i * 4].data, in[i * 4 + 1].data);
-      __m512d t2   = _mm512_unpacklo_pd(in[i * 4 + 2].data, in[i * 4 + 3].data);
-      __m512d t3   = _mm512_unpackhi_pd(in[i * 4 + 2].data, in[i * 4 + 3].data);
-      __m512d v0   = _mm512_permutex2var_pd(t0, mask1, t2);
-      __m512d v1   = _mm512_permutex2var_pd(t0, mask2, t2);
-      __m512d v2   = _mm512_permutex2var_pd(t1, mask1, t3);
-      __m512d v3   = _mm512_permutex2var_pd(t1, mask2, t3);
-      __m256d res0 = _mm512_extractf64x4_pd(v0, 0);
-      __m256d res4 = _mm512_extractf64x4_pd(v0, 1);
-      __m256d res1 = _mm512_extractf64x4_pd(v2, 0);
-      __m256d res5 = _mm512_extractf64x4_pd(v2, 1);
-      __m256d res2 = _mm512_extractf64x4_pd(v1, 0);
-      __m256d res6 = _mm512_extractf64x4_pd(v1, 1);
-      __m256d res3 = _mm512_extractf64x4_pd(v3, 0);
-      __m256d res7 = _mm512_extractf64x4_pd(v3, 1);
-
       if (add_into)
         {
           res0 = _mm256_add_pd(_mm256_loadu_pd(out[0] + 4 * i), res0);
@@ -4494,6 +4149,32 @@ vectorized_transpose_and_store(const bool                        add_into,
     for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
       for (unsigned int v = 0; v < 8; ++v)
         out[v][i] = in[i][v];
+}
+
+
+
+/**
+ * Specialization for double and AVX-512.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
+vectorized_transpose_and_store(const bool                        add_into,
+                               const unsigned int                n_entries,
+                               const VectorizedArray<double, 8> *in,
+                               const unsigned int               *offsets,
+                               double                           *out)
+{
+  vectorized_transpose_and_store(add_into,
+                                 n_entries,
+                                 in,
+                                 {{out + offsets[0],
+                                   out + offsets[1],
+                                   out + offsets[2],
+                                   out + offsets[3],
+                                   out + offsets[4],
+                                   out + offsets[5],
+                                   out + offsets[6],
+                                   out + offsets[7]}});
 }
 
 
@@ -4891,67 +4572,14 @@ private:
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int          n_entries,
-                              const float                *in,
-                              const unsigned int         *offsets,
-                              VectorizedArray<float, 16> *out)
+vectorized_load_and_transpose(const unsigned int                   n_entries,
+                              const std::array<const float *, 16> &in,
+                              VectorizedArray<float, 16>          *out)
 {
   // Similar to the double case, we perform the work on smaller entities. In
   // this case, we start from 128 bit arrays and insert them into a full 512
   // bit index. This reduces the code size and register pressure because we do
   // shuffles on 4 numbers rather than 16.
-  const unsigned int n_chunks = n_entries / 4;
-
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m512 t0, t1, t2, t3 = {};
-
-      t0 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[0] + 4 * i), 0);
-      t0 = _mm512_insertf32x4(t0, _mm_loadu_ps(in + offsets[4] + 4 * i), 1);
-      t0 = _mm512_insertf32x4(t0, _mm_loadu_ps(in + offsets[8] + 4 * i), 2);
-      t0 = _mm512_insertf32x4(t0, _mm_loadu_ps(in + offsets[12] + 4 * i), 3);
-      t1 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[1] + 4 * i), 0);
-      t1 = _mm512_insertf32x4(t1, _mm_loadu_ps(in + offsets[5] + 4 * i), 1);
-      t1 = _mm512_insertf32x4(t1, _mm_loadu_ps(in + offsets[9] + 4 * i), 2);
-      t1 = _mm512_insertf32x4(t1, _mm_loadu_ps(in + offsets[13] + 4 * i), 3);
-      t2 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[2] + 4 * i), 0);
-      t2 = _mm512_insertf32x4(t2, _mm_loadu_ps(in + offsets[6] + 4 * i), 1);
-      t2 = _mm512_insertf32x4(t2, _mm_loadu_ps(in + offsets[10] + 4 * i), 2);
-      t2 = _mm512_insertf32x4(t2, _mm_loadu_ps(in + offsets[14] + 4 * i), 3);
-      t3 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[3] + 4 * i), 0);
-      t3 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[7] + 4 * i), 1);
-      t3 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[11] + 4 * i), 2);
-      t3 = _mm512_insertf32x4(t3, _mm_loadu_ps(in + offsets[15] + 4 * i), 3);
-
-      __m512 v0 = _mm512_shuffle_ps(t0, t1, 0x44);
-      __m512 v1 = _mm512_shuffle_ps(t0, t1, 0xee);
-      __m512 v2 = _mm512_shuffle_ps(t2, t3, 0x44);
-      __m512 v3 = _mm512_shuffle_ps(t2, t3, 0xee);
-
-      out[4 * i + 0].data = _mm512_shuffle_ps(v0, v2, 0x88);
-      out[4 * i + 1].data = _mm512_shuffle_ps(v0, v2, 0xdd);
-      out[4 * i + 2].data = _mm512_shuffle_ps(v1, v3, 0x88);
-      out[4 * i + 3].data = _mm512_shuffle_ps(v1, v3, 0xdd);
-    }
-
-  // remainder loop of work that does not divide by 4
-  for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-    out[i].gather(in + i, offsets);
-}
-
-
-
-/**
- * Specialization for float and AVX-512.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_load_and_transpose(const unsigned int             n_entries,
-                              const std::array<float *, 16> &in,
-                              VectorizedArray<float, 16>    *out)
-{
-  // see the comments in the vectorized_load_and_transpose above
-
   const unsigned int n_chunks = n_entries / 4;
 
   for (unsigned int i = 0; i < n_chunks; ++i)
@@ -4997,11 +4625,42 @@ vectorized_load_and_transpose(const unsigned int             n_entries,
  */
 template <>
 inline DEAL_II_ALWAYS_INLINE void
+vectorized_load_and_transpose(const unsigned int          n_entries,
+                              const float                *in,
+                              const unsigned int         *offsets,
+                              VectorizedArray<float, 16> *out)
+{
+  vectorized_load_and_transpose(n_entries,
+                                {{in + offsets[0],
+                                  in + offsets[1],
+                                  in + offsets[2],
+                                  in + offsets[3],
+                                  in + offsets[4],
+                                  in + offsets[5],
+                                  in + offsets[6],
+                                  in + offsets[7],
+                                  in + offsets[8],
+                                  in + offsets[9],
+                                  in + offsets[10],
+                                  in + offsets[11],
+                                  in + offsets[12],
+                                  in + offsets[13],
+                                  in + offsets[14],
+                                  in + offsets[15]}},
+                                out);
+}
+
+
+
+/**
+ * Specialization for float and AVX-512.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
 vectorized_transpose_and_store(const bool                        add_into,
                                const unsigned int                n_entries,
                                const VectorizedArray<float, 16> *in,
-                               const unsigned int               *offsets,
-                               float                            *out)
+                               const std::array<float *, 16>    &out)
 {
   const unsigned int n_chunks = n_entries / 4;
   for (unsigned int i = 0; i < n_chunks; ++i)
@@ -5037,118 +4696,6 @@ vectorized_transpose_and_store(const bool                        add_into,
       // Cannot use the same store instructions in both paths of the 'if'
       // because the compiler cannot know that there is no aliasing between
       // pointers
-      if (add_into)
-        {
-          res0 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[0]), res0);
-          _mm_storeu_ps(out + 4 * i + offsets[0], res0);
-          res1 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[1]), res1);
-          _mm_storeu_ps(out + 4 * i + offsets[1], res1);
-          res2 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[2]), res2);
-          _mm_storeu_ps(out + 4 * i + offsets[2], res2);
-          res3 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[3]), res3);
-          _mm_storeu_ps(out + 4 * i + offsets[3], res3);
-          res4 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[4]), res4);
-          _mm_storeu_ps(out + 4 * i + offsets[4], res4);
-          res5 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[5]), res5);
-          _mm_storeu_ps(out + 4 * i + offsets[5], res5);
-          res6 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[6]), res6);
-          _mm_storeu_ps(out + 4 * i + offsets[6], res6);
-          res7 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[7]), res7);
-          _mm_storeu_ps(out + 4 * i + offsets[7], res7);
-          res8 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[8]), res8);
-          _mm_storeu_ps(out + 4 * i + offsets[8], res8);
-          res9 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[9]), res9);
-          _mm_storeu_ps(out + 4 * i + offsets[9], res9);
-          res10 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[10]), res10);
-          _mm_storeu_ps(out + 4 * i + offsets[10], res10);
-          res11 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[11]), res11);
-          _mm_storeu_ps(out + 4 * i + offsets[11], res11);
-          res12 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[12]), res12);
-          _mm_storeu_ps(out + 4 * i + offsets[12], res12);
-          res13 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[13]), res13);
-          _mm_storeu_ps(out + 4 * i + offsets[13], res13);
-          res14 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[14]), res14);
-          _mm_storeu_ps(out + 4 * i + offsets[14], res14);
-          res15 = _mm_add_ps(_mm_loadu_ps(out + 4 * i + offsets[15]), res15);
-          _mm_storeu_ps(out + 4 * i + offsets[15], res15);
-        }
-      else
-        {
-          _mm_storeu_ps(out + 4 * i + offsets[0], res0);
-          _mm_storeu_ps(out + 4 * i + offsets[1], res1);
-          _mm_storeu_ps(out + 4 * i + offsets[2], res2);
-          _mm_storeu_ps(out + 4 * i + offsets[3], res3);
-          _mm_storeu_ps(out + 4 * i + offsets[4], res4);
-          _mm_storeu_ps(out + 4 * i + offsets[5], res5);
-          _mm_storeu_ps(out + 4 * i + offsets[6], res6);
-          _mm_storeu_ps(out + 4 * i + offsets[7], res7);
-          _mm_storeu_ps(out + 4 * i + offsets[8], res8);
-          _mm_storeu_ps(out + 4 * i + offsets[9], res9);
-          _mm_storeu_ps(out + 4 * i + offsets[10], res10);
-          _mm_storeu_ps(out + 4 * i + offsets[11], res11);
-          _mm_storeu_ps(out + 4 * i + offsets[12], res12);
-          _mm_storeu_ps(out + 4 * i + offsets[13], res13);
-          _mm_storeu_ps(out + 4 * i + offsets[14], res14);
-          _mm_storeu_ps(out + 4 * i + offsets[15], res15);
-        }
-    }
-
-  // remainder loop of work that does not divide by 4
-  if (add_into)
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 16; ++v)
-        out[offsets[v] + i] += in[i][v];
-  else
-    for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
-      for (unsigned int v = 0; v < 16; ++v)
-        out[offsets[v] + i] = in[i][v];
-}
-
-
-
-/**
- * Specialization for float and AVX-512.
- */
-template <>
-inline DEAL_II_ALWAYS_INLINE void
-vectorized_transpose_and_store(const bool                        add_into,
-                               const unsigned int                n_entries,
-                               const VectorizedArray<float, 16> *in,
-                               std::array<float *, 16>          &out)
-{
-  // see the comments in the vectorized_transpose_and_store above
-
-  const unsigned int n_chunks = n_entries / 4;
-  for (unsigned int i = 0; i < n_chunks; ++i)
-    {
-      __m512 t0 = _mm512_shuffle_ps(in[4 * i].data, in[1 + 4 * i].data, 0x44);
-      __m512 t1 = _mm512_shuffle_ps(in[4 * i].data, in[1 + 4 * i].data, 0xee);
-      __m512 t2 =
-        _mm512_shuffle_ps(in[2 + 4 * i].data, in[3 + 4 * i].data, 0x44);
-      __m512 t3 =
-        _mm512_shuffle_ps(in[2 + 4 * i].data, in[3 + 4 * i].data, 0xee);
-      __m512 u0 = _mm512_shuffle_ps(t0, t2, 0x88);
-      __m512 u1 = _mm512_shuffle_ps(t0, t2, 0xdd);
-      __m512 u2 = _mm512_shuffle_ps(t1, t3, 0x88);
-      __m512 u3 = _mm512_shuffle_ps(t1, t3, 0xdd);
-
-      __m128 res0  = _mm512_extractf32x4_ps(u0, 0);
-      __m128 res4  = _mm512_extractf32x4_ps(u0, 1);
-      __m128 res8  = _mm512_extractf32x4_ps(u0, 2);
-      __m128 res12 = _mm512_extractf32x4_ps(u0, 3);
-      __m128 res1  = _mm512_extractf32x4_ps(u1, 0);
-      __m128 res5  = _mm512_extractf32x4_ps(u1, 1);
-      __m128 res9  = _mm512_extractf32x4_ps(u1, 2);
-      __m128 res13 = _mm512_extractf32x4_ps(u1, 3);
-      __m128 res2  = _mm512_extractf32x4_ps(u2, 0);
-      __m128 res6  = _mm512_extractf32x4_ps(u2, 1);
-      __m128 res10 = _mm512_extractf32x4_ps(u2, 2);
-      __m128 res14 = _mm512_extractf32x4_ps(u2, 3);
-      __m128 res3  = _mm512_extractf32x4_ps(u3, 0);
-      __m128 res7  = _mm512_extractf32x4_ps(u3, 1);
-      __m128 res11 = _mm512_extractf32x4_ps(u3, 2);
-      __m128 res15 = _mm512_extractf32x4_ps(u3, 3);
-
       if (add_into)
         {
           res0 = _mm_add_ps(_mm_loadu_ps(out[0] + 4 * i), res0);
@@ -5213,6 +4760,40 @@ vectorized_transpose_and_store(const bool                        add_into,
     for (unsigned int i = 4 * n_chunks; i < n_entries; ++i)
       for (unsigned int v = 0; v < 16; ++v)
         out[v][i] = in[i][v];
+}
+
+
+
+/**
+ * Specialization for float and AVX-512.
+ */
+template <>
+inline DEAL_II_ALWAYS_INLINE void
+vectorized_transpose_and_store(const bool                        add_into,
+                               const unsigned int                n_entries,
+                               const VectorizedArray<float, 16> *in,
+                               const unsigned int               *offsets,
+                               float                            *out)
+{
+  vectorized_transpose_and_store(add_into,
+                                 n_entries,
+                                 in,
+                                 {{out + offsets[0],
+                                   out + offsets[1],
+                                   out + offsets[2],
+                                   out + offsets[3],
+                                   out + offsets[4],
+                                   out + offsets[5],
+                                   out + offsets[6],
+                                   out + offsets[7],
+                                   out + offsets[8],
+                                   out + offsets[9],
+                                   out + offsets[10],
+                                   out + offsets[11],
+                                   out + offsets[12],
+                                   out + offsets[13],
+                                   out + offsets[14],
+                                   out + offsets[15]}});
 }
 
 #  endif

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -409,9 +409,14 @@ namespace internal
       VectorizedArrayType                                      *dof_values,
       std::bool_constant<true>) const
     {
-      dealii::vectorized_load_and_transpose(dofs_per_cell,
-                                            global_ptr,
-                                            dof_values);
+      // The API of the vectorized_load_and_transpose function requires us to
+      // provide const pointers
+      dealii::vectorized_load_and_transpose(
+        dofs_per_cell,
+        reinterpret_cast<
+          const std::array<const Number2 *, VectorizedArrayType::size()> &>(
+          global_ptr),
+        dof_values);
     }
 
 

--- a/tests/base/vectorization_15.cc
+++ b/tests/base/vectorization_15.cc
@@ -35,16 +35,20 @@ do_test()
   for (unsigned int v = 0; v < n_vectors; ++v)
     offsets[v] = v * n_numbers;
 
-  std::array<Number *, width> other_and_offset;
+  std::array<const Number *, width> other_and_offset_const;
   for (unsigned int v = 0; v < width; ++v)
-    other_and_offset[v] = other + offsets[v];
+    other_and_offset_const[v] = other + offsets[v];
+
+  std::array<Number *, width> other_and_offset_nonconst;
+  for (unsigned int v = 0; v < width; ++v)
+    other_and_offset_nonconst[v] = other + offsets[v];
 
   for (unsigned int i = 0; i < n_vectors; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       other[i * n_numbers + j] = i * n_numbers + j;
 
   vectorized_load_and_transpose<Number, width>(n_numbers,
-                                               other_and_offset,
+                                               other_and_offset_const,
                                                arr);
   unsigned int n_errors = 0;
   for (unsigned int j = 0; j < n_numbers; ++j)
@@ -67,7 +71,7 @@ do_test()
   vectorized_transpose_and_store<Number, width>(true,
                                                 n_numbers,
                                                 arr,
-                                                other_and_offset);
+                                                other_and_offset_nonconst);
   n_errors = 0;
   for (unsigned int i = 0; i < n_vectors; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
@@ -89,7 +93,7 @@ do_test()
   vectorized_transpose_and_store<Number, width>(false,
                                                 n_numbers,
                                                 arr,
-                                                other_and_offset);
+                                                other_and_offset_nonconst);
   n_errors = 0;
   for (unsigned int i = 0; i < n_vectors; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)


### PR DESCRIPTION
Back in #9556 we hesitated to use a single implementation for the two variants of `vectorized_load_and_transpose` and `vectorized_transpose_and_store`, because compilers were sometimes struggling to generate good code in the more common version taking a single base pointer and a int array of offsets for the different lanes. I revisited some important cases and could not spot a difference in the generated code, so I think it is time to go with a single implementation. This forced me to switch some functions to be able to call one function from the other.

Edit: Note that, apart from making some interfaces `const` in a more appropriate way as outlined below and moving code around, there are no changes of code in this PR.