### PR TITLE
Fix calling TpetrWrappers::vmult with dealii::Vector arguments

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -143,6 +143,7 @@ namespace LinearAlgebra
           kokkos_dual_view_src);
 
         M.trilinos_matrix().apply(tpetra_src, tpetra_dst, mode, alpha, beta);
+        Kokkos::deep_copy(kokkos_view_dst, mirror_view_dst);
       }
 
 


### PR DESCRIPTION
Apprently, `M.trilinos_matrix().apply` never ensures that the `DualView` is in sync after the call. Since we are doing all the setup for the input arguments ourselves anyway, just copy the result back manully instead of using `DualView` calls.
This fixes
- trilinos_tpetra/add_matrices_06
- trilinos_tpetra/sparse_matrix_vector_08

when running with a GPU backend.