### PR TITLE
Rename a few variables into n_lanes. Remove unneeded ones

### DIFF
--- a/tests/base/vectorization_01.cc
+++ b/tests/base/vectorization_01.cc
@@ -27,57 +27,57 @@ test()
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
   VectorizedArray<Number> a, b, c;
-  const unsigned int      n_vectors = VectorizedArray<Number>::size();
-  a                                 = Number(2.);
-  b                                 = Number(-1.);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  const unsigned int      n_lanes = VectorizedArray<Number>::size();
+  a                               = Number(2.);
+  b                               = Number(-1.);
+  for (unsigned int i = 0; i < n_lanes; ++i)
     c[i] = Number(i);
 
-  AssertDimension(n_vectors, a.size());
+  AssertDimension(n_lanes, a.size());
   AssertDimension(a.size(), sizeof(a) / sizeof(Number));
   AssertDimension(VectorizedArray<Number>::size(), sizeof(a) / sizeof(Number));
 
   deallog << "Addition: ";
   VectorizedArray<Number> d = a + b;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == 1, ExcInternalError());
   deallog << "OK" << std::endl << "Subtraction: ";
   VectorizedArray<Number> e = d - b;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(e[i] == a[i], ExcInternalError());
   deallog << "OK" << std::endl << "Multiplication: ";
   d = a * c;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == a[i] * c[i], ExcInternalError());
   deallog << "OK" << std::endl << "Division: ";
   e = d / a;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(e[i] == c[i], ExcInternalError());
   deallog << "OK" << std::endl << "Multiplication scalar: ";
   a = Number(2.) * a;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(a[i] == 4., ExcInternalError());
   deallog << "OK" << std::endl << "Division scalar left: ";
   d = Number(1.) / a;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == 0.25, ExcInternalError());
   deallog << "OK" << std::endl << "Division scalar right: ";
   e = d / Number(0.25);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(e[i] == 1, ExcInternalError());
   deallog << "OK" << std::endl << "Unary operator -: ";
   d = -c;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == -(Number)i, ExcInternalError());
   deallog << "OK" << std::endl << "Unary operator +: ";
   d = c;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == i, ExcInternalError());
 
 
   deallog << "OK" << std::endl << "Square root: ";
   d = std::sqrt(c);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::sqrt(Number(i))) <
                   std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
@@ -85,99 +85,99 @@ test()
   deallog << "OK" << std::endl << "Absolute value: ";
   d = -c;
   d = std::abs(d);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == Number(i), ExcInternalError());
   deallog << "OK" << std::endl << "Maximum value: ";
   d = std::max(a, c);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == std::max(a[i], c[i]), ExcInternalError());
   deallog << "OK" << std::endl << "Minimum value: ";
   d = std::min(Number(0.5) * a + b, c);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(d[i] == std::min(Number(0.5 * a[i] + b[i]), c[i]),
                 ExcInternalError());
 
   deallog << "OK" << std::endl << "Sine: ";
   e = std::sin(d);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(e[i] - std::sin(d[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Arc sine: ";
   d = std::asin(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::asin(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Cosine: ";
   e = std::cos(c);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(e[i] - std::cos(c[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Arc cosine: ";
   c = std::acos(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(c[i] - std::acos(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Tangent: ";
   d = std::tan(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::tan(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Arc tangent: ";
   d = std::atan(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::atan(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Hyperbolic cosine: ";
   e = std::cosh(c);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(e[i] - std::cosh(c[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Area hyperbolic cosine: ";
   c = std::acosh(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(c[i] - std::acosh(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Hyperbolic sine: ";
   e = std::sinh(d);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(e[i] - std::sinh(d[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Area hyperbolic sine: ";
   d = std::asinh(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::asinh(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Hyperbolic tangent: ";
   d = std::tanh(e);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::tanh(e[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Area hyperbolic tangent: ";
   e = std::atanh(d);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(e[i] - std::atanh(d[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Exponential: ";
   d = std::exp(c - a);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(d[i] - std::exp(c[i] - a[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());
   deallog << "OK" << std::endl << "Logarithm: ";
   e = std::log(d);
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     AssertThrow(std::fabs(e[i] - (c[i] - a[i])) <
                   10. * std::numeric_limits<Number>::epsilon(),
                 ExcInternalError());

--- a/tests/base/vectorization_02.cc
+++ b/tests/base/vectorization_02.cc
@@ -21,14 +21,14 @@
 void
 test()
 {
-  using vector_t               = VectorizedArray<double>;
-  const unsigned int n_vectors = VectorizedArray<double>::size();
-  using VEC                    = AlignedVector<vector_t>;
+  using vector_t             = VectorizedArray<double>;
+  const unsigned int n_lanes = VectorizedArray<double>::size();
+  using VEC                  = AlignedVector<vector_t>;
   std::vector<double> a_ref(4), b_ref;
   VEC                 a(4);
   deallog << "Constructor: ";
   for (unsigned int i = 0; i < a.size(); ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == 0, ExcInternalError());
   deallog << "OK" << std::endl;
 
@@ -50,21 +50,21 @@ test()
 
   deallog << "Insertion: ";
   for (unsigned int i = 0; i < a.size(); ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == a_ref[i], ExcInternalError());
   deallog << "OK" << std::endl;
 
   a.resize(4);
   deallog << "Shrinking: ";
   for (unsigned int i = 0; i < a.size(); ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == a_ref[i], ExcInternalError());
   deallog << "OK" << std::endl;
 
   a.reserve(100);
   deallog << "Reserve: ";
   for (unsigned int i = 0; i < a.size(); ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == a_ref[i], ExcInternalError());
   deallog << "OK" << std::endl;
 
@@ -72,7 +72,7 @@ test()
   a_ref = b_ref;
   deallog << "Assignment: ";
   for (unsigned int i = 0; i < a.size(); ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == a_ref[i], ExcInternalError());
   deallog << "OK" << std::endl;
 
@@ -81,7 +81,7 @@ test()
   a.resize(100000, make_vectorized_array(1.));
   deallog << "Check large initialization: ";
   for (unsigned int i = 0; i < 100000; ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == 1., ExcInternalError());
   deallog << "OK" << std::endl;
 
@@ -90,13 +90,13 @@ test()
   a.resize(200000, make_vectorized_array(2.));
   a.resize(400000);
   for (unsigned int i = 0; i < 100000; ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == 1., ExcInternalError());
   for (unsigned int i = 100000; i < 200000; ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == 2., ExcInternalError());
   for (unsigned int i = 200000; i < 400000; ++i)
-    for (unsigned int d = 0; d < n_vectors; ++d)
+    for (unsigned int d = 0; d < n_lanes; ++d)
       AssertThrow(a[i][d] == 0., ExcInternalError());
   deallog << "OK" << std::endl;
 }

--- a/tests/base/vectorization_04.cc
+++ b/tests/base/vectorization_04.cc
@@ -22,35 +22,35 @@ template <typename Number, typename VectorizedArrayType>
 void
 test()
 {
-  const unsigned int  n_vectors = VectorizedArrayType::size();
-  std::vector<Number> values(n_vectors * 5);
+  const unsigned int  n_lanes = VectorizedArrayType::size();
+  std::vector<Number> values(n_lanes * 5);
   for (unsigned int i = 0; i < values.size(); ++i)
     values[i] = i;
   AlignedVector<VectorizedArrayType> copied(4);
 
   // test load operation for all possible values of alignment
-  for (unsigned int shift = 0; shift < n_vectors; ++shift)
+  for (unsigned int shift = 0; shift < n_lanes; ++shift)
     {
       for (unsigned int i = 0; i < 4; ++i)
-        copied[i].load(&values[i * n_vectors + shift]);
+        copied[i].load(&values[i * n_lanes + shift]);
       for (unsigned int i = 0; i < 4; ++i)
-        for (unsigned int v = 0; v < n_vectors; ++v)
-          AssertThrow(copied[i][v] == values[i * n_vectors + v + shift],
+        for (unsigned int v = 0; v < n_lanes; ++v)
+          AssertThrow(copied[i][v] == values[i * n_lanes + v + shift],
                       ExcInternalError());
     }
   deallog << "load OK" << std::endl;
 
   // test store operation
-  std::vector<Number> stored(n_vectors * 5);
-  for (unsigned int shift = 0; shift < n_vectors; ++shift)
+  std::vector<Number> stored(n_lanes * 5);
+  for (unsigned int shift = 0; shift < n_lanes; ++shift)
     {
       for (unsigned int i = 0; i < 4; ++i)
         {
           VectorizedArrayType tmp;
-          tmp.load(&values[i * n_vectors]);
-          tmp.store(&stored[i * n_vectors + shift]);
+          tmp.load(&values[i * n_lanes]);
+          tmp.store(&stored[i * n_lanes + shift]);
         }
-      for (unsigned int i = 0; i < 4 * n_vectors; ++i)
+      for (unsigned int i = 0; i < 4 * n_lanes; ++i)
         AssertThrow(stored[i + shift] == i, ExcInternalError());
     }
   deallog << "store OK" << std::endl;

--- a/tests/base/vectorization_05.cc
+++ b/tests/base/vectorization_05.cc
@@ -28,21 +28,21 @@ test()
 {
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
-  const unsigned int      n_vectors = VectorizedArray<Number>::size();
+  const unsigned int      n_lanes = VectorizedArray<Number>::size();
   VectorizedArray<Number> arr[n_numbers];
-  Number                  other[n_vectors * n_numbers];
-  unsigned int            offsets[n_vectors];
-  for (unsigned int v = 0; v < n_vectors; ++v)
+  Number                  other[n_lanes * n_numbers];
+  unsigned int            offsets[n_lanes];
+  for (unsigned int v = 0; v < n_lanes; ++v)
     offsets[v] = v * n_numbers;
 
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       other[i * n_numbers + j] = i * n_numbers + j + 13;
 
   vectorized_load_and_transpose(n_numbers, other, offsets, arr);
   unsigned int n_errors = 0;
   for (unsigned int j = 0; j < n_numbers; ++j)
-    for (unsigned int i = 0; i < n_vectors; ++i)
+    for (unsigned int i = 0; i < n_lanes; ++i)
       if (arr[j][i] != i * n_numbers + j + 13)
         ++n_errors;
   deallog << "load_and_transpose at          n=" << n_numbers
@@ -50,21 +50,21 @@ test()
   if (n_errors > 0)
     for (unsigned int i = 0; i < n_numbers; ++i)
       {
-        for (unsigned int j = 0; j < n_vectors; ++j)
+        for (unsigned int j = 0; j < n_lanes; ++j)
           deallog << arr[i][j] << ' ';
         deallog << std::endl;
       }
 
   vectorized_transpose_and_store(true, n_numbers, arr, offsets, other);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       if (other[i * n_numbers + j] != 2. * (i * n_numbers + j + 13))
         ++n_errors;
   deallog << "transpose_and_store (  add) at n=" << n_numbers
           << ": #errors: " << n_errors << std::endl;
   if (n_errors > 0)
-    for (unsigned int i = 0; i < n_vectors; ++i)
+    for (unsigned int i = 0; i < n_lanes; ++i)
       {
         for (unsigned int j = 0; j < n_numbers; ++j)
           deallog << other[i * n_numbers + j] << ' ';
@@ -73,14 +73,14 @@ test()
 
   vectorized_transpose_and_store(false, n_numbers, arr, offsets, other);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       if (other[i * n_numbers + j] != (i * n_numbers + j + 13))
         ++n_errors;
   deallog << "transpose_and_store (noadd) at n=" << n_numbers
           << ": #errors: " << n_errors << std::endl;
   if (n_errors > 0)
-    for (unsigned int i = 0; i < n_vectors; ++i)
+    for (unsigned int i = 0; i < n_lanes; ++i)
       {
         for (unsigned int j = 0; j < n_numbers; ++j)
           deallog << other[i * n_numbers + j] << ' ';

--- a/tests/base/vectorization_06.cc
+++ b/tests/base/vectorization_06.cc
@@ -32,63 +32,63 @@ test()
   for (unsigned int i = 0; i < vec.size(); ++i)
     vec[i] = i + 1;
 
-  const unsigned int n_vectors = VectorizedArray<Number>::size();
-  unsigned int       indices[n_vectors];
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  const unsigned int n_lanes = VectorizedArray<Number>::size();
+  unsigned int       indices[n_lanes];
+  for (unsigned int i = 0; i < n_lanes; ++i)
     indices[i] = i;
   VectorizedArray<Number> arr;
   arr = Number(-1000);
 
   arr.gather(&vec[0], indices);
   unsigned int n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     if (arr[i] != i + 1)
       ++n_errors;
   deallog << "gather contiguous #errors:      " << n_errors << std::endl;
   if (n_errors > 0)
     {
-      for (unsigned int j = 0; j < n_vectors; ++j)
+      for (unsigned int j = 0; j < n_lanes; ++j)
         deallog << arr[j] << " vs " << j + 1 << "   ";
       deallog << std::endl;
     }
 
   arr.gather(&vec[2], indices);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     if (arr[i] != i + 3)
       ++n_errors;
   deallog << "gather contiguous #errors:      " << n_errors << std::endl;
   if (n_errors > 0)
     {
-      for (unsigned int j = 0; j < n_vectors; ++j)
+      for (unsigned int j = 0; j < n_lanes; ++j)
         deallog << arr[j] << " vs " << j + 3 << "   ";
       deallog << std::endl;
     }
 
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     indices[i] = 3 * i + 1;
   arr.gather(&vec[0], indices);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     if (arr[i] != 3 * i + 2)
       ++n_errors;
   deallog << "gather non-contiguous #errors:  " << n_errors << std::endl;
   if (n_errors > 0)
     {
-      for (unsigned int j = 0; j < n_vectors; ++j)
+      for (unsigned int j = 0; j < n_lanes; ++j)
         deallog << arr[j] << " vs " << 3 * j + 2 << "   ";
       deallog << std::endl;
     }
 
   arr.gather(&vec[3], indices);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     if (arr[i] != 3 * i + 5)
       ++n_errors;
   deallog << "gather non-contiguous #errors:  " << n_errors << std::endl;
   if (n_errors > 0)
     {
-      for (unsigned int j = 0; j < n_vectors; ++j)
+      for (unsigned int j = 0; j < n_lanes; ++j)
         deallog << arr[j] << " vs " << 3 * j + 5 << "   ";
       deallog << std::endl;
     }
@@ -96,10 +96,10 @@ test()
   arr = Number(-1);
   arr.scatter(indices, &vec[0]);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     if (vec[indices[i]] != -1)
       ++n_errors;
-  unsigned int *start = &indices[0], *end = start + n_vectors;
+  unsigned int *start = &indices[0], *end = start + n_lanes;
   for (unsigned int i = 0; i < vec.size(); ++i)
     if (std::find(start, end, i) == end && vec[i] < 0)
       ++n_errors;

--- a/tests/base/vectorization_09.cc
+++ b/tests/base/vectorization_09.cc
@@ -22,21 +22,21 @@ template <typename Number>
 void
 test()
 {
-  const unsigned int  n_chunks  = 50000;
-  const unsigned int  n_vectors = VectorizedArray<Number>::size();
-  std::vector<Number> values(n_vectors * n_chunks);
+  const unsigned int  n_chunks = 50000;
+  const unsigned int  n_lanes  = VectorizedArray<Number>::size();
+  std::vector<Number> values(n_lanes * n_chunks);
   for (unsigned int i = 0; i < values.size(); ++i)
     values[i] = i;
 
   // test store operation
-  AlignedVector<Number> stored(n_vectors * n_chunks);
+  AlignedVector<Number> stored(n_lanes * n_chunks);
   for (unsigned int i = 0; i < n_chunks; ++i)
     {
       VectorizedArray<Number> tmp;
-      tmp.load(&values[i * n_vectors]);
-      tmp.streaming_store(&stored[i * n_vectors]);
+      tmp.load(&values[i * n_lanes]);
+      tmp.streaming_store(&stored[i * n_lanes]);
     }
-  for (unsigned int i = 0; i < n_chunks * n_vectors; ++i)
+  for (unsigned int i = 0; i < n_chunks * n_lanes; ++i)
     AssertThrow(stored[i] == i, ExcInternalError());
   deallog << "streaming store OK" << std::endl;
 }

--- a/tests/base/vectorization_10.cc
+++ b/tests/base/vectorization_10.cc
@@ -28,21 +28,21 @@ do_test()
 {
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
-  const unsigned int n_vectors = VectorizedArray<Number, width>::size();
+  const unsigned int n_lanes = VectorizedArray<Number, width>::size();
   VectorizedArray<Number, width> arr[n_numbers];
-  Number                         other[n_vectors * n_numbers];
-  unsigned int                   offsets[n_vectors];
-  for (unsigned int v = 0; v < n_vectors; ++v)
+  Number                         other[n_lanes * n_numbers];
+  unsigned int                   offsets[n_lanes];
+  for (unsigned int v = 0; v < n_lanes; ++v)
     offsets[v] = v * n_numbers;
 
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       other[i * n_numbers + j] = i * n_numbers + j;
 
   vectorized_load_and_transpose(n_numbers, other, offsets, arr);
   unsigned int n_errors = 0;
   for (unsigned int j = 0; j < n_numbers; ++j)
-    for (unsigned int i = 0; i < n_vectors; ++i)
+    for (unsigned int i = 0; i < n_lanes; ++i)
       if (arr[j][i] != i * n_numbers + j)
         ++n_errors;
   if (n_errors > 0)
@@ -52,7 +52,7 @@ do_test()
 
       for (unsigned int i = 0; i < n_numbers; ++i)
         {
-          for (unsigned int j = 0; j < n_vectors; ++j)
+          for (unsigned int j = 0; j < n_lanes; ++j)
             deallog << arr[i][j] << ' ';
           deallog << std::endl;
         }
@@ -60,7 +60,7 @@ do_test()
 
   vectorized_transpose_and_store(true, n_numbers, arr, offsets, other);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       if (other[i * n_numbers + j] != 2. * (i * n_numbers + j))
         ++n_errors;
@@ -69,7 +69,7 @@ do_test()
       deallog << "transpose_and_store (  add) at n=" << n_numbers
               << " width=" << width << ": #errors: " << n_errors << std::endl;
 
-      for (unsigned int i = 0; i < n_vectors; ++i)
+      for (unsigned int i = 0; i < n_lanes; ++i)
         {
           for (unsigned int j = 0; j < n_numbers; ++j)
             deallog << other[i * n_numbers + j] << ' ';
@@ -79,7 +79,7 @@ do_test()
 
   vectorized_transpose_and_store(false, n_numbers, arr, offsets, other);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       if (other[i * n_numbers + j] != (i * n_numbers + j))
         ++n_errors;
@@ -88,7 +88,7 @@ do_test()
       deallog << "transpose_and_store (noadd) at n=" << n_numbers
               << " width=" << width << ": #errors: " << n_errors << std::endl;
 
-      for (unsigned int i = 0; i < n_vectors; ++i)
+      for (unsigned int i = 0; i < n_lanes; ++i)
         {
           for (unsigned int j = 0; j < n_numbers; ++j)
             deallog << other[i * n_numbers + j] << ' ';

--- a/tests/base/vectorization_15.cc
+++ b/tests/base/vectorization_15.cc
@@ -28,18 +28,18 @@ do_test()
 {
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
-  const unsigned int n_vectors = VectorizedArray<Number, width>::size();
+  const unsigned int n_lanes = VectorizedArray<Number, width>::size();
   VectorizedArray<Number, width> arr[n_numbers];
-  Number                         other[n_vectors * n_numbers];
-  unsigned int                   offsets[n_vectors];
-  for (unsigned int v = 0; v < n_vectors; ++v)
+  Number                         other[n_lanes * n_numbers];
+  unsigned int                   offsets[n_lanes];
+  for (unsigned int v = 0; v < n_lanes; ++v)
     offsets[v] = v * n_numbers;
 
   std::array<Number *, width> other_and_offset;
   for (unsigned int v = 0; v < width; ++v)
     other_and_offset[v] = other + offsets[v];
 
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       other[i * n_numbers + j] = i * n_numbers + j;
 
@@ -48,7 +48,7 @@ do_test()
                                                arr);
   unsigned int n_errors = 0;
   for (unsigned int j = 0; j < n_numbers; ++j)
-    for (unsigned int i = 0; i < n_vectors; ++i)
+    for (unsigned int i = 0; i < n_lanes; ++i)
       if (arr[j][i] != i * n_numbers + j)
         ++n_errors;
   if (n_errors > 0)
@@ -58,7 +58,7 @@ do_test()
 
       for (unsigned int i = 0; i < n_numbers; ++i)
         {
-          for (unsigned int j = 0; j < n_vectors; ++j)
+          for (unsigned int j = 0; j < n_lanes; ++j)
             deallog << arr[i][j] << ' ';
           deallog << std::endl;
         }
@@ -69,7 +69,7 @@ do_test()
                                                 arr,
                                                 other_and_offset);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       if (other[i * n_numbers + j] != 2. * (i * n_numbers + j))
         ++n_errors;
@@ -78,7 +78,7 @@ do_test()
       deallog << "transpose_and_store (  add) at n=" << n_numbers
               << " width=" << width << ": #errors: " << n_errors << std::endl;
 
-      for (unsigned int i = 0; i < n_vectors; ++i)
+      for (unsigned int i = 0; i < n_lanes; ++i)
         {
           for (unsigned int j = 0; j < n_numbers; ++j)
             deallog << other[i * n_numbers + j] << ' ';
@@ -91,7 +91,7 @@ do_test()
                                                 arr,
                                                 other_and_offset);
   n_errors = 0;
-  for (unsigned int i = 0; i < n_vectors; ++i)
+  for (unsigned int i = 0; i < n_lanes; ++i)
     for (unsigned int j = 0; j < n_numbers; ++j)
       if (other[i * n_numbers + j] != (i * n_numbers + j))
         ++n_errors;
@@ -100,7 +100,7 @@ do_test()
       deallog << "transpose_and_store (noadd) at n=" << n_numbers
               << " width=" << width << ": #errors: " << n_errors << std::endl;
 
-      for (unsigned int i = 0; i < n_vectors; ++i)
+      for (unsigned int i = 0; i < n_lanes; ++i)
         {
           for (unsigned int j = 0; j < n_numbers; ++j)
             deallog << other[i * n_numbers + j] << ' ';

--- a/tests/matrix_free/matrix_vector_12.cc
+++ b/tests/matrix_free/matrix_vector_12.cc
@@ -79,9 +79,6 @@ template <int dim, int fe_degree, typename Number>
 class MatrixFreeTest
 {
 public:
-  using vector_t                     = VectorizedArray<Number>;
-  static const std::size_t n_vectors = VectorizedArray<Number>::size();
-
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 

--- a/tests/matrix_free/matrix_vector_13.cc
+++ b/tests/matrix_free/matrix_vector_13.cc
@@ -79,9 +79,6 @@ template <int dim, int fe_degree, typename Number>
 class MatrixFreeTest
 {
 public:
-  using vector_t                     = VectorizedArray<Number>;
-  static const std::size_t n_vectors = VectorizedArray<Number>::size();
-
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 

--- a/tests/matrix_free/matrix_vector_20.cc
+++ b/tests/matrix_free/matrix_vector_20.cc
@@ -91,9 +91,6 @@ template <int dim, int fe_degree, typename Number>
 class MatrixFreeTest
 {
 public:
-  using vector_t                     = VectorizedArray<Number>;
-  static const std::size_t n_vectors = VectorizedArray<Number>::size();
-
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 

--- a/tests/matrix_free/matrix_vector_21.cc
+++ b/tests/matrix_free/matrix_vector_21.cc
@@ -81,9 +81,6 @@ template <int dim, int fe_degree, typename Number>
 class MatrixFreeTest
 {
 public:
-  using vector_t                     = VectorizedArray<Number>;
-  static const std::size_t n_vectors = VectorizedArray<Number>::size();
-
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 

--- a/tests/matrix_free/matrix_vector_22.cc
+++ b/tests/matrix_free/matrix_vector_22.cc
@@ -80,9 +80,6 @@ template <int dim, int fe_degree, typename Number>
 class MatrixFreeTest
 {
 public:
-  using vector_t                     = VectorizedArray<Number>;
-  static const std::size_t n_vectors = VectorizedArray<Number>::size();
-
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 

--- a/tests/matrix_free/matrix_vector_23.cc
+++ b/tests/matrix_free/matrix_vector_23.cc
@@ -92,9 +92,6 @@ template <int dim, int fe_degree, typename Number>
 class MatrixFreeTest
 {
 public:
-  using vector_t                     = VectorizedArray<Number>;
-  static const std::size_t n_vectors = VectorizedArray<Number>::size();
-
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};
 


### PR DESCRIPTION
Writing a new test for #19837 I noted some poorly named variables. Change the name to our standard convention. While there, removed a few places where this variable was introduced but not used.