### PR TITLE
Add missing compress() calls in example programs

### DIFF
--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1083,6 +1083,8 @@ namespace Step31
         stokes_constraints.distribute_local_to_global(
           local_matrix, local_dof_indices, stokes_preconditioner_matrix);
       }
+
+    stokes_preconditioner_matrix.compress(VectorOperation::add);
   }
 
 
@@ -1359,6 +1361,9 @@ namespace Step31
                                                         stokes_rhs);
       }
 
+    stokes_matrix.compress(VectorOperation::add);
+    stokes_rhs.compress(VectorOperation::add);
+
     rebuild_stokes_matrix = false;
 
     std::cout << std::endl;
@@ -1456,6 +1461,8 @@ namespace Step31
           temperature_stiffness_matrix);
       }
 
+    temperature_mass_matrix.compress(VectorOperation::add);
+    temperature_stiffness_matrix.compress(VectorOperation::add);
     rebuild_temperature_matrices = false;
   }
 

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -308,6 +308,9 @@ namespace Step41
                                                system_rhs,
                                                true);
       }
+
+    system_matrix.compress(VectorOperation::add);
+    system_rhs.compress(VectorOperation::add);
   }
 
 
@@ -368,6 +371,8 @@ namespace Step41
                                                local_dof_indices,
                                                mass_matrix);
       }
+
+    mass_matrix.compress(VectorOperation::add);
   }
 
 


### PR DESCRIPTION
Breaking out the second set of changes of #19808, adding calls to `compress()`. Tpetra seems to require these calls for matrices, even if the program is not MPI parallel. Since I am adding them for matrices, it makes sense to add them for the vectors too.

There will be more examples that need changes like this, but I need to go through them when the other related PRs are resolved.