### PR TITLE
Don't explicitly instantiate `MeshWorker::DoFInfo` or `MeshWorker::DoFInfoBox`.

### DIFF
--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -423,6 +423,38 @@ namespace MeshWorker
 
   //----------------------------------------------------------------------//
 
+  template <int dim, int spacedim, typename number>
+  inline DoFInfo<dim, spacedim, number>::DoFInfo(const BlockInfo &info)
+    : face_number(numbers::invalid_unsigned_int)
+    , sub_number(numbers::invalid_unsigned_int)
+    , block_info(&info, typeid(*this).name())
+    , level_cell(false)
+  {
+    indices_by_block.resize(info.local().size());
+    for (unsigned int i = 0; i < indices_by_block.size(); ++i)
+      indices_by_block[i].resize(info.local().block_size(i));
+  }
+
+
+
+  template <int dim, int spacedim, typename number>
+  inline void
+  DoFInfo<dim, spacedim, number>::set_block_indices()
+  {
+    for (unsigned int i = 0; i < indices.size(); ++i)
+      {
+        const std::pair<unsigned int, unsigned int> bi =
+          block_info->local().global_to_local(this->block_info->renumber(i));
+        indices_by_block[bi.first][bi.second] = indices_org[i];
+      }
+    // Remove this after
+    // changing block codes
+    for (unsigned int i = 0; i < indices.size(); ++i)
+      indices[this->block_info->renumber(i)] = indices_org[i];
+  }
+
+
+
   template <int dim, class DOFINFO>
   inline DoFInfoBox<dim, DOFINFO>::DoFInfoBox(const DOFINFO &seed)
     : cell(seed)
@@ -436,6 +468,7 @@ namespace MeshWorker
         exterior_face_available[i] = false;
       }
   }
+
 
 
   template <int dim, class DOFINFO>
@@ -452,6 +485,7 @@ namespace MeshWorker
         exterior_face_available[i] = false;
       }
   }
+
 
 
   template <int dim, class DOFINFO>
@@ -471,6 +505,7 @@ namespace MeshWorker
   }
 
 
+
   template <int dim, class DOFINFO>
   inline void
   DoFInfoBox<dim, DOFINFO>::reset()
@@ -482,6 +517,7 @@ namespace MeshWorker
         exterior_face_available[i] = false;
       }
   }
+
 
 
   template <int dim, class DOFINFO>

--- a/include/deal.II/meshworker/dof_info.templates.h
+++ b/include/deal.II/meshworker/dof_info.templates.h
@@ -16,47 +16,12 @@
 
 #include <deal.II/base/config.h>
 
-#include <deal.II/base/quadrature_lib.h>
-
 #include <deal.II/meshworker/dof_info.h>
 
+DEAL_II_WARNING("This file is deprecated."
+                "Use deal.II/meshworker/dof_info.h instead.")
+
 DEAL_II_NAMESPACE_OPEN
-
-
-namespace MeshWorker
-{
-  template <int dim, int spacedim, typename number>
-  DoFInfo<dim, spacedim, number>::DoFInfo(const BlockInfo &info)
-    : face_number(numbers::invalid_unsigned_int)
-    , sub_number(numbers::invalid_unsigned_int)
-    , block_info(&info, typeid(*this).name())
-    , level_cell(false)
-  {
-    indices_by_block.resize(info.local().size());
-    for (unsigned int i = 0; i < indices_by_block.size(); ++i)
-      indices_by_block[i].resize(info.local().block_size(i));
-  }
-
-
-
-  template <int dim, int spacedim, typename number>
-  void
-  DoFInfo<dim, spacedim, number>::set_block_indices()
-  {
-    for (unsigned int i = 0; i < indices.size(); ++i)
-      {
-        const std::pair<unsigned int, unsigned int> bi =
-          block_info->local().global_to_local(this->block_info->renumber(i));
-        indices_by_block[bi.first][bi.second] = indices_org[i];
-      }
-    // Remove this after
-    // changing block codes
-    for (unsigned int i = 0; i < indices.size(); ++i)
-      indices[this->block_info->renumber(i)] = indices_org[i];
-  }
-} // namespace MeshWorker
-
-
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/source/meshworker/mesh_worker_info.cc
+++ b/source/meshworker/mesh_worker_info.cc
@@ -16,7 +16,6 @@
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
-#include <deal.II/meshworker/dof_info.templates.h>
 #include <deal.II/meshworker/integration_info.templates.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/source/meshworker/mesh_worker_info.inst.in
+++ b/source/meshworker/mesh_worker_info.inst.in
@@ -21,23 +21,11 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       template class IntegrationInfoBox<deal_II_dimension,
                                         deal_II_space_dimension>;
 
-      template class DoFInfo<deal_II_dimension, deal_II_space_dimension, float>;
-      template class DoFInfoBox<
-        deal_II_dimension,
-        DoFInfo<deal_II_dimension, deal_II_space_dimension, float>>;
-
       template void
       IntegrationInfo<deal_II_dimension, deal_II_space_dimension>::
         fill_local_data(
           const DoFInfo<deal_II_dimension, deal_II_space_dimension, float> &,
           bool);
-
-      template class DoFInfo<deal_II_dimension,
-                             deal_II_space_dimension,
-                             double>;
-      template class DoFInfoBox<
-        deal_II_dimension,
-        DoFInfo<deal_II_dimension, deal_II_space_dimension, double>>;
 
       template void
       IntegrationInfo<deal_II_dimension, deal_II_space_dimension>::


### PR DESCRIPTION
These classes are very small (we only have two functions in the `.templates.h` file). Let's save some space and not explicitly instantiate them.