### PR TITLE
Arkode: fix callback documentation for ARKode and steppers

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -85,8 +85,15 @@ namespace SUNDIALS
    * The integrator settings are primarily customized by setting up fields of
    * ARKode::AdditionalData passed to the constructors. For most of the cases,
    * it is advised to set at least the end time up to which the time integrator
-   * should run and the initial time step size. The ARKode behavior can be
-   * further tuned via function object custom_setup().
+   * should run and the initial time step size.
+   *
+   * The following functions can be provided to tune the behavior of ARKode:
+   *  - custom_setup() to set up additional ARKODE settings,
+   *  - solver_should_restart() to control whether the solver has to be
+   * reconstructed at the current time step,
+   *  - get_local_tolerances() to set up individual tolerances for the vector
+   * components being integrated by ARKODE,
+   *  - output_step() to produce output at fixed steps.
    */
   template <typename VectorType = Vector<double>>
   class ARKode

--- a/include/deal.II/sundials/arkode_stepper.h
+++ b/include/deal.II/sundials/arkode_stepper.h
@@ -338,14 +338,6 @@ namespace SUNDIALS
    * and, optionally,
    * - jacobian_preconditioner_setup() and/or mass_preconditioner_setup()
    *
-   * Also the following functions could be rewritten. By default
-   * they do nothing, or are not required.
-   *  - solver_should_restart()
-   *  - get_local_tolerances()
-   *
-   * To produce output at fixed steps, set the function
-   *  - output_step()
-   *
    * Any other custom settings of the ARKStep object can be specified in
    *  - custom_setup()
    *


### PR DESCRIPTION
Some comments were irrelevant and should belong to class `ARKode` and not steppers.