### PR TITLE
Deprecate the classes in namespace Algorithms.

### DIFF
--- a/doc/news/changes/minor/20260610Bangerth
+++ b/doc/news/changes/minor/20260610Bangerth
@@ -1,0 +1,6 @@
+Deprecated: The classes Algorithms::Event, Algorithms::OperatorBase,
+Algorithms::OutputOperator, Algorithms::Newton,
+Algorithms::ThetaTimestepping, Algorithms::TimestepControl, and
+Algorithms::DoFOutputOperator have been marked as deprecated.
+<br>
+(Wolfgang Bangerth, 2026/06/10)

--- a/include/deal.II/algorithms/newton.h
+++ b/include/deal.II/algorithms/newton.h
@@ -67,7 +67,7 @@ namespace Algorithms
    * residual"</tt> is inserted before <tt>"Newton iterate"</tt>.
    */
   template <typename VectorType>
-  class Newton : public OperatorBase
+  class DEAL_II_DEPRECATED_EARLY Newton : public OperatorBase
   {
   public:
     /**

--- a/include/deal.II/algorithms/operator.h
+++ b/include/deal.II/algorithms/operator.h
@@ -61,7 +61,7 @@ namespace Algorithms
    * providing additional information and forwarded to the inner Operator
    * objects of the nested iteration.
    */
-  class OperatorBase : public EnableObserverPointer
+  class DEAL_II_DEPRECATED_EARLY OperatorBase : public EnableObserverPointer
   {
   public:
     /**
@@ -100,7 +100,7 @@ namespace Algorithms
    * in each step of an iteration.
    */
   template <typename VectorType>
-  class OutputOperator : public EnableObserverPointer
+  class DEAL_II_DEPRECATED_EARLY OutputOperator : public EnableObserverPointer
   {
   public:
     /**

--- a/include/deal.II/algorithms/theta_timestepping.h
+++ b/include/deal.II/algorithms/theta_timestepping.h
@@ -281,7 +281,7 @@ namespace Algorithms
    * @endcode
    */
   template <typename VectorType>
-  class ThetaTimestepping : public OperatorBase
+  class DEAL_II_DEPRECATED_EARLY ThetaTimestepping : public OperatorBase
   {
   public:
     /**

--- a/include/deal.II/algorithms/timestep_control.h
+++ b/include/deal.II/algorithms/timestep_control.h
@@ -55,7 +55,7 @@ namespace Algorithms
    * with a more modern interface and better programming guarantees. Consider
    * using DiscreteTime instead of TimestepControl.
    */
-  class TimestepControl : public EnableObserverPointer
+  class DEAL_II_DEPRECATED_EARLY TimestepControl : public EnableObserverPointer
   {
   public:
     /**

--- a/include/deal.II/base/event.h
+++ b/include/deal.II/base/event.h
@@ -43,7 +43,7 @@ namespace Algorithms
    * Event A::event = Event::assign("Event for A");
    * @endcode
    */
-  class Event
+  class DEAL_II_DEPRECATED_EARLY Event
   {
   public:
     /**


### PR DESCRIPTION
Closes #19842.

Removing `Algorithms::Newton` will also eventually address #15026. Same for the time steppers in `namespace Algorithms`, see #2004.