### PR TITLE
Only keep Tpetra vector view as long as necessary

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1150,13 +1150,13 @@ namespace LinearAlgebra
        * To avoid creating new views during element-wise access, store
        * a view to the vector.
        */
-      array_view_type vector_1d_view;
+      mutable std::optional<array_view_type> vector_1d_view;
 
       /**
        * To avoid creating new views during element-wise access, store
        * a view to the nonlocal vector.
        */
-      array_view_type nonlocal_vector_1d_view;
+      mutable std::optional<array_view_type> nonlocal_vector_1d_view;
 
       /**
        * CommunicationPattern for the communication between the
@@ -1264,6 +1264,26 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::add;
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
+      if (!nonlocal_vector_1d_view && !nonlocal_vector.is_null())
+        {
+          auto nonlocal_vector_2d_view =
+            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          nonlocal_vector_1d_view =
+            Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       for (size_type i = 0; i < n_elements; ++i)
         {
           const size_type row = indices[i];
@@ -1275,7 +1295,7 @@ namespace LinearAlgebra
                 vector->getMap()->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
-              vector_1d_view(local_row) += values[i];
+              (*vector_1d_view)(local_row) += values[i];
 
               // Set the compressed state to false only if there is nonlocal
               // part in this distributed vector, otherwise it's always
@@ -1319,7 +1339,7 @@ namespace LinearAlgebra
 
 #  endif
 
-              nonlocal_vector_1d_view(nonlocal_row) += values[i];
+              (*nonlocal_vector_1d_view)(nonlocal_row) += values[i];
               compressed = false;
             }
         }
@@ -1358,6 +1378,26 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::insert;
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
+      if (!nonlocal_vector_1d_view && !nonlocal_vector.is_null())
+        {
+          auto nonlocal_vector_2d_view =
+            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          nonlocal_vector_1d_view =
+            Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       for (size_type i = 0; i < n_elements; ++i)
         {
           const size_type row = indices[i];
@@ -1369,7 +1409,7 @@ namespace LinearAlgebra
                 vector->getMap()->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
-              vector_1d_view(local_row) = values[i];
+              (*vector_1d_view)(local_row) = values[i];
 
               // Set the compressed state to false only if there is nonlocal
               // part in this distributed vector, otherwise it's always
@@ -1413,8 +1453,8 @@ namespace LinearAlgebra
 
 #  endif
 
-              nonlocal_vector_1d_view(nonlocal_row) = values[i];
-              compressed                            = false;
+              (*nonlocal_vector_1d_view)(nonlocal_row) = values[i];
+              compressed                               = false;
             }
         }
     }

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -460,7 +460,7 @@ namespace LinearAlgebra
 
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
-          // Create a writeable view of this vector
+          // Create a writable view of this vector
           auto vector_2d_view =
             vector->template getLocalView<Kokkos::HostSpace>(
               Tpetra::Access::ReadWriteStruct{});

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -98,20 +98,11 @@ namespace LinearAlgebra
                TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                              Teuchos::Copy))
     {
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
-
       if (!V.nonlocal_vector.is_null())
         {
           nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.nonlocal_vector,
                                                           Teuchos::Copy);
-          auto nonlocal_vector_2d =
-            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
-          nonlocal_vector_1d_view =
-            Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
         }
       source_stored_elements  = V.source_stored_elements;
       local_entries           = V.local_entries;
@@ -130,10 +121,6 @@ namespace LinearAlgebra
       , last_action(VectorOperation::unknown)
       , vector(V)
     {
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
-
       // If there are ghost entries, we do not know which process owns which
       // entries. Assume no one owns any entries, which will allow read access,
       // but no write access.
@@ -156,11 +143,7 @@ namespace LinearAlgebra
           parallel_partitioner.make_tpetra_map_rcp<
             TpetraTypes::NodeType<MemorySpace>>(communicator, true)))
       , local_entries(parallel_partitioner)
-    {
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
-    }
+    {}
 
 
 
@@ -184,9 +167,6 @@ namespace LinearAlgebra
             parallel_partitioner
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
-          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-            Tpetra::Access::ReadWriteStruct{});
-          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
         }
       else
         {
@@ -196,9 +176,6 @@ namespace LinearAlgebra
                 communicator, false);
           vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(map);
-          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-            Tpetra::Access::ReadWriteStruct{});
-          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
           IndexSet nonlocal_entries = ghost_entries;
           nonlocal_entries.subtract_set(locally_owned_entries);
@@ -207,12 +184,6 @@ namespace LinearAlgebra
             nonlocal_entries
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
-
-          auto nonlocal_vector_2d =
-            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
-          nonlocal_vector_1d_view =
-            Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
         }
 
       has_ghost = (vector->getMap()->isOneToOne() == false);
@@ -238,16 +209,14 @@ namespace LinearAlgebra
         Utilities::Trilinos::internal::make_rcp<
           TpetraTypes::MapType<MemorySpace>>(
           0, 0, Utilities::Trilinos::tpetra_comm_self()));
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+      vector_1d_view.reset();
 
       has_ghost   = false;
       compressed  = true;
       last_action = VectorOperation::unknown;
 
       nonlocal_vector.reset();
-      nonlocal_vector_1d_view = array_view_type();
+      nonlocal_vector_1d_view.reset();
 
       source_stored_elements.clear();
       local_entries.clear();
@@ -266,9 +235,9 @@ namespace LinearAlgebra
                                         const bool /*omit_zeroing_entries*/)
     {
       vector.reset();
-      vector_1d_view = array_view_type();
+      vector_1d_view.reset();
       nonlocal_vector.reset();
-      nonlocal_vector_1d_view = array_view_type();
+      nonlocal_vector_1d_view.reset();
       source_stored_elements.clear();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
@@ -283,9 +252,6 @@ namespace LinearAlgebra
         parallel_partitioner
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
             communicator, true));
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
     }
 
 
@@ -298,8 +264,9 @@ namespace LinearAlgebra
                                         const bool      vector_writable)
     {
       // release memory before reallocation
+      vector_1d_view.reset();
       nonlocal_vector.reset();
-      nonlocal_vector_1d_view = array_view_type();
+      nonlocal_vector_1d_view.reset();
       source_stored_elements.clear();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
@@ -319,9 +286,6 @@ namespace LinearAlgebra
             parallel_partitioner
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
-          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-            Tpetra::Access::ReadWriteStruct{});
-          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
         }
       else
         {
@@ -335,9 +299,6 @@ namespace LinearAlgebra
               vector.reset();
               vector = Utilities::Trilinos::internal::make_rcp<
                 TpetraTypes::VectorType<Number, MemorySpace>>(map);
-              auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-                Tpetra::Access::ReadWriteStruct{});
-              vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
             }
           else
             vector->putScalar(0);
@@ -350,11 +311,6 @@ namespace LinearAlgebra
             nonlocal_entries
               .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(
                 communicator, true));
-          auto nonlocal_vector_2d =
-            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
-          nonlocal_vector_1d_view =
-            Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
         }
 
       has_ghost   = (vector->getMap()->isOneToOne() == false);
@@ -376,15 +332,17 @@ namespace LinearAlgebra
         vector.get() != nullptr && V.vector.get() != nullptr &&
         vector->getMap()->isSameAs(*V.vector->getMap());
 
+      // Reset the cached views, because the vector should be in a state
+      // just like after calling compress()
+      vector_1d_view.reset();
+      nonlocal_vector_1d_view.reset();
+
       // If V has a different distribution, construct a new vector,
       // otherwise just zero out this vector if so requested.
       if (!same_vector_map)
         {
           vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(V.vector->getMap());
-          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-            Tpetra::Access::ReadWriteStruct{});
-          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
         }
       else if (vector.get() != nullptr && omit_zeroing_entries == false)
         vector->putScalar(Number(0));
@@ -406,16 +364,10 @@ namespace LinearAlgebra
               nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
                 TpetraTypes::VectorType<Number, MemorySpace>>(
                 V.nonlocal_vector->getMap());
-              auto nonlocal_vector_2d_view =
-                nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-                  Tpetra::Access::ReadWriteStruct{});
-              nonlocal_vector_1d_view =
-                Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
             }
           else
             {
               nonlocal_vector.reset();
-              nonlocal_vector_1d_view = array_view_type();
             }
         }
       else if (nonlocal_vector.get() != nullptr &&
@@ -445,6 +397,16 @@ namespace LinearAlgebra
     {
       AssertDimension(indices.size(), elements.size());
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       for (unsigned int i = 0; i < indices.size(); ++i)
         {
           AssertIndexRange(indices[i], size());
@@ -471,7 +433,7 @@ namespace LinearAlgebra
 #  endif
 
           if (local_row != Teuchos::OrdinalTraits<int>::invalid())
-            elements[i] = vector_1d_view(local_row);
+            elements[i] = (*vector_1d_view)(local_row);
         }
     }
 
@@ -493,6 +455,17 @@ namespace LinearAlgebra
 
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
+          // Make sure we have a view available to access the vector entries.
+          if (!vector_1d_view)
+            {
+              auto vector_2d_view =
+                vector->template getLocalView<Kokkos::HostSpace>(
+                  Tpetra::Access::ReadWriteStruct{});
+
+              vector_1d_view =
+                Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+            }
+
           // Create a read-only Kokkos view from the source vector
           auto source_vector_2d =
             V.vector->template getLocalView<Kokkos::HostSpace>(
@@ -502,7 +475,7 @@ namespace LinearAlgebra
             Kokkos::subview(source_vector_2d, Kokkos::ALL(), 0);
 
           // Copy the data
-          Kokkos::deep_copy(vector_1d_view, source_vector_1d_view);
+          Kokkos::deep_copy((*vector_1d_view), source_vector_1d_view);
         }
       else if (size() == V.size())
         {
@@ -547,24 +520,16 @@ namespace LinearAlgebra
           vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                           Teuchos::Copy);
-          auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-            Tpetra::Access::ReadWriteStruct{});
-          vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
+          vector_1d_view.reset();
 
           nonlocal_vector.reset();
-          nonlocal_vector_1d_view = array_view_type();
+          nonlocal_vector_1d_view.reset();
 
           if (!V.nonlocal_vector.is_null())
             {
               nonlocal_vector = Utilities::Trilinos::internal::make_rcp<
                 TpetraTypes::VectorType<Number, MemorySpace>>(
                 *V.nonlocal_vector, Teuchos::Copy);
-
-              auto nonlocal_vector_2d =
-                nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-                  Tpetra::Access::ReadWriteStruct{});
-              nonlocal_vector_1d_view =
-                Kokkos::subview(nonlocal_vector_2d, Kokkos::ALL(), 0);
             }
 
           compressed             = V.compressed;
@@ -596,9 +561,10 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator=(const dealii::Vector<OtherNumber> &V)
     {
       vector.reset();
-      vector_1d_view = array_view_type();
+      vector_1d_view.reset();
 
       nonlocal_vector.reset();
+      nonlocal_vector_1d_view.reset();
       nonlocal_cached_indices.clear();
       nonlocal_cached_values.clear();
 
@@ -608,9 +574,6 @@ namespace LinearAlgebra
         V.locally_owned_elements()
           .template make_tpetra_map_rcp<TpetraTypes::NodeType<MemorySpace>>(),
         vector_data);
-      auto vector_2d = vector->template getLocalView<Kokkos::HostSpace>(
-        Tpetra::Access::ReadWriteStruct{});
-      vector_1d_view = Kokkos::subview(vector_2d, Kokkos::ALL(), 0);
 
       local_entries = V.locally_owned_elements();
 
@@ -854,7 +817,17 @@ namespace LinearAlgebra
                                         vector->getMap()->getMaxLocalIndex()));
 #  endif
 
-      return vector_1d_view[local_index];
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
+      return (*vector_1d_view)[local_index];
     }
 
 
@@ -869,10 +842,20 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       const size_t localLength = vector->getLocalLength();
       for (size_t k = 0; k < localLength; ++k)
         {
-          vector_1d_view(k) += a;
+          (*vector_1d_view)(k) += a;
         }
     }
 
@@ -1083,13 +1066,23 @@ namespace LinearAlgebra
              ExcMessage(
                "Not implemented for complex number types at the moment."));
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       Number min_value = std::numeric_limits<Number>::max();
 
       const size_t this_local_length = vector->getLocalLength();
 
       for (size_type i = 0; i < this_local_length; ++i)
-        if (vector_1d_view(i) < min_value)
-          min_value = vector_1d_view(i);
+        if ((*vector_1d_view)(i) < min_value)
+          min_value = (*vector_1d_view)(i);
 
       return Utilities::MPI::min(min_value, get_mpi_communicator());
     }
@@ -1180,6 +1173,16 @@ namespace LinearAlgebra
       if (this_local_length != other_local_length)
         return false;
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       auto other_vector_2d_view =
         v.vector->template getLocalView<Kokkos::HostSpace>(
           Tpetra::Access::ReadOnlyStruct{});
@@ -1188,7 +1191,7 @@ namespace LinearAlgebra
         Kokkos::subview(other_vector_2d_view, Kokkos::ALL(), 0);
 
       for (size_type i = 0; i < this_local_length; ++i)
-        if (vector_1d_view(i) != other_vector_1d_view(i))
+        if ((*vector_1d_view)(i) != other_vector_1d_view(i))
           return false;
 
       return true;
@@ -1390,10 +1393,10 @@ namespace LinearAlgebra
                        ExcInternalError());
 
                 if (operation == VectorOperation::insert)
-                  nonlocal_vector_1d_view(local_row) =
+                  (*nonlocal_vector_1d_view)(local_row) =
                     nonlocal_cached_values[i];
                 else if (operation == VectorOperation::add)
-                  nonlocal_vector_1d_view(local_row) +=
+                  (*nonlocal_vector_1d_view)(local_row) +=
                     nonlocal_cached_values[i];
                 else
                   DEAL_II_NOT_IMPLEMENTED();
@@ -1425,13 +1428,14 @@ namespace LinearAlgebra
       if (nonlocal_vector_is_temporary)
         {
           nonlocal_vector.reset();
-          nonlocal_vector_1d_view = array_view_type();
           nonlocal_cached_values.clear();
           nonlocal_cached_indices.clear();
         }
       else
         nonlocal_vector->putScalar(Number(0));
 
+      nonlocal_vector_1d_view.reset();
+      vector_1d_view.reset();
       compressed  = true;
       last_action = VectorOperation::unknown;
     }
@@ -1499,6 +1503,16 @@ namespace LinearAlgebra
       else
         out.setf(std::ios::fixed, std::ios::floatfield);
 
+      // Make sure we have a view available to access the vector entries.
+      if (!vector_1d_view)
+        {
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
+
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+        }
+
       const size_t local_length = vector->getLocalLength();
 
       if (size() != local_length)
@@ -1509,7 +1523,7 @@ namespace LinearAlgebra
             {
               const TrilinosWrappers::types::int_type global_row =
                 vector->getMap()->getGlobalElement(i);
-              out << "[" << global_row << "]: " << vector_1d_view(i)
+              out << "[" << global_row << "]: " << (*vector_1d_view)(i)
                   << std::endl;
             }
         }
@@ -1517,10 +1531,10 @@ namespace LinearAlgebra
         {
           if (across)
             for (unsigned int i = 0; i < local_length; ++i)
-              out << vector_1d_view(i) << ' ';
+              out << (*vector_1d_view)(i) << ' ';
           else
             for (unsigned int i = 0; i < local_length; ++i)
-              out << vector_1d_view(i) << std::endl;
+              out << (*vector_1d_view)(i) << std::endl;
           out << std::endl;
         }
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -460,18 +460,14 @@ namespace LinearAlgebra
 
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
-          // Make sure we have a view available to access the vector entries.
-          if (!vector_1d_view)
-            {
-              auto vector_2d_view =
-                vector->template getLocalView<Kokkos::HostSpace>(
-                  Tpetra::Access::ReadWriteStruct{});
+          // Create a writeable view of this vector
+          auto vector_2d_view =
+            vector->template getLocalView<Kokkos::HostSpace>(
+              Tpetra::Access::ReadWriteStruct{});
 
-              vector_1d_view =
-                Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
-            }
+          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
 
-          // Create a read-only Kokkos view from the source vector
+          // Create a read-only Kokkos view of the source vector
           auto source_vector_2d =
             V.vector->template getLocalView<Kokkos::HostSpace>(
               Tpetra::Access::ReadOnlyStruct{});
@@ -481,6 +477,9 @@ namespace LinearAlgebra
 
           // Copy the data
           Kokkos::deep_copy((*vector_1d_view), source_vector_1d_view);
+
+          // Reset the local view again as if we had called compress()
+          vector_1d_view.reset();
         }
       else if (size() == V.size())
         {
@@ -541,11 +540,6 @@ namespace LinearAlgebra
           tpetra_comm_pattern    = V.tpetra_comm_pattern;
           local_entries          = V.local_entries;
         }
-
-      // Reset our cached vector views so that trilinos operations on device do
-      // not detect an existing host view.
-      vector_1d_view.reset();
-      nonlocal_vector_1d_view.reset();
 
       // Because V is compressed and has no pending changes
       // clear our local cache as well.
@@ -719,12 +713,6 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator*=(const Number factor)
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
-      Assert(is_compressed(),
-             ExcMessage(
-               "You are trying an operation on a vector that is only "
-               "allowed if the vector is compressed, but the vector you "
-               "are operating on reports compress() has not been called "
-               "since the last relevant operation."));
       AssertIsFinite(factor);
 
       // Reset our cached vector view so that trilinos operations on device do
@@ -743,12 +731,6 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator/=(const Number factor)
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
-      Assert(is_compressed(),
-             ExcMessage(
-               "You are trying an operation on a vector that is only "
-               "allowed if the vector is compressed, but the vector you "
-               "are operating on reports compress() has not been called "
-               "since the last relevant operation."));
       AssertIsFinite(factor);
       Assert(factor != Number(0.), ExcZero());
 
@@ -771,12 +753,6 @@ namespace LinearAlgebra
       Assert(this->size() == V.size(),
              ExcDimensionMismatch(this->size(), V.size()));
       Assert(!has_ghost_elements(), ExcGhostsPresent());
-      Assert(is_compressed(),
-             ExcMessage(
-               "You are trying an operation on a vector that is only "
-               "allowed if the vector is compressed, but the vector you "
-               "are operating on reports compress() has not been called "
-               "since the last relevant operation."));
 
       // Reset our cached vector view so that trilinos operations on device do
       // not detect an existing host view.
@@ -813,17 +789,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator-=(
       const Vector<Number, MemorySpace> &V)
     {
-      Assert(this->size() == V.size(),
-             ExcDimensionMismatch(this->size(), V.size()));
-      Assert(vector->getMap()->isSameAs(*V.trilinos_vector().getMap()),
-             ExcDifferentParallelPartitioning());
       Assert(!has_ghost_elements(), ExcGhostsPresent());
-      Assert(is_compressed(),
-             ExcMessage(
-               "You are trying an operation on a vector that is only "
-               "allowed if the vector is compressed, but the vector you "
-               "are operating on reports compress() has not been called "
-               "since the last relevant operation."));
 
       // Reset our cached vector view so that trilinos operations on device do
       // not detect an existing host view.
@@ -846,12 +812,6 @@ namespace LinearAlgebra
       Assert(vector->getMap()->isSameAs(*V.trilinos_vector().getMap()),
              ExcDifferentParallelPartitioning());
       Assert(!has_ghost_elements(), ExcGhostsPresent());
-      Assert(is_compressed(),
-             ExcMessage(
-               "You are trying an operation on a vector that is only "
-               "allowed if the vector is compressed, but the vector you "
-               "are operating on reports compress() has not been called "
-               "since the last relevant operation."));
 
       // Reset our cached vector view so that trilinos operations on device do
       // not detect an existing host view.
@@ -1525,6 +1485,8 @@ namespace LinearAlgebra
           }
         }
 
+      // Destroy the views already here, because we are calling doExport() or
+      // putScalar() below.
       nonlocal_vector_1d_view.reset();
       vector_1d_view.reset();
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -453,6 +453,11 @@ namespace LinearAlgebra
                              "been compressed. Please call compress() on the "
                              "source vector before using operator=()."));
 
+      // Reset our cached vector views so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+      nonlocal_vector_1d_view.reset();
+
       if (vector->getMap()->isSameAs(*V.vector->getMap()))
         {
           // Make sure we have a view available to access the vector entries.
@@ -520,10 +525,8 @@ namespace LinearAlgebra
           vector = Utilities::Trilinos::internal::make_rcp<
             TpetraTypes::VectorType<Number, MemorySpace>>(*V.vector,
                                                           Teuchos::Copy);
-          vector_1d_view.reset();
 
           nonlocal_vector.reset();
-          nonlocal_vector_1d_view.reset();
 
           if (!V.nonlocal_vector.is_null())
             {
@@ -538,6 +541,11 @@ namespace LinearAlgebra
           tpetra_comm_pattern    = V.tpetra_comm_pattern;
           local_entries          = V.local_entries;
         }
+
+      // Reset our cached vector views so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+      nonlocal_vector_1d_view.reset();
 
       // Because V is compressed and has no pending changes
       // clear our local cache as well.
@@ -596,6 +604,11 @@ namespace LinearAlgebra
         Assert(!has_ghost_elements(), ExcGhostsPresent());
       AssertIsFinite(s);
 
+      // Reset our cached vector views so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+      nonlocal_vector_1d_view.reset();
+
       // First set the elements of the locally owned part of
       // the vector to 's':
       vector->putScalar(s);
@@ -622,6 +635,10 @@ namespace LinearAlgebra
       const Teuchos::RCP<const Utilities::MPI::CommunicationPatternBase>
         &communication_pattern)
     {
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+
       // If no communication pattern is given, create one. Otherwise, use the
       // one given.
       if (communication_pattern.is_null())
@@ -702,7 +719,17 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator*=(const Number factor)
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+      Assert(is_compressed(),
+             ExcMessage(
+               "You are trying an operation on a vector that is only "
+               "allowed if the vector is compressed, but the vector you "
+               "are operating on reports compress() has not been called "
+               "since the last relevant operation."));
       AssertIsFinite(factor);
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       vector->scale(factor);
 
@@ -716,8 +743,18 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator/=(const Number factor)
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+      Assert(is_compressed(),
+             ExcMessage(
+               "You are trying an operation on a vector that is only "
+               "allowed if the vector is compressed, but the vector you "
+               "are operating on reports compress() has not been called "
+               "since the last relevant operation."));
       AssertIsFinite(factor);
       Assert(factor != Number(0.), ExcZero());
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       *this *= Number(1.) / factor;
 
@@ -731,7 +768,19 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator+=(
       const Vector<Number, MemorySpace> &V)
     {
+      Assert(this->size() == V.size(),
+             ExcDimensionMismatch(this->size(), V.size()));
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+      Assert(is_compressed(),
+             ExcMessage(
+               "You are trying an operation on a vector that is only "
+               "allowed if the vector is compressed, but the vector you "
+               "are operating on reports compress() has not been called "
+               "since the last relevant operation."));
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       // If the maps are the same we can update right away.
       if (vector->getMap()->isSameAs(*(V.trilinos_vector().getMap())))
@@ -740,9 +789,6 @@ namespace LinearAlgebra
         }
       else
         {
-          Assert(this->size() == V.size(),
-                 ExcDimensionMismatch(this->size(), V.size()));
-
           // TODO: Tpetra doesn't have a combine mode that also updates local
           // elements, maybe there is a better workaround.
           Tpetra::Vector<Number,
@@ -767,7 +813,21 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::operator-=(
       const Vector<Number, MemorySpace> &V)
     {
+      Assert(this->size() == V.size(),
+             ExcDimensionMismatch(this->size(), V.size()));
+      Assert(vector->getMap()->isSameAs(*V.trilinos_vector().getMap()),
+             ExcDifferentParallelPartitioning());
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+      Assert(is_compressed(),
+             ExcMessage(
+               "You are trying an operation on a vector that is only "
+               "allowed if the vector is compressed, but the vector you "
+               "are operating on reports compress() has not been called "
+               "since the last relevant operation."));
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       this->add(-1., V);
 
@@ -786,6 +846,16 @@ namespace LinearAlgebra
       Assert(vector->getMap()->isSameAs(*V.trilinos_vector().getMap()),
              ExcDifferentParallelPartitioning());
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+      Assert(is_compressed(),
+             ExcMessage(
+               "You are trying an operation on a vector that is only "
+               "allowed if the vector is compressed, but the vector you "
+               "are operating on reports compress() has not been called "
+               "since the last relevant operation."));
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       return vector->dot(V.trilinos_vector());
     }
@@ -875,6 +945,10 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+
       vector->update(a, V.trilinos_vector(), 1.);
     }
 
@@ -898,6 +972,10 @@ namespace LinearAlgebra
       // if we have ghost values, do not allow
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       vector->update(a, V.trilinos_vector(), b, W.trilinos_vector(), 1.);
     }
@@ -926,6 +1004,10 @@ namespace LinearAlgebra
       AssertDimension(size(), V.size());
       AssertIsFinite(s);
       AssertIsFinite(a);
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       // We assume that the vectors have the same Map
       // if the local size is the same and if the vectors are not ghosted
@@ -967,6 +1049,10 @@ namespace LinearAlgebra
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+
       vector->elementWiseMultiply(1., *scaling_factors.vector, *vector, 0.);
     }
 
@@ -982,6 +1068,10 @@ namespace LinearAlgebra
       // if we have ghost values, do not allow
       // writing to this vector at all.
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       // If we don't have the same map, copy.
       if (vector->getMap()->isSameAs(*V.trilinos_vector().getMap()) == false)
@@ -999,6 +1089,9 @@ namespace LinearAlgebra
     bool
     Vector<Number, MemorySpace>::all_zero() const
     {
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
       Teuchos::ArrayRCP<const Number> data = vector->getData();
 
       const bool local_all_zero =
@@ -1015,6 +1108,10 @@ namespace LinearAlgebra
     bool
     Vector<Number, MemorySpace>::is_non_negative() const
     {
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+
       if constexpr (!std::is_same_v<Number, std::complex<double>> &&
                     !std::is_same_v<Number, std::complex<float>>)
         {
@@ -1052,6 +1149,10 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::mean_value() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       return vector->meanValue();
     }
@@ -1097,6 +1198,10 @@ namespace LinearAlgebra
              ExcMessage(
                "Not implemented for complex number types at the moment."));
 
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+
       return vector->normInf();
     }
 
@@ -1107,6 +1212,10 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::l1_norm() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       return vector->norm1();
     }
@@ -1119,6 +1228,10 @@ namespace LinearAlgebra
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
 
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
+
       return vector->norm2();
     }
 
@@ -1129,6 +1242,10 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::linfty_norm() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       return vector->normInf();
     }
@@ -1153,6 +1270,10 @@ namespace LinearAlgebra
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());
       AssertIsFinite(a);
+
+      // Reset our cached vector view so that trilinos operations on device do
+      // not detect an existing host view.
+      vector_1d_view.reset();
 
       this->add(a, V);
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1525,6 +1525,9 @@ namespace LinearAlgebra
           }
         }
 
+      nonlocal_vector_1d_view.reset();
+      vector_1d_view.reset();
+
       // Handle vector additions
       // If the nonlocal vector is permanent (=fixed-size) we cannot guarantee
       // that all processes that store an entry have written into it. Therefore
@@ -1555,8 +1558,6 @@ namespace LinearAlgebra
       else
         nonlocal_vector->putScalar(Number(0));
 
-      nonlocal_vector_1d_view.reset();
-      vector_1d_view.reset();
       compressed  = true;
       last_action = VectorOperation::unknown;
     }

--- a/tests/trilinos_tpetra/precondition.cc
+++ b/tests/trilinos_tpetra/precondition.cc
@@ -219,6 +219,7 @@ Step4<dim>::assemble_system()
       constraints.distribute_local_to_global(
         cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
     }
+  system_rhs.compress(VectorOperation::add);
   system_matrix.compress(VectorOperation::add);
 }
 

--- a/tests/trilinos_tpetra/slowness_02.cc
+++ b/tests/trilinos_tpetra/slowness_02.cc
@@ -76,6 +76,7 @@ test()
   v2.reinit(complete_index_set(N * N), MPI_COMM_WORLD);
   for (unsigned int i = 0; i < N * N; ++i)
     v1(i) = i;
+  v1.compress(VectorOperation::insert);
   matrix.vmult(v2, v1);
 
   deallog << v1 * v2 << std::endl;

--- a/tests/trilinos_tpetra/slowness_03.cc
+++ b/tests/trilinos_tpetra/slowness_03.cc
@@ -76,6 +76,7 @@ test()
     indices, MPI_COMM_WORLD);
   for (unsigned int i = 0; i < N * N; ++i)
     v1(i) = i;
+  v1.compress(VectorOperation::insert);
   matrix.vmult(v2, v1);
 
   deallog << v1 * v2 << std::endl;

--- a/tests/trilinos_tpetra/slowness_04.cc
+++ b/tests/trilinos_tpetra/slowness_04.cc
@@ -107,6 +107,7 @@ test()
     indices, MPI_COMM_WORLD);
   for (unsigned int i = 0; i < N * N; ++i)
     v1(i) = i;
+  v1.compress(VectorOperation::insert);
   matrix.vmult(v2, v1);
 
   deallog << v1 * v2 << std::endl;

--- a/tests/trilinos_tpetra/sparse_matrix_vector_08.cc
+++ b/tests/trilinos_tpetra/sparse_matrix_vector_08.cc
@@ -37,6 +37,7 @@ test(Vector<double> &v, Vector<double> &w)
   for (unsigned int i = 0; i < v.size(); ++i)
     v(i) = i;
 
+  v.compress(VectorOperation::insert);
   m.compress(VectorOperation::insert);
 
   // w:=Mv


### PR DESCRIPTION
A possible fix for the problem reported in https://github.com/dealii/dealii/pull/19542#issuecomment-4664591220.

I am not done testing this, but it compiles and passes all trilinos_tpetra tests except for `trilinos_tpetra/vector_tools_interpolate_01`, I need to look into that one.

@masterleinad I thought I open this early to give you the chance to take a look and maybe test it with a GPU build if possible.

With this PR we only cache the Kokkos view for as long as necessary, namely between first accessing one of the vector elements and until calling `compress` (or until reinitializing or overwriting the vector). This should make sure that there shouldnt be any active host view while doing linear algebra operations with the vector.