### PR TITLE
Avoid some static variables.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -4019,60 +4019,75 @@ ReferenceCell<dim>::face_tangent_vector(const unsigned int face_no,
         AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
         return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
       case ReferenceCells::Triangle:
-        {
-          AssertIndexRange(face_no, 3);
-          static const std::array<Tensor<1, dim>, 3> table = {
-            {Point<dim>(1, 0),
-             Point<dim>(-std::sqrt(0.5), +std::sqrt(0.5)),
-             Point<dim>(0, -1)}};
+        if constexpr (dim == 2)
+          {
+            AssertIndexRange(face_no, 3);
+            constexpr std::array<Tensor<1, dim>, 3> table = {
+              {Point<dim>(1, 0),
+               Point<dim>(-numbers::SQRT1_2, +numbers::SQRT1_2),
+               Point<dim>(0, -1)}};
 
-          return table[face_no];
-        }
+            return table[face_no];
+          }
+        else
+          DEAL_II_ASSERT_UNREACHABLE();
       case ReferenceCells::Tetrahedron:
-        {
-          AssertIndexRange(face_no, 4);
-          static const ndarray<Tensor<1, dim>, 4, 2> table = {
-            {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-             {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
-             {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
-             {{Point<dim>(-std::pow(1.0 / 3.0, 1.0 / 4.0),
-                          +std::pow(1.0 / 3.0, 1.0 / 4.0),
-                          0),
-               Point<dim>(-std::pow(1.0 / 3.0, 1.0 / 4.0),
-                          0,
-                          +std::pow(1.0 / 3.0, 1.0 / 4.0))}}}};
+        if constexpr (dim == 3)
+          {
+            AssertIndexRange(face_no, 4);
+            // We need std::pow(1.0/3.0, 0.25) in a constexpr context, but that
+            // function isn't constexpr yet so hard-code the value and assert
+            // that it is close
+            constexpr double third_r4 = 0.7598356856515925473311877;
+            Assert(std::abs((third_r4 * third_r4) * (third_r4 * third_r4) -
+                            1.0 / 3.0) < 1e-14,
+                   ExcInternalError());
+            constexpr ndarray<Tensor<1, dim>, 4, 2> table = {
+              {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+               {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
+               {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
+               {{Point<dim>(-third_r4, +third_r4, 0),
+                 Point<dim>(-third_r4, 0, +third_r4)}}}};
 
-          return table[face_no][i];
-        }
+            return table[face_no][i];
+          }
+        else
+          DEAL_II_ASSERT_UNREACHABLE();
       case ReferenceCells::Pyramid:
-        {
-          AssertIndexRange(face_no, 5);
-          static const ndarray<Tensor<1, dim>, 5, 2> table = {
-            {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-             {{Point<dim>(+1.0 / std::sqrt(2.0), 0, +1.0 / std::sqrt(2.0)),
-               Point<dim>(0, 1, 0)}},
-             {{Point<dim>(+1.0 / std::sqrt(2.0), 0, -1.0 / std::sqrt(2.0)),
-               Point<dim>(0, 1, 0)}},
-             {{Point<dim>(1, 0, 0),
-               Point<dim>(0, +1.0 / std::sqrt(2.0), +1.0 / std::sqrt(2.0))}},
-             {{Point<dim>(1, 0, 0),
-               Point<dim>(0, +1.0 / std::sqrt(2.0), -1.0 / std::sqrt(2.0))}}}};
+        if constexpr (dim == 3)
+          {
+            AssertIndexRange(face_no, 5);
+            constexpr ndarray<Tensor<1, dim>, 5, 2> table = {
+              {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+               {{Point<dim>(+numbers::SQRT1_2, 0, +numbers::SQRT1_2),
+                 Point<dim>(0, 1, 0)}},
+               {{Point<dim>(+numbers::SQRT1_2, 0, -numbers::SQRT1_2),
+                 Point<dim>(0, 1, 0)}},
+               {{Point<dim>(1, 0, 0),
+                 Point<dim>(0, +numbers::SQRT1_2, +numbers::SQRT1_2)}},
+               {{Point<dim>(1, 0, 0),
+                 Point<dim>(0, +numbers::SQRT1_2, -numbers::SQRT1_2)}}}};
 
-          return table[face_no][i];
-        }
+            return table[face_no][i];
+          }
+        else
+          DEAL_II_ASSERT_UNREACHABLE();
       case ReferenceCells::Wedge:
-        {
-          AssertIndexRange(face_no, 5);
-          static const ndarray<Tensor<1, dim>, 5, 2> table = {
-            {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-             {{Point<dim>(1, 0, 0), Point<dim>(0, 1, 0)}},
-             {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
-             {{Point<dim>(-1 / std::sqrt(2.0), +1 / std::sqrt(2.0), 0),
-               Point<dim>(0, 0, 1)}},
-             {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}}}};
+        if constexpr (dim == 3)
+          {
+            AssertIndexRange(face_no, 5);
+            constexpr ndarray<Tensor<1, dim>, 5, 2> table = {
+              {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+               {{Point<dim>(1, 0, 0), Point<dim>(0, 1, 0)}},
+               {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
+               {{Point<dim>(-numbers::SQRT1_2, +numbers::SQRT1_2, 0),
+                 Point<dim>(0, 0, 1)}},
+               {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}}}};
 
-          return table[face_no][i];
-        }
+            return table[face_no][i];
+          }
+        else
+          DEAL_II_ASSERT_UNREACHABLE();
       default:
         DEAL_II_NOT_IMPLEMENTED();
     }

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -56,6 +56,8 @@ and using the 'signals' keyword. You can either #include the Qt headers (or any 
 
 // Forward declarations
 #ifndef DOXYGEN
+// We need to forward-declare Manifold here since Manifold depends on
+// Triangulation (e.g., it has functions which take face iterators as inputs).
 template <int dim, int spacedim>
 class Manifold;
 
@@ -4593,6 +4595,14 @@ private:
    */
   std::map<types::manifold_id, std::unique_ptr<const Manifold<dim, spacedim>>>
     manifolds;
+
+  /**
+   * The default FlatManifold.
+   *
+   * @note Since this header must forward-declare Manifold this must be a
+   * pointer: see the note in the forward declarations for more information.
+   */
+  const std::unique_ptr<const Manifold<dim, spacedim>> default_flat_manifold;
 
   /**
    * Flag indicating whether anisotropic refinement took place.

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4117,8 +4117,7 @@ namespace parallel
       &Triangulation<1, spacedim>::get_p4est_tree_to_coarse_cell_permutation()
         const
     {
-      static std::vector<types::global_dof_index> a;
-      return a;
+      return p4est_tree_to_coarse_cell_permutation;
     }
 
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -1518,7 +1518,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
   getline(in, line);
   AssertThrow(line == "Quadrilaterals", ExcInvalidDBMESHInput(line));
 
-  static constexpr std::array<unsigned int, 8> local_vertex_numbering = {
+  constexpr std::array<unsigned int, 8> local_vertex_numbering = {
     {0, 1, 5, 4, 2, 3, 7, 6}};
   std::vector<CellData<dim>> cells;
   SubCellData                subcelldata;
@@ -2502,13 +2502,13 @@ GridIn<dim, spacedim>::read_msh(std::istream &input_stream)
 
   // Assert we reached the end of the block
   in >> line;
-  static const std::string end_nodes_marker[] = {"$ENDNOD", "$EndNodes"};
+  const std::array<std::string, 2> end_nodes_marker{{"$ENDNOD", "$EndNodes"}};
   AssertThrow(line == end_nodes_marker[gmsh_file_format == 10 ? 0 : 1],
               ExcInvalidGMSHInput(line));
 
   // Now read in next bit
   in >> line;
-  static const std::string begin_elements_marker[] = {"$ELM", "$Elements"};
+  const std::array<std::string, 2> begin_elements_marker{{"$ELM", "$Elements"}};
   AssertThrow(line == begin_elements_marker[gmsh_file_format == 10 ? 0 : 1],
               ExcInvalidGMSHInput(line));
 
@@ -2543,7 +2543,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &input_stream)
   std::map<unsigned int, unsigned int> vertex_counts;
 
   {
-    static constexpr std::array<unsigned int, 8> local_vertex_numbering = {
+    constexpr std::array<unsigned int, 8> local_vertex_numbering = {
       {0, 1, 5, 4, 2, 3, 7, 6}};
     unsigned int global_cell = 0;
     for (int entity_block = 0; entity_block < n_entity_blocks; ++entity_block)
@@ -2879,7 +2879,8 @@ GridIn<dim, spacedim>::read_msh(std::istream &input_stream)
   }
   // Assert that we reached the end of the block
   in >> line;
-  static const std::string end_elements_marker[] = {"$ENDELM", "$EndElements"};
+  const std::array<std::string, 2> end_elements_marker{
+    {"$ENDELM", "$EndElements"}};
   AssertThrow(line == end_elements_marker[gmsh_file_format == 10 ? 0 : 1],
               ExcInvalidGMSHInput(line));
   AssertThrow(in.fail() == false, ExcIO());
@@ -4045,7 +4046,7 @@ GridIn<dim, spacedim>::read_assimp(const std::string &filename,
   unsigned int v_offset = 0;
   unsigned int c_offset = 0;
 
-  static constexpr std::array<unsigned int, 8> local_vertex_numbering = {
+  constexpr std::array<unsigned int, 8> local_vertex_numbering = {
     {0, 1, 5, 4, 2, 3, 7, 6}};
   // The index of the mesh will be used as a material index.
   for (unsigned int m = start_mesh; m < end_mesh; ++m)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12918,6 +12918,7 @@ Triangulation<dim, spacedim>::Triangulation(
   , vertex_to_manifold_id_map_1d(std::move(tria.vertex_to_manifold_id_map_1d))
 {
   tria.number_cache = internal::TriangulationImplementation::NumberCache<dim>();
+  tria.strides      = {};
 
   if (tria.policy)
     this->policy = tria.policy->clone();
@@ -12948,6 +12949,7 @@ Triangulation<dim, spacedim> &Triangulation<dim, spacedim>::operator=(
   vertex_to_manifold_id_map_1d = std::move(tria.vertex_to_manifold_id_map_1d);
 
   tria.number_cache = internal::TriangulationImplementation::NumberCache<dim>();
+  tria.strides      = {};
 
   if (tria.policy)
     this->policy = tria.policy->clone();

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12848,15 +12848,6 @@ namespace internal
         return false;
       }
     };
-
-
-    template <int dim, int spacedim>
-    const Manifold<dim, spacedim> &
-    get_default_flat_manifold()
-    {
-      static const FlatManifold<dim, spacedim> flat_manifold;
-      return flat_manifold;
-    }
   } // namespace TriangulationImplementation
 } // namespace internal
 
@@ -12875,6 +12866,7 @@ Triangulation<dim, spacedim>::Triangulation(
   const bool          check_for_distorted_cells)
   : cell_attached_data({0, 0, {}, {}})
   , smooth_grid(smooth_grid)
+  , default_flat_manifold(std::make_unique<const FlatManifold<dim, spacedim>>())
   , anisotropic_refinement(false)
   , check_for_distorted_cells(check_for_distorted_cells)
 {
@@ -12911,6 +12903,7 @@ Triangulation<dim, spacedim>::Triangulation(
   , vertices(std::move(tria.vertices))
   , vertices_used(std::move(tria.vertices_used))
   , manifolds(std::move(tria.manifolds))
+  , default_flat_manifold(std::make_unique<const FlatManifold<dim, spacedim>>())
   , anisotropic_refinement(tria.anisotropic_refinement)
   , check_for_distorted_cells(tria.check_for_distorted_cells)
   , number_cache(std::move(tria.number_cache))
@@ -13086,10 +13079,7 @@ void Triangulation<dim, spacedim>::reset_manifold(
   AssertIndexRange(m_number, numbers::flat_manifold_id);
 
   // delete the entry located at number.
-  manifolds[m_number] =
-    internal::TriangulationImplementation::get_default_flat_manifold<dim,
-                                                                     spacedim>()
-      .clone();
+  manifolds[m_number] = default_flat_manifold->clone();
 }
 
 
@@ -13098,9 +13088,7 @@ DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void Triangulation<dim, spacedim>::reset_all_manifolds()
 {
   for (auto &m : manifolds)
-    m.second = internal::TriangulationImplementation::
-                 get_default_flat_manifold<dim, spacedim>()
-                   .clone();
+    m.second = default_flat_manifold->clone();
 }
 
 
@@ -13182,8 +13170,7 @@ const Manifold<dim, spacedim> &Triangulation<dim, spacedim>::get_manifold(
 {
   // check if flat manifold has been queried
   if (m_number == numbers::flat_manifold_id)
-    return internal::TriangulationImplementation::
-      get_default_flat_manifold<dim, spacedim>();
+    return *default_flat_manifold;
 
   // look, if there is a manifold stored at
   // manifold_id number.
@@ -13202,8 +13189,7 @@ const Manifold<dim, spacedim> &Triangulation<dim, spacedim>::get_manifold(
       " has been attached to the triangulation. "
       "Please attach the right manifold with Triangulation::set_manifold()."));
 
-  return internal::TriangulationImplementation::
-    get_default_flat_manifold<dim, spacedim>(); // never reached
+  return *default_flat_manifold; // never reached
 }
 
 
@@ -18585,6 +18571,7 @@ std::size_t Triangulation<dim, spacedim>::memory_consumption() const
     mem += MemoryConsumption::memory_consumption(*level);
   mem += MemoryConsumption::memory_consumption(vertices);
   mem += MemoryConsumption::memory_consumption(vertices_used);
+  mem += sizeof(default_flat_manifold) + sizeof(*default_flat_manifold);
   mem += sizeof(manifolds);
   mem += sizeof(smooth_grid);
   mem += MemoryConsumption::memory_consumption(number_cache);


### PR DESCRIPTION
#19829 introduces enough new objects (in the compiler sense) that MSVC cannot link the debug version of the library any more. Let's try to fix that by removing some static variables (which, in turn, removes the guard variables set up to guarantee they are initialized exactly once).