### PR TITLE
Add constant mode extraction to Tpetra MueLu

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_precondition.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.h
@@ -1432,7 +1432,7 @@ namespace LinearAlgebra
         /**
          * Specifies the constant modes (forming the near null space) of the
          * matrix. This parameter helps MueLu consider that null space
-         * when building the preconditoner. Additionaly, it also tells
+         * when building the preconditioner. Additionally, it also tells
          * MueLu whether we work on a scalar equation (with a single
          * constant mode) or on a vector-valued
          * equation (with as many constant modes as solution components).

--- a/include/deal.II/lac/trilinos_tpetra_precondition.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition.h
@@ -1349,26 +1349,49 @@ namespace LinearAlgebra
          *
          * By default, we pretend to work on elliptic problems with linear
          * finite elements on a scalar equation.
+
+         * Making use of the DoFTools::extract_constant_modes() function, the
+         * @p constant_modes vector can be initialized for a given field in the
+         * following manner:
+         *
+         * @code
+         *   #include <deal.II/dofs/dof_tools.h>
+         *   ...
+         *
+         *   DoFHandler<...> dof_handler;
+         *   FEValuesExtractors::Type... field_extractor;
+         *   ...
+         *
+         *   LinearAlgebra::TpetraWrappers::PreconditionAMGMueLu::AdditionalData
+         *     data;
+         *   DoFTools::extract_constant_modes(
+         *     dof_handler,
+         *     dof_handler.get_fe_collection().component_mask(field_extractor),
+         *     data.constant_modes);
+         * @endcode
          *
          * @param elliptic Optimize MueLu for elliptic problems.
          * @param symmetric Assume for A to be symmetric.
          * @param w_cycle Use W-cycle instead of V-cycle.
          * @param aggregation_threshold Threshold for coarsening.
+         * @param constant_modes Determine the nullspace of the equation.
          * @param smoother_sweeps Number of times to apply the smoother.
          * @param smoother_overlap Overlap of smoother if run in parallel.
          * @param output_details Print additional info to screen.
          * @param smoother_type Determine the smoother to use.
          * @param coarse_type Determine the coarse solver.
          */
-        AdditionalData(const bool         elliptic              = true,
-                       const bool         symmetric             = true,
-                       const bool         w_cycle               = false,
-                       const double       aggregation_threshold = 1e-4,
-                       const int          smoother_sweeps       = 2,
-                       const int          smoother_overlap      = 0,
-                       const bool         output_details        = false,
-                       const std::string &smoother_type         = "Chebyshev",
-                       const std::string &coarse_type           = "KLU2");
+        AdditionalData(const bool   elliptic              = true,
+                       const bool   symmetric             = true,
+                       const bool   w_cycle               = false,
+                       const double aggregation_threshold = 1e-4,
+                       const std::vector<std::vector<bool>> &constant_modes =
+                         std::vector<std::vector<bool>>(0),
+                       const int          smoother_sweeps  = 2,
+                       const int          smoother_overlap = 0,
+                       const bool         output_details   = false,
+                       const std::string &smoother_type    = "Chebyshev",
+                       const std::string &coarse_type      = "KLU2");
 
         /**
          * @brief Optimize for elliptic problems.
@@ -1405,6 +1428,19 @@ namespace LinearAlgebra
          * times the diagonal element couple strongly.
          */
         double aggregation_threshold;
+
+        /**
+         * Specifies the constant modes (forming the near null space) of the
+         * matrix. This parameter helps MueLu consider that null space
+         * when building the preconditoner. Additionaly, it also tells
+         * MueLu whether we work on a scalar equation (with a single
+         * constant mode) or on a vector-valued
+         * equation (with as many constant modes as solution components).
+         * Providing the correct constant modes, provided by
+         * DoFTools::extract_constant_modes() can significantly increase
+         * the performance of the preconditioner.
+         */
+        std::vector<std::vector<bool>> constant_modes;
 
         /**
          * @brief Number of times pre- and post-smoothing are applied.

--- a/include/deal.II/lac/trilinos_tpetra_precondition_muelu.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_precondition_muelu.templates.h
@@ -47,19 +47,21 @@ namespace LinearAlgebra
     /* ---------------------- PreconditionAMGMueLu ------------------------ */
     template <typename Number, typename MemorySpace>
     PreconditionAMGMueLu<Number, MemorySpace>::AdditionalData::AdditionalData(
-      const bool         elliptic,
-      const bool         symmetric,
-      const bool         w_cycle,
-      const double       aggregation_threshold,
-      const int          smoother_sweeps,
-      const int          smoother_overlap,
-      const bool         output_details,
-      const std::string &smoother_type,
-      const std::string &coarse_type)
+      const bool                            elliptic,
+      const bool                            symmetric,
+      const bool                            w_cycle,
+      const double                          aggregation_threshold,
+      const std::vector<std::vector<bool>> &constant_modes,
+      const int                             smoother_sweeps,
+      const int                             smoother_overlap,
+      const bool                            output_details,
+      const std::string                    &smoother_type,
+      const std::string                    &coarse_type)
       : elliptic(elliptic)
       , symmetric(symmetric)
       , w_cycle(w_cycle)
       , aggregation_threshold(aggregation_threshold)
+      , constant_modes(constant_modes)
       , smoother_sweeps(smoother_sweeps)
       , smoother_overlap(smoother_overlap)
       , output_details(output_details)
@@ -230,6 +232,65 @@ namespace LinearAlgebra
       parameter_list.set("aggregation: drop tol", ad.aggregation_threshold);
 
       parameter_list.set("coarse: max size", 2000);
+
+      using size_type = typename SparseMatrix<Number, MemorySpace>::size_type;
+      const auto domain_map               = A.trilinos_rcp()->getDomainMap();
+      const auto constant_modes_dimension = ad.constant_modes.size();
+
+      // Create the nullspace vector
+      Teuchos::RCP<TpetraTypes::MultiVectorType<Number, MemorySpace>>
+        distributed_constant_modes = Utilities::Trilinos::internal::make_rcp<
+          TpetraTypes::MultiVectorType<Number, MemorySpace>>(
+          domain_map,
+          constant_modes_dimension > 0 ? constant_modes_dimension : 1);
+
+      if (constant_modes_dimension > 0)
+        {
+          // MueLu benefits from knowing how many solution components
+          // a vector-valued problem has. We do not have this information
+          // readily available, except if the constant modes are given by
+          // the user. In that case one constant mode corresponds to each
+          // solution component. Provide a good guess if possible, otherwise use
+          // the default of 1.
+          parameter_list.set("number of equations",
+                             static_cast<int>(constant_modes_dimension));
+
+          const size_type n_rows = A.trilinos_rcp()->getGlobalNumRows();
+          const bool      constant_modes_are_global =
+            ad.constant_modes[0].size() == n_rows;
+          const size_type n_relevant_rows =
+            constant_modes_are_global ? n_rows : ad.constant_modes[0].size();
+          const size_type my_size = domain_map->getLocalNumElements();
+          if (constant_modes_are_global == false)
+            Assert(n_relevant_rows == my_size,
+                   ExcDimensionMismatch(n_relevant_rows, my_size));
+          Assert(n_rows == static_cast<size_type>(
+                             distributed_constant_modes->getGlobalLength()),
+                 ExcDimensionMismatch(
+                   n_rows, distributed_constant_modes->getGlobalLength()));
+
+          auto vector_2d = distributed_constant_modes
+                             ->template getLocalView<Kokkos::HostSpace>(
+                               Tpetra::Access::ReadWriteStruct{});
+
+          // Convert the given constant modes into a Tpetra multi-vector
+          for (size_type d = 0; d < constant_modes_dimension; ++d)
+            {
+              for (size_type row = 0; row < my_size; ++row)
+                {
+                  const auto global_row_id =
+                    constant_modes_are_global ?
+                      domain_map->getGlobalElement(row) :
+                      row;
+                  vector_2d(row, d) =
+                    static_cast<Number>(ad.constant_modes[d][global_row_id]);
+                }
+            }
+
+          Teuchos::ParameterList &userParams =
+            parameter_list.sublist("user data");
+          userParams.set("Nullspace", distributed_constant_modes);
+        }
 
       if (ad.output_details == true)
         parameter_list.set("verbosity", "high");

--- a/tests/trilinos_tpetra/precondition_muelu_dgp.cc
+++ b/tests/trilinos_tpetra/precondition_muelu_dgp.cc
@@ -197,6 +197,8 @@ Step4<dim>::solve()
   LinearAlgebra::TpetraWrappers::PreconditionAMGMueLu<double> preconditioner;
   LinearAlgebra::TpetraWrappers::PreconditionAMGMueLu<double>::AdditionalData
     data;
+  data.constant_modes =
+    DoFTools::extract_constant_modes(dof_handler, std::vector<bool>(1, true));
   data.smoother_sweeps = 2;
   {
     solution = 0;
@@ -208,8 +210,8 @@ Step4<dim>::solve()
     check_solver_within_range(
       solver.solve(system_matrix, solution, system_rhs, preconditioner),
       solver_control.last_step(),
-      40,
-      100);
+      18,
+      32);
   }
   deallog.pop();
 }

--- a/tests/trilinos_tpetra/precondition_muelu_dgp.with_trilinos_with_tpetra_muelu=on.output
+++ b/tests/trilinos_tpetra/precondition_muelu_dgp.with_trilinos_with_tpetra_muelu=on.output
@@ -1,3 +1,3 @@
 
 DEAL:00768::Solver stopped after 1 iterations
-DEAL:03072::Solver stopped within 40 - 100 iterations
+DEAL:03072::Solver stopped within 18 - 32 iterations


### PR DESCRIPTION
This PR adds the functionality to remove a near nullspace inside MueLu preconditioner when Tpetra is used.

This functionality was already available for Epetra and ML (in `trilinos_precondition_ml.cc`) and Epetra MueLu (in `trilinos_precondition_muelu.cc`), but was missing for Tpetra MueLu. This PR essentially takes the existing implementations and merges them, then replaces all the Epetra classes with Tpetra classes and makes use of some (pretty hard to find) functionality of MueLu (like that the Nullspace parameter needs to go into a sublist called "user data").

The functionality works in principle, since it improves the convergence of the modified test significantly. However, I cannot make it work for more than one component. During initialization of the preconditioner memory errors appear and cause segmentation faults. A rough guess is that copying the parameter list (with the nullspace vectors included) during the initialization somehow breaks, or that I setup the structure of the nullspace vector incorrectly, however I cannot figure out what is happening. Advice would be welcome, but for single component systems this already seems to work (I left an assert if someone tries to use this for multi-component systems).

This will be needed/useful for #19808 and geodynamics/aspect#6990, but for both we would need to make this work for multiple constant mode vectors.
