### PR TITLE
Add `adjust_quad_dof_index_for_face_orientation_table` for `FE_SimplexP`

### DIFF
--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -776,8 +776,65 @@ FE_SimplexP<dim, spacedim>::FE_SimplexP(const unsigned int degree)
     for (unsigned int i = 0; i < this->n_dofs_per_line(); ++i)
       this->adjust_line_dof_index_for_line_orientation_table[i] =
         this->n_dofs_per_line() - 1 - i - i;
-  // We do not support multiple DoFs per quad yet
-  Assert(degree <= 3, ExcNotImplemented());
+
+  // for 1d and 2d or if there are no DoFs on the quads
+  // we can skip adjust_quad_dof_index_for_face_orientation_table
+  if (dim < 3 || degree < 3)
+    return;
+
+  // do some sanity checks
+  AssertDimension(this->n_unique_faces(), 1);
+  const unsigned int face_no = 0;
+
+  Assert(
+    this->adjust_quad_dof_index_for_face_orientation_table[0].n_elements() ==
+      this->reference_cell().n_face_orientations(face_no) *
+        this->n_dofs_per_quad(face_no),
+    ExcInternalError());
+
+  Assert((degree - 2) * (degree - 1) / 2 == this->n_dofs_per_quad(face_no),
+         ExcInternalError());
+
+  const auto face_reference_cell =
+    this->reference_cell().face_reference_cell(face_no);
+
+  // the interior nodes build a new triangle with lower degree r
+  const unsigned int r = degree - 3;
+
+  // now loop over all DoFs on the triangle
+  // 0 <= i + j <= r holds on the triangle
+  for (unsigned int j = 0, dof_index = 0; j <= r; ++j)
+    for (unsigned int i = 0; i <= r - j; ++i, ++dof_index)
+      {
+        // index in the style of barycentric coordinates
+        // the first entry is the remainder as i + j <= r has to hold
+        const std::array<unsigned int, 3> local_indices{{r - i - j, i, j}};
+
+        // go over all possible orientations
+        for (types::geometric_orientation orientation = 0;
+             orientation < this->reference_cell().n_face_orientations(face_no);
+             ++orientation)
+          {
+            // get the correct permutation for the current orientation
+            const auto permuted_indices =
+              face_reference_cell.permute_by_combined_orientation(
+                make_array_view(local_indices),
+                face_reference_cell.get_inverse_combined_orientation(
+                  orientation));
+
+            // now reconstruct the index of from the permuted i and j
+            // take orientation 0 which is the standard orientation
+            // then the index k is k =  i + j*(r+1) - (j*(j-1))/2
+            const unsigned int k =
+              permuted_indices[1] + permuted_indices[2] * (r + 1) -
+              (permuted_indices[2] * (permuted_indices[2] - 1)) / 2;
+
+            const int offset =
+              static_cast<int>(k) - static_cast<int>(dof_index);
+            this->adjust_quad_dof_index_for_face_orientation_table[face_no](
+              dof_index, orientation) = offset;
+          }
+      }
 }
 
 

--- a/tests/simplex/adjust_quad_dof_index_for_face_orientation_01.cc
+++ b/tests/simplex/adjust_quad_dof_index_for_face_orientation_01.cc
@@ -1,0 +1,208 @@
+/* ------------------------------------------------------------------------
+ *
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+ * Copyright (C) 2023 - 2026 by the deal.II authors
+ *
+ * This file is part of the deal.II library.
+ *
+ * Part of the source code is dual licensed under Apache-2.0 WITH
+ * LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+ * governing the source code and code contributions can be found in
+ * LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+ *
+ * ------------------------------------------------------------------------
+ */
+
+// Check that adjust_quad_dof_index_for_face_orientation gives consistent DoF
+// indices. Test a mesh with two tetrahedra for all possible orientations.
+// Similar to orientation_02 but checks that DoFs on the faces are correct.
+
+#include <deal.II/base/function_lib.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_simplex_p.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include "../tests.h"
+
+std::tuple<unsigned int, unsigned int>
+create_triangulation(const std::vector<Point<3>>    &vertices_,
+                     const std::vector<CellData<3>> &cell_data_,
+                     const unsigned int              face_n,
+                     const unsigned int              n_permutations,
+                     Triangulation<3>               &tria)
+{
+  const ReferenceCell<3> ref_cell  = ReferenceCells::Tetrahedron;
+  auto                   vertices  = vertices_;
+  auto                   cell_data = cell_data_;
+
+  Point<3> extra_vertex;
+  for (unsigned int i = 0; i < 3; ++i)
+    extra_vertex += ref_cell.vertex(ref_cell.face_to_cell_vertices(
+      face_n, i, numbers::default_geometric_orientation));
+
+  extra_vertex /= 3.0;
+  extra_vertex += ref_cell.face_normal_vector(face_n);
+
+  vertices.push_back(extra_vertex);
+
+  cell_data.emplace_back();
+  cell_data.back().vertices.resize(0);
+  for (unsigned int i = 0; i < 3; ++i)
+    cell_data.back().vertices.push_back(ref_cell.face_to_cell_vertices(
+      face_n, i, numbers::default_geometric_orientation));
+  cell_data.back().vertices.push_back(ref_cell.n_vertices());
+  std::sort(cell_data.back().vertices.begin(), cell_data.back().vertices.end());
+
+  unsigned int permutation_n = 0;
+  do
+    {
+      tria.clear();
+      tria.create_triangulation(vertices, cell_data, SubCellData());
+      ++permutation_n;
+    }
+  while ((permutation_n < n_permutations) &&
+         std::next_permutation(cell_data.back().vertices.begin(),
+                               cell_data.back().vertices.end()));
+
+  const auto cell = tria.begin();
+
+  const auto face = cell->face(face_n);
+
+  auto ncell = tria.begin();
+  ncell++;
+
+  unsigned int nf = 0;
+  for (; nf < ref_cell.n_faces(); ++nf)
+    if (ncell->face(nf) == face)
+      break;
+
+  return {nf, ncell->combined_face_orientation(nf)};
+}
+
+
+template <int dim>
+void
+test(const unsigned int degree)
+{
+  for (unsigned int f = 0; f < 4; ++f)
+    {
+      for (unsigned int r = 0; r < 24; ++r)
+        {
+          unsigned int orientation = r;
+          unsigned int face_no     = f;
+
+          Triangulation<dim> tria;
+
+          Triangulation<dim> dummy;
+          GridGenerator::reference_cell(dummy, ReferenceCells::Tetrahedron);
+
+          auto vertices = dummy.get_vertices();
+
+          std::vector<CellData<dim>> cells;
+
+          {
+            CellData<dim> cell;
+            cell.vertices    = {0, 1, 2, 3};
+            cell.material_id = 0;
+            cells.push_back(cell);
+          }
+
+          std::tie(face_no, orientation) =
+            create_triangulation(vertices, cells, face_no, r, tria);
+
+          FE_SimplexP<dim> fe(degree);
+          DoFHandler<dim>  dof_handler(tria);
+          dof_handler.distribute_dofs(fe);
+
+          const auto cell          = dof_handler.begin();
+          auto       neighbor_cell = dof_handler.begin();
+          neighbor_cell++;
+
+          Assert(cell->neighbor(f) == neighbor_cell, ExcInternalError());
+          Assert(neighbor_cell->neighbor(face_no) == cell, ExcInternalError());
+
+          deallog << "Degree: " << degree << std::endl;
+          deallog << "Face number, orientation: " << f << " "
+                  << std::to_string(cell->combined_face_orientation(f))
+                  << " neighbor face number, orientation: " << face_no << " "
+                  << orientation << std::endl;
+
+
+          std::vector<types::global_dof_index> dof_indices(
+            fe.n_dofs_per_cell());
+          std::vector<types::global_dof_index> neighbor_dof_indices(
+            fe.n_dofs_per_cell());
+
+          cell->get_dof_indices(dof_indices);
+          neighbor_cell->get_dof_indices(neighbor_dof_indices);
+
+          std::vector<types::global_dof_index> dof_indices_on_quad(
+            fe.n_dofs_per_quad(f), numbers::invalid_dof_index);
+          std::vector<types::global_dof_index> neighbor_dof_indices_on_quad(
+            fe.n_dofs_per_quad(face_no), numbers::invalid_dof_index);
+
+          for (unsigned int i = 0; i < fe.n_dofs_per_quad(f); ++i)
+            dof_indices_on_quad[i] = dof_indices[4 + 6 * fe.n_dofs_per_line() +
+                                                 f * fe.n_dofs_per_quad(f) + i];
+
+          for (unsigned int i = 0; i < fe.n_dofs_per_quad(face_no); ++i)
+            neighbor_dof_indices_on_quad[i] =
+              neighbor_dof_indices[4 + 6 * fe.n_dofs_per_line() +
+                                   face_no * fe.n_dofs_per_quad(face_no) + i];
+
+          if (degree == 3)
+            {
+              // 1 DoF per face
+              for (unsigned int i = 0; i < neighbor_dof_indices_on_quad.size();
+                   ++i)
+                {
+                  if (neighbor_dof_indices_on_quad[i] == dof_indices_on_quad[i])
+                    deallog << " ok ";
+                  else
+                    deallog << " error !!!!" << std::endl;
+                }
+            }
+          else if (degree == 4)
+            {
+              for (unsigned int i = 0; i < neighbor_dof_indices_on_quad.size();
+                   ++i)
+                {
+                  // 3 DoFs per face
+                  // permute according to orientation
+                  // same as applying the inverse permutation to
+                  // neighbor_dof_indices_on_quad
+                  if (dof_indices_on_quad[fe.reference_cell()
+                                            .face_to_cell_vertices(
+                                              0, i, orientation)] ==
+                      neighbor_dof_indices_on_quad[i])
+                    deallog << " ok ";
+                  else
+                    {
+                      deallog << " error !!!!" << std::endl;
+                    }
+                }
+            }
+          deallog << std::endl;
+        }
+    }
+
+  deallog << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  test<3>(3);
+}

--- a/tests/simplex/adjust_quad_dof_index_for_face_orientation_01.output
+++ b/tests/simplex/adjust_quad_dof_index_for_face_orientation_01.output
@@ -1,0 +1,290 @@
+
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 1 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 1 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 2 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 2 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 1 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 1 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 2 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 2 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 1 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 0 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 1 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 2 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 2 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 3 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 3 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 3 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 3 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 0 0 neighbor face number, orientation: 3 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 1 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 1 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 2 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 2 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 1 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 1 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 2 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 2 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 1 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 0 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 1 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 2 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 2 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 3 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 3 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 3 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 3 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 1 0 neighbor face number, orientation: 3 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 1 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 1 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 2 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 2 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 1 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 1 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 2 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 2 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 1 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 0 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 1 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 2 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 2 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 3 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 3 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 3 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 3 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 2 0 neighbor face number, orientation: 3 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 1 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 1 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 2 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 2 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 1 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 1 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 2 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 2 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 1 4
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 0 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 1 1
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 2 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 2 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 3 0
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 3 3
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 3 5
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 3 2
+DEAL:: ok 
+DEAL::Degree: 3
+DEAL::Face number, orientation: 3 0 neighbor face number, orientation: 3 4
+DEAL:: ok 
+DEAL::

--- a/tests/simplex/adjust_quad_dof_index_for_face_orientation_02.cc
+++ b/tests/simplex/adjust_quad_dof_index_for_face_orientation_02.cc
@@ -1,0 +1,209 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2009 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+
+// check that DoFs on FESimplexP are distributed correctly on the faces in
+// higher order
+
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_lib.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test_interpolation(const unsigned int        degree,
+                   const Triangulation<dim> &triangulation)
+{
+  const FE_SimplexP<dim> fe(degree);
+
+  deallog << "Testing interpolation " << fe.get_name() << std::endl;
+
+  DoFHandler<dim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe);
+
+  Vector<double> interpolant(dof_handler.n_dofs());
+  Vector<float>  error(triangulation.n_active_cells());
+
+  // interpolate monomials of the form x1^a*x2^b*x3^c
+  // tets can interpolate a + b + c <= degree exactly
+  std::vector<Tensor<1, dim>> exponents;
+  for (unsigned int a = 0; a <= degree; ++a)
+    for (unsigned int b = 0; b <= degree - a; ++b)
+      for (unsigned int c = 0; c <= degree - a - b; ++c)
+        {
+          Tensor<1, dim> exponent;
+
+          exponent[0] = a;
+          if constexpr (dim > 1)
+            exponent[1] = b;
+          if constexpr (dim > 2)
+            exponent[2] = c;
+
+          exponents.emplace_back(exponent);
+        }
+
+  deallog << "  Relative interpolation errors:";
+  for (const auto &exponent : exponents)
+    {
+      const Functions::Monomial<dim> test_function(exponent, fe.n_components());
+
+      MappingFE<dim> mapping(FE_SimplexP<dim>(1));
+      // interpolate the function
+      VectorTools::interpolate(mapping,
+                               dof_handler,
+                               test_function,
+                               interpolant);
+
+      // then compute the interpolation error
+      QGaussSimplex<dim> quad(4);
+      VectorTools::integrate_difference(mapping,
+                                        dof_handler,
+                                        interpolant,
+                                        test_function,
+                                        error,
+                                        quad,
+                                        VectorTools::L2_norm);
+
+      if (error.l2_norm() / interpolant.l2_norm() < 1e-12)
+        deallog << " ok";
+
+      Assert(error.l2_norm() < 1e-12 * interpolant.l2_norm(),
+             ExcInternalError());
+    }
+  deallog << std::endl;
+}
+
+
+
+template <int dim>
+void
+create_tria(const unsigned int  face_no,
+            unsigned int        nf,
+            unsigned int        orientation,
+            Triangulation<dim> &tria)
+{
+  Triangulation<3> dummy;
+  GridGenerator::reference_cell(dummy, ReferenceCells::Tetrahedron);
+
+  auto vertices = dummy.get_vertices();
+
+  std::vector<CellData<3>> cells;
+
+  {
+    CellData<3> cell;
+    cell.vertices    = {0, 1, 2, 3};
+    cell.material_id = 0;
+    cells.push_back(cell);
+  }
+
+  {
+    const auto face = dummy.begin()->face(face_no);
+    const auto permuted =
+      ReferenceCells::Triangle.permute_according_orientation(
+        std::array<unsigned int, 3>{{face->vertex_index(0),
+                                     face->vertex_index(1),
+                                     face->vertex_index(2)}},
+        orientation);
+
+    auto direction =
+      cross_product_3d(vertices[permuted[1]] - vertices[permuted[0]],
+                       vertices[permuted[2]] - vertices[permuted[0]]);
+    direction = direction / direction.norm();
+
+    vertices.push_back(face->center() + direction);
+
+    CellData<3> cell;
+    if (nf == 0)
+      cell.vertices = {permuted[0], permuted[1], permuted[2], 4};
+    else if (nf == 1)
+      cell.vertices = {permuted[1], permuted[0], 4, permuted[2]};
+    else if (nf == 2)
+      cell.vertices = {permuted[0], 4, permuted[1], permuted[2]};
+    else if (nf == 3)
+      cell.vertices = {4, permuted[1], permuted[0], permuted[2]};
+
+    cell.material_id = 1;
+    cells.push_back(cell);
+  }
+
+  tria.create_triangulation(vertices, cells, {});
+
+  const auto cell = tria.begin();
+
+  const auto face = cell->face(face_no);
+
+  auto ncell = tria.begin();
+  ncell++;
+
+  unsigned int nf_true = 0;
+  for (; nf_true < 4; ++nf_true)
+    if (ncell->face(nf_true) == face)
+      break;
+
+  deallog << "Face number " << face_no << " neighbor face number " << nf_true
+          << " orientation " << int(ncell->combined_face_orientation(nf_true))
+          << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  // degree, face, face orientation
+  //  just test some
+  // for (unsigned int f = 0; f < 4; ++f)
+  // for (unsigned int nf = 0; nf < 4; ++nf)
+  // for (unsigned int r :{0,1,2,3,4,5})
+  for (unsigned int f : {0, 1})
+    for (unsigned int nf : {2, 3})
+      for (unsigned int r : {1, 2})
+        {
+          Triangulation<3> tria;
+          create_tria<3>(f, nf, r, tria);
+          for (unsigned int i = 3; i < 4; ++i)
+            test_interpolation<3>(i, tria);
+        }
+
+  return 0;
+}

--- a/tests/simplex/adjust_quad_dof_index_for_face_orientation_02.output
+++ b/tests/simplex/adjust_quad_dof_index_for_face_orientation_02.output
@@ -1,0 +1,25 @@
+
+DEAL::Face number 0 neighbor face number 2 orientation 1
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 0 neighbor face number 2 orientation 2
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 0 neighbor face number 3 orientation 1
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 0 neighbor face number 3 orientation 2
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 1 neighbor face number 2 orientation 1
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 1 neighbor face number 2 orientation 2
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 1 neighbor face number 3 orientation 1
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok
+DEAL::Face number 1 neighbor face number 3 orientation 2
+DEAL::Testing interpolation FE_SimplexP<3>(3)
+DEAL::  Relative interpolation errors: ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok ok


### PR DESCRIPTION
To be able to correctly use continuous high order elements on tetrahedral grids, the DoFs on the faces have to be matched according to their orientation. This PR implements `adjust_quad_dof_index_for_face_orientation_table` for `FE_SimplexP` elements. The code loops over all the DoFs and reverses the orientation by calling  `get_inverse_combined_orientation` of the triangle.

For now the test are kind of meaningless, as third order elements only have one DoF on each face, yet the test run successfully for polynomials of order four and five when using `ScalarLagrangePolynomialSimplex` for basisfunctions. 