### PR TITLE
Provide MueLu if ML is not available

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h
+++ b/include/deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h
@@ -83,6 +83,9 @@ namespace LinearAlgebra::TpetraWrappers
 
   template <typename Number, typename MemorySpace>
   class PreconditionBlockSSOR;
+
+  template <typename Number, typename MemorySpace>
+  class PreconditionAMGMueLu;
 } // namespace LinearAlgebra::TpetraWrappers
 #  endif
 
@@ -155,6 +158,8 @@ namespace TrilinosWrappers
     PreconditionBlockSOR<double, MemorySpace::Host>;
   using PreconditionBlockSSOR = ::dealii::LinearAlgebra::TpetraWrappers::
     PreconditionBlockSSOR<double, MemorySpace::Host>;
+  using PreconditionAMG = ::dealii::LinearAlgebra::TpetraWrappers::
+    PreconditionAMGMueLu<double, MemorySpace::Host>;
 #  else
   class PreconditionBase;
   class PreconditionIdentity;
@@ -171,6 +176,7 @@ namespace TrilinosWrappers
   class PreconditionBlockJacobi;
   class PreconditionBlockSOR;
   class PreconditionBlockSSOR;
+  class PreconditionAMG;
 #  endif
 } // namespace TrilinosWrappers
 


### PR DESCRIPTION
This is the first part of splitting #19808 into small pieces.

This PR starts by making `PreconditionAMGMueLu` available as `PreconditionAMG` if we compile without Epetra. `PreconditionAMG` is used in many examples and user codes, and `PreconditionAMGMueLu` offers almost the same interface and functionality (missing #19841 at the moment).