### PR TITLE
MappingFE::compute_mapping_support_points(): re-use an array.

### DIFF
--- a/include/deal.II/fe/mapping_fe.h
+++ b/include/deal.II/fe/mapping_fe.h
@@ -25,6 +25,8 @@
 
 #include <deal.II/grid/tria_iterator.h>
 
+#include <boost/container/small_vector.hpp>
+
 #include <array>
 #include <cmath>
 
@@ -451,9 +453,10 @@ protected:
   /**
    * Return the locations of support points for the mapping.
    */
-  virtual std::vector<Point<spacedim>>
+  virtual void
   compute_mapping_support_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell) const;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    boost::container::small_vector<Point<spacedim>, 200>       &points) const;
 
 private:
   Table<2, double> mapping_support_point_weights;

--- a/include/deal.II/fe/mapping_fe.h
+++ b/include/deal.II/fe/mapping_fe.h
@@ -453,10 +453,9 @@ protected:
   /**
    * Return the locations of support points for the mapping.
    */
-  virtual void
+  virtual boost::container::small_vector<Point<spacedim>, 200>
   compute_mapping_support_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    boost::container::small_vector<Point<spacedim>, 200>       &points) const;
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell) const;
 
 private:
   Table<2, double> mapping_support_point_weights;

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/quadrature.h>
 #include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/std_cxx26/inplace_vector.h>
 #include <deal.II/base/table.h>
 #include <deal.II/base/tensor_product_polynomials.h>
 
@@ -898,8 +899,8 @@ MappingFE<dim, spacedim>::transform_unit_to_real_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const Point<dim>                                           &p) const
 {
-  const std::vector<Point<spacedim>> support_points =
-    this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> support_points;
+  this->compute_mapping_support_points(cell, support_points);
 
   Point<spacedim> mapped_point;
 
@@ -917,8 +918,8 @@ MappingFE<dim, spacedim>::transform_real_to_unit_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const Point<spacedim>                                      &p) const
 {
-  const std::vector<Point<spacedim>> support_points =
-    this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> support_points;
+  this->compute_mapping_support_points(cell, support_points);
 
   const double       eps        = 1.e-12 * cell->diameter();
   const unsigned int loop_limit = 10;
@@ -1126,7 +1127,10 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // object attached to the cell and all of its bounding faces/edges,
   // etc. to reliably test that the "cell" we are on is, therefore,
   // not easily done
-  data.mapping_support_points = this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> support_points;
+  this->compute_mapping_support_points(cell, support_points);
+  data.mapping_support_points.assign(support_points.begin(),
+                                     support_points.end());
 
   // if the order of the mapping is greater than 1, then do not reuse any cell
   // similarity information. This is necessary because the cell similarity
@@ -1591,7 +1595,10 @@ MappingFE<dim, spacedim>::fill_fe_face_values(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  data.mapping_support_points = this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> support_points;
+  this->compute_mapping_support_points(cell, support_points);
+  data.mapping_support_points.assign(support_points.begin(),
+                                     support_points.end());
 
   internal::MappingFEImplementation::do_fill_fe_face_values(
     *this,
@@ -1626,7 +1633,10 @@ MappingFE<dim, spacedim>::fill_fe_subface_values(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  data.mapping_support_points = this->compute_mapping_support_points(cell);
+  boost::container::small_vector<Point<spacedim>, 200> support_points;
+  this->compute_mapping_support_points(cell, support_points);
+  data.mapping_support_points.assign(support_points.begin(),
+                                     support_points.end());
 
   internal::MappingFEImplementation::do_fill_fe_face_values(
     *this,
@@ -2141,24 +2151,25 @@ namespace
 
 
 template <int dim, int spacedim>
-std::vector<Point<spacedim>>
+void
 MappingFE<dim, spacedim>::compute_mapping_support_points(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  boost::container::small_vector<Point<spacedim>, 200>       &points) const
 {
-  std::vector<Point<spacedim>> mapping_support_points(
-    fe->get_unit_support_points().size());
-
-  std::vector<Point<spacedim>> vertices(cell->n_vertices());
+  std_cxx26::inplace_vector<Point<spacedim>,
+                            ReferenceCells::max_n_vertices<dim>()>
+    vertices(cell->n_vertices());
   for (const unsigned int i : cell->vertex_indices())
     vertices[i] = cell->vertex(i);
 
+  points.resize(mapping_support_point_weights.size(0));
   if (check_all_manifold_ids_identical(cell))
     {
       // version 1) all geometric entities have the same manifold:
-
-      cell->get_manifold().get_new_points(vertices,
+      cell->get_manifold().get_new_points(ArrayView<const Point<spacedim>>(
+                                            vertices),
                                           mapping_support_point_weights,
-                                          mapping_support_points);
+                                          ArrayView<Point<spacedim>>(points));
     }
   else
     {
@@ -2188,12 +2199,13 @@ MappingFE<dim, spacedim>::compute_mapping_support_points(
               mapping_support_point_weights(
                 indices[p + (indices.size() - n_points)], i);
 
-        manifold.get_new_points(vertices,
+        manifold.get_new_points(ArrayView<const Point<spacedim>>(vertices),
                                 mapping_support_point_weights_local,
-                                mapping_support_points_local);
+                                ArrayView<Point<spacedim>>(
+                                  mapping_support_points_local));
 
         for (unsigned int p = 0; p < n_points; ++p)
-          mapping_support_points[indices[p + (indices.size() - n_points)]] =
+          points[indices[p + (indices.size() - n_points)]] =
             mapping_support_points_local[p];
       };
 
@@ -2209,7 +2221,7 @@ MappingFE<dim, spacedim>::compute_mapping_support_points(
 
       // add vertices
       for (const unsigned int i : cell->vertex_indices())
-        mapping_support_points[i] = cell->vertex(i);
+        points[i] = vertices[i];
 
       // process and add line support points
       for (unsigned int l = 0; l < cell_ref->n_lines(); ++l)
@@ -2244,8 +2256,6 @@ MappingFE<dim, spacedim>::compute_mapping_support_points(
                   (dim == 2) ? fe.n_dofs_per_quad() : fe.n_dofs_per_hex());
         }
     }
-
-  return mapping_support_points;
 }
 
 
@@ -2255,7 +2265,9 @@ BoundingBox<spacedim>
 MappingFE<dim, spacedim>::get_bounding_box(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
-  return BoundingBox<spacedim>(this->compute_mapping_support_points(cell));
+  boost::container::small_vector<Point<spacedim>, 200> support_points;
+  this->compute_mapping_support_points(cell, support_points);
+  return BoundingBox<spacedim>(support_points);
 }
 
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -899,8 +899,7 @@ MappingFE<dim, spacedim>::transform_unit_to_real_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const Point<dim>                                           &p) const
 {
-  boost::container::small_vector<Point<spacedim>, 200> support_points;
-  this->compute_mapping_support_points(cell, support_points);
+  const auto support_points = this->compute_mapping_support_points(cell);
 
   Point<spacedim> mapped_point;
 
@@ -918,8 +917,7 @@ MappingFE<dim, spacedim>::transform_real_to_unit_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const Point<spacedim>                                      &p) const
 {
-  boost::container::small_vector<Point<spacedim>, 200> support_points;
-  this->compute_mapping_support_points(cell, support_points);
+  const auto support_points = this->compute_mapping_support_points(cell);
 
   const double       eps        = 1.e-12 * cell->diameter();
   const unsigned int loop_limit = 10;
@@ -1127,8 +1125,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // object attached to the cell and all of its bounding faces/edges,
   // etc. to reliably test that the "cell" we are on is, therefore,
   // not easily done
-  boost::container::small_vector<Point<spacedim>, 200> support_points;
-  this->compute_mapping_support_points(cell, support_points);
+  const auto support_points = this->compute_mapping_support_points(cell);
   data.mapping_support_points.assign(support_points.begin(),
                                      support_points.end());
 
@@ -1595,8 +1592,7 @@ MappingFE<dim, spacedim>::fill_fe_face_values(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  boost::container::small_vector<Point<spacedim>, 200> support_points;
-  this->compute_mapping_support_points(cell, support_points);
+  const auto support_points = this->compute_mapping_support_points(cell);
   data.mapping_support_points.assign(support_points.begin(),
                                      support_points.end());
 
@@ -1633,8 +1629,7 @@ MappingFE<dim, spacedim>::fill_fe_subface_values(
          ExcInternalError());
   const InternalData &data = static_cast<const InternalData &>(internal_data);
 
-  boost::container::small_vector<Point<spacedim>, 200> support_points;
-  this->compute_mapping_support_points(cell, support_points);
+  const auto support_points = this->compute_mapping_support_points(cell);
   data.mapping_support_points.assign(support_points.begin(),
                                      support_points.end());
 
@@ -2151,11 +2146,11 @@ namespace
 
 
 template <int dim, int spacedim>
-void
+boost::container::small_vector<Point<spacedim>, 200>
 MappingFE<dim, spacedim>::compute_mapping_support_points(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-  boost::container::small_vector<Point<spacedim>, 200>       &points) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
+  boost::container::small_vector<Point<spacedim>, 200> points;
   std_cxx26::inplace_vector<Point<spacedim>,
                             ReferenceCells::max_n_vertices<dim>()>
     vertices(cell->n_vertices());
@@ -2256,6 +2251,8 @@ MappingFE<dim, spacedim>::compute_mapping_support_points(
                   (dim == 2) ? fe.n_dofs_per_quad() : fe.n_dofs_per_hex());
         }
     }
+
+  return points;
 }
 
 
@@ -2265,9 +2262,7 @@ BoundingBox<spacedim>
 MappingFE<dim, spacedim>::get_bounding_box(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
-  boost::container::small_vector<Point<spacedim>, 200> support_points;
-  this->compute_mapping_support_points(cell, support_points);
-  return BoundingBox<spacedim>(support_points);
+  return BoundingBox<spacedim>(this->compute_mapping_support_points(cell));
 }
 
 


### PR DESCRIPTION
Follow-up to #19759. This lets us avoid allocating most of the time in this function.