### PR TITLE
C++20 modules: Fix psblas headers

### DIFF
--- a/include/deal.II/lac/psblas_common.h
+++ b/include/deal.II/lac/psblas_common.h
@@ -20,13 +20,15 @@
 
 
 #ifdef DEAL_II_WITH_PSBLAS
-
 #  include <psb_base_cbind.h>
 #  include <psb_c_base.h>
 #  include <psb_c_dbase.h>
+#endif
+
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PSBLAS
 namespace PSCToolkitWrappers
 {
 
@@ -271,13 +273,8 @@ namespace PSCToolkitWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
-#else
+#endif // DEAL_II_WITH_PSBLAS
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
 DEAL_II_NAMESPACE_CLOSE
 
-#endif // DEAL_II_WITH_PSBLAS
 #endif

--- a/include/deal.II/lac/psblas_sparse_matrix.h
+++ b/include/deal.II/lac/psblas_sparse_matrix.h
@@ -25,12 +25,13 @@
 
 
 #ifdef DEAL_II_WITH_PSBLAS
-
 #  include <deal.II/lac/psblas_sparsity_pattern.h>
 #  include <deal.II/lac/psblas_vector.h>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PSBLAS
 namespace PSCToolkitWrappers
 {
 
@@ -411,13 +412,7 @@ namespace PSCToolkitWrappers
 
 
 DEAL_II_NAMESPACE_CLOSE
-#else
-
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
+#endif // DEAL_II_WITH_PSBLAS
 DEAL_II_NAMESPACE_CLOSE
 
-#endif // DEAL_II_WITH_PSBLAS
 #endif

--- a/include/deal.II/lac/psblas_sparsity_pattern.h
+++ b/include/deal.II/lac/psblas_sparsity_pattern.h
@@ -18,11 +18,12 @@
 #include <deal.II/lac/sparsity_pattern_base.h>
 
 #ifdef DEAL_II_WITH_PSBLAS
-
 #  include <deal.II/lac/psblas_common.h>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef DEAL_II_WITH_PSBLAS
 namespace PSCToolkitWrappers
 {
 
@@ -116,13 +117,8 @@ namespace PSCToolkitWrappers
 
 DEAL_II_NAMESPACE_CLOSE
 
-#else
+#endif // DEAL_II_WITH_PSBLAS
 
-// Make sure the scripts that create the C++20 module input files have
-// something to latch on if the preprocessor #ifdef above would
-// otherwise lead to an empty content of the file.
-DEAL_II_NAMESPACE_OPEN
 DEAL_II_NAMESPACE_CLOSE
 
-#endif // DEAL_II_WITH_PSBLAS
 #endif


### PR DESCRIPTION
This should fix the Modules CI build. See, e.g., https://github.com/dealii/dealii/actions/runs/27111545782/job/80010318204?pr=19829:
```
"/usr/bin/clang-scan-deps-23" -format=p1689 -- /usr/bin/clang++-23 -DBOOST_IOSTREAMS_DYN_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SERIALIZATION_NO_LIB -DDEAL_II_BUILDING_CXX20_MODULE -DDEBUG -DKOKKOS_DEPENDENCE -D_GLIBCXX_ASSERTIONS -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE -Ddealii_module_debug_EXPORTS -I/__w/dealii/dealii/build/include -I/__w/dealii/dealii/build/source -I/__w/dealii/dealii/include -I/__w/dealii/dealii/build/module/../include -isystem /__w/dealii/dealii/bundled/taskflow-3.10.0 -isystem /usr/lib/x86_64-linux-gnu/openmpi/include -isystem /usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -isystem /usr/include/petsc -isystem /usr/include/suitesparse -isystem /__w/dealii/kokkos-install/include -isystem /usr/include/ArborX -isystem /usr/include/ArborX/geometry -isystem /usr/include/ArborX/cluster -isystem /usr/include/ArborX/distributed -isystem /usr/include/ArborX/interpolation -isystem /usr/include/ArborX/spatial -isystem /usr/local/include/magic_enum -isystem /usr/include/opencascade -isystem /usr/include/slepc -isystem /usr/local/include/symengine/utilities/cereal/include -isystem /usr/include/flint -isystem /usr/include/vtk-9.1 -std=c++23 -fPIC -pedantic -Wall -Wextra -Wmissing-braces -Woverloaded-virtual -Wpointer-arith -Wsign-compare -Wsuggest-override -Wswitch -Wsynth -Wwrite-strings -Wno-deprecated-declarations -Wno-psabi -Wno-misleading-indentation -Wfloat-conversion -Qunused-arguments -Wno-unsupported-friend -Wno-pass-failed -Wno-unused-local-typedefs -openmp-simd -ffp-exception-behavior=strict -Og -ggdb -Wa,--compress-debug-sections -x c++ /__w/dealii/dealii/build/module/interface_module_partitions/lac/psblas_sparse_matrix.ccm -c -o module/CMakeFiles/dealii_module_debug.dir/interface_module_partitions/lac/psblas_sparse_matrix.ccm.o -MT module/CMakeFiles/dealii_module_debug.dir/interface_module_partitions/lac/psblas_sparse_matrix.ccm.o.ddi -MD -MF module/CMakeFiles/dealii_module_debug.dir/interface_module_partitions/lac/psblas_sparse_matrix.ccm.o.ddi.d > module/CMakeFiles/dealii_module_debug.dir/interface_module_partitions/lac/psblas_sparse_matrix.ccm.o.ddi.tmp && mv module/CMakeFiles/dealii_module_debug.dir/interface_module_partitions/lac/psblas_sparse_matrix.ccm.o.ddi.tmp module/CMakeFiles/dealii_module_debug.dir/interface_module_partitions/lac/psblas_sparse_matrix.ccm.o.ddi
Diagnostics while scanning dependencies for '/__w/dealii/dealii/build/module/interface_module_partitions/lac/psblas_sparse_matrix.ccm':
/__w/dealii/dealii/build/module/interface_module_partitions/lac/psblas_sparse_matrix.ccm:430:8: error: module directive lines are not allowed on lines controlled by preprocessor conditionals
```