### PR TITLE
Guard AMG parameter only available for Epetra ML

### DIFF
--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1160,8 +1160,10 @@ namespace Step31
     // pointer, which makes it easier to recreate the preconditioner next time
     // around since we do not have to care about destroying the previously
     // used object.
-    amg_data.elliptic              = true;
+    amg_data.elliptic = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
     amg_data.higher_order_elements = true;
+#endif
     amg_data.smoother_sweeps       = 2;
     amg_data.aggregation_threshold = 0.02;
     Amg_preconditioner->initialize(stokes_preconditioner_matrix.block(0, 0),

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2173,9 +2173,11 @@ namespace Step32
     Amg_preconditioner = std::make_shared<TrilinosWrappers::PreconditionAMG>();
 
     TrilinosWrappers::PreconditionAMG::AdditionalData Amg_data;
-    Amg_data.constant_modes        = constant_modes;
-    Amg_data.elliptic              = true;
+    Amg_data.constant_modes = constant_modes;
+    Amg_data.elliptic       = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
     Amg_data.higher_order_elements = true;
+#endif
     Amg_data.smoother_sweeps       = 2;
     Amg_data.aggregation_threshold = 0.02;
 

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1642,9 +1642,11 @@ namespace Step42
         DoFTools::extract_constant_modes(dof_handler);
 
       TrilinosWrappers::PreconditionAMG::AdditionalData additional_data;
-      additional_data.constant_modes        = constant_modes;
-      additional_data.elliptic              = true;
-      additional_data.n_cycles              = 1;
+      additional_data.constant_modes = constant_modes;
+      additional_data.elliptic       = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+      additional_data.n_cycles = 1;
+#endif
       additional_data.w_cycle               = false;
       additional_data.output_details        = false;
       additional_data.smoother_sweeps       = 2;

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -1133,7 +1133,9 @@ namespace Step50
 #else
             Amg_data.elliptic              = true;
             Amg_data.smoother_type         = "Jacobi";
+#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
             Amg_data.higher_order_elements = true;
+#  endif
             Amg_data.smoother_sweeps       = settings.smoother_steps;
             Amg_data.aggregation_threshold = 0.02;
 #endif

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -608,8 +608,10 @@ namespace Step75
     TrilinosWrappers::PreconditionAMG                 precondition_amg;
     TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
     amg_data.smoother_sweeps = mg_data.coarse_solver.smoother_sweeps;
-    amg_data.n_cycles        = mg_data.coarse_solver.n_cycles;
-    amg_data.smoother_type   = mg_data.coarse_solver.smoother_type.c_str();
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+    amg_data.n_cycles = mg_data.coarse_solver.n_cycles;
+#endif
+    amg_data.smoother_type = mg_data.coarse_solver.smoother_type.c_str();
 
     precondition_amg.initialize(mg_matrices[min_level]->get_system_matrix(),
                                 amg_data);

--- a/examples/step-90/step-90.cc
+++ b/examples/step-90/step-90.cc
@@ -958,9 +958,11 @@ namespace Step90
           DoFTools::extract_constant_modes(dof_handler);
         TrilinosWrappers::PreconditionAMG preconditioner_stiffness;
         TrilinosWrappers::PreconditionAMG::AdditionalData Amg_data;
-        Amg_data.constant_modes        = constant_modes;
-        Amg_data.elliptic              = true;
+        Amg_data.constant_modes = constant_modes;
+        Amg_data.elliptic       = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
         Amg_data.higher_order_elements = false;
+#endif
         Amg_data.smoother_sweeps       = 2;
         Amg_data.aggregation_threshold = 0.02;
         Amg_data.output_details        = true;

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -338,8 +338,10 @@ namespace Step27
 
     LA::MPI::PreconditionAMG                 preconditioner;
     LA::MPI::PreconditionAMG::AdditionalData data;
-    data.elliptic              = true;
+    data.elliptic = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
     data.higher_order_elements = true;
+#endif
     preconditioner.initialize(system_matrix, data);
 
     cg.solve(system_matrix,

--- a/tests/multigrid-global-coarsening/multigrid_util.h
+++ b/tests/multigrid-global-coarsening/multigrid_util.h
@@ -411,8 +411,10 @@ mg_solve(SolverControl                        &solver_control,
 #ifdef DEAL_II_WITH_TRILINOS
       TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
       amg_data.smoother_sweeps = mg_data.coarse_solver.smoother_sweeps;
-      amg_data.n_cycles        = mg_data.coarse_solver.n_cycles;
-      amg_data.smoother_type   = mg_data.coarse_solver.smoother_type.c_str();
+#  ifdef DEAL_II_TRILINOS_WITH_EPETRA
+      amg_data.n_cycles = mg_data.coarse_solver.n_cycles;
+#  endif
+      amg_data.smoother_type = mg_data.coarse_solver.smoother_type.c_str();
 
       // CG with AMG as preconditioner
       precondition_amg.initialize(mg_matrices[min_level].get_system_matrix(),

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -574,10 +574,12 @@ namespace Step50
     {
       deallog << "AMG:" << std::endl;
       LA::MPI::PreconditionAMG::AdditionalData Amg_data;
-      Amg_data.elliptic              = true;
+      Amg_data.elliptic = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
       Amg_data.higher_order_elements = true;
       Amg_data.n_cycles              = 1;
-      Amg_data.smoother_sweeps       = 1;
+#endif
+      Amg_data.smoother_sweeps = 1;
       MGCoarseAMG<LA::MPI::Vector> coarse_grid_solver(coarse_matrix, Amg_data);
 
       vcycle(coarse_grid_solver);

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -481,7 +481,9 @@ namespace Step50
 
          TrilinosWrappers::PreconditionAMG::AdditionalData Amg_data;
          Amg_data.elliptic = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
          Amg_data.higher_order_elements = true;
+#endif
          Amg_data.smoother_sweeps = 2;
          Amg_data.aggregation_threshold = 0.02;
 

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -616,7 +616,9 @@ namespace Step31
     TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
     amg_data.constant_modes_values = constant_modes_values;
     amg_data.elliptic              = true;
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
     amg_data.higher_order_elements = true;
+#endif
     amg_data.smoother_sweeps       = 2;
     amg_data.aggregation_threshold = 0.02;
     Amg_preconditioner->initialize(stokes_preconditioner_matrix.block(0, 0),


### PR DESCRIPTION
One more breakout PR of #19808, this time guarding the two parameters in `PreconditionAMG::AdditionalData` that are only available for Epetra/ML or Epetra/MueLu and not for Tpetra/MueLu.