### PR TITLE
Simplify MeshWorkers::Assemblers::CellsAndFaces.

### DIFF
--- a/doc/news/changes/incompatibilities/20260610Bangerth
+++ b/doc/news/changes/incompatibilities/20260610Bangerth
@@ -1,0 +1,8 @@
+Changed: `MeshWorker::Assembler::CellsAndFaces` now stores cell contributions
+by `cell->active_cell_index()` instead of `cell->user_index()`. As a result,
+user code no longer needs to assign cell user indices before using this
+assembler for cell-based output vectors, but any code that relied on custom
+cell `user_index()` values to choose storage locations must be updated.
+Face-only storage with `separate_faces=true` still uses `face->user_index()`.
+<br>
+(Wolfgang Bangerth, 2026/06/10)

--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -856,26 +856,12 @@ namespace Step39
 
   // Another clone of the assemble function. The big difference to the
   // previous ones is here that we also have an input vector.
+  // The results of the estimator are stored in a vector with one entry per
+  // cell.
   template <int dim>
   double InteriorPenaltyProblem<dim>::estimate()
   {
-    // The results of the estimator are stored in a vector with one entry per
-    // cell. Since cells in deal.II are not numbered, we have to create our
-    // own numbering in order to use this vector. For the assembler used below
-    // the information in which component of a vector the result is stored is
-    // transmitted by the user_index variable for each cell. We need to set this
-    // numbering up here.
-    //
-    // On the other hand, somebody might have used the user indices
-    // already. So, let's be good citizens and save them before tampering with
-    // them.
-    std::vector<unsigned int> old_user_indices;
-    triangulation.save_user_indices(old_user_indices);
-
     estimates.block(0).reinit(triangulation.n_active_cells());
-    unsigned int i = 0;
-    for (const auto &cell : triangulation.active_cell_iterators())
-      cell->set_user_index(i++);
 
     // This starts like before,
     MeshWorker::IntegrationInfoBox<dim> info_box;
@@ -926,9 +912,6 @@ namespace Step39
                                &Estimator::face<dim>,
                                assembler);
 
-    // Right before we return the result of the error estimate, we restore the
-    // old user indices.
-    triangulation.load_user_indices(old_user_indices);
     return estimates.block(0).l2_norm();
   }
 
@@ -946,12 +929,6 @@ namespace Step39
     BlockVector<double> errors(2);
     errors.block(0).reinit(triangulation.n_active_cells());
     errors.block(1).reinit(triangulation.n_active_cells());
-
-    std::vector<unsigned int> old_user_indices;
-    triangulation.save_user_indices(old_user_indices);
-    unsigned int i = 0;
-    for (const auto &cell : triangulation.active_cell_iterators())
-      cell->set_user_index(i++);
 
     MeshWorker::IntegrationInfoBox<dim> info_box;
     const unsigned int                  n_gauss_points =
@@ -986,7 +963,6 @@ namespace Step39
                                &ErrorIntegrator::boundary<dim>,
                                &ErrorIntegrator::face<dim>,
                                assembler);
-    triangulation.load_user_indices(old_user_indices);
 
     std::cout << "energy-error: " << errors.block(0).l2_norm() << std::endl;
     std::cout << "L2-error:     " << errors.block(1).l2_norm() << std::endl;

--- a/include/deal.II/meshworker/functional.h
+++ b/include/deal.II/meshworker/functional.h
@@ -93,9 +93,14 @@ namespace MeshWorker
     /**
      * Compute cell and face contributions of one or several functionals,
      * typically for error estimates. The information in which component the
-     * result is stored for a given cell or face is transmitted by its
-     * user_index variable. Hence, you need to make sure to set these variables
-     * appropriately before using this class.
+     * result is stored for a given cell or face is given by whatever
+     * `cell->active_cell_iterator` returns. For cases where face
+     * integrals are computed and stored separately into values for the
+     * two adjacent cells (i.e., if `separate_faces` is set to `true`
+     * in the call to initialize()), the code queries
+     * `cell->face(f)->user_index()` for what vector entry the value
+     * should be written into; user code must therefore set the user index
+     * appropriately for the faces on which integrals shall be computed.
      *
      * @ingroup MeshWorker
      */
@@ -261,7 +266,7 @@ namespace MeshWorker
         v = results.entry<BlockVector<double> *>(0);
 
       for (unsigned int i = 0; i < info.n_values(); ++i)
-        v->block(i)(info.cell->user_index()) += info.value(i);
+        v->block(i)(info.cell->active_cell_index()) += info.value(i);
     }
 
 
@@ -283,8 +288,10 @@ namespace MeshWorker
           else
             {
               BlockVector<double> *v0 = results.entry<BlockVector<double> *>(0);
-              v0->block(i)(info1.cell->user_index()) += .5 * info1.value(i);
-              v0->block(i)(info2.cell->user_index()) += .5 * info2.value(i);
+              v0->block(i)(info1.cell->active_cell_index()) +=
+                .5 * info1.value(i);
+              v0->block(i)(info2.cell->active_cell_index()) +=
+                .5 * info2.value(i);
             }
         }
     }


### PR DESCRIPTION
This also allows me to remove a bunch of now unnecessary code from step-39.

This is strictly an incompatible change, but only step-39 uses this functionality and there really isn't any other reasonable choice for what one would set the `user_index` to than the same value as `active_cell_index`. So I'm not overly aggrieved by the incompatibility. 

This class will eventually go away anyway with #17696.