### PR TITLE
SolutionTransfer: add a scratch array for packing data.

### DIFF
--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -21,6 +21,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/observer_pointer.h>
+#include <deal.II/base/thread_local_storage.h>
 
 #include <deal.II/dofs/dof_handler.h>
 
@@ -429,6 +430,13 @@ private:
    * copy over from the old to the new mesh.
    */
   std::vector<const VectorType *> input_vectors;
+
+  /**
+   * Scratch per-cell values used during data packing.
+   */
+  mutable Threads::ThreadLocalStorage<
+    std::vector<Vector<typename VectorType::value_type>>>
+    cell_dof_values;
 
   /**
    * The handle that the Triangulation has assigned to this object

--- a/include/deal.II/numerics/solution_transfer.templates.h
+++ b/include/deal.II/numerics/solution_transfer.templates.h
@@ -360,8 +360,9 @@ SolutionTransfer<dim, VectorType, spacedim>::pack_callback(
   typename DoFHandler<dim, spacedim>::cell_iterator cell(*cell_, dof_handler);
 
   // create buffer for each individual object
-  std::vector<::dealii::Vector<typename VectorType::value_type>> dof_values(
-    input_vectors.size());
+  std::vector<Vector<typename VectorType::value_type>> &dof_values =
+    cell_dof_values.get();
+  dof_values.resize(input_vectors.size());
 
   unsigned int fe_index = 0;
   if (dof_handler->has_hp_capabilities())


### PR DESCRIPTION
This lowers the number of allocations in step-32's execute_coarsening_and_refinement() step by about 50% (which is about 3% of total allocations when running without threads).