### PR TITLE
MappingQ: reuse the FE_DGQ object.

### DIFF
--- a/doc/news/changes/incompatibilities/20260608Wells
+++ b/doc/news/changes/incompatibilities/20260608Wells
@@ -1,0 +1,3 @@
+Changed: The `mapping_q.h` header no longer includes `quadrature_lib.h`.
+<br>
+(David Wells, 2026/06/08)

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -19,6 +19,7 @@
 // step-37, step-48, and step-59
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/timer.h>
 #include <deal.II/base/time_stepping.h>
 #include <deal.II/base/utilities.h>

--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -23,6 +23,7 @@
 #include <deal.II/base/time_stepping.h>
 #include <deal.II/base/timer.h>
 #include <deal.II/base/utilities.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/vectorization.h>
 
 #include <deal.II/distributed/tria.h>

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -18,7 +18,6 @@
 
 #include <deal.II/base/derivative_form.h>
 #include <deal.II/base/polynomial.h>
-#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/vectorization.h>
 
@@ -375,16 +374,6 @@ public:
      */
     const unsigned int n_shape_functions;
 
-    /*
-     * The default line support points. Is used in when the shape function
-     * values are computed.
-     *
-     * The number of quadrature points depends on the degree of this
-     * class, and it matches the number of degrees of freedom of an
-     * FE_Q<1>(this->degree).
-     */
-    QGaussLobatto<1> line_support_points;
-
     /**
      * For the fast tensor-product path of the MappingQ class, we choose SIMD
      * vectors that are as wide as possible to minimize the number of
@@ -525,16 +514,6 @@ protected:
    * lexicographic to hierarchic numbering.
    */
   const std::shared_ptr<const FE_DGQ<1, 1>> fe_dgq_1d;
-
-  /*
-   * The default line support points. These are used when computing the
-   * location in real space of the support points on lines and quads, which
-   * are needed by the Manifold<dim,spacedim> class.
-   *
-   * The number of points depends on the degree of this class, and it matches
-   * the number of degrees of freedom of an FE_Q<1>(this->degree).
-   */
-  const std::vector<Point<1>> line_support_points;
 
   /*
    * The one-dimensional polynomials defined as Lagrange polynomials from the

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -36,6 +36,8 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 template <int, int>
 class MappingQCache;
+template <int, int>
+class FE_DGQ;
 #endif
 
 /**
@@ -298,6 +300,13 @@ public:
      */
     InternalData(const unsigned int polynomial_degree);
 
+    /**
+     * Constructor. Re-uses an FE_DGQ (typically the same one owned by a
+     * MappingQ) which defines the one-dimensional polynomial space used by this
+     * mapping.
+     */
+    InternalData(const std::shared_ptr<const FE_DGQ<1, 1>> &fe_dgq_1d);
+
     // Documentation see Mapping::InternalDataBase.
     virtual void
     reinit(const UpdateFlags      update_flags,
@@ -348,6 +357,12 @@ public:
      * used (with minor adjustments) by MappingQ, we need to store this.
      */
     const unsigned int polynomial_degree;
+
+    /**
+     * FiniteElement which defines the one-dimensional polynomial space used by
+     * the mapping.
+     */
+    const std::shared_ptr<const FE_DGQ<1, 1>> fe_dgq_1d;
 
     /**
      * Number of shape functions. If this is a Q1 mapping, then it is simply
@@ -504,6 +519,12 @@ protected:
    * cells.
    */
   const unsigned int polynomial_degree;
+
+  /**
+   * FiniteElement used for some internal setup, such as computing the
+   * lexicographic to hierarchic numbering.
+   */
+  const std::shared_ptr<const FE_DGQ<1, 1>> fe_dgq_1d;
 
   /*
    * The default line support points. These are used when computing the

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -18,6 +18,7 @@
 #include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/polynomial.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/signaling_nan.h>
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/vectorization.h>

--- a/include/deal.II/numerics/tensor_product_matrix_creator.h
+++ b/include/deal.II/numerics/tensor_product_matrix_creator.h
@@ -16,7 +16,7 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/quadrature.h>
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -16,6 +16,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/vectorization.h>
 
@@ -37,10 +38,6 @@ template <int dim, int spacedim>
 class Mapping;
 template <int dim, typename number, typename VectorizedArrayType>
 class MatrixFree;
-template <int dim>
-class Quadrature;
-template <int dim>
-class QGauss;
 template <typename Number, std::size_t width>
 class VectorizedArray;
 namespace hp

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -50,7 +50,6 @@ MappingQ<dim, spacedim>::InternalData::InternalData(
   : polynomial_degree(polynomial_degree)
   , fe_dgq_1d(std::make_shared<const FE_DGQ<1, 1>>(polynomial_degree))
   , n_shape_functions(Utilities::fixed_power<dim>(polynomial_degree + 1))
-  , line_support_points(QGaussLobatto<1>(polynomial_degree + 1))
   , tensor_product_quadrature(false)
   , output_data(nullptr)
 {}
@@ -63,7 +62,6 @@ MappingQ<dim, spacedim>::InternalData::InternalData(
   : polynomial_degree(fe_dgq_1d->tensor_degree())
   , fe_dgq_1d(fe_dgq_1d)
   , n_shape_functions(Utilities::fixed_power<dim>(polynomial_degree + 1))
-  , line_support_points(QGaussLobatto<1>(polynomial_degree + 1))
   , tensor_product_quadrature(false)
   , output_data(nullptr)
 {}
@@ -227,15 +225,13 @@ template <int dim, int spacedim>
 MappingQ<dim, spacedim>::MappingQ(const unsigned int p)
   : polynomial_degree(p)
   , fe_dgq_1d(std::make_shared<const FE_DGQ<1, 1>>(polynomial_degree))
-  , line_support_points(
-      QGaussLobatto<1>(this->polynomial_degree + 1).get_points())
-  , polynomials_1d(
-      Polynomials::generate_complete_Lagrange_basis(line_support_points))
+  , polynomials_1d(Polynomials::generate_complete_Lagrange_basis(
+      fe_dgq_1d->get_unit_support_points()))
   , renumber_lexicographic_to_hierarchic(
       FETools::lexicographic_to_hierarchic_numbering<dim>(p))
   , unit_cell_support_points(
       internal::MappingQImplementation::unit_support_points<dim>(
-        line_support_points,
+        fe_dgq_1d->get_unit_support_points(),
         renumber_lexicographic_to_hierarchic))
   , support_point_weights_perimeter_to_interior(
       internal::MappingQImplementation::
@@ -257,7 +253,6 @@ template <int dim, int spacedim>
 MappingQ<dim, spacedim>::MappingQ(const MappingQ<dim, spacedim> &mapping)
   : polynomial_degree(mapping.polynomial_degree)
   , fe_dgq_1d(mapping.fe_dgq_1d)
-  , line_support_points(mapping.line_support_points)
   , polynomials_1d(mapping.polynomials_1d)
   , renumber_lexicographic_to_hierarchic(
       mapping.renumber_lexicographic_to_hierarchic)
@@ -1709,6 +1704,8 @@ MappingQ<2, 3>::add_quad_support_points(
 
   Table<2, double> weights(Utilities::fixed_power<2>(polynomial_degree - 1),
                            GeometryInfo<2>::vertices_per_cell);
+  const std::vector<Point<1>> &line_support_points =
+    fe_dgq_1d->get_unit_support_points();
   for (unsigned int q = 0, q2 = 0; q2 < polynomial_degree - 1; ++q2)
     for (unsigned int q1 = 0; q1 < polynomial_degree - 1; ++q1, ++q)
       {

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -48,6 +48,20 @@ template <int dim, int spacedim>
 MappingQ<dim, spacedim>::InternalData::InternalData(
   const unsigned int polynomial_degree)
   : polynomial_degree(polynomial_degree)
+  , fe_dgq_1d(std::make_shared<const FE_DGQ<1, 1>>(polynomial_degree))
+  , n_shape_functions(Utilities::fixed_power<dim>(polynomial_degree + 1))
+  , line_support_points(QGaussLobatto<1>(polynomial_degree + 1))
+  , tensor_product_quadrature(false)
+  , output_data(nullptr)
+{}
+
+
+
+template <int dim, int spacedim>
+MappingQ<dim, spacedim>::InternalData::InternalData(
+  const std::shared_ptr<const FE_DGQ<1, 1>> &fe_dgq_1d)
+  : polynomial_degree(fe_dgq_1d->tensor_degree())
+  , fe_dgq_1d(fe_dgq_1d)
   , n_shape_functions(Utilities::fixed_power<dim>(polynomial_degree + 1))
   , line_support_points(QGaussLobatto<1>(polynomial_degree + 1))
   , tensor_product_quadrature(false)
@@ -61,6 +75,8 @@ std::size_t
 MappingQ<dim, spacedim>::InternalData::memory_consumption() const
 {
   return (Mapping<dim, spacedim>::InternalDataBase::memory_consumption() +
+          MemoryConsumption::memory_consumption(fe_dgq_1d) +
+          fe_dgq_1d->memory_consumption() +
           MemoryConsumption::memory_consumption(quadrature_points) +
           MemoryConsumption::memory_consumption(unit_tangentials) +
           MemoryConsumption::memory_consumption(aux) +
@@ -135,8 +151,7 @@ MappingQ<dim, spacedim>::InternalData::reinit(const UpdateFlags update_flags,
               // use a 1d FE_DGQ and adjust the hierarchic -> lexicographic
               // numbering manually (building an FE_Q<dim> is relatively
               // expensive due to constraints)
-              const FE_DGQ<1> fe(polynomial_degree);
-              shape_info.reinit(quadrature.get_tensor_basis()[0], fe);
+              shape_info.reinit(quadrature.get_tensor_basis()[0], *fe_dgq_1d);
               shape_info.lexicographic_numbering =
                 FETools::lexicographic_to_hierarchic_numbering<dim>(
                   polynomial_degree);
@@ -164,8 +179,7 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
   if (dim > 1 && tensor_product_quadrature)
     {
       constexpr unsigned int facedim = dim - 1;
-      const FE_DGQ<1>        fe(polynomial_degree);
-      shape_info.reinit(quadrature.get_tensor_basis()[0], fe);
+      shape_info.reinit(quadrature.get_tensor_basis()[0], *fe_dgq_1d);
       shape_info.lexicographic_numbering =
         FETools::lexicographic_to_hierarchic_numbering<facedim>(
           polynomial_degree);
@@ -212,6 +226,7 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
 template <int dim, int spacedim>
 MappingQ<dim, spacedim>::MappingQ(const unsigned int p)
   : polynomial_degree(p)
+  , fe_dgq_1d(std::make_shared<const FE_DGQ<1, 1>>(polynomial_degree))
   , line_support_points(
       QGaussLobatto<1>(this->polynomial_degree + 1).get_points())
   , polynomials_1d(
@@ -241,6 +256,7 @@ MappingQ<dim, spacedim>::MappingQ(const unsigned int p)
 template <int dim, int spacedim>
 MappingQ<dim, spacedim>::MappingQ(const MappingQ<dim, spacedim> &mapping)
   : polynomial_degree(mapping.polynomial_degree)
+  , fe_dgq_1d(mapping.fe_dgq_1d)
   , line_support_points(mapping.line_support_points)
   , polynomials_1d(mapping.polynomials_1d)
   , renumber_lexicographic_to_hierarchic(
@@ -795,8 +811,7 @@ std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
 MappingQ<dim, spacedim>::get_data(const UpdateFlags      update_flags,
                                   const Quadrature<dim> &q) const
 {
-  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
-    std::make_unique<InternalData>(polynomial_degree);
+  auto data_ptr = std::make_unique<InternalData>(fe_dgq_1d);
   data_ptr->reinit(update_flags, q);
   return data_ptr;
 }
@@ -811,9 +826,8 @@ MappingQ<dim, spacedim>::get_face_data(
 {
   AssertDimension(quadrature.size(), 1);
 
-  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
-    std::make_unique<InternalData>(polynomial_degree);
-  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  auto  data_ptr = std::make_unique<InternalData>(fe_dgq_1d);
+  auto &data     = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
                          ReferenceCells::get_hypercube<dim>(), quadrature),
@@ -830,9 +844,8 @@ MappingQ<dim, spacedim>::get_subface_data(
   const UpdateFlags          update_flags,
   const Quadrature<dim - 1> &quadrature) const
 {
-  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
-    std::make_unique<InternalData>(polynomial_degree);
-  auto &data = dynamic_cast<InternalData &>(*data_ptr);
+  auto  data_ptr = std::make_unique<InternalData>(fe_dgq_1d);
+  auto &data     = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
                          ReferenceCells::get_hypercube<dim>(), quadrature),

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/work_stream.h>
 

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
@@ -16,6 +16,7 @@
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/distributed/tria.h>
 

--- a/tests/hp/fe_face_values_reinit_01.cc
+++ b/tests/hp/fe_face_values_reinit_01.cc
@@ -15,6 +15,8 @@
 // Test different versions of hp::FEFaceValues::reinit().
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/lac/tensor_product_matrix_07.cc
+++ b/tests/lac/tensor_product_matrix_07.cc
@@ -14,6 +14,8 @@
 // Test TensorProductMatrixSymmetricSum for zero (constrained) rows and columns.
 // We consider a single cell with DBC applied to face 2*(dim-1).
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/matrix_free/assemble_matrix_01.cc
+++ b/tests/matrix_free/assemble_matrix_01.cc
@@ -15,6 +15,8 @@
 // test FEEvaluation for assembling the Laplace matrix. It is enough to just
 // consider the resulting element matrices element by element
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free/assemble_matrix_02.cc
+++ b/tests/matrix_free/assemble_matrix_02.cc
@@ -14,6 +14,8 @@
 
 // test FEEvaluation for assembling the Stokes matrix with Q2-Q1 finite elements
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free/assemble_matrix_03.cc
+++ b/tests/matrix_free/assemble_matrix_03.cc
@@ -16,6 +16,7 @@
 // assemble_matrix_01 but doing the whole thing in parallel with WorkStream
 
 
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/boundary_id.cc
+++ b/tests/matrix_free/boundary_id.cc
@@ -16,6 +16,8 @@
 // (exceeding a very old case of 8 bit integers)
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free/categorize_ghost_01.cc
+++ b/tests/matrix_free/categorize_ghost_01.cc
@@ -14,6 +14,8 @@
 
 // tests categorization of ghost cells
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/distributed/shared_tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/cell_categorization_03.cc
+++ b/tests/matrix_free/cell_categorization_03.cc
@@ -16,6 +16,8 @@
 // a separate category for each cell, using a lexicographic order of cells
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/mapping_q1.h>
 

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -16,6 +16,7 @@
 // facilities with the alternative reinit(cell_index, face_number) approach
 
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/distributed/tria.h>

--- a/tests/matrix_free/compute_diagonal_08.cc
+++ b/tests/matrix_free/compute_diagonal_08.cc
@@ -14,6 +14,8 @@
 
 // Compute diagonal and matrix for SIP with MatrixFreeTools.
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/matrix_free/compute_diagonal_09.cc
+++ b/tests/matrix_free/compute_diagonal_09.cc
@@ -15,6 +15,8 @@
 // Similar to compute_diagonal_08 but with different dof_handler_index and
 // quadrature_index.
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/matrix_free/compute_diagonal_10.cc
+++ b/tests/matrix_free/compute_diagonal_10.cc
@@ -17,6 +17,8 @@
 //   (2) compute with multiple FEEvaluation instances
 //
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
 

--- a/tests/matrix_free/compute_diagonal_11.cc
+++ b/tests/matrix_free/compute_diagonal_11.cc
@@ -15,6 +15,8 @@
 // Similar to compute_diagonal_11 but for MatrixFreeTools::compute_diagonal().
 //
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
 

--- a/tests/matrix_free/faces_value_optimization.cc
+++ b/tests/matrix_free/faces_value_optimization.cc
@@ -15,6 +15,8 @@
 // tests matrix-free face evaluation with the option to compress
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/matrix_free/faces_value_optimization_02.cc
+++ b/tests/matrix_free/faces_value_optimization_02.cc
@@ -15,6 +15,8 @@
 // tests matrix-free face evaluation with the option to compress
 // This is the same as face_value_optimization but uses fe_degree=-1
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/matrix_free/faces_value_optimization_03.cc
+++ b/tests/matrix_free/faces_value_optimization_03.cc
@@ -15,6 +15,8 @@
 // like faces_value_optimization but mixed types
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/matrix_free/fe_eval_vector_access.cc
+++ b/tests/matrix_free/fe_eval_vector_access.cc
@@ -17,6 +17,8 @@
 
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/matrix_free/fe_evaluation_dofs_per_cell.cc
+++ b/tests/matrix_free/fe_evaluation_dofs_per_cell.cc
@@ -14,6 +14,8 @@
 
 // Test the basic member variables of FEEvaluation
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgp.h>

--- a/tests/matrix_free/fe_evaluation_dynamic_cast.cc
+++ b/tests/matrix_free/fe_evaluation_dynamic_cast.cc
@@ -14,6 +14,8 @@
 
 // Test that FEEvaluationData is virtual.
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free/get_cell_category_01.cc
+++ b/tests/matrix_free/get_cell_category_01.cc
@@ -15,6 +15,8 @@
 // tests MatrixFree::get_cell_category() and
 // MatrixFree::get_cell_range_category()
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/distributed/shared_tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/get_functions_variants.cc
+++ b/tests/matrix_free/get_functions_variants.cc
@@ -19,6 +19,7 @@
 // is computed to the function that extracts all data at the same time (the
 // correctness of that must be tested elsewhere). No constraints.
 
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/get_functions_variants_gl.cc
+++ b/tests/matrix_free/get_functions_variants_gl.cc
@@ -15,6 +15,7 @@
 // same as get_functions_variants for testing values, gradients, and
 // Laplacians individually but now on Gauss-Lobatto elements
 
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/hp_dg_01.cc
+++ b/tests/matrix_free/hp_dg_01.cc
@@ -12,6 +12,8 @@
 
 // Check if initialization of FEFaceEvaluation works for hp + DG in 3D.
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/mapping_q1.h>
 

--- a/tests/matrix_free/inverse_mass_01.cc
+++ b/tests/matrix_free/inverse_mass_01.cc
@@ -16,6 +16,8 @@
 // random vector to a CG solver
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/matrix_free/inverse_mass_03.cc
+++ b/tests/matrix_free/inverse_mass_03.cc
@@ -16,6 +16,8 @@
 // inverse_mass_02 but using different coefficients on different components
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/matrix_free/inverse_mass_05.cc
+++ b/tests/matrix_free/inverse_mass_05.cc
@@ -16,6 +16,7 @@
 // random vector to a CG solver. Same as inverse_mass_01, but using
 // FE_DGQHermite instead of FE_DGQ
 
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_handler.h>
 

--- a/tests/matrix_free/inverse_mass_06.cc
+++ b/tests/matrix_free/inverse_mass_06.cc
@@ -15,6 +15,8 @@
 // Tests CellwiseInverseMassMatrix::apply() with implicit definition from
 // FEEvaluationBase::JxW(), otherwise the same as inverse_mass_01
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/matrix_free/inverse_mass_08.cc
+++ b/tests/matrix_free/inverse_mass_08.cc
@@ -17,6 +17,8 @@
 // FEEvaluation, otherwise the same as inverse_mass_06 and inverse_mass_01
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_dgq.h>

--- a/tests/matrix_free/jxw_values.cc
+++ b/tests/matrix_free/jxw_values.cc
@@ -16,6 +16,8 @@
 // when compared to FEValues
 
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 

--- a/tests/matrix_free/laplace_operator_04.cc
+++ b/tests/matrix_free/laplace_operator_04.cc
@@ -14,6 +14,7 @@
 
 // check the diagonal of LaplaceOperator for the scalar and vector-valued case
 
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/loop_boundary.cc
+++ b/tests/matrix_free/loop_boundary.cc
@@ -17,6 +17,8 @@
 // implementation, we used to miss to exchange some ghost entries upon the
 // compress() functionality within the matrix-free loop
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/matrix_free/matrix_vector_stokes_base.cc
+++ b/tests/matrix_free/matrix_vector_stokes_base.cc
@@ -15,6 +15,7 @@
 // based on MatrixFreeOperators::Base by comparing with a matrix version.
 
 #include <deal.II/base/multithread_info.h>
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_renumbering.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/matrix_free/reinit_matrix_free_mg.cc
+++ b/tests/matrix_free/reinit_matrix_free_mg.cc
@@ -14,6 +14,7 @@
 // processes without any cells on a larger mesh (we need 17 processes to have
 // a 8x8 mesh with one process not having a cell on level 1).
 
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/distributed/tria.h>
 

--- a/tests/matrix_free/reinit_matrix_free_threading.cc
+++ b/tests/matrix_free/reinit_matrix_free_threading.cc
@@ -13,6 +13,7 @@
 // Verify that MatrixFree::reinit() works without errors if run with
 // multithreadingf and multiple ranks.
 
+#include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/distributed/tria.h>
 

--- a/tests/matrix_free_kokkos/assemble_matrix_01.cc
+++ b/tests/matrix_free_kokkos/assemble_matrix_01.cc
@@ -15,6 +15,8 @@
 // test Portable::FEEvaluation for assembling the system matrix of elasticity
 // problems
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_01.cc
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_01.cc
@@ -13,6 +13,8 @@
 
 // test Portable::MatrixFree::get_cell_iterator()
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_02.cc
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_02.cc
@@ -13,6 +13,8 @@
 
 // test Portable::MatrixFree::get_cell_iterator() with coloring enabled
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/dofs/dof_handler.h>
 
 #include <deal.II/fe/fe_q.h>

--- a/tests/non_matching/coupling_01.cc
+++ b/tests/non_matching/coupling_01.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/non_matching/coupling_02.cc
+++ b/tests/non_matching/coupling_02.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/non_matching/coupling_03.cc
+++ b/tests/non_matching/coupling_03.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/non_matching/coupling_07.cc
+++ b/tests/non_matching/coupling_07.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/point.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/tensor.h>
 
 #include <deal.II/dofs/dof_tools.h>

--- a/tests/petsc/step-67-with-petsc-ts.cc
+++ b/tests/petsc/step-67-with-petsc-ts.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/time_stepping.h>
 #include <deal.II/base/timer.h>
 #include <deal.II/base/utilities.h>


### PR DESCRIPTION
There are several places in `MappingQ` and `MappingQ::InternalData` where we need an `FE_DGQ` for renumbering or other purposes. Since this element's support points are the same as `MappingQ`'s, we can also reuse them instead of independently setting up a `QGaussLobatto<1>`.

Including #19829, this patch lowers the number of allocations in WorkStream and step-32 by about 30% (1.4 million to 940k). Critically, the control block of `std::shared_ptr` is thread-safe: the C++17 standard states "Changes in use_count() do not reflect modifications that can introduce data races", so we can create more `std::shared_ptr<const FE_DGQ<1>>`s in parallel without any problems.