### PR TITLE
enable affine constraints to use PETScWrappers::MPI full matrices

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -36,6 +36,7 @@
 #include <deal.II/lac/matrix_block.h>
 #include <deal.II/lac/petsc_block_sparse_matrix.h>
 #include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_full_matrix.h>
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
 #include <deal.II/lac/psblas_sparse_matrix.h>

--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -94,8 +94,12 @@ INSTANTIATE_DLTG_VECTOR(PETScWrappers::MPI::BlockVector);
 INSTANTIATE_DLTG_VECTORMATRIX(PETScWrappers::SparseMatrix, Vector<PetscScalar>);
 INSTANTIATE_DLTG_VECTORMATRIX(PETScWrappers::SparseMatrix,
                               PETScWrappers::MPI::Vector);
+INSTANTIATE_DLTG_VECTORMATRIX(PETScWrappers::MPI::FullMatrix,
+                              Vector<PetscScalar>);
 INSTANTIATE_DLTG_VECTORMATRIX(PETScWrappers::MPI::SparseMatrix,
                               Vector<PetscScalar>);
+INSTANTIATE_DLTG_VECTORMATRIX(PETScWrappers::MPI::FullMatrix,
+                              PETScWrappers::MPI::Vector);
 INSTANTIATE_DLTG_VECTORMATRIX(PETScWrappers::MPI::SparseMatrix,
                               PETScWrappers::MPI::Vector);
 
@@ -105,6 +109,7 @@ INSTANTIATE_DLTG_BLOCK_VECTORMATRIX(PETScWrappers::MPI::BlockSparseMatrix,
                                     PETScWrappers::MPI::BlockVector);
 
 INSTANTIATE_DLTG_MATRIX(PETScWrappers::SparseMatrix);
+INSTANTIATE_DLTG_MATRIX(PETScWrappers::MPI::FullMatrix);
 INSTANTIATE_DLTG_MATRIX(PETScWrappers::MPI::SparseMatrix);
 INSTANTIATE_DLTG_MATRIX(PETScWrappers::MPI::BlockSparseMatrix);
 #  ifndef DOXYGEN


### PR DESCRIPTION
I ran into this when writing my tests.