### PR TITLE
Remove incompatibilities between mpc and mpich

### DIFF
--- a/include/deal.II/base/mpi_stub.h
+++ b/include/deal.II/base/mpi_stub.h
@@ -22,6 +22,18 @@
 #if defined(DEAL_II_WITH_MPI)
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+// Avoid a macro collision between mpc.h and MPICH's C++ headers by
+// undefining DOUBLE_COMPLEX and LONG_DOUBLE_COMPLEX before including <mpi.h>
+// On some macOS setups mpc.h (from libmpc) defines macros
+// DOUBLE_COMPLEX/LONG_DOUBLE_COMPLEX that expand into C keywords
+// (e.g. double _Complex). These break MPICH's mpicxx.h declarations
+// (e.g. extern Datatype DOUBLE_COMPLEX;), causing compile errors.
+#  ifdef DOUBLE_COMPLEX
+#    undef DOUBLE_COMPLEX
+#  endif
+#  ifdef LONG_DOUBLE_COMPLEX
+#    undef LONG_DOUBLE_COMPLEX
+#  endif
 #  include <mpi.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 


### PR DESCRIPTION
I'm in the process of building the deal.II dmg image for the upcoming release. I managed to update all of the packages, and I'm now fighting against a few incompatibilities among our dependencies, and trying to get PSBLAS to work with spack.

This small patch avoids a macro collision between `mpc.h` and MPICH's C++ headers by undefining DOUBLE_COMPLEX and LONG_DOUBLE_COMPLEX before including `<mpi.h>` in `include/deal.II/base/mpi_stub.h`.

On some macOS setups `mpc.h` (from libmpc) defines macros DOUBLE_COMPLEX/LONG_DOUBLE_COMPLEX that expand into C keywords (e.g. double _Complex). 

These break MPICH's `mpicxx.h` declarations (e.g. extern Datatype DOUBLE_COMPLEX;), causing compile errors. Undefining the macros prevents accidental macro expansion and resolves the compile error. 