### PR TITLE
Make Tpetra vector element operations thread-safe

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1279,8 +1279,10 @@ namespace LinearAlgebra
         const typename TpetraTypes::VectorType<Number, MemorySpace>::map_type>
         vector_map;
       {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
         // Make this part of the function thread safe
         std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
         vector_map = vector->getMap().ptr();
 
@@ -1326,8 +1328,10 @@ namespace LinearAlgebra
             }
           else if (nonlocal_vector.get() == nullptr)
             {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
               std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
               // The element is not in the locally owned part, and
               // there is no specified nonlocal_vector, i.e. this is
@@ -1339,8 +1343,10 @@ namespace LinearAlgebra
             }
           else
             {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
               std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
               // If the element was not in the locally owned part,
               // and we have a predetermined nonlocal buffer, we need
@@ -1411,8 +1417,10 @@ namespace LinearAlgebra
         const typename TpetraTypes::VectorType<Number, MemorySpace>::map_type>
         vector_map;
       {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
         // Make this part of the function thread safe
         std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
         vector_map = vector->getMap().ptr();
 
@@ -1458,8 +1466,10 @@ namespace LinearAlgebra
             }
           else if (nonlocal_vector.get() == nullptr)
             {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
               std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
               // The element is not in the locally owned part, and
               // there is no specified nonlocal_vector, i.e. this is
@@ -1471,8 +1481,10 @@ namespace LinearAlgebra
             }
           else
             {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
               std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
               // If the element was not in the locally owned part,
               // and we have a predetermined nonlocal buffer, we need

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1160,10 +1160,11 @@ namespace LinearAlgebra
 
       /**
        * A lock that ensures thread-safety for relevant
-       * functions. In particular, any functions accessing
+       * functions. In particular, any function accessing
        * reference counted pointers of the trilinos vector
        * needs to be guarded unless Trilinos is compiled
-       * using -D Trilinos_ENABLE_THREAD_SAFE=ON.
+       * using -D Trilinos_ENABLE_THREAD_SAFE=ON or
+       * -D Teuchos_ENABLE_THREAD_SAFE=ON.
        */
       mutable std::mutex mutex;
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1159,6 +1159,15 @@ namespace LinearAlgebra
       mutable std::optional<array_view_type> nonlocal_vector_1d_view;
 
       /**
+       * A lock that ensures thread-safety for relevant
+       * functions. In particular, any functions accessing
+       * reference counted pointers of the trilinos vector
+       * needs to be guarded unless Trilinos is compiled
+       * using -D Trilinos_ENABLE_THREAD_SAFE=ON.
+       */
+      mutable std::mutex mutex;
+
+      /**
        * CommunicationPattern for the communication between the
        * source_stored_elements IndexSet and the current vector.
        */
@@ -1264,25 +1273,37 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::add;
 
-      // Make sure we have a view available to access the vector entries.
-      if (!vector_1d_view)
-        {
-          auto vector_2d_view =
-            vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
+      // Create a non-owning pointer to the vector map. This way we avoid thread
+      // safety problems with owning pointers.
+      Teuchos::Ptr<
+        const typename TpetraTypes::VectorType<Number, MemorySpace>::map_type>
+        vector_map;
+      {
+        // Make this part of the function thread safe
+        std::lock_guard<std::mutex> lock(mutex);
 
-          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
-        }
+        vector_map = vector->getMap().ptr();
 
-      if (!nonlocal_vector_1d_view && !nonlocal_vector.is_null())
-        {
-          auto nonlocal_vector_2d_view =
-            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
+        // Make sure we have a view available to access the vector entries.
+        if (!vector_1d_view)
+          {
+            auto vector_2d_view =
+              vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
 
-          nonlocal_vector_1d_view =
-            Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
-        }
+            vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+          }
+
+        if (!nonlocal_vector_1d_view && !nonlocal_vector.is_null())
+          {
+            auto nonlocal_vector_2d_view =
+              nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
+
+            nonlocal_vector_1d_view =
+              Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
+          }
+      }
 
       for (size_type i = 0; i < n_elements; ++i)
         {
@@ -1292,7 +1313,7 @@ namespace LinearAlgebra
           // If so, we can write right into the locally owned
           // part of the vector.
           if (TrilinosWrappers::types::int_type local_row =
-                vector->getMap()->getLocalElement(row);
+                vector_map->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
               (*vector_1d_view)(local_row) += values[i];
@@ -1305,6 +1326,9 @@ namespace LinearAlgebra
             }
           else if (nonlocal_vector.get() == nullptr)
             {
+              // Make this part of the function thread safe
+              std::lock_guard<std::mutex> lock(mutex);
+
               // The element is not in the locally owned part, and
               // there is no specified nonlocal_vector, i.e. this is
               // a fully distributed vector with a nonlocal cache.
@@ -1315,6 +1339,9 @@ namespace LinearAlgebra
             }
           else
             {
+              // Make this part of the function thread safe
+              std::lock_guard<std::mutex> lock(mutex);
+
               // If the element was not in the locally owned part,
               // and we have a predetermined nonlocal buffer, we need
               // to figure out whether it is in the nonlocal
@@ -1378,25 +1405,37 @@ namespace LinearAlgebra
 
       last_action = VectorOperation::insert;
 
-      // Make sure we have a view available to access the vector entries.
-      if (!vector_1d_view)
-        {
-          auto vector_2d_view =
-            vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
+      // Create a non-owning pointer to the vector map. This way we avoid thread
+      // safety problems with owning pointers.
+      Teuchos::Ptr<
+        const typename TpetraTypes::VectorType<Number, MemorySpace>::map_type>
+        vector_map;
+      {
+        // Make this part of the function thread safe
+        std::lock_guard<std::mutex> lock(mutex);
 
-          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
-        }
+        vector_map = vector->getMap().ptr();
 
-      if (!nonlocal_vector_1d_view && !nonlocal_vector.is_null())
-        {
-          auto nonlocal_vector_2d_view =
-            nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
+        // Make sure we have a view available to access the vector entries.
+        if (!vector_1d_view)
+          {
+            auto vector_2d_view =
+              vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
 
-          nonlocal_vector_1d_view =
-            Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
-        }
+            vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+          }
+
+        if (!nonlocal_vector_1d_view && !nonlocal_vector.is_null())
+          {
+            auto nonlocal_vector_2d_view =
+              nonlocal_vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
+
+            nonlocal_vector_1d_view =
+              Kokkos::subview(nonlocal_vector_2d_view, Kokkos::ALL(), 0);
+          }
+      }
 
       for (size_type i = 0; i < n_elements; ++i)
         {
@@ -1406,7 +1445,7 @@ namespace LinearAlgebra
           // If so, we can write right into the locally owned
           // part of the vector.
           if (TrilinosWrappers::types::int_type local_row =
-                vector->getMap()->getLocalElement(row);
+                vector_map->getLocalElement(row);
               local_row != Teuchos::OrdinalTraits<int>::invalid())
             {
               (*vector_1d_view)(local_row) = values[i];
@@ -1419,6 +1458,9 @@ namespace LinearAlgebra
             }
           else if (nonlocal_vector.get() == nullptr)
             {
+              // Make this part of the function thread safe
+              std::lock_guard<std::mutex> lock(mutex);
+
               // The element is not in the locally owned part, and
               // there is no specified nonlocal_vector, i.e. this is
               // a fully distributed vector with a nonlocal cache.
@@ -1429,6 +1471,9 @@ namespace LinearAlgebra
             }
           else
             {
+              // Make this part of the function thread safe
+              std::lock_guard<std::mutex> lock(mutex);
+
               // If the element was not in the locally owned part,
               // and we have a predetermined nonlocal buffer, we need
               // to figure out whether it is in the nonlocal

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -397,38 +397,48 @@ namespace LinearAlgebra
     {
       AssertDimension(indices.size(), elements.size());
 
-      // Make sure we have a view available to access the vector entries.
-      if (!vector_1d_view)
-        {
-          auto vector_2d_view =
-            vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
+      // Create a non-owning pointer to the vector map. This way we avoid thread
+      // safety problems with owning pointers.
+      Teuchos::Ptr<
+        const typename TpetraTypes::VectorType<Number, MemorySpace>::map_type>
+        vector_map;
+      {
+        // Make this part of the function thread safe
+        std::lock_guard<std::mutex> lock(mutex);
 
-          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
-        }
+        vector_map = vector->getMap().ptr();
+
+        // Make sure we have a view available to access the vector entries.
+        if (!vector_1d_view)
+          {
+            auto vector_2d_view =
+              vector->template getLocalView<Kokkos::HostSpace>(
+                Tpetra::Access::ReadWriteStruct{});
+
+            vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+          }
+      }
 
       for (unsigned int i = 0; i < indices.size(); ++i)
         {
-          AssertIndexRange(indices[i], size());
+          AssertIndexRange(indices[i], vector_map->getGlobalNumElements());
           const size_type                   row = indices[i];
           TrilinosWrappers::types::int_type local_row =
-            vector->getMap()->getLocalElement(row);
+            vector_map->getLocalElement(row);
 
 
 #  if DEAL_II_TRILINOS_VERSION_GTE(14, 0, 0)
-          Assert(
-            local_row != Teuchos::OrdinalTraits<int>::invalid(),
-            ExcAccessToNonLocalElement(row,
-                                       vector->getMap()->getLocalNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
+          Assert(local_row != Teuchos::OrdinalTraits<int>::invalid(),
+                 ExcAccessToNonLocalElement(row,
+                                            vector_map->getLocalNumElements(),
+                                            vector_map->getMinLocalIndex(),
+                                            vector_map->getMaxLocalIndex()));
 #  else
-          Assert(
-            local_row != Teuchos::OrdinalTraits<int>::invalid(),
-            ExcAccessToNonLocalElement(row,
-                                       vector->getMap()->getNodeNumElements(),
-                                       vector->getMap()->getMinLocalIndex(),
-                                       vector->getMap()->getMaxLocalIndex()));
+          Assert(local_row != Teuchos::OrdinalTraits<int>::invalid(),
+                 ExcAccessToNonLocalElement(row,
+                                            vector_map->getNodeNumElements(),
+                                            vector_map->getMinLocalIndex(),
+                                            vector_map->getMaxLocalIndex()));
 
 #  endif
 
@@ -826,6 +836,9 @@ namespace LinearAlgebra
     Number
     Vector<Number, MemorySpace>::operator()(const size_type index) const
     {
+      // make this function thread safe
+      std::lock_guard<std::mutex> lock(mutex);
+
       // Get the local index
       const TrilinosWrappers::types::int_type local_index =
         vector->getMap()->getLocalElement(
@@ -1294,6 +1307,9 @@ namespace LinearAlgebra
     typename Vector<Number, MemorySpace>::size_type
     Vector<Number, MemorySpace>::size() const
     {
+      // make this function thread safe
+      std::lock_guard<std::mutex> lock(mutex);
+
       return vector->getGlobalLength();
     }
 
@@ -1313,6 +1329,9 @@ namespace LinearAlgebra
               typename Vector<Number, MemorySpace>::size_type>
     Vector<Number, MemorySpace>::local_range() const
     {
+      // make this function thread safe
+      std::lock_guard<std::mutex> lock(mutex);
+
       const size_type begin = vector->getMap()->getMinGlobalIndex();
       const size_type end   = vector->getMap()->getMaxGlobalIndex() + 1;
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -403,8 +403,10 @@ namespace LinearAlgebra
         const typename TpetraTypes::VectorType<Number, MemorySpace>::map_type>
         vector_map;
       {
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
         // Make this part of the function thread safe
         std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
         vector_map = vector->getMap().ptr();
 
@@ -836,8 +838,10 @@ namespace LinearAlgebra
     Number
     Vector<Number, MemorySpace>::operator()(const size_type index) const
     {
-      // make this function thread safe
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
+      // Make this part of the function thread safe
       std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
       // Get the local index
       const TrilinosWrappers::types::int_type local_index =
@@ -1307,8 +1311,10 @@ namespace LinearAlgebra
     typename Vector<Number, MemorySpace>::size_type
     Vector<Number, MemorySpace>::size() const
     {
-      // make this function thread safe
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
+      // Make this part of the function thread safe
       std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
       return vector->getGlobalLength();
     }
@@ -1329,8 +1335,10 @@ namespace LinearAlgebra
               typename Vector<Number, MemorySpace>::size_type>
     Vector<Number, MemorySpace>::local_range() const
     {
-      // make this function thread safe
+#  ifndef HAVE_TEUCHOS_THREAD_SAFE
+      // Make this part of the function thread safe
       std::lock_guard<std::mutex> lock(mutex);
+#  endif
 
       const size_type begin = vector->getMap()->getMinGlobalIndex();
       const size_type end   = vector->getMap()->getMaxGlobalIndex() + 1;


### PR DESCRIPTION
As discussed in #19808 the class `Tpetrawrappers::Vector` is not thread-safe, mostly because Trilinos RCP pointers reference-counting doesnt seem to be thread safe unless Trilinos is compiled with `-D Trilinos_ENABLE_THREAD_SAFE=ON` (which we cannot enforce at the moment). This PR introduces thread-safe modifications to the following functions:
- `size()`
- `add()` (add to specific element)
- `set()` (set specific elements)
- `extract_subvector_to` (read specific elements)
- `operator()` (read one element)
- `local_range()`

In functions where I couldnt find a better way I simply used a mutex-guard for the whole function (`operator()`, `size()`, `local_range()`). But for the others we can do better, by only guarding the part of the function that is not thread-safe (retrieving the map of the vector, and initializing our cached view).

I profiled this through the first 3 time steps of step-31 (even though callgrind may be not super reliable for thread-parallel code), here are the relevant changes:

- `add()`: about 1.66x slower than before, still faster than before #19542
- `set()`: about 2x slower than before, still faster than before #19542
- `operator()`: About 2x slower than before but still much faster than before #19542. This shouldnt be called that often, but it turns out `Tpetrawrappers::BlockVector::extract_subvector_to()` does not make use of `Vector::extract_subvector_to()` but instead uses `operator()`. So this is called for retrieving DoF values of block vectors. This should be looked at as a follow up.
- `extract_subvector_to()`: Actually 20% faster than before due to less calls to `getMap()`, this is the function that is called most often for several elements at a time (in step-31 exactly 9, which makes sense for Q2 elements in a 2D model). Even though `add()` and `set()` could be called for multiple elements at a time, they seem to be called individually per DoF in step-31 (maybe something to look into in a follow-up).


There could be ways to optimize this further (such as caching the pointer to the map in our vector class), but they would require more code changes. This at least brings us to a state where we can run step-31 multi-threaded with Trilinos 17.