### PR TITLE
Be more consistent about the use of types::fe_index.

### DIFF
--- a/doc/news/changes/incompatibilities/20260613Bangerth
+++ b/doc/news/changes/incompatibilities/20260613Bangerth
@@ -1,0 +1,12 @@
+Changed: Many of the functions in hp::FECollection that are used to
+resolve how finite elements interact with each other have historically
+used `unsigned int` to denote the index of an element within the
+collection. However, in other contexts, we have switched to using
+types::fe_index to make the type descriptive of what it actually
+represents.
+
+Several of the functions in hp::FECollection have been switched to use
+the latter type. This is an incompatible change, but most of these
+functions are not widely used in user programs.
+<br>
+(Wolfgang Bangerth, 2026/06/13)

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1344,12 +1344,12 @@ public:
     unsigned int sub_face_no_neighbor;
 
     // optional
-    unsigned int fe_index               = numbers::invalid_unsigned_int;
-    unsigned int q_index                = numbers::invalid_unsigned_int;
-    unsigned int mapping_index          = numbers::invalid_unsigned_int;
-    unsigned int fe_index_neighbor      = numbers::invalid_unsigned_int;
-    unsigned int q_index_neighbor       = numbers::invalid_unsigned_int;
-    unsigned int mapping_index_neighbor = numbers::invalid_unsigned_int;
+    types::fe_index fe_index               = numbers::invalid_fe_index;
+    unsigned int    q_index                = numbers::invalid_unsigned_int;
+    unsigned int    mapping_index          = numbers::invalid_unsigned_int;
+    types::fe_index fe_index_neighbor      = numbers::invalid_fe_index;
+    unsigned int    q_index_neighbor       = numbers::invalid_unsigned_int;
+    unsigned int    mapping_index_neighbor = numbers::invalid_unsigned_int;
   };
   /**
    * Number of quadrature points.
@@ -1527,10 +1527,10 @@ public:
          const CellNeighborIteratorType &cell_neighbor,
          const unsigned int              face_no_neighbor,
          const unsigned int              sub_face_no_neighbor,
-         const unsigned int q_index           = numbers::invalid_unsigned_int,
-         const unsigned int mapping_index     = numbers::invalid_unsigned_int,
-         const unsigned int fe_index          = numbers::invalid_unsigned_int,
-         const unsigned int fe_index_neighbor = numbers::invalid_unsigned_int);
+         const unsigned int    q_index       = numbers::invalid_unsigned_int,
+         const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+         const types::fe_index fe_index      = numbers::invalid_fe_index,
+         const types::fe_index fe_index_neighbor = numbers::invalid_fe_index);
 
   /**
    * Same as above, takes additional interface data to identify hp indices
@@ -1584,7 +1584,7 @@ public:
          const unsigned int      face_no,
          const unsigned int      q_index       = numbers::invalid_unsigned_int,
          const unsigned int      mapping_index = numbers::invalid_unsigned_int,
-         const unsigned int      fe_index      = numbers::invalid_unsigned_int);
+         const types::fe_index   fe_index      = numbers::invalid_fe_index);
 
   /**
    * Return a reference to the FEFaceValues or FESubfaceValues object
@@ -2452,8 +2452,8 @@ FEInterfaceValues<dim, spacedim>::reinit(
   const unsigned int              sub_face_no_neighbor,
   const unsigned int              q_index,
   const unsigned int              mapping_index,
-  const unsigned int              fe_index_in,
-  const unsigned int              fe_index_neighbor_in)
+  const types::fe_index           fe_index_in,
+  const types::fe_index           fe_index_neighbor_in)
 {
   InterfaceData data(face_no,
                      sub_face_no,
@@ -2497,8 +2497,8 @@ FEInterfaceValues<dim, spacedim>::reinit(
   const unsigned int face_no_neighbor     = interface_data.face_no_neighbor;
   const unsigned int sub_face_no_neighbor = interface_data.sub_face_no_neighbor;
 
-  unsigned int active_fe_index          = 0;
-  unsigned int active_fe_index_neighbor = 0;
+  types::fe_index active_fe_index          = 0;
+  types::fe_index active_fe_index_neighbor = 0;
 
   if (internal_fe_face_values)
     {
@@ -2536,11 +2536,11 @@ FEInterfaceValues<dim, spacedim>::reinit(
     {
       active_fe_index = interface_data.fe_index;
       active_fe_index_neighbor =
-        (interface_data.fe_index_neighbor == numbers::invalid_unsigned_int) ?
+        (interface_data.fe_index_neighbor == numbers::invalid_fe_index) ?
           interface_data.fe_index :
           interface_data.fe_index_neighbor;
 
-      if (active_fe_index == numbers::invalid_unsigned_int)
+      if (active_fe_index == numbers::invalid_fe_index)
         {
           if constexpr (is_dof_cell_accessor)
             active_fe_index = cell->active_fe_index();
@@ -2548,7 +2548,7 @@ FEInterfaceValues<dim, spacedim>::reinit(
             active_fe_index = 0;
         }
 
-      if (active_fe_index_neighbor == numbers::invalid_unsigned_int)
+      if (active_fe_index_neighbor == numbers::invalid_fe_index)
         {
           if constexpr (is_dof_cell_accessor_neighbor)
             active_fe_index_neighbor = cell_neighbor->active_fe_index();
@@ -2585,13 +2585,13 @@ FEInterfaceValues<dim, spacedim>::reinit(
       if ((used_q_index == numbers::invalid_unsigned_int) ||
           (used_mapping_index == numbers::invalid_unsigned_int))
         {
-          const unsigned int dominated_fe_index =
+          const types::fe_index dominated_fe_index =
             ((used_q_index == numbers::invalid_unsigned_int) ||
                  (used_mapping_index == numbers::invalid_unsigned_int) ?
                internal_hp_fe_face_values->get_fe_collection()
                  .find_dominated_fe(
                    {active_fe_index, active_fe_index_neighbor}) :
-               numbers::invalid_unsigned_int);
+               numbers::invalid_fe_index);
 
           if (used_q_index == numbers::invalid_unsigned_int)
             {
@@ -2799,7 +2799,7 @@ FEInterfaceValues<dim, spacedim>::reinit(const CellIteratorType &cell,
                                          const unsigned int      face_no,
                                          const unsigned int      q_index,
                                          const unsigned int      mapping_index,
-                                         const unsigned int      fe_index)
+                                         const types::fe_index   fe_index)
 {
   Assert(internal_fe_face_values || internal_hp_fe_face_values,
          ExcNotInitialized());
@@ -2811,7 +2811,7 @@ FEInterfaceValues<dim, spacedim>::reinit(const CellIteratorType &cell,
       Assert((mapping_index == 0 ||
               mapping_index == numbers::invalid_unsigned_int),
              ExcNotImplemented());
-      Assert((fe_index == 0 || fe_index == numbers::invalid_unsigned_int),
+      Assert((fe_index == 0 || fe_index == numbers::invalid_fe_index),
              ExcNotImplemented());
 
       internal_fe_face_values->reinit(cell, face_no);

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -339,15 +339,15 @@ namespace hp
      * from `fe_index` to `dof_index`, which is conceptually of course
      * equivalent to a `std::set` of pairs, but in practice is easier to query.
      */
-    std::vector<std::map<unsigned int, unsigned int>>
-    hp_vertex_dof_identities(const std::set<unsigned int> &fes) const;
+    std::vector<std::map<types::fe_index, unsigned int>>
+    hp_vertex_dof_identities(const std::set<types::fe_index> &fes) const;
 
     /**
      * Same as hp_vertex_dof_indices(), except that the function treats degrees
      * of freedom on lines.
      */
-    std::vector<std::map<unsigned int, unsigned int>>
-    hp_line_dof_identities(const std::set<unsigned int> &fes) const;
+    std::vector<std::map<types::fe_index, unsigned int>>
+    hp_line_dof_identities(const std::set<types::fe_index> &fes) const;
 
     /**
      * Same as hp_vertex_dof_indices(), except that the function treats degrees
@@ -357,9 +357,10 @@ namespace hp
      * where the first entry in each pair identifies the `fe_index` and
      * the second entry is the corresponding `face_no`.
      */
-    std::vector<std::map<unsigned int, unsigned int>>
-    hp_quad_dof_identities(const std::set<std::pair<unsigned int, unsigned int>>
-                             &fes_and_faces) const;
+    std::vector<std::map<types::fe_index, unsigned int>>
+    hp_quad_dof_identities(
+      const std::set<std::pair<types::fe_index, unsigned int>> &fes_and_faces)
+      const;
 
     /**
      * Return the indices of finite elements in this FECollection that dominate
@@ -382,9 +383,9 @@ namespace hp
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
-    std::set<unsigned int>
-    find_common_fes(const std::set<unsigned int> &fes,
-                    const unsigned int            codim = 0) const;
+    std::set<types::fe_index>
+    find_common_fes(const std::set<types::fe_index> &fes,
+                    const unsigned int               codim = 0) const;
 
     /**
      * Return the indices of finite elements in this FECollection that are
@@ -407,9 +408,9 @@ namespace hp
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
-    std::set<unsigned int>
-    find_enclosing_fes(const std::set<unsigned int> &fes,
-                       const unsigned int            codim = 0) const;
+    std::set<types::fe_index>
+    find_enclosing_fes(const std::set<types::fe_index> &fes,
+                       const unsigned int               codim = 0) const;
 
     /**
      * Return the index of a finite element from the provided set of indices @p fes
@@ -443,9 +444,9 @@ namespace hp
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
-    unsigned int
-    find_dominating_fe(const std::set<unsigned int> &fes,
-                       const unsigned int            codim = 0) const;
+    types::fe_index
+    find_dominating_fe(const std::set<types::fe_index> &fes,
+                       const unsigned int               codim = 0) const;
 
     /**
      * Return the index of a finite element from the provided set of indices @p fes
@@ -479,9 +480,9 @@ namespace hp
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
-    unsigned int
-    find_dominated_fe(const std::set<unsigned int> &fes,
-                      const unsigned int            codim = 0) const;
+    types::fe_index
+    find_dominated_fe(const std::set<types::fe_index> &fes,
+                      const unsigned int               codim = 0) const;
 
     /**
      * Return the index of a finite element from the provided set of indices @p fes
@@ -506,9 +507,9 @@ namespace hp
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
-    unsigned int
-    find_dominating_fe_extended(const std::set<unsigned int> &fes,
-                                const unsigned int            codim = 0) const;
+    types::fe_index
+    find_dominating_fe_extended(const std::set<types::fe_index> &fes,
+                                const unsigned int codim = 0) const;
 
     /**
      * Return the index of a finite element from the provided set of indices @p fes
@@ -532,9 +533,9 @@ namespace hp
      * subspace and specifies that it is subject to this comparison. See
      * FiniteElement::compare_for_domination() for more information.
      */
-    unsigned int
-    find_dominated_fe_extended(const std::set<unsigned int> &fes,
-                               const unsigned int            codim = 0) const;
+    types::fe_index
+    find_dominated_fe_extended(const std::set<types::fe_index> &fes,
+                               const unsigned int codim = 0) const;
 
     /**
      * @}

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -192,9 +192,9 @@ namespace hp
      * also reinit() the selected FEValues object.
      */
     FEValuesType &
-    select_fe_values(const unsigned int fe_index,
-                     const unsigned int mapping_index,
-                     const unsigned int q_index);
+    select_fe_values(const types::fe_index fe_index,
+                     const unsigned int    mapping_index,
+                     const unsigned int    q_index);
 
   protected:
     /**
@@ -384,9 +384,9 @@ namespace hp
     template <bool lda>
     void
     reinit(const TriaIterator<DoFCellAccessor<dim, spacedim, lda>> &cell,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Like the previous function, but for non-DoFHandler iterators. The reason
@@ -402,9 +402,9 @@ namespace hp
      */
     void
     reinit(const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
   };
 
 
@@ -534,9 +534,9 @@ namespace hp
     void
     reinit(const TriaIterator<DoFCellAccessor<dim, spacedim, lda>> &cell,
            const unsigned int                                       face_no,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Reinitialize the object for the given cell and face.
@@ -547,9 +547,9 @@ namespace hp
     void
     reinit(const TriaIterator<DoFCellAccessor<dim, spacedim, lda>>    &cell,
            const typename Triangulation<dim, spacedim>::face_iterator &face,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Like the previous function, but for non-DoFHandler iterators. The reason
@@ -566,9 +566,9 @@ namespace hp
     void
     reinit(const typename Triangulation<dim, spacedim>::cell_iterator &cell,
            const unsigned int                                          face_no,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Reinitialize the object for the given cell and face.
@@ -578,9 +578,9 @@ namespace hp
     void
     reinit(const typename Triangulation<dim, spacedim>::cell_iterator &cell,
            const typename Triangulation<dim, spacedim>::face_iterator &face,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
   };
 
 
@@ -656,9 +656,9 @@ namespace hp
     reinit(const TriaIterator<DoFCellAccessor<dim, spacedim, lda>> &cell,
            const unsigned int                                       face_no,
            const unsigned int                                       subface_no,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Like the previous function, but for non-DoFHandler iterators. The reason
@@ -675,10 +675,10 @@ namespace hp
     void
     reinit(const typename Triangulation<dim, spacedim>::cell_iterator &cell,
            const unsigned int                                          face_no,
-           const unsigned int subface_no,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    subface_no,
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
   };
 
 } // namespace hp

--- a/include/deal.II/non_matching/fe_values.h
+++ b/include/deal.II/non_matching/fe_values.h
@@ -262,9 +262,9 @@ namespace NonMatching
      */
     void
     reinit(const TriaIterator<CellAccessor<dim, dim>> &cell,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Return an dealii::FEValues object reinitialized with a quadrature for the
@@ -307,7 +307,7 @@ namespace NonMatching
     reinit_internal(const CellIteratorType &cell,
                     const unsigned int      q_index,
                     const unsigned int      mapping_index,
-                    const unsigned int      fe_index);
+                    const types::fe_index   fe_index);
 
     /**
      * Do work common to the constructors. The incoming QCollection should be
@@ -341,7 +341,7 @@ namespace NonMatching
     /**
      * Active fe index of the last cell that reinit was called with.
      */
-    unsigned int active_fe_index;
+    types::fe_index active_fe_index;
 
     /**
      * The update flags passed to the constructor.
@@ -577,9 +577,9 @@ namespace NonMatching
            const CellNeighborIteratorType &cell_neighbor,
            const unsigned int              face_no_neighbor,
            const unsigned int              sub_face_no_neighbor,
-           const unsigned int q_index       = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int    q_index       = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
 
     /**
@@ -593,9 +593,9 @@ namespace NonMatching
     void
     reinit(const CellIteratorType &cell,
            const unsigned int      face_no,
-           const unsigned int      q_index  = numbers::invalid_unsigned_int,
-           const unsigned int mapping_index = numbers::invalid_unsigned_int,
-           const unsigned int fe_index      = numbers::invalid_unsigned_int);
+           const unsigned int      q_index     = numbers::invalid_unsigned_int,
+           const unsigned int    mapping_index = numbers::invalid_unsigned_int,
+           const types::fe_index fe_index      = numbers::invalid_fe_index);
 
     /**
      * Return an dealii::FEInterfaceValues object reinitialized with a
@@ -641,7 +641,7 @@ namespace NonMatching
     do_reinit(const TriaIterator<CellAccessorType>          &cell,
               const unsigned int                             face_no,
               const unsigned int                             q_index,
-              const unsigned int                             active_fe_index,
+              const types::fe_index                          active_fe_index,
               const std::function<void(dealii::FEInterfaceValues<dim> &,
                                        const unsigned int)> &call_reinit);
 
@@ -726,7 +726,7 @@ namespace NonMatching
                                  const unsigned int      face_no,
                                  const unsigned int      q_index,
                                  const unsigned int      mapping_index,
-                                 const unsigned int      active_fe_index)
+                                 const types::fe_index   active_fe_index)
   {
     // Lambda describing how we should call reinit on a single
     // dealii::FEInterfaceValues object.
@@ -749,11 +749,11 @@ namespace NonMatching
                                  const unsigned int              face_no,
                                  const unsigned int              sub_face_no,
                                  const CellNeighborIteratorType &cell_neighbor,
-                                 const unsigned int face_no_neighbor,
-                                 const unsigned int sub_face_no_neighbor,
-                                 const unsigned int q_index,
-                                 const unsigned int mapping_index,
-                                 const unsigned int active_fe_index)
+                                 const unsigned int    face_no_neighbor,
+                                 const unsigned int    sub_face_no_neighbor,
+                                 const unsigned int    q_index,
+                                 const unsigned int    mapping_index,
+                                 const types::fe_index active_fe_index)
   {
     Assert(sub_face_no == numbers::invalid_unsigned_int, ExcNotImplemented());
     Assert(sub_face_no_neighbor == numbers::invalid_unsigned_int,

--- a/include/deal.II/numerics/solution_transfer.templates.h
+++ b/include/deal.II/numerics/solution_transfer.templates.h
@@ -875,7 +875,7 @@ namespace Legacy
             // to since that is not implied by the global FE as in the non-hp-
             // case. we choose the 'least dominant fe' on all children from
             // the associated FECollection.
-            std::set<unsigned int> fe_indices_children;
+            std::set<types::fe_index> fe_indices_children;
             for (const auto &child : cell->child_iterators())
               {
                 Assert(child->is_active() && child->coarsen_flag_set(),

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1603,8 +1603,7 @@ namespace internal
           Assert(!children_fe_indices.empty(), ExcInternalError());
 
           // convert vector to set
-          // TODO: Change set to types::fe_index
-          const std::set<unsigned int> children_fe_indices_set(
+          const std::set<types::fe_index> children_fe_indices_set(
             children_fe_indices.begin(), children_fe_indices.end());
 
           const types::fe_index dominated_fe_index =
@@ -1641,8 +1640,7 @@ namespace internal
             dof_handler.has_hp_capabilities(),
             (typename DoFHandler<dim, spacedim>::ExcOnlyAvailableWithHP()));
 
-          // TODO: Change set to types::fe_index
-          std::set<unsigned int> future_fe_indices_children;
+          std::set<types::fe_index> future_fe_indices_children;
           for (const auto &child : parent->child_iterators())
             {
               Assert(

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -97,40 +97,30 @@ namespace internal
           // exists
           if (identities.get() == nullptr)
             {
-              // TODO: Change to
-              // std::vector<std::map<types::fe_index, unsigned int>>
-              std::vector<std::map<unsigned int, unsigned int>>
+              std::vector<std::map<types::fe_index, unsigned int>>
                 complete_identities;
 
               switch (structdim)
                 {
                   case 0:
                     {
-                      // TODO: Change set to types::fe_index
-                      complete_identities = fes.hp_vertex_dof_identities(
-                        std::set<unsigned int>{fe_index_1, fe_index_2});
+                      complete_identities =
+                        fes.hp_vertex_dof_identities({fe_index_1, fe_index_2});
                       break;
                     }
 
                   case 1:
                     {
-                      // TODO: Change set to types::fe_index
-                      complete_identities = fes.hp_line_dof_identities(
-                        std::set<unsigned int>{fe_index_1, fe_index_2});
+                      complete_identities =
+                        fes.hp_line_dof_identities({fe_index_1, fe_index_2});
                       break;
                     }
 
                   case 2:
                     {
-                      // TODO: Change set to types::fe_index
-                      std::pair<unsigned int, unsigned int> p1{fe_index_1,
-                                                               face_no};
-                      std::pair<unsigned int, unsigned int> p2{
-                        fe_index_2, face_no_neighbor};
-
                       complete_identities = fes.hp_quad_dof_identities(
-                        std::set<std::pair<unsigned int, unsigned int>>{p1,
-                                                                        p2});
+                        {{fe_index_1, face_no},
+                         {fe_index_2, face_no_neighbor}});
                       break;
                     }
 

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -2425,7 +2425,7 @@ namespace DoFTools
                 // auxiliary variable which holds FE indices of the mother face
                 // and its subfaces. This knowledge will be needed in hp-case
                 // with neither_element_dominates.
-                std::set<unsigned int> fe_ind_face_subface;
+                std::set<types::fe_index> fe_ind_face_subface;
 
                 if (dof_handler.has_hp_capabilities())
                   {

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -111,10 +111,10 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  std::set<unsigned int>
+  std::set<types::fe_index>
   FECollection<dim, spacedim>::find_common_fes(
-    const std::set<unsigned int> &fes,
-    const unsigned int            codim) const
+    const std::set<types::fe_index> &fes,
+    const unsigned int               codim) const
   {
     if constexpr (running_in_debug_mode())
       {
@@ -128,8 +128,9 @@ namespace hp
     // Check if any element of this FECollection is able to dominate all
     // elements of @p fes. If one was found, we add it to the set of
     // dominating elements.
-    std::set<unsigned int> dominating_fes;
-    for (unsigned int current_fe = 0; current_fe < this->size(); ++current_fe)
+    std::set<types::fe_index> dominating_fes;
+    for (types::fe_index current_fe = 0; current_fe < this->size();
+         ++current_fe)
       {
         // Check if current_fe can dominate all elements in @p fes.
         FiniteElementDomination::Domination domination =
@@ -152,10 +153,10 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  std::set<unsigned int>
+  std::set<types::fe_index>
   FECollection<dim, spacedim>::find_enclosing_fes(
-    const std::set<unsigned int> &fes,
-    const unsigned int            codim) const
+    const std::set<types::fe_index> &fes,
+    const unsigned int               codim) const
   {
     if constexpr (running_in_debug_mode())
       {
@@ -169,8 +170,9 @@ namespace hp
     // Check if any element of this FECollection is dominated by all
     // elements of @p fes. If one was found, we add it to the set of
     // dominated elements.
-    std::set<unsigned int> dominated_fes;
-    for (unsigned int current_fe = 0; current_fe < this->size(); ++current_fe)
+    std::set<types::fe_index> dominated_fes;
+    for (types::fe_index current_fe = 0; current_fe < this->size();
+         ++current_fe)
       {
         // Check if current_fe is dominated by all other elements in @p fes.
         FiniteElementDomination::Domination domination =
@@ -193,10 +195,10 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  unsigned int
+  types::fe_index
   FECollection<dim, spacedim>::find_dominating_fe(
-    const std::set<unsigned int> &fes,
-    const unsigned int            codim) const
+    const std::set<types::fe_index> &fes,
+    const unsigned int               codim) const
   {
     // If the set of elements contains only a single element,
     // then this very element is considered to be the dominating one.
@@ -241,10 +243,10 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  unsigned int
+  types::fe_index
   FECollection<dim, spacedim>::find_dominated_fe(
-    const std::set<unsigned int> &fes,
-    const unsigned int            codim) const
+    const std::set<types::fe_index> &fes,
+    const unsigned int               codim) const
   {
     // If the set of elements contains only a single element,
     // then this very element is considered to be the dominated one.
@@ -289,16 +291,16 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  unsigned int
+  types::fe_index
   FECollection<dim, spacedim>::find_dominating_fe_extended(
-    const std::set<unsigned int> &fes,
-    const unsigned int            codim) const
+    const std::set<types::fe_index> &fes,
+    const unsigned int               codim) const
   {
-    unsigned int fe_index = find_dominating_fe(fes, codim);
+    types::fe_index fe_index = find_dominating_fe(fes, codim);
 
     if (fe_index == numbers::invalid_fe_index)
       {
-        const std::set<unsigned int> dominating_fes =
+        const std::set<types::fe_index> dominating_fes =
           find_common_fes(fes, codim);
         fe_index = find_dominated_fe(dominating_fes, codim);
       }
@@ -309,16 +311,16 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  unsigned int
+  types::fe_index
   FECollection<dim, spacedim>::find_dominated_fe_extended(
-    const std::set<unsigned int> &fes,
-    const unsigned int            codim) const
+    const std::set<types::fe_index> &fes,
+    const unsigned int               codim) const
   {
-    unsigned int fe_index = find_dominated_fe(fes, codim);
+    types::fe_index fe_index = find_dominated_fe(fes, codim);
 
     if (fe_index == numbers::invalid_fe_index)
       {
-        const std::set<unsigned int> dominated_fes =
+        const std::set<types::fe_index> dominated_fes =
           find_enclosing_fes(fes, codim);
         fe_index = find_dominating_fe(dominated_fes, codim);
       }
@@ -334,12 +336,12 @@ namespace hp
      * Implement the action of the hp_*_dof_identities() functions
      * in a generic way.
      */
-    std::vector<std::map<unsigned int, unsigned int>>
+    std::vector<std::map<types::fe_index, unsigned int>>
     compute_hp_dof_identities(
-      const std::set<unsigned int> &fes,
+      const std::set<types::fe_index> &fes,
       const std::function<std::vector<std::pair<unsigned int, unsigned int>>(
-        const unsigned int,
-        const unsigned int)>       &query_identities)
+        const types::fe_index,
+        const types::fe_index)>       &query_identities)
     {
       // Let's deal with the easy cases first. If the set of fe indices is empty
       // or has only one entry, then there are no identities:
@@ -351,19 +353,20 @@ namespace hp
       // need. We just need to prefix its output with the respective fe indices:
       if (fes.size() == 2)
         {
-          const unsigned int fe_index_1 = *fes.begin();
-          const unsigned int fe_index_2 = *(++fes.begin());
-          const auto         reduced_identities =
+          const types::fe_index fe_index_1 = *fes.begin();
+          const types::fe_index fe_index_2 = *(++fes.begin());
+          const auto            reduced_identities =
             query_identities(fe_index_1, fe_index_2);
 
-          std::vector<std::map<unsigned int, unsigned int>> complete_identities;
+          std::vector<std::map<types::fe_index, unsigned int>>
+            complete_identities;
 
           for (const auto &reduced_identity : reduced_identities)
             {
               // Each identity returned by query_identities() is a pair of
               // dof indices. Prefix each with its fe index and put the result
               // into a vector
-              std::map<unsigned int, unsigned int> complete_identity = {
+              std::map<types::fe_index, unsigned int> complete_identity = {
                 {fe_index_1, reduced_identity.first},
                 {fe_index_2, reduced_identity.second}};
               complete_identities.emplace_back(std::move(complete_identity));
@@ -380,13 +383,13 @@ namespace hp
       // selected in the argument say. Let us first build this graph, where we
       // only store the edges of the graph, and as a consequence ignore nodes
       // (DoFs) that simply don't show up at all in any of the identities:
-      using Node  = std::pair<unsigned int, unsigned int>;
+      using Node  = std::pair<types::fe_index, unsigned int>;
       using Edge  = std::pair<Node, Node>;
       using Graph = std::set<Edge>;
 
       Graph identities_graph;
-      for (const unsigned int fe_index_1 : fes)
-        for (const unsigned int fe_index_2 : fes)
+      for (const types::fe_index fe_index_1 : fes)
+        for (const types::fe_index fe_index_2 : fes)
           if (fe_index_1 != fe_index_2)
             for (const auto &identity :
                  query_identities(fe_index_1, fe_index_2))
@@ -454,7 +457,7 @@ namespace hp
       // run through because it modifies the graph and thus invalidates
       // iterators. But because SG stores all of these edges, we can remove them
       // all from G after collecting the edges in SG.)
-      std::vector<std::map<unsigned int, unsigned int>> identities;
+      std::vector<std::map<types::fe_index, unsigned int>> identities;
       while (identities_graph.size() > 0)
         {
           Graph          sub_graph;       // SG
@@ -530,26 +533,28 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  std::vector<std::map<unsigned int, unsigned int>>
+  std::vector<std::map<types::fe_index, unsigned int>>
   FECollection<dim, spacedim>::hp_vertex_dof_identities(
-    const std::set<unsigned int> &fes) const
+    const std::set<types::fe_index> &fes) const
   {
-    auto query_vertex_dof_identities = [this](const unsigned int fe_index_1,
-                                              const unsigned int fe_index_2) {
-      return (*this)[fe_index_1].hp_vertex_dof_identities((*this)[fe_index_2]);
-    };
+    auto query_vertex_dof_identities =
+      [this](const types::fe_index fe_index_1,
+             const types::fe_index fe_index_2) {
+        return (*this)[fe_index_1].hp_vertex_dof_identities(
+          (*this)[fe_index_2]);
+      };
     return compute_hp_dof_identities(fes, query_vertex_dof_identities);
   }
 
 
 
   template <int dim, int spacedim>
-  std::vector<std::map<unsigned int, unsigned int>>
+  std::vector<std::map<types::fe_index, unsigned int>>
   FECollection<dim, spacedim>::hp_line_dof_identities(
-    const std::set<unsigned int> &fes) const
+    const std::set<types::fe_index> &fes) const
   {
-    auto query_line_dof_identities = [this](const unsigned int fe_index_1,
-                                            const unsigned int fe_index_2) {
+    auto query_line_dof_identities = [this](const types::fe_index fe_index_1,
+                                            const types::fe_index fe_index_2) {
       return (*this)[fe_index_1].hp_line_dof_identities((*this)[fe_index_2]);
     };
     return compute_hp_dof_identities(fes, query_line_dof_identities);
@@ -558,19 +563,20 @@ namespace hp
 
 
   template <int dim, int spacedim>
-  std::vector<std::map<unsigned int, unsigned int>>
+  std::vector<std::map<types::fe_index, unsigned int>>
   FECollection<dim, spacedim>::hp_quad_dof_identities(
-    const std::set<std::pair<unsigned int, unsigned int>> &fes_and_faces) const
+    const std::set<std::pair<types::fe_index, unsigned int>> &fes_and_faces)
+    const
   {
     // first entry in the pair is the fe_index, the second entry is the face_no
-    std::pair<unsigned int, unsigned int> fe_and_face_1 =
+    std::pair<types::fe_index, unsigned int> fe_and_face_1 =
       *fes_and_faces.begin();
-    std::pair<unsigned int, unsigned int> fe_and_face_2 =
+    std::pair<types::fe_index, unsigned int> fe_and_face_2 =
       *(++fes_and_faces.begin());
 
     auto query_quad_dof_identities =
-      [this, &fe_and_face_1, &fe_and_face_2](const unsigned int fe_index_1,
-                                             const unsigned int fe_index_2) {
+      [this, &fe_and_face_1, &fe_and_face_2](const types::fe_index fe_index_1,
+                                             const types::fe_index fe_index_2) {
         // check if fe_index_1 is the same fe index as in fe_and_face_1
         // then use the corresponding face
         const unsigned int face_no = fe_index_1 == fe_and_face_1.first ?
@@ -580,9 +586,8 @@ namespace hp
                                                           face_no);
       };
 
-    return compute_hp_dof_identities(
-      std::set<unsigned int>{fe_and_face_1.first, fe_and_face_2.first},
-      query_quad_dof_identities);
+    return compute_hp_dof_identities({fe_and_face_1.first, fe_and_face_2.first},
+                                     query_quad_dof_identities);
   }
 
 

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -174,9 +174,9 @@ namespace hp
   template <int dim, int q_dim, typename FEValuesType>
   FEValuesType &
   FEValuesBase<dim, q_dim, FEValuesType>::select_fe_values(
-    const unsigned int fe_index,
-    const unsigned int mapping_index,
-    const unsigned int q_index)
+    const types::fe_index fe_index,
+    const unsigned int    mapping_index,
+    const unsigned int    q_index)
   {
     AssertIndexRange(fe_index, fe_collection->size());
     AssertIndexRange(mapping_index, mapping_collection->size());
@@ -295,7 +295,7 @@ namespace hp
     const TriaIterator<DoFCellAccessor<dim, spacedim, lda>> &cell,
     const unsigned int                                       q_index,
     const unsigned int                                       mapping_index,
-    const unsigned int                                       fe_index)
+    const types::fe_index                                    fe_index)
   {
     // determine which indices we should actually use
     unsigned int real_q_index = q_index, real_mapping_index = mapping_index,
@@ -317,7 +317,7 @@ namespace hp
           real_mapping_index = 0;
       }
 
-    if (real_fe_index == numbers::invalid_unsigned_int)
+    if (real_fe_index == numbers::invalid_fe_index)
       real_fe_index = cell->active_fe_index();
 
     // some checks
@@ -338,7 +338,7 @@ namespace hp
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const unsigned int                                          q_index,
     const unsigned int                                          mapping_index,
-    const unsigned int                                          fe_index)
+    const types::fe_index                                       fe_index)
   {
     // determine which indices we should actually use
     unsigned int real_q_index = q_index, real_mapping_index = mapping_index,
@@ -350,7 +350,7 @@ namespace hp
     if (real_mapping_index == numbers::invalid_unsigned_int)
       real_mapping_index = 0;
 
-    if (real_fe_index == numbers::invalid_unsigned_int)
+    if (real_fe_index == numbers::invalid_fe_index)
       real_fe_index = 0;
 
     // some checks
@@ -426,7 +426,7 @@ namespace hp
     const unsigned int                                       face_no,
     const unsigned int                                       q_index,
     const unsigned int                                       mapping_index,
-    const unsigned int                                       fe_index)
+    const types::fe_index                                    fe_index)
   {
     // determine which indices we
     // should actually use
@@ -449,7 +449,7 @@ namespace hp
           real_mapping_index = 0;
       }
 
-    if (real_fe_index == numbers::invalid_unsigned_int)
+    if (real_fe_index == numbers::invalid_fe_index)
       real_fe_index = cell->active_fe_index();
 
     // some checks
@@ -472,7 +472,7 @@ namespace hp
     const typename Triangulation<dim, spacedim>::face_iterator &face,
     const unsigned int                                          q_index,
     const unsigned int                                          mapping_index,
-    const unsigned int                                          fe_index)
+    const types::fe_index                                       fe_index)
   {
     const auto face_n = cell->face_iterator_to_index(face);
     reinit(cell, face_n, q_index, mapping_index, fe_index);
@@ -487,7 +487,7 @@ namespace hp
     const unsigned int                                          face_no,
     const unsigned int                                          q_index,
     const unsigned int                                          mapping_index,
-    const unsigned int                                          fe_index)
+    const types::fe_index                                       fe_index)
   {
     // determine which indices we
     // should actually use
@@ -500,7 +500,7 @@ namespace hp
     if (real_mapping_index == numbers::invalid_unsigned_int)
       real_mapping_index = 0;
 
-    if (real_fe_index == numbers::invalid_unsigned_int)
+    if (real_fe_index == numbers::invalid_fe_index)
       real_fe_index = 0;
 
     // some checks
@@ -522,7 +522,7 @@ namespace hp
     const typename Triangulation<dim, spacedim>::face_iterator &face,
     const unsigned int                                          q_index,
     const unsigned int                                          mapping_index,
-    const unsigned int                                          fe_index)
+    const types::fe_index                                       fe_index)
   {
     const auto face_n = cell->face_iterator_to_index(face);
     reinit(cell, face_n, q_index, mapping_index, fe_index);
@@ -567,7 +567,7 @@ namespace hp
     const unsigned int                                       subface_no,
     const unsigned int                                       q_index,
     const unsigned int                                       mapping_index,
-    const unsigned int                                       fe_index)
+    const types::fe_index                                    fe_index)
   {
     // determine which indices we should actually use
     unsigned int real_q_index = q_index, real_mapping_index = mapping_index,
@@ -589,7 +589,7 @@ namespace hp
           real_mapping_index = 0;
       }
 
-    if (real_fe_index == numbers::invalid_unsigned_int)
+    if (real_fe_index == numbers::invalid_fe_index)
       real_fe_index = cell->active_fe_index();
 
     // some checks
@@ -612,7 +612,7 @@ namespace hp
     const unsigned int                                          subface_no,
     const unsigned int                                          q_index,
     const unsigned int                                          mapping_index,
-    const unsigned int                                          fe_index)
+    const types::fe_index                                       fe_index)
   {
     // determine which indices we should actually use
     unsigned int real_q_index = q_index, real_mapping_index = mapping_index,
@@ -624,7 +624,7 @@ namespace hp
     if (real_mapping_index == numbers::invalid_unsigned_int)
       real_mapping_index = 0;
 
-    if (real_fe_index == numbers::invalid_unsigned_int)
+    if (real_fe_index == numbers::invalid_fe_index)
       real_fe_index = 0;
 
     // some checks

--- a/source/hp/fe_values.inst.in
+++ b/source/hp/fe_values.inst.in
@@ -92,7 +92,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
           DoFCellAccessor<deal_II_dimension, deal_II_space_dimension, lda>> &,
         unsigned int,
         unsigned int,
-        unsigned int);
+        types::fe_index);
       template void
       FEFaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
         const TriaIterator<
@@ -100,7 +100,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
         unsigned int,
         unsigned int,
         unsigned int,
-        unsigned int);
+        types::fe_index);
       template void
       FEFaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
         const TriaIterator<
@@ -109,7 +109,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
                             deal_II_space_dimension>::face_iterator &,
         unsigned int,
         unsigned int,
-        unsigned int);
+        types::fe_index);
       template void
       FESubfaceValues<deal_II_dimension, deal_II_space_dimension>::reinit(
         const TriaIterator<
@@ -118,7 +118,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
         unsigned int,
         unsigned int,
         unsigned int,
-        unsigned int);
+        types::fe_index);
 #endif
     \}
   }

--- a/source/non_matching/fe_values.cc
+++ b/source/non_matching/fe_values.cc
@@ -100,7 +100,7 @@ namespace NonMatching
   FEValues<dim>::initialize(const hp::QCollection<dim> &q_collection)
   {
     current_cell_location = LocationToLevelSet::unassigned;
-    active_fe_index       = numbers::invalid_unsigned_int;
+    active_fe_index       = numbers::invalid_fe_index;
 
     Assert(fe_collection->size() > 0,
            ExcMessage("Incoming hp::FECollection can not be empty."));
@@ -121,7 +121,7 @@ namespace NonMatching
     // on the non-intersected cells.
     fe_values_inside_full_quadrature.resize(fe_collection->size());
     fe_values_outside_full_quadrature.resize(fe_collection->size());
-    for (unsigned int fe_index = 0; fe_index < fe_collection->size();
+    for (types::fe_index fe_index = 0; fe_index < fe_collection->size();
          ++fe_index)
       {
         const unsigned int mapping_index =
@@ -163,8 +163,8 @@ namespace NonMatching
   void
   FEValues<dim>::reinit(const TriaIterator<CellAccessor<dim, dim>> &cell,
                         const unsigned int                          q_index,
-                        const unsigned int mapping_index,
-                        const unsigned int fe_index)
+                        const unsigned int    mapping_index,
+                        const types::fe_index fe_index)
   {
     this->reinit_internal(cell, q_index, mapping_index, fe_index);
   }
@@ -177,11 +177,11 @@ namespace NonMatching
   FEValues<dim>::reinit_internal(const CellIteratorType &cell,
                                  const unsigned int      q_index_in,
                                  const unsigned int      mapping_index_in,
-                                 const unsigned int      fe_index_in)
+                                 const types::fe_index   fe_index_in)
   {
     current_cell_location = mesh_classifier->location_to_level_set(cell);
 
-    if (fe_index_in == numbers::invalid_unsigned_int)
+    if (fe_index_in == numbers::invalid_fe_index)
       this->active_fe_index = 0;
     else
       this->active_fe_index = fe_index_in;
@@ -434,7 +434,7 @@ namespace NonMatching
     const TriaIterator<CellAccessorType>          &cell,
     const unsigned int                             face_no,
     const unsigned int                             q_index_in,
-    const unsigned int                             active_fe_index_in,
+    const types::fe_index                          active_fe_index_in,
     const std::function<void(dealii::FEInterfaceValues<dim> &,
                              const unsigned int)> &call_reinit)
   {
@@ -464,9 +464,9 @@ namespace NonMatching
 
             if (q_index == numbers::invalid_unsigned_int)
               {
-                unsigned int active_fe_index = active_fe_index_in;
+                types::fe_index active_fe_index = active_fe_index_in;
 
-                if (active_fe_index == numbers::invalid_unsigned_int)
+                if (active_fe_index == numbers::invalid_fe_index)
                   {
                     if constexpr (std::is_same_v<
                                     DoFCellAccessor<dim, dim, true>,

--- a/source/non_matching/fe_values.inst.in
+++ b/source/non_matching/fe_values.inst.in
@@ -69,7 +69,7 @@ for (deal_II_dimension : DIMENSIONS)
       const TriaIterator<CellAccessor<deal_II_dimension, deal_II_dimension>> &,
       const unsigned int,
       const unsigned int,
-      const unsigned int,
+      const types::fe_index,
       const std::function<void(dealii::FEInterfaceValues<deal_II_dimension> &,
                                const unsigned int)> &);
   }
@@ -87,7 +87,7 @@ for (deal_II_dimension : DIMENSIONS; lda : BOOL)
         DoFCellAccessor<deal_II_dimension, deal_II_dimension, lda>> &,
       const unsigned int,
       const unsigned int,
-      const unsigned int,
+      const types::fe_index,
       const std::function<void(dealii::FEInterfaceValues<deal_II_dimension> &,
                                const unsigned int)> &);
   }

--- a/tests/hp/fe_collection_05.cc
+++ b/tests/hp/fe_collection_05.cc
@@ -43,7 +43,7 @@ template <int dim>
 void
 test()
 {
-  std::set<unsigned int> fes;
+  std::set<types::fe_index> fes;
   fes.insert(2);
   fes.insert(3);
 
@@ -75,7 +75,7 @@ test()
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(1), 2));
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(3), 1, FE_Q<dim>(4), 1));
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(4), 1, FE_Q<dim>(3), 1));
-    std::set<unsigned int> fes;
+    std::set<types::fe_index> fes;
     fes.insert(1);
     fes.insert(2);
     deallog << fe_collection.find_dominating_fe_extended(fes, /*codim=*/1)
@@ -147,7 +147,7 @@ test()
     fe_collection.push_back(FE_Q<dim>(2));
     fe_collection.push_back(FE_Q<dim>(4));
     fe_collection.push_back(FE_Q<dim>(3));
-    std::set<unsigned int> fes;
+    std::set<types::fe_index> fes;
     fes.insert(3);
     deallog << fe_collection.find_dominating_fe_extended(fes, /*codim=*/1)
             << std::endl;

--- a/tests/hp/fe_collection_06.cc
+++ b/tests/hp/fe_collection_06.cc
@@ -42,7 +42,7 @@ template <int dim>
 void
 test()
 {
-  std::set<unsigned int> fes;
+  std::set<types::fe_index> fes;
   fes.insert(2);
   fes.insert(3);
 
@@ -74,7 +74,7 @@ test()
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(5), 2));
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(3), 1, FE_Q<dim>(4), 1));
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(4), 1, FE_Q<dim>(3), 1));
-    std::set<unsigned int> fes;
+    std::set<types::fe_index> fes;
     fes.insert(1);
     fes.insert(2);
     deallog << fe_collection.find_dominated_fe_extended(fes, /*codim=*/1)
@@ -146,7 +146,7 @@ test()
     fe_collection.push_back(FE_Q<dim>(2));
     fe_collection.push_back(FE_Q<dim>(4));
     fe_collection.push_back(FE_Q<dim>(3));
-    std::set<unsigned int> fes;
+    std::set<types::fe_index> fes;
     fes.insert(3);
     deallog << fe_collection.find_dominated_fe_extended(fes, /*codim=*/1)
             << std::endl;

--- a/tests/hp/hp_line_dof_identities_mixed_multiway.cc
+++ b/tests/hp/hp_line_dof_identities_mixed_multiway.cc
@@ -41,7 +41,7 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_line_dof_identities_q_equidistant_multiway.cc
+++ b/tests/hp/hp_line_dof_identities_q_equidistant_multiway.cc
@@ -45,7 +45,7 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_line_dof_identities_q_multiway.cc
+++ b/tests/hp/hp_line_dof_identities_q_multiway.cc
@@ -35,7 +35,7 @@ test()
     fe_collection.push_back(FE_Q<dim>(i));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_line_dof_identities_q_system_multiway.cc
+++ b/tests/hp/hp_line_dof_identities_q_system_multiway.cc
@@ -37,7 +37,7 @@ test()
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(i), 2));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_quad_dof_identities_mixed_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_mixed_multiway.cc
@@ -41,7 +41,7 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_quad_dof_identities_q_equidistant_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_q_equidistant_multiway.cc
@@ -45,7 +45,7 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_quad_dof_identities_q_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_q_multiway.cc
@@ -35,7 +35,7 @@ test()
     fe_collection.push_back(FE_Q<dim>(i));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_quad_dof_identities_q_system_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_q_system_multiway.cc
@@ -37,7 +37,7 @@ test()
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(i), 2));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_vertex_dof_identities_mixed_multiway.cc
+++ b/tests/hp/hp_vertex_dof_identities_mixed_multiway.cc
@@ -41,7 +41,7 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_vertex_dof_identities_q_multiway.cc
+++ b/tests/hp/hp_vertex_dof_identities_q_multiway.cc
@@ -35,7 +35,7 @@ test()
     fe_collection.push_back(FE_Q<dim>(i));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 

--- a/tests/hp/hp_vertex_dof_identities_q_system_multiway.cc
+++ b/tests/hp/hp_vertex_dof_identities_q_system_multiway.cc
@@ -37,7 +37,7 @@ test()
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(i), 2));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<types::fe_index> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
     fe_indices.emplace(i);
 


### PR DESCRIPTION
In https://github.com/dealii/dealii/pull/19859#pullrequestreview-4478736566, we lamented that we're not more consistent with the use of `types::fe_index`. This patch addresses this at least in a number of places in `hp::FECollection` where we're using `unsigned int` instead of `types::fe_index`.

This is an incompatible change. At the same time, these aren't widely used functions but mostly used in resolving constraints and DoF identities.