### PR TITLE
Deprecate MeshWorker::Functional.

### DIFF
--- a/doc/news/changes/minor/20260610Bangerth-2
+++ b/doc/news/changes/minor/20260610Bangerth-2
@@ -1,0 +1,4 @@
+Deprecated: The class MeshWorker::Assembler::Functional has been marked as
+deprecated and will be removed in a future release.
+<br>
+(Wolfgang Bangerth, 2026/06/10)

--- a/include/deal.II/meshworker/functional.h
+++ b/include/deal.II/meshworker/functional.h
@@ -38,12 +38,12 @@ namespace MeshWorker
      * The class assembling local contributions to a functional into global
      * functionals.
      *
-     *
+     * @deprecated This class is deprecated and will be removed in a future release.
      *
      * @ingroup MeshWorker
      */
     template <typename number = double>
-    class Functional
+    class DEAL_II_DEPRECATED_EARLY Functional
     {
     public:
       /**


### PR DESCRIPTION
This class is not used anywhere in the tutorials, and we've long wanted to get rid of these sorts of classes (see also #17696).