### PR TITLE
[WIP] Remove IC preconditioner from tests if unavailable

### DIFF
--- a/tests/lac/linear_operator_10.cc
+++ b/tests/lac/linear_operator_10.cc
@@ -279,6 +279,7 @@ main(int argc, char *argv[])
       deallog.pop();
     }
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
     {
       deallog.push("PreconditionIC");
       using PREC = TrilinosWrappers::PreconditionIC;
@@ -286,6 +287,7 @@ main(int argc, char *argv[])
       test_preconditioner<PREC>(A, c);
       deallog.pop();
     }
+#endif
 
     {
       deallog.push("PreconditionIdentity");

--- a/tests/lac/linear_operator_10a.cc
+++ b/tests/lac/linear_operator_10a.cc
@@ -274,6 +274,7 @@ main(int argc, char *argv[])
       deallog.pop();
     }
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
     {
       deallog.push("PreconditionIC");
       using PREC = TrilinosWrappers::PreconditionIC;
@@ -281,6 +282,7 @@ main(int argc, char *argv[])
       test_preconditioner<PREC>(A, c);
       deallog.pop();
     }
+#endif
 
     {
       deallog.push("PreconditionIdentity");

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -289,8 +289,19 @@ namespace Step31
     double                         old_time_step;
     unsigned int                   timestep_number;
     std::shared_ptr<TrilinosWrappers::PreconditionAMG> Amg_preconditioner;
-    std::shared_ptr<TrilinosWrappers::PreconditionIC>  Mp_preconditioner;
-    bool                                               rebuild_stokes_matrix;
+
+    // Next, we select the type used for the preconditioner. For older versions of Trilinos, which
+    // have the historical Epetra sub-package, we can use an incomplete Cholesky (IC)
+    // preconditioner. For newer Trilinos versions that no longer have Epetra, we use
+    // a Jacobi preconditioner.
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+    using MpPreconditionType = TrilinosWrappers::PreconditionIC;
+#else
+    using MpPreconditionType = TrilinosWrappers::PreconditionJacobi;
+#endif
+    std::shared_ptr<MpPreconditionType> Mp_preconditioner;
+
+    bool rebuild_stokes_matrix;
     bool rebuild_temperature_matrices;
     bool rebuild_stokes_preconditioner;
   };
@@ -623,7 +634,7 @@ namespace Step31
     amg_data.aggregation_threshold = 0.02;
     Amg_preconditioner->initialize(stokes_preconditioner_matrix.block(0, 0),
                                    amg_data);
-    Mp_preconditioner = std::make_shared<TrilinosWrappers::PreconditionIC>();
+    Mp_preconditioner = std::make_shared<MpPreconditionType>();
     Mp_preconditioner->initialize(stokes_preconditioner_matrix.block(1, 1));
     deallog << std::endl;
     rebuild_stokes_preconditioner = false;
@@ -899,12 +910,12 @@ namespace Step31
     deallog << "   Solving..." << std::endl;
     {
       const LinearSolvers::InverseMatrix<TrilinosWrappers::SparseMatrix,
-                                         TrilinosWrappers::PreconditionIC>
+                                         MpPreconditionType>
         mp_inverse(stokes_preconditioner_matrix.block(1, 1),
                    *Mp_preconditioner);
       const LinearSolvers::BlockSchurPreconditioner<
         TrilinosWrappers::PreconditionAMG,
-        TrilinosWrappers::PreconditionIC>
+        MpPreconditionType>
         preconditioner(stokes_matrix, mp_inverse, *Amg_preconditioner);
       SolverControl solver_control(stokes_matrix.m(),
                                    1e-6 * stokes_rhs.l2_norm());
@@ -936,7 +947,7 @@ namespace Step31
       SolverControl solver_control(temperature_matrix.m(),
                                    1e-8 * temperature_rhs.l2_norm());
       SolverCG<TrilinosWrappers::MPI::Vector> cg(solver_control);
-      TrilinosWrappers::PreconditionIC        preconditioner;
+      MpPreconditionType                      preconditioner;
       preconditioner.initialize(temperature_matrix);
       cg.solve(temperature_matrix,
                temperature_solution,

--- a/tests/trilinos/precondition.cc
+++ b/tests/trilinos/precondition.cc
@@ -327,6 +327,7 @@ Step4<dim>::solve(int cycle)
     deallog.pop();
   }
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
   {
     deallog.push("IC");
     static constexpr std::array<unsigned int, 2> lower{{48, 62}};
@@ -342,6 +343,7 @@ Step4<dim>::solve(int cycle)
       lower[cycle] + 10);
     deallog.pop();
   }
+#endif
 
   {
     static constexpr std::array<unsigned int, 2> lower{{30, 56}};


### PR DESCRIPTION
This is a part of #19857 that needs a bit of further work as discussed in that PR.

This is not critical for 9.8, it only ensures these tests do not fail if we are compiling with trilinos 17.