### PR TITLE
Support for agglomeration-based DG discretizations

### DIFF
--- a/include/deal.II/dofs/agglomeration_accessor.h
+++ b/include/deal.II/dofs/agglomeration_accessor.h
@@ -1,0 +1,799 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#ifndef dealii_agglomeration_accessor_h
+#define dealii_agglomeration_accessor_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/iterator_range.h>
+
+#include <deal.II/fe/fe.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+
+#include <vector>
+
+DEAL_II_NAMESPACE_OPEN
+
+
+// Forward declarations
+#ifndef DOXYGEN
+template <int, int>
+class AgglomerationHandler;
+template <int, int>
+class AgglomerationIterator;
+#endif
+
+
+/**
+ * Accessor class used by AgglomerationIterator to access agglomeration data.
+ */
+template <int dim, int spacedim = dim>
+class AgglomerationAccessor
+{
+public:
+  /**
+   * Type for storing the polygons in an agglomerate.
+   */
+  using AgglomerationContainer =
+    std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>;
+
+
+  /**
+   * Get the DoFs indices associated to the agglomerate.
+   */
+  void
+  get_dof_indices(std::vector<types::global_dof_index> &) const;
+
+  /**
+   * Return, for a cell, the number of faces. In case the cell is a standard
+   * cell, then the number of faces is the classical one. If it's a master cell,
+   * then it returns the number of faces of the agglomeration identified by the
+   * master cell itself.
+   */
+  unsigned int
+  n_faces() const;
+
+  /**
+   * Return the number of deal.II faces that is building a polygon face.
+   */
+  unsigned int
+  n_agglomerated_faces() const;
+
+  /**
+   * Return the agglomerate which shares face f.
+   */
+  const AgglomerationIterator<dim, spacedim>
+  neighbor(const unsigned int f) const;
+
+  /**
+   * Return the present index (seen from the neighboring agglomerate) of the
+   * present face f.
+   */
+  unsigned int
+  neighbor_of_agglomerated_neighbor(const unsigned int f) const;
+
+  /**
+   *
+   * This function generalizes the behaviour of cell->face(f)->at_boundary()
+   * in the case where f is an index out of the range [0,..., n_faces).
+   * In practice, if you call this function with a standard deal.II cell, you
+   * have precisely the same result as calling cell->face(f)->at_boundary().
+   * Otherwise, if the cell is a master one, you have a boolean returning true
+   * is that face for the agglomeration is on the boundary or not.
+   */
+  bool
+  at_boundary(const unsigned int f) const;
+
+  /**
+   * Return a vector of face iterators describing the boundary of agglomerate.
+   */
+  const std::vector<typename Triangulation<dim>::active_face_iterator> &
+  polytope_boundary() const;
+
+  /**
+   *
+   * Return the volume of a polytope.
+   */
+  double
+  volume() const;
+
+  /**
+   * Return the diameter of the present polytopal element.
+   */
+  double
+  diameter() const;
+
+  /**
+   * Returns the deal.II cells that build the agglomerate.
+   */
+  AgglomerationContainer
+  get_agglomerate() const;
+
+  /**
+   * Return the BoundingBox which bounds the present polytope. In case the
+   * present polytope is not locally owned, it returns the BoundingBox of that
+   * ghosted polytope.
+   */
+  const BoundingBox<dim> &
+  get_bounding_box() const;
+
+  /**
+   * Return the index of the present polytope.
+   */
+  types::global_cell_index
+  index() const;
+
+  /**
+   * Returns an active cell iterator for the dof_handler, matching the polytope
+   * referenced by the input iterator. The type of the returned object is a
+   * DoFHandler::active_cell_iterator which can be used to initialize
+   * FiniteElement data.
+   */
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+  as_dof_handler_iterator(const DoFHandler<dim, spacedim> &dof_handler) const;
+
+  /**
+   * Returns the number of classical deal.II cells that are building the present
+   * polygon.
+   */
+  unsigned int
+  n_background_cells() const;
+
+  /* Returns true if this polygon is owned by the current processor. On a serial
+   * Triangulation this returs always true, but may yield false for a
+   * parallel::distributed::Triangulation.
+   */
+  bool
+  is_locally_owned() const;
+
+  /**
+   * The polytopal analogue of CellAccessor::id(). It provides a way to uniquely
+   * identify cells in a parallel Triangulation such as a
+   * parallel::distributed::Triangulation.
+   */
+  CellId
+  id() const;
+
+  /**
+   * The polytopal analogue of CellAccessor::subdomain_id(). In case of a serial
+   * Triangulation, it returns the numbers::invalid_subdomain_id.
+   */
+  types::subdomain_id
+  subdomain_id() const;
+
+  /**
+   * Returns a vector of indices identifying the children polytopes.
+   */
+  inline const std::vector<types::global_cell_index> &
+  children() const;
+
+  /**
+   * Returns the FiniteElement object used by the current polytope.
+   * This function should only be called after the corresponding agglomeration
+   * handler has invoked distribute_agglomerated_dofs().
+   */
+  const FiniteElement<dim, spacedim> &
+  get_fe() const;
+
+  /**
+   * Sets the active finite element index.
+   * This function should be called when using hp::FECollection to specify
+   * which finite element in the collection is assigned to the current polytope.
+   */
+  void
+  set_active_fe_index(const types::fe_index index) const;
+
+  /**
+   * Returns the index of the active finite element.
+   * When using hp::FECollection, this function retrieves the index
+   * of the finite element assigned to the current polytope.
+   */
+  types::fe_index
+  active_fe_index() const;
+
+private:
+  /**
+   * Private default constructor. This is not supposed to be used and hence will
+   * throw.
+   */
+  AgglomerationAccessor();
+
+  /**
+   * Private constructor for an agglomerate. This is meant to be invoked by
+   * the AgglomerationIterator class. It takes as input the master cell of the
+   * agglomerate and a pointer to the handler.
+   */
+  AgglomerationAccessor(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+                                              &master_cell,
+    const AgglomerationHandler<dim, spacedim> *ah);
+
+  /**
+   * Same as above, but needed when the argument @p cells is a ghost cell.
+   */
+  AgglomerationAccessor(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+    const CellId                                                      &cell_id,
+    const AgglomerationHandler<dim, spacedim>                         *ah);
+
+  /**
+   * Default destructor.
+   */
+  ~AgglomerationAccessor() = default;
+
+
+  /**
+   * The unique deal.II cell associated to the present polytope.
+   */
+  typename Triangulation<dim, spacedim>::active_cell_iterator master_cell;
+
+  /**
+   * The index of the present polytope.
+   */
+  types::global_cell_index present_index;
+
+  /**
+   * The index of the present polytope.
+   */
+  CellId present_id;
+
+  /**
+   * The rank owning of the present polytope.
+   */
+  types::subdomain_id present_subdomain_id;
+
+  /**
+   * A pointer to the Handler.
+   */
+  AgglomerationHandler<dim, spacedim> *handler;
+
+  /**
+   * Comparison operator for Accessor. Two accessors are equal if they refer to
+   * the same polytopal element.
+   */
+  bool
+  operator==(const AgglomerationAccessor<dim, spacedim> &other) const;
+
+  /**
+   * Compare for inequality.
+   */
+  bool
+  operator!=(const AgglomerationAccessor<dim, spacedim> &other) const;
+
+  /**
+   * Move to the next cell in the polytopal mesh.
+   */
+  void
+  next();
+
+  /**
+   * Move to the previous cell in the polytopal mesh.
+   */
+  void
+  prev();
+
+  /**
+   * Returns the slaves of the present agglomeration.
+   */
+  const AgglomerationContainer &
+  get_slaves() const;
+
+  unsigned int
+  n_agglomerated_faces_per_cell(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
+    const;
+
+  template <int, int>
+  friend class AgglomerationIterator;
+};
+
+
+
+template <int dim, int spacedim>
+unsigned int
+AgglomerationAccessor<dim, spacedim>::n_agglomerated_faces_per_cell(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell) const
+{
+  unsigned int n_neighbors = 0;
+  for (const auto &f : cell->face_indices())
+    {
+      const auto &neighboring_cell = cell->neighbor(f);
+      if ((cell->face(f)->at_boundary()) ||
+          (neighboring_cell->is_active() &&
+           !handler->are_cells_agglomerated(cell, neighboring_cell)))
+        {
+          ++n_neighbors;
+        }
+    }
+  return n_neighbors;
+}
+
+
+
+template <int dim, int spacedim>
+unsigned int
+AgglomerationAccessor<dim, spacedim>::n_faces() const
+{
+  Assert(!handler->is_slave_cell(master_cell),
+         ExcMessage("You cannot pass a slave cell."));
+  return handler->number_of_agglomerated_faces[present_index];
+}
+
+
+
+template <int dim, int spacedim>
+const AgglomerationIterator<dim, spacedim>
+AgglomerationAccessor<dim, spacedim>::neighbor(const unsigned int f) const
+{
+  if (!at_boundary(f))
+    {
+      if (master_cell->is_ghost())
+        {
+          // The following path is needed when the present function is called
+          // from neighbor_of_neighbor()
+
+          const unsigned int sender_rank = master_cell->subdomain_id();
+
+          const CellId &master_id_ghosted_neighbor =
+            handler->recv_ghosted_master_id.at(sender_rank)
+              .at(present_id)
+              .at(f);
+
+          // Use the id of the master cell to uniquely identify the neighboring
+          // agglomerate
+
+          return {master_cell, master_id_ghosted_neighbor, handler};
+        }
+
+      const types::global_cell_index polytope_index =
+        handler->master2polygon.at(master_cell->active_cell_index());
+
+
+      const auto &neigh =
+        handler->polytope_cache.cell_face_at_boundary.at({polytope_index, f})
+          .second;
+
+
+      if (neigh->is_locally_owned())
+        {
+          typename DoFHandler<dim, spacedim>::active_cell_iterator cell_dh(
+            *neigh, &(handler->agglo_dh));
+          return {cell_dh, handler};
+        }
+      else
+        {
+          // Get master_id from the neighboring ghost polytope. This uniquely
+          // identifies the neighboring polytope among all processors.
+          const CellId &master_id_neighbor =
+            handler->polytope_cache.ghosted_master_id.at({present_id, f});
+
+          // Use the id of the master cell to uniquely identify the neighboring
+          // agglomerate
+          return {neigh, master_id_neighbor, handler};
+        }
+    }
+  else
+    {
+      return {};
+    }
+}
+
+
+
+template <int dim, int spacedim>
+unsigned int
+AgglomerationAccessor<dim, spacedim>::neighbor_of_agglomerated_neighbor(
+  const unsigned int f) const
+{
+  // First, make sure it's not a boundary face.
+  if (!at_boundary(f))
+    {
+      const auto &neigh_polytope =
+        neighbor(f); // returns the neighboring master and id
+
+      AssertThrow(neigh_polytope.state() == IteratorState::valid,
+                  ExcInternalError());
+
+      unsigned int n_faces_agglomerated_neighbor;
+
+      // if it is locally owned, retrieve the number of faces
+      if (neigh_polytope->is_locally_owned())
+        {
+          n_faces_agglomerated_neighbor = neigh_polytope->n_faces();
+        }
+      else
+        {
+          // The neighboring polytope is not locally owned. We need to get the
+          // number of its faces from the neighboring rank.
+
+          // First, retrieve the CellId of the neighboring polytope.
+          const CellId &master_id_neighbor = neigh_polytope->id();
+
+          // Then, get the neighboring rank
+          const unsigned int sender_rank = neigh_polytope->subdomain_id();
+
+          // From the neighboring rank, use the CellId of the neighboring
+          // polytope to get the number of its faces.
+          n_faces_agglomerated_neighbor =
+            handler->recv_n_faces.at(sender_rank).at(master_id_neighbor);
+        }
+
+
+      // Loop over all faces of neighboring agglomerate
+      for (unsigned int f_out = 0; f_out < n_faces_agglomerated_neighbor;
+           ++f_out)
+        {
+          // Check if same CellId
+          if (neigh_polytope->neighbor(f_out).state() == IteratorState::valid)
+            if (neigh_polytope->neighbor(f_out)->id() == present_id)
+              return f_out;
+        }
+      return numbers::invalid_unsigned_int;
+    }
+  else
+    {
+      // Face is at boundary
+      return numbers::invalid_unsigned_int;
+    }
+}
+
+// ------------------------------ inline functions -------------------------
+
+template <int dim, int spacedim>
+inline AgglomerationAccessor<dim, spacedim>::AgglomerationAccessor()
+{}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationAccessor<dim, spacedim>::AgglomerationAccessor(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+  const AgglomerationHandler<dim, spacedim>                         *ah)
+{
+  handler = const_cast<AgglomerationHandler<dim, spacedim> *>(ah);
+  if (&(*handler->master_cells_container.end()) == std::addressof(cell))
+    {
+      present_index        = handler->master_cells_container.size();
+      master_cell          = *handler->master_cells_container.end();
+      present_id           = CellId(); // invalid id (TODO)
+      present_subdomain_id = numbers::invalid_subdomain_id;
+    }
+  else
+    {
+      present_index = handler->master2polygon.at(cell->active_cell_index());
+      master_cell   = cell;
+      present_id    = master_cell->id();
+      present_subdomain_id = master_cell->subdomain_id();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationAccessor<dim, spacedim>::AgglomerationAccessor(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &neigh_cell,
+  const CellId                              &master_cell_id,
+  const AgglomerationHandler<dim, spacedim> *ah)
+{
+  Assert(neigh_cell->is_ghost(), ExcInternalError());
+  // neigh_cell is ghosted
+
+  handler       = const_cast<AgglomerationHandler<dim, spacedim> *>(ah);
+  master_cell   = neigh_cell;
+  present_index = numbers::invalid_unsigned_int;
+  // neigh_cell is ghosted, use the CellId of that agglomerate
+  present_id           = master_cell_id;
+  present_subdomain_id = master_cell->subdomain_id();
+}
+
+
+
+template <int dim, int spacedim>
+inline void
+AgglomerationAccessor<dim, spacedim>::get_dof_indices(
+  std::vector<types::global_dof_index> &dof_indices) const
+{
+  Assert(dof_indices.size() > 0,
+         ExcMessage(
+           "The vector of DoFs indices must be already properly resized."));
+  if (is_locally_owned())
+    {
+      // Forward the call to the master cell
+      typename DoFHandler<dim, spacedim>::cell_iterator master_cell_dh(
+        *master_cell, &(handler->agglo_dh));
+      master_cell_dh->get_dof_indices(dof_indices);
+    }
+  else
+    {
+      const std::vector<types::global_dof_index> &recv_dof_indices =
+        handler->recv_ghost_dofs.at(present_subdomain_id).at(present_id);
+
+      std::copy(recv_dof_indices.cbegin(),
+                recv_dof_indices.cend(),
+                dof_indices.begin());
+    }
+}
+
+
+
+template <int dim, int spacedim>
+inline typename AgglomerationAccessor<dim, spacedim>::AgglomerationContainer
+AgglomerationAccessor<dim, spacedim>::get_agglomerate() const
+{
+  auto agglomeration = get_slaves();
+  agglomeration.push_back(master_cell);
+  return agglomeration;
+}
+
+
+
+template <int dim, int spacedim>
+inline const std::vector<typename Triangulation<dim>::active_face_iterator> &
+AgglomerationAccessor<dim, spacedim>::polytope_boundary() const
+{
+  return handler->polygon_boundary[master_cell];
+}
+
+
+
+template <int dim, int spacedim>
+inline double
+AgglomerationAccessor<dim, spacedim>::diameter() const
+{
+  Assert(!handler->is_slave_cell(master_cell),
+         ExcMessage("The present function cannot be called for slave cells."));
+
+  if (handler->is_master_cell(master_cell))
+    {
+      // Get the bounding box associated with the master cell
+      const auto &bdary_pts =
+        handler->bboxes[present_index].get_boundary_points();
+      return (bdary_pts.second - bdary_pts.first).norm();
+    }
+  else
+    {
+      // Standard deal.II way to get the measure of a cell.
+      return master_cell->diameter();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+inline const BoundingBox<dim> &
+AgglomerationAccessor<dim, spacedim>::get_bounding_box() const
+{
+  if (is_locally_owned())
+    return handler->bboxes[present_index];
+  else
+    return handler->recv_ghosted_bbox.at(present_subdomain_id).at(present_id);
+}
+
+
+
+template <int dim, int spacedim>
+inline double
+AgglomerationAccessor<dim, spacedim>::volume() const
+{
+  Assert(!handler->is_slave_cell(master_cell),
+         ExcMessage("The present function cannot be called for slave cells."));
+
+  if (handler->is_master_cell(master_cell))
+    {
+      return handler->bboxes[present_index].volume();
+    }
+  else
+    {
+      return master_cell->measure();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+inline void
+AgglomerationAccessor<dim, spacedim>::next()
+{
+  // Increment the present index and update the polytope
+  ++present_index;
+
+  // Make sure not to query the CellId if it's past the last
+  if (present_index < handler->master_cells_container.size())
+    {
+      master_cell          = handler->master_cells_container[present_index];
+      present_id           = master_cell->id();
+      present_subdomain_id = master_cell->subdomain_id();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+inline void
+AgglomerationAccessor<dim, spacedim>::prev()
+{
+  // Decrement the present index and update the polytope
+  --present_index;
+  master_cell = handler->master_cells_container[present_index];
+  present_id  = master_cell->id();
+}
+
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationAccessor<dim, spacedim>::operator==(
+  const AgglomerationAccessor<dim, spacedim> &other) const
+{
+  return present_index == other.present_index;
+}
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationAccessor<dim, spacedim>::operator!=(
+  const AgglomerationAccessor<dim, spacedim> &other) const
+{
+  return !(*this == other);
+}
+
+
+
+template <int dim, int spacedim>
+inline types::global_cell_index
+AgglomerationAccessor<dim, spacedim>::index() const
+{
+  return present_index;
+}
+
+
+
+template <int dim, int spacedim>
+typename DoFHandler<dim, spacedim>::active_cell_iterator
+AgglomerationAccessor<dim, spacedim>::as_dof_handler_iterator(
+  const DoFHandler<dim, spacedim> &dof_handler) const
+{
+  // Forward the call to the master cell using the right DoFHandler.
+  return master_cell->as_dof_handler_iterator(dof_handler);
+}
+
+
+
+template <int dim, int spacedim>
+inline const typename AgglomerationAccessor<dim,
+                                            spacedim>::AgglomerationContainer &
+AgglomerationAccessor<dim, spacedim>::get_slaves() const
+{
+  return handler->master2slaves.at(master_cell->active_cell_index());
+}
+
+
+
+template <int dim, int spacedim>
+inline unsigned int
+AgglomerationAccessor<dim, spacedim>::n_background_cells() const
+{
+  AssertThrow(get_agglomerate().size() > 0, ExcMessage("Empty agglomeration."));
+  return get_agglomerate().size();
+}
+
+
+
+template <int dim, int spacedim>
+unsigned int
+AgglomerationAccessor<dim, spacedim>::n_agglomerated_faces() const
+{
+  const auto  &agglomeration = get_agglomerate();
+  unsigned int n_neighbors   = 0;
+  for (const auto &cell : agglomeration)
+    n_neighbors += n_agglomerated_faces_per_cell(cell);
+  return n_neighbors;
+}
+
+
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationAccessor<dim, spacedim>::at_boundary(const unsigned int f) const
+{
+  if (master_cell->is_ghost())
+    {
+      const unsigned int sender_rank = master_cell->subdomain_id();
+      return handler->recv_bdary_info.at(sender_rank).at(present_id).at(f);
+    }
+  else
+    {
+      Assert(!handler->is_slave_cell(master_cell),
+             ExcMessage(
+               "This function should not be called for a slave cell."));
+
+
+      typename DoFHandler<dim, spacedim>::active_cell_iterator cell_dh(
+        *master_cell, &(handler->agglo_dh));
+      return handler->at_boundary(cell_dh, f);
+    }
+}
+
+
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationAccessor<dim, spacedim>::is_locally_owned() const
+{
+  return master_cell->is_locally_owned();
+}
+
+
+
+template <int dim, int spacedim>
+inline CellId
+AgglomerationAccessor<dim, spacedim>::id() const
+{
+  return present_id;
+}
+
+
+
+template <int dim, int spacedim>
+inline types::subdomain_id
+AgglomerationAccessor<dim, spacedim>::subdomain_id() const
+{
+  return present_subdomain_id;
+}
+
+template <int dim, int spacedim>
+inline const std::vector<types::global_cell_index> &
+AgglomerationAccessor<dim, spacedim>::children() const
+{
+  Assert(!handler->parent_child_info.empty(), ExcInternalError());
+  return handler->parent_child_info.at(
+    {present_index, handler->present_extraction_level});
+}
+
+template <int dim, int spacedim>
+inline const FiniteElement<dim, spacedim> &
+AgglomerationAccessor<dim, spacedim>::get_fe() const
+{
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+    master_cell_as_dof_handler_iterator =
+      master_cell->as_dof_handler_iterator(handler->agglo_dh);
+  return master_cell_as_dof_handler_iterator->get_fe();
+}
+
+template <int dim, int spacedim>
+inline void
+AgglomerationAccessor<dim, spacedim>::set_active_fe_index(
+  const types::fe_index index) const
+{
+  Assert(!handler->is_slave_cell(master_cell),
+         ExcMessage("The present function cannot be called for slave cells."));
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+    master_cell_as_dof_handler_iterator =
+      master_cell->as_dof_handler_iterator(handler->agglo_dh);
+  master_cell_as_dof_handler_iterator->set_active_fe_index(index);
+}
+
+template <int dim, int spacedim>
+inline types::fe_index
+AgglomerationAccessor<dim, spacedim>::active_fe_index() const
+{
+  typename DoFHandler<dim, spacedim>::active_cell_iterator
+    master_cell_as_dof_handler_iterator =
+      master_cell->as_dof_handler_iterator(handler->agglo_dh);
+  return master_cell_as_dof_handler_iterator->active_fe_index();
+}
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/dofs/agglomeration_handler.h
+++ b/include/deal.II/dofs/agglomeration_handler.h
@@ -1,0 +1,1227 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2009 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef dealii_agglomeration_handler_h
+#define dealii_agglomeration_handler_h
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/observer_pointer.h>
+#include <deal.II/base/quadrature.h>
+#include <deal.II/base/subscriptor.h>
+
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/agglomeration_iterator.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_box.h>
+#include <deal.II/fe/mapping_fe_field.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/agglomeration_tools.h>
+#include <deal.II/grid/agglomerator.h>
+#include <deal.II/grid/grid_tools_cache.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/hp/fe_collection.h>
+
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/sparsity_pattern.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/meshworker/scratch_data.h>
+
+#include <deal.II/non_matching/fe_immersed_values.h>
+#include <deal.II/non_matching/immersed_surface_quadrature.h>
+
+#include <fstream>
+
+DEAL_II_NAMESPACE_OPEN
+
+// Forward declarations
+template <int dim, int spacedim>
+class AgglomerationHandler;
+
+namespace internal
+{
+  /**
+   * Helper class to reinit finite element spaces on polytopal cells.
+   */
+  template <int, int>
+  class AgglomerationHandlerImplementation;
+} // namespace internal
+
+
+
+/**
+ * Helper class for the storage of connectivity information of the polytopal
+ * grid.
+ */
+namespace internal
+{
+  template <int dim, int spacedim>
+  class PolytopeCache
+  {
+  public:
+    /**
+     * Default constructor.
+     */
+    PolytopeCache() = default;
+
+    /**
+     * Destructor. It simply calls clear() for all of its members.
+     */
+    ~PolytopeCache() = default;
+
+    void
+    clear()
+    {
+      // clear all the members
+      cell_face_at_boundary.clear();
+      interface.clear();
+      visited_cell_and_faces.clear();
+    }
+
+    /**
+     * Standard std::set for recording the standard cells and faces (in the
+     * deal.II lingo) that have been already visited. The first argument of
+     * the pair identifies the global index of a deal.II cell, while the
+     * second its local face number.
+     *
+     */
+    mutable std::set<std::pair<types::global_cell_index, unsigned int>>
+      visited_cell_and_faces;
+
+
+    mutable std::set<std::pair<CellId, unsigned int>> visited_cell_and_faces_id;
+
+
+
+    /**
+     * Map that associate the pair of (polytopal index, polytopal face) to
+     * (b,cell). The latter pair indicates whether or not the present face is
+     * on boundary. If it's on the boundary, then b is true and cell is an
+     * invalid cell iterator. Otherwise, b is false and cell points to the
+     * neighboring polytopal cell.
+     *
+     */
+    mutable std::map<
+      std::pair<types::global_cell_index, unsigned int>,
+      std::pair<bool,
+                typename Triangulation<dim, spacedim>::active_cell_iterator>>
+      cell_face_at_boundary;
+
+    /**
+     * Map that associate the *local* pair of (polytope id, polytopal face)
+     * to the master idx of the neighboring *ghosted* cell.
+     */
+    mutable std::map<std::pair<CellId, unsigned int>, CellId> ghosted_master_id;
+
+    /**
+     * Standard std::map that associated to a pair of neighboring polytopic
+     * cells (current_polytope, neighboring_polytope) a sequence of
+     * ({deal_cell,deal_face_index}) which is meant to describe their
+     * interface.
+     * Indeed, the pair is identified by the two polytopic global indices,
+     * while the interface is described by a std::vector of deal.II cells and
+     * faces.
+     *
+     */
+    mutable std::map<
+      std::pair<CellId, CellId>,
+      std::vector<
+        std::pair<typename Triangulation<dim, spacedim>::active_cell_iterator,
+                  unsigned int>>>
+      interface;
+  };
+} // namespace internal
+
+
+/**
+ * The Handler class that stores all the data used in the agglomeration.
+ */
+template <int dim, int spacedim = dim>
+class AgglomerationHandler : public Subscriptor
+{
+public:
+  using agglomeration_iterator = AgglomerationIterator<dim, spacedim>;
+
+  using AgglomerationContainer =
+    typename AgglomerationIterator<dim, spacedim>::AgglomerationContainer;
+
+  /**
+   * Enumeration for type of cells used in master_slave_relationships
+   */
+  enum CellAgglomerationType
+  {
+    master = 0,
+    slave  = 1
+  };
+
+
+
+  explicit AgglomerationHandler(
+    const GridTools::Cache<dim, spacedim> &cached_tria);
+
+  AgglomerationHandler() = default;
+
+  ~AgglomerationHandler()
+  {
+    // disconnect the signal
+    tria_listener.disconnect();
+  }
+
+  /**
+   * Iterator to the first polytope element of const object.
+   */
+  agglomeration_iterator
+  begin() const;
+
+  /**
+   * Iterator to the first polytope element.
+   */
+  agglomeration_iterator
+  begin();
+
+  /**
+   * Iterator to one after the last polygonal element of const object.
+   */
+  agglomeration_iterator
+  end() const;
+
+  /**
+   * Iterator to one after the last polygonal element.
+   */
+  agglomeration_iterator
+  end();
+
+  /**
+   * Iterator to the last polygonal element.
+   */
+  agglomeration_iterator
+  last();
+
+  /**
+   * Returns an IteratorRange that makes up all the polygonal elements in the
+   * mesh.
+   */
+  IteratorRange<agglomeration_iterator>
+  polytope_iterators() const;
+
+  template <int, int>
+  friend class AgglomerationIterator;
+
+  template <int, int>
+  friend class AgglomerationAccessor;
+
+  /**
+   * Distribute degrees of freedom on a grid where some cells have been
+   * agglomerated.
+   */
+  void
+  distribute_agglomerated_dofs(const FiniteElement<dim> &fe_space);
+
+  /**
+   *
+   * Set the degree of the quadrature formula to be used and the proper flags
+   * for the FEValues object on the agglomerated cell.
+   */
+  void
+  initialize_fe_values(
+    const Quadrature<dim>     &cell_quadrature = QGauss<dim>(1),
+    const UpdateFlags         &flags           = UpdateFlags::update_default,
+    const Quadrature<dim - 1> &face_quadrature = QGauss<dim - 1>(1),
+    const UpdateFlags         &face_flags      = UpdateFlags::update_default);
+
+  /**
+   * Given a Triangulation with some agglomerated cells, create the sparsity
+   * pattern corresponding to a Discontinuous Galerkin discretization where the
+   * agglomerated cells are seen as one **unique** cell, with only the DoFs
+   * associated to the master cell of the agglomeration.
+   */
+  template <typename SparsityPatternType, typename Number = double>
+  void
+  create_agglomeration_sparsity_pattern(
+    SparsityPatternType             &sparsity_pattern,
+    const AffineConstraints<Number> &constraints = AffineConstraints<Number>(),
+    const bool                       keep_constrained_dofs = true,
+    const types::subdomain_id subdomain_id = numbers::invalid_subdomain_id);
+
+  /**
+   * Store internally that the given cells are agglomerated. The convenction we
+   * take is the following:
+   * -1: cell is a master cell
+   *
+   * @note cells are assumed to be adjacent one to each other, and no check
+   * about this is done.
+   */
+  agglomeration_iterator
+  define_agglomerate(const AgglomerationContainer &cells);
+
+  /**
+   * Same as above, but checking that every vector of cells is connected. If
+   * not, each connected component is agglomerated by part by calling the
+   * define_agglomerate() function defined above.
+   */
+  void
+  define_agglomerate_with_check(const AgglomerationContainer &cells);
+
+  /**
+   * Returns a constant reference of the Triangulation of the calling
+   * agglomeration.
+   */
+  inline const Triangulation<dim, spacedim> &
+  get_triangulation() const;
+
+  /**
+   * Returns a constant reference of the FiniteElement of the calling
+   * agglomeration.
+   */
+  inline const FiniteElement<dim, spacedim> &
+  get_fe() const;
+
+  /**
+   * Returns the default mapping used when initialize the mesh
+   */
+  inline const Mapping<dim> &
+  get_mapping() const;
+
+  /**
+   * Returns the mapping of bounding box used in agglomeration
+   */
+  inline const MappingBox<dim> &
+  get_agglomeration_mapping() const;
+
+  /**
+   * Return the vector of bounding box of the polytope
+   */
+  inline const std::vector<BoundingBox<dim>> &
+  get_local_bboxes() const;
+
+  /**
+   * Return the mesh size of the polytopal mesh. It simply takes the maximum
+   * diameter over all the polytopes.
+   */
+  // double
+  // get_mesh_size() const;
+
+  /**
+   * Given a master cell, return the index of the related polytope
+   */
+  inline types::global_cell_index
+  cell_to_polytope_index(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
+    const;
+
+  /**
+   * Return a map between the pair of index of two adjacent polytopes and the
+   * vector of cell and interface id that constructs this interface, which
+   * represents a interface between two polytopes
+   */
+  inline decltype(auto)
+  get_interface() const;
+
+  /**
+   * Helper function to determine whether or not a cell is a master or a slave
+   */
+  template <typename CellIterator>
+  inline bool
+  is_master_cell(const CellIterator &cell) const;
+
+  /**
+   * Find (if any) the cells that have the given master index. Note that `idx`
+   * is as it can be equal to -1 (meaning that the cell is a master one).
+   */
+  inline const std::vector<
+    typename Triangulation<dim, spacedim>::active_cell_iterator> &
+  get_slaves_of_idx(types::global_cell_index idx) const;
+
+  /**
+   * Return the vector that stores the correspondence of master and slave cells.
+   * The vector has two kinds of elements, if the cell corresponds to the index
+   * i is a master cell, the ith vector element is -1; if it's a slave cell, the
+   * ith vector element is the index of the master cell of the polytope it
+   * belongs to.
+   */
+  inline const LinearAlgebra::distributed::Vector<float> &
+  get_relationships() const;
+
+  /**
+   * TODO: remove this in favour of the accessor version.
+   *
+   * @param master_cell
+   * @return std::vector<
+   * typename Triangulation<dim, spacedim>::active_cell_iterator>
+   */
+  inline std::vector<
+    typename Triangulation<dim, spacedim>::active_cell_iterator>
+  get_agglomerate(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+      &master_cell) const;
+
+  /**
+   * Return a nested map associating a neighboring subdomain id and a pair of
+   * ghost cell id and face index to the shape gradients evaluated at the
+   * quadrature points on that specific interface.
+   */
+  inline decltype(auto)
+  get_recv_gradients() const;
+
+  /**
+   * Return a nested map associating a neighboring subdomain id and a pair of
+   * ghost cell id and face index to the shape values evaluated at the
+   * quadrature points on that specific interface.
+   */
+  inline decltype(auto)
+  get_recv_values() const;
+
+  /**
+   * Return a nested map associating a neighboring subdomain id and a pair of
+   * ghost cell id and face index to the JxW (Jacobian determinant times
+   * quadrature weight) values evaluated at the quadrature points on that
+   * specific interface.
+   */
+  inline decltype(auto)
+  get_recv_jxws() const;
+
+  /**
+   * Display the indices of the vector identifying which cell is agglomerated
+   * with which master.
+   */
+  template <class StreamType>
+  void
+  print_agglomeration(StreamType &out);
+
+  /**
+   *
+   * Return a constant reference to the DoFHandler underlying the
+   * agglomeration. It knows which cell have been agglomerated, and which FE
+   * spaces are present on each cell of the triangulation.
+   */
+  inline const DoFHandler<dim, spacedim> &
+  get_dof_handler() const;
+
+  /**
+   * Returns the number of agglomerate cells in the grid.
+   */
+  unsigned int
+  n_agglomerates() const;
+
+  /**
+   * Return the number of agglomerated faces for a generic deal.II cell.
+   */
+  // unsigned int
+  // n_agglomerated_faces_per_cell(
+  //   const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
+  //   const;
+
+  /**
+   * Construct a finite element space on the agglomeration.
+   */
+  const FEValues<dim, spacedim> &
+  reinit(const AgglomerationIterator<dim, spacedim> &polytope) const;
+
+  /**
+   * For a given polytope and face index, initialize shape functions, normals
+   * and quadratures rules to integrate there.
+   */
+  const FEValuesBase<dim, spacedim> &
+  reinit(const AgglomerationIterator<dim, spacedim> &polytope,
+         const unsigned int                          face_index) const;
+
+  /**
+   *
+   * Return a pair of FEValuesBase object reinited from the two component
+   * polytopes of the agglomeration.
+   */
+  std::pair<const FEValuesBase<dim, spacedim> &,
+            const FEValuesBase<dim, spacedim> &>
+  reinit_interface(const AgglomerationIterator<dim, spacedim> &polytope_in,
+                   const AgglomerationIterator<dim, spacedim> &neigh_polytope,
+                   const unsigned int                          local_in,
+                   const unsigned int local_outside) const;
+
+  /**
+   * Return the agglomerated quadrature for the given agglomeration. This
+   * amounts to looping over all cells in an agglomeration, collecting together
+   * all the rules, and mapping the quadrature points to the reference unit of
+   * bounding box.
+   */
+  Quadrature<dim>
+  agglomerated_quadrature(
+    const AgglomerationContainer &cells,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+      &master_cell) const;
+
+
+  /**
+   *
+   * This function generalizes the behaviour of cell->face(f)->at_boundary()
+   * in the case where f is an index out of the range [0,..., n_faces).
+   * In practice, if you call this function with a standard deal.II cell, you
+   * have exactly the same result as calling cell->face(f)->at_boundary().
+   * Otherwise, if the cell is a master one, it returns a boolean showing
+   * whether that face of the agglomeration is on the boundary or not.
+   */
+  inline bool
+  at_boundary(
+    const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+    const unsigned int                                              f) const;
+
+  /**
+   * Return the number of degrees of freedom per cell.
+   */
+  inline unsigned int
+  n_dofs_per_cell() const noexcept;
+
+  /**
+   * Return the number of degrees of the whole mesh
+   */
+  inline types::global_dof_index
+  n_dofs() const noexcept;
+
+
+
+  /**
+   * Return the collection of boundary faces describing the boundary of the
+   * polytope associated to the master cell `cell`. The return type is meant to
+   * describe a sequence of edges (in 2D) or faces (in 3D).
+   */
+  inline const std::vector<
+    typename Triangulation<dim, spacedim>::active_face_iterator> &
+  polytope_boundary(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell);
+
+
+  /**
+   * DoFHandler for the agglomerated space
+   */
+  DoFHandler<dim, spacedim> agglo_dh;
+
+  /**
+   * DoFHandler for the finest space: classical deal.II space
+   */
+  DoFHandler<dim, spacedim> output_dh;
+
+  std::unique_ptr<MappingBox<dim>> box_mapping;
+
+  /**
+   * This function stores the information needed to identify which polytopes are
+   * ghosted w.r.t the local partition. The issue this function addresses is due
+   * to the fact that the layer of ghost cells is made by just one layer of
+   * deal.II cells. Therefore, the neighboring polytopes will always be made by
+   * some ghost cells and **artificial** ones. This implies that we need to
+   * communicate the missing information from the neighboring rank.
+   */
+  void
+  setup_ghost_polytopes();
+
+  /**
+   * This function collects all the information needed for discontinuous
+   * galerkin method, and exchanges the information with all the interfaces of
+   * the neighbor polytope in different MPI ranks. The relevant data is declared
+   * in the downside private part, from qpoints to gradients.
+   */
+  void
+  exchange_interface_values();
+
+  /**
+   * Given the index of a polytopic element, return a DoFHandler iterator
+   * for which DoFs associated to that polytope can be queried.
+   */
+  inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+  polytope_to_dh_iterator(const types::global_cell_index polytope_index) const;
+
+  /**
+   *
+   */
+  // template <typename RtreeType>
+  // void
+  // connect_hierarchy(const CellsAgglomerator<dim, RtreeType> &agglomerator);
+
+private:
+  /**
+   * Initialize connectivity informations
+   */
+  void
+  initialize_agglomeration_data(
+    const std::unique_ptr<GridTools::Cache<dim, spacedim>> &cache_tria);
+
+
+  /**
+   * Helper function to determine whether or not a cell is a slave cell.
+   * Instead of returning a boolean, it gives the index of the master cell. If
+   * it's a master cell, then the it returns -1, by construction.
+   */
+
+  inline typename Triangulation<dim, spacedim>::active_cell_iterator &
+  is_slave_cell_of(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell);
+
+  /**
+   * Construct bounding boxes for an agglomeration described by a sequence of
+   * cells. This fills also the euler vector
+   */
+  void
+  create_bounding_box(const AgglomerationContainer &polytope);
+
+  /**
+   * Return the master index of the polytope this cell belongs to.
+   */
+  inline types::global_cell_index
+  get_master_idx_of_cell(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
+    const;
+
+  /**
+   * Returns true if the two given cells are agglomerated together.
+   */
+  inline bool
+  are_cells_agglomerated(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+      &other_cell) const;
+
+  /**
+   * Assign a finite element index on each cell of a triangulation, depending
+   * if it is a master cell, a slave cell, or a standard deal.II cell. A user
+   * doesn't need to know the internals of this, the only thing that is
+   * relevant is that after the call to the present function, DoFs are
+   * distributed in a different way if a cell is a master, slave, or standard
+   * cell.
+   */
+  void
+  initialize_hp_structure();
+
+
+  /**
+   * Helper function to call reinit on a master cell.
+   */
+  const FEValuesBase<dim, spacedim> &
+  reinit_master(
+    const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+    const unsigned int                                              face_number,
+    std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
+      &agglo_isv_ptr) const;
+
+
+  /**
+   * Helper function to determine whether or not a cell is a slave cell, without
+   * any information about his parents.
+   */
+  template <typename CellIterator>
+  inline bool
+  is_slave_cell(const CellIterator &cell) const;
+
+
+  /**
+   * Initialize all the necessary connectivity information for an
+   * agglomeration. #TODO: loop over polytopes, avoid using explicitly
+   * master cells.
+   */
+  void
+  setup_connectivity_of_agglomeration();
+
+
+  /**
+   * Record the number of agglomerations on the grid.
+   */
+  unsigned int n_agglomerations;
+
+
+  /**
+   * Vector of indices such that v[cell->active_cell_index()] returns
+   * { -1 if `cell` is a master cell
+   * { `cell_master->active_cell_index()`, i.e. the index of the master cell if
+   * `cell` is a slave cell.
+   */
+  LinearAlgebra::distributed::Vector<float> master_slave_relationships;
+
+  /**
+   * Same as the one above, but storing cell iterators rather than indices.
+   *
+   */
+  std::map<types::global_cell_index,
+           typename Triangulation<dim, spacedim>::active_cell_iterator>
+    master_slave_relationships_iterators;
+
+  using ScratchData = MeshWorker::ScratchData<dim, spacedim>;
+
+  /**
+   * Vector that stores how many faces the ith polytope has.
+   */
+  mutable std::vector<types::global_cell_index> number_of_agglomerated_faces;
+
+  /**
+   * Associate a master cell (hence, a given polytope) to its boundary faces.
+   * The boundary is described through a vector of face iterators.
+   *
+   */
+  mutable std::map<
+    const typename Triangulation<dim, spacedim>::active_cell_iterator,
+    std::vector<typename Triangulation<dim>::active_face_iterator>>
+    polygon_boundary;
+
+
+  /**
+   * Vector of `BoundingBoxes` s.t. `bboxes[idx]` equals BBOx associated to the
+   * agglomeration with master cell indexed by ìdx`. Othwerwise default BBox is
+   * empty
+   *
+   */
+  std::vector<BoundingBox<spacedim>> bboxes;
+
+  ////////////////////////////////////////////////////////
+
+
+  // n_faces
+  mutable std::map<types::subdomain_id, std::map<CellId, unsigned int>>
+    local_n_faces;
+
+  mutable std::map<types::subdomain_id, std::map<CellId, unsigned int>>
+    recv_n_faces;
+
+
+  // CellId (including slaves)
+  mutable std::map<types::subdomain_id, std::map<CellId, CellId>>
+    local_cell_ids_neigh_cell;
+
+  mutable std::map<types::subdomain_id, std::map<CellId, CellId>>
+    recv_cell_ids_neigh_cell;
+
+
+  // send to neighborign rank the information that
+  // - current polytope id
+  // - face f
+  // has the following neighboring id.
+  mutable std::map<types::subdomain_id,
+                   std::map<CellId, std::map<unsigned int, CellId>>>
+    local_ghosted_master_id;
+
+  mutable std::map<types::subdomain_id,
+                   std::map<CellId, std::map<unsigned int, CellId>>>
+    recv_ghosted_master_id;
+
+  // CellIds from neighboring rank
+  mutable std::map<types::subdomain_id,
+                   std::map<CellId, std::map<unsigned int, bool>>>
+    local_bdary_info;
+
+  mutable std::map<types::subdomain_id,
+                   std::map<CellId, std::map<unsigned int, bool>>>
+    recv_bdary_info;
+
+  // Exchange neighboring bounding boxes
+  mutable std::map<types::subdomain_id, std::map<CellId, BoundingBox<dim>>>
+    local_ghosted_bbox;
+
+  mutable std::map<types::subdomain_id, std::map<CellId, BoundingBox<dim>>>
+    recv_ghosted_bbox;
+
+  // Exchange DoF indices with ghosted polytopes
+  mutable std::map<types::subdomain_id,
+                   std::map<CellId, std::vector<types::global_dof_index>>>
+    local_ghost_dofs;
+
+  mutable std::map<types::subdomain_id,
+                   std::map<CellId, std::vector<types::global_dof_index>>>
+    recv_ghost_dofs;
+
+  // Exchange qpoints
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<Point<spacedim>>>>
+    local_qpoints;
+
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<Point<spacedim>>>>
+    recv_qpoints;
+
+  // Exchange jxws
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<double>>>
+    local_jxws;
+
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<double>>>
+    recv_jxws;
+
+  // Exchange normals
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<Tensor<1, spacedim>>>>
+    local_normals;
+
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<Tensor<1, spacedim>>>>
+    recv_normals;
+
+  // Exchange values
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<std::vector<double>>>>
+    local_values;
+
+  mutable std::map<
+    types::subdomain_id,
+    std::map<std::pair<CellId, unsigned int>, std::vector<std::vector<double>>>>
+    recv_values;
+
+  // Exchange gradients
+  mutable std::map<types::subdomain_id,
+                   std::map<std::pair<CellId, unsigned int>,
+                            std::vector<std::vector<Tensor<1, spacedim>>>>>
+    local_gradients;
+
+  mutable std::map<types::subdomain_id,
+                   std::map<std::pair<CellId, unsigned int>,
+                            std::vector<std::vector<Tensor<1, spacedim>>>>>
+    recv_gradients;
+
+  ////////////////////////////////////////////////////////
+
+  SmartPointer<const Triangulation<dim, spacedim>> tria;
+
+  SmartPointer<const Mapping<dim, spacedim>> mapping;
+
+  std::unique_ptr<GridTools::Cache<dim, spacedim>> cached_tria;
+
+  const MPI_Comm communicator;
+
+  // The FiniteElement space we have on each cell. Currently supported types are
+  // FE_DGQ and FE_DGP elements.
+  std::unique_ptr<FiniteElement<dim>> fe;
+
+  hp::FECollection<dim, spacedim> fe_collection;
+
+  /**
+   * Eulerian vector describing the new cells obtained by the bounding boxes
+   */
+  LinearAlgebra::distributed::Vector<double> euler_vector;
+
+
+  /**
+   * Use this in reinit(cell) for  (non-agglomerated, standard)  cells,
+   * and return the result of scratch.reinit(cell) for cells
+   */
+  mutable std::unique_ptr<ScratchData> standard_scratch;
+
+  /**
+   * Fill this up in reinit(cell), for agglomerated cells, using the custom
+   * quadrature, and return the result of
+   * scratch.reinit(cell);
+   */
+  mutable std::unique_ptr<ScratchData> agglomerated_scratch;
+
+  /**
+   * Pointer for Immersed Surface Values on non-matching agglomerations.
+   * These unique_ptrs cache the FEValues-like objects needed to compute shape
+   * functions and gradients within the polytope, across internal interfaces,
+   * and on physical boundaries.
+   */
+  mutable std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
+    agglomerated_isv;
+
+  mutable std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
+    agglomerated_isv_neigh;
+
+  mutable std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
+    agglomerated_isv_bdary;
+
+  /**
+   * Listens for mesh modifications to automatically invalidate and rebuild the
+   * agglomeration caches.
+   */
+  boost::signals2::connection tria_listener;
+
+  /**
+   * Mandatory internal flags required by the handler for cell evaluation.
+   */
+  UpdateFlags agglomeration_flags;
+
+  const UpdateFlags internal_agglomeration_flags =
+    update_values | update_gradients | update_JxW_values |
+    update_quadrature_points;
+
+  /**
+   * Update flags for face/interface FE evaluation.
+   */
+  UpdateFlags agglomeration_face_flags;
+
+  const UpdateFlags internal_agglomeration_face_flags =
+    update_quadrature_points | update_normal_vectors | update_values |
+    update_gradients | update_JxW_values | update_inverse_jacobians;
+
+  /**
+   * Quadrature for current polytope/polytopal face.
+   */
+  Quadrature<dim> agglomeration_quad;
+
+  Quadrature<dim - 1> agglomeration_face_quad;
+
+  /**
+   * Maps the global active cell index of a master cell to a vector containing
+   * the active cell iterators of all its constituent slave cells.
+   */
+  std::unordered_map<
+    types::global_cell_index,
+    std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>>
+    master2slaves;
+
+  /**
+   * Map the master cell index with the polytope index.
+   */
+  std::map<types::global_cell_index, types::global_cell_index> master2polygon;
+
+
+  std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
+    master_disconnected;
+
+  // Dummy FiniteElement objects needed only to generate quadratures
+  /**
+   * Dummy FE_Nothing
+   */
+  FE_Nothing<dim, spacedim> dummy_fe;
+
+  /**
+   * Dummy FEValues, needed for cell quadratures.
+   */
+  std::unique_ptr<FEValues<dim, spacedim>> no_values;
+
+  /**
+   * Dummy FEFaceValues, needed for face quadratures.
+   */
+  std::unique_ptr<FEFaceValues<dim, spacedim>> no_face_values;
+
+  /**
+   * A contiguous container for all of the master cells.
+   */
+  std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
+    master_cells_container;
+
+  friend class internal::AgglomerationHandlerImplementation<dim, spacedim>;
+
+  internal::PolytopeCache<dim, spacedim> polytope_cache;
+
+  /**
+   * Bool that keeps track whether the mesh is composed also by standard deal.II
+   * cells as (trivial) polytopes.
+   */
+  bool hybrid_mesh;
+
+  /*std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+           std::vector<types::global_cell_index>>
+    parent_child_info;*/
+
+  unsigned int present_extraction_level;
+};
+
+
+
+// ------------------------------ inline functions -------------------------
+template <int dim, int spacedim>
+inline const FiniteElement<dim, spacedim> &
+AgglomerationHandler<dim, spacedim>::get_fe() const
+{
+  return *fe;
+}
+
+template <int dim, int spacedim>
+inline const Mapping<dim> &
+AgglomerationHandler<dim, spacedim>::get_mapping() const
+{
+  return *mapping;
+}
+
+template <int dim, int spacedim>
+inline const MappingBox<dim> &
+AgglomerationHandler<dim, spacedim>::get_agglomeration_mapping() const
+{
+  return *box_mapping;
+}
+
+template <int dim, int spacedim>
+inline const Triangulation<dim, spacedim> &
+AgglomerationHandler<dim, spacedim>::get_triangulation() const
+{
+  return *tria;
+}
+
+template <int dim, int spacedim>
+inline const std::vector<BoundingBox<dim>> &
+AgglomerationHandler<dim, spacedim>::get_local_bboxes() const
+{
+  return bboxes;
+}
+
+template <int dim, int spacedim>
+inline types::global_cell_index
+AgglomerationHandler<dim, spacedim>::cell_to_polytope_index(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell) const
+{
+  return master2polygon.at(cell->active_cell_index());
+}
+
+template <int dim, int spacedim>
+inline decltype(auto)
+AgglomerationHandler<dim, spacedim>::get_interface() const
+{
+  return polytope_cache.interface;
+}
+
+template <int dim, int spacedim>
+inline const LinearAlgebra::distributed::Vector<float> &
+AgglomerationHandler<dim, spacedim>::get_relationships() const
+{
+  return master_slave_relationships;
+}
+
+template <int dim, int spacedim>
+inline std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
+AgglomerationHandler<dim, spacedim>::get_agglomerate(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator
+    &master_cell) const
+{
+  Assert(is_master_cell(master_cell), ExcInternalError());
+  auto agglomeration = get_slaves_of_idx(master_cell->active_cell_index());
+  agglomeration.push_back(master_cell);
+  return agglomeration;
+}
+
+template <int dim, int spacedim>
+inline decltype(auto)
+AgglomerationHandler<dim, spacedim>::get_recv_gradients() const
+{
+  return (recv_gradients);
+}
+
+template <int dim, int spacedim>
+inline decltype(auto)
+AgglomerationHandler<dim, spacedim>::get_recv_values() const
+{
+  return (recv_values);
+}
+
+template <int dim, int spacedim>
+inline decltype(auto)
+AgglomerationHandler<dim, spacedim>::get_recv_jxws() const
+{
+  return (recv_jxws);
+}
+
+template <int dim, int spacedim>
+template <class StreamType>
+void
+AgglomerationHandler<dim, spacedim>::print_agglomeration(StreamType &out)
+{
+  for (const auto &cell : tria->active_cell_iterators())
+    out << "Cell with index: " << cell->active_cell_index()
+        << " has associated value: "
+        << master_slave_relationships[cell->global_active_cell_index()]
+        << std::endl;
+}
+
+template <int dim, int spacedim>
+inline const DoFHandler<dim, spacedim> &
+AgglomerationHandler<dim, spacedim>::get_dof_handler() const
+{
+  return agglo_dh;
+}
+
+template <int dim, int spacedim>
+inline const std::vector<
+  typename Triangulation<dim, spacedim>::active_cell_iterator> &
+AgglomerationHandler<dim, spacedim>::get_slaves_of_idx(
+  types::global_cell_index idx) const
+{
+  return master2slaves.at(idx);
+}
+
+template <int dim, int spacedim>
+template <typename CellIterator>
+inline bool
+AgglomerationHandler<dim, spacedim>::is_master_cell(
+  const CellIterator &cell) const
+{
+  return master_slave_relationships[cell->global_active_cell_index()] == -1;
+}
+
+template <int dim, int spacedim>
+template <typename CellIterator>
+inline bool
+AgglomerationHandler<dim, spacedim>::is_slave_cell(
+  const CellIterator &cell) const
+{
+  return master_slave_relationships[cell->global_active_cell_index()] >= 0;
+}
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationHandler<dim, spacedim>::at_boundary(
+  const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+  const unsigned int face_index) const
+{
+  Assert(!is_slave_cell(cell),
+         ExcMessage("This function should not be called for a slave cell."));
+
+  return polytope_cache.cell_face_at_boundary
+    .at({master2polygon.at(cell->active_cell_index()), face_index})
+    .first;
+}
+
+template <int dim, int spacedim>
+inline unsigned int
+AgglomerationHandler<dim, spacedim>::n_dofs_per_cell() const noexcept
+{
+  return fe->n_dofs_per_cell();
+}
+
+template <int dim, int spacedim>
+inline types::global_dof_index
+AgglomerationHandler<dim, spacedim>::n_dofs() const noexcept
+{
+  return agglo_dh.n_dofs();
+}
+
+template <int dim, int spacedim>
+inline const std::vector<
+  typename Triangulation<dim, spacedim>::active_face_iterator> &
+AgglomerationHandler<dim, spacedim>::polytope_boundary(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
+{
+  return polygon_boundary[cell];
+}
+
+template <int dim, int spacedim>
+inline typename Triangulation<dim, spacedim>::active_cell_iterator &
+AgglomerationHandler<dim, spacedim>::is_slave_cell_of(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
+{
+  return master_slave_relationships_iterators.at(cell->active_cell_index());
+}
+
+template <int dim, int spacedim>
+inline types::global_cell_index
+AgglomerationHandler<dim, spacedim>::get_master_idx_of_cell(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell) const
+{
+  auto idx = master_slave_relationships[cell->global_active_cell_index()];
+  if (idx == -1)
+    return cell->global_active_cell_index();
+  else
+    return static_cast<types::global_cell_index>(idx);
+}
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationHandler<dim, spacedim>::are_cells_agglomerated(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &other_cell)
+  const
+{
+  // if different subdomain, then **by construction** they will not be together
+  // if (cell->subdomain_id() != other_cell->subdomain_id())
+  //   return false;
+  // else
+  return (get_master_idx_of_cell(cell) == get_master_idx_of_cell(other_cell));
+}
+
+template <int dim, int spacedim>
+inline unsigned int
+AgglomerationHandler<dim, spacedim>::n_agglomerates() const
+{
+  return n_agglomerations;
+}
+
+template <int dim, int spacedim>
+inline const typename DoFHandler<dim, spacedim>::active_cell_iterator
+AgglomerationHandler<dim, spacedim>::polytope_to_dh_iterator(
+  const types::global_cell_index polytope_index) const
+{
+  return master_cells_container[polytope_index]->as_dof_handler_iterator(
+    agglo_dh);
+}
+
+template <int dim, int spacedim>
+AgglomerationIterator<dim, spacedim>
+AgglomerationHandler<dim, spacedim>::begin() const
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+  return {*master_cells_container.begin(), this};
+}
+
+template <int dim, int spacedim>
+AgglomerationIterator<dim, spacedim>
+AgglomerationHandler<dim, spacedim>::begin()
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+  return {*master_cells_container.begin(), this};
+}
+
+template <int dim, int spacedim>
+AgglomerationIterator<dim, spacedim>
+AgglomerationHandler<dim, spacedim>::end() const
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+  return {*master_cells_container.end(), this};
+}
+
+template <int dim, int spacedim>
+AgglomerationIterator<dim, spacedim>
+AgglomerationHandler<dim, spacedim>::end()
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+  return {*master_cells_container.end(), this};
+}
+
+template <int dim, int spacedim>
+AgglomerationIterator<dim, spacedim>
+AgglomerationHandler<dim, spacedim>::last()
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+  return {master_cells_container.back(), this};
+}
+
+template <int dim, int spacedim>
+IteratorRange<
+  typename AgglomerationHandler<dim, spacedim>::agglomeration_iterator>
+AgglomerationHandler<dim, spacedim>::polytope_iterators() const
+{
+  return IteratorRange<
+    typename AgglomerationHandler<dim, spacedim>::agglomeration_iterator>(
+    begin(), end());
+}
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/dofs/agglomeration_iterator.h
+++ b/include/deal.II/dofs/agglomeration_iterator.h
@@ -1,0 +1,310 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef dealii_agglomeration_iterator_h
+#define dealii_agglomeration_iterator_h
+
+
+#include <deal.II/dofs/agglomeration_accessor.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+/**
+ * A class that is used to iterate over polygons. Together with the
+ * AgglomerationAccessor class this is used to hide the internal implementation
+ * of the particle class and the particle container.
+ */
+template <int dim, int spacedim = dim>
+class AgglomerationIterator
+{
+public:
+  using AgglomerationContainer =
+    typename AgglomerationAccessor<dim, spacedim>::AgglomerationContainer;
+
+  /**
+   * Empty constructor. This constructor creates an iterator pointing to an
+   * invalid object.
+   */
+  AgglomerationIterator();
+
+  /**
+   * Constructor of the iterator. Takes a reference to the master cell encoding
+   * the actual polytope.
+   */
+  AgglomerationIterator(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+    const AgglomerationHandler<dim, spacedim>                         *handler);
+
+  /**
+   * Same as above, needed for ghosted elements.
+   */
+  AgglomerationIterator(
+    const typename Triangulation<dim, spacedim>::active_cell_iterator
+                                              &master_cell,
+    const CellId                              &cell_id,
+    const AgglomerationHandler<dim, spacedim> *handler);
+
+  /**
+   * Dereferencing operator, returns a reference to an accessor. Usage is thus
+   * like <tt>(*i).get_dof_indices ();</tt>
+   */
+  const AgglomerationAccessor<dim, spacedim> &
+  operator*() const;
+
+  /**
+   * Dereferencing operator, non-@p const version.
+   */
+  AgglomerationAccessor<dim, spacedim> &
+  operator*();
+
+  /**
+   * Dereferencing operator, returns a pointer of the particle pointed to.
+   * Usage is thus like <tt>i->get_dof_indices ();</tt>
+   *
+   * There is a @p const and a non-@p const version.
+   */
+  const AgglomerationAccessor<dim, spacedim> *
+  operator->() const;
+
+  /**
+   * Dereferencing operator, non-@p const version.
+   */
+  AgglomerationAccessor<dim, spacedim> *
+  operator->();
+
+  /**
+   * Compare for equality.
+   */
+  bool
+  operator==(const AgglomerationIterator<dim, spacedim> &) const;
+
+  /**
+   * Compare for inequality.
+   */
+  bool
+  operator!=(const AgglomerationIterator<dim, spacedim> &) const;
+
+  /**
+   * Prefix <tt>++</tt> operator: <tt>++iterator</tt>. This operator advances
+   * the iterator to the next element and returns a reference to
+   * <tt>*this</tt>.
+   */
+  AgglomerationIterator &
+  operator++();
+
+  /**
+   * Postfix <tt>++</tt> operator: <tt>iterator++</tt>. This operator advances
+   * the iterator to the next element, but returns an iterator to the element
+   * previously pointed to.
+   */
+  AgglomerationIterator
+  operator++(int);
+
+  /**
+   * Prefix <tt>\--</tt> operator: <tt>\--iterator</tt>. This operator moves
+   * the iterator to the previous element and returns a reference to
+   * <tt>*this</tt>.
+   */
+  AgglomerationIterator &
+  operator--();
+
+  /**
+   * Postfix <tt>\--</tt> operator: <tt>iterator\--</tt>. This operator moves
+   * the iterator to the previous element, but returns an iterator to the
+   * element previously pointed to.
+   */
+  AgglomerationIterator
+  operator--(int);
+
+  /**
+   * Return the state of the present iterator.
+   */
+  IteratorState::IteratorStates
+  state() const;
+
+  /**
+   * Return the master cell associated to the present polytope.
+   */
+  const typename Triangulation<dim, spacedim>::active_cell_iterator &
+  master_cell() const;
+
+  /**
+   * Mark the class as bidirectional iterator and declare some alias which
+   * are standard for iterators and are used by algorithms to enquire about
+   * the specifics of the iterators they work on.
+   */
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type        = AgglomerationAccessor<dim, spacedim>;
+  using difference_type   = std::ptrdiff_t;
+  using pointer           = AgglomerationAccessor<dim, spacedim> *;
+  using reference         = AgglomerationAccessor<dim, spacedim> &;
+
+private:
+  /**
+   * The accessor to the actual polytope.
+   */
+  AgglomerationAccessor<dim, spacedim> accessor;
+};
+
+
+
+// ------------------------------ inline functions -------------------------
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim>::AgglomerationIterator()
+  : accessor()
+{}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim>::AgglomerationIterator(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator
+                                            &master_cell,
+  const AgglomerationHandler<dim, spacedim> *handler)
+  : accessor(master_cell, handler)
+{}
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim>::AgglomerationIterator(
+  const typename Triangulation<dim, spacedim>::active_cell_iterator
+                                            &master_cell,
+  const CellId                              &cell_id,
+  const AgglomerationHandler<dim, spacedim> *handler)
+  : accessor(master_cell, cell_id, handler)
+{}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationAccessor<dim, spacedim> &
+AgglomerationIterator<dim, spacedim>::operator*()
+{
+  return accessor;
+}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationAccessor<dim, spacedim> *
+AgglomerationIterator<dim, spacedim>::operator->()
+{
+  return &(this->operator*());
+}
+
+
+
+template <int dim, int spacedim>
+inline const AgglomerationAccessor<dim, spacedim> &
+AgglomerationIterator<dim, spacedim>::operator*() const
+{
+  return accessor;
+}
+
+
+
+template <int dim, int spacedim>
+inline const AgglomerationAccessor<dim, spacedim> *
+AgglomerationIterator<dim, spacedim>::operator->() const
+{
+  return &(this->operator*());
+}
+
+
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationIterator<dim, spacedim>::operator!=(
+  const AgglomerationIterator<dim, spacedim> &other) const
+{
+  return accessor != other.accessor;
+}
+
+
+
+template <int dim, int spacedim>
+inline bool
+AgglomerationIterator<dim, spacedim>::operator==(
+  const AgglomerationIterator<dim, spacedim> &other) const
+{
+  return accessor == other.accessor;
+}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim> &
+AgglomerationIterator<dim, spacedim>::operator++()
+{
+  accessor.next();
+  return *this;
+}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim>
+AgglomerationIterator<dim, spacedim>::operator++(int)
+{
+  AgglomerationIterator tmp(*this);
+  operator++();
+
+  return tmp;
+}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim> &
+AgglomerationIterator<dim, spacedim>::operator--()
+{
+  accessor.prev();
+  return *this;
+}
+
+
+
+template <int dim, int spacedim>
+inline AgglomerationIterator<dim, spacedim>
+AgglomerationIterator<dim, spacedim>::operator--(int)
+{
+  AgglomerationIterator tmp(*this);
+  operator--();
+
+  return tmp;
+}
+
+
+
+template <int dim, int spacedim>
+inline IteratorState::IteratorStates
+AgglomerationIterator<dim, spacedim>::state() const
+{
+  return accessor.master_cell.state();
+}
+
+
+
+template <int dim, int spacedim>
+inline const typename Triangulation<dim, spacedim>::active_cell_iterator &
+AgglomerationIterator<dim, spacedim>::master_cell() const
+{
+  return accessor.master_cell;
+}
+
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/fe/mapping_box.h
+++ b/include/deal.II/fe/mapping_box.h
@@ -1,0 +1,390 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2001 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#ifndef dealii_mapping_box_h
+#define dealii_mapping_box_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/bounding_box.h>
+#include <deal.II/base/qprojector.h>
+
+#include <deal.II/fe/mapping.h>
+
+#include <cmath>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * @addtogroup mapping
+ * @{
+ */
+
+/**
+ * A class providing a mapping from the reference cell to cells that are
+ * axiparallel, i.e., that have the shape of rectangles (in 2d) or
+ * boxes (in 3d) with edges parallel to the coordinate directions. The
+ * class therefore provides functionality that is equivalent to what,
+ * for example, MappingQ would provide for such cells. However, knowledge
+ * of the shape of cells allows this class to be substantially more
+ * efficient.
+ *
+ * Specifically, the mapping is meant for cells for which the mapping from
+ * the reference to the real cell is a scaling along the coordinate
+ * directions: The transformation from reference coordinates $\hat {\mathbf
+ * x}$ to real coordinates $\mathbf x$ on each cell is of the form
+ * @f{align*}{
+ *   {\mathbf x}(\hat {\mathbf x})
+ *   =
+ *   \begin{pmatrix}
+ *     h_x & 0 \\
+ *     0 & h_y
+ *   \end{pmatrix}
+ *   \hat{\mathbf x}
+ *   + {\mathbf v}_0
+ * @f}
+ * in 2d, and
+ * @f{align*}{
+ *   {\mathbf x}(\hat {\mathbf x})
+ *   =
+ *   \begin{pmatrix}
+ *     h_x & 0 & 0 \\
+ *     0 & h_y & 0 \\
+ *     0 & 0 & h_z
+ *   \end{pmatrix}
+ *   \hat{\mathbf x}
+ *   + {\mathbf v}_0
+ * @f}
+ * in 3d, where ${\mathbf v}_0$ is the bottom left vertex and $h_x,h_y,h_z$
+ * are the extents of the cell along the axes.
+ *
+ * The class is intended for efficiency, and it does not do a whole lot of
+ * error checking. If you apply this mapping to a cell that does not conform
+ * to the requirements above, you will get strange results.
+ */
+template <int dim, int spacedim = dim>
+class MappingBox : public Mapping<dim, spacedim>
+{
+public:
+  MappingBox(const std::vector<BoundingBox<dim>> &local_boxes,
+             const std::map<types::global_cell_index, types::global_cell_index>
+               &polytope_translator);
+  // for documentation, see the Mapping base class
+  virtual std::unique_ptr<Mapping<dim, spacedim>>
+  clone() const override;
+
+  /**
+   * Return @p true because MappingBox preserves vertex
+   * locations.
+   */
+  virtual bool
+  preserves_vertex_locations() const override;
+
+#if DEAL_II_VERSION_GTE(9, 8, 0)
+  virtual bool
+  is_compatible_with(const ReferenceCell<dim> &reference_cell) const override;
+#else
+  virtual bool
+  is_compatible_with(const ReferenceCell &reference_cell) const override;
+#endif
+
+  /**
+   * @name Mapping points between reference and real cells
+   * @{
+   */
+
+  // for documentation, see the Mapping base class
+  virtual Point<spacedim>
+  transform_unit_to_real_cell(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const Point<dim> &p) const override;
+
+  // for documentation, see the Mapping base class
+  virtual Point<dim>
+  transform_real_to_unit_cell(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const Point<spacedim> &p) const override;
+
+  // for documentation, see the Mapping base class
+  virtual void
+  transform_points_real_to_unit_cell(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const ArrayView<const Point<spacedim>>                     &real_points,
+    const ArrayView<Point<dim>> &unit_points) const override;
+
+  /**
+   * @}
+   */
+
+  /**
+   * @name Functions to transform tensors from reference to real coordinates
+   * @{
+   */
+
+  // for documentation, see the Mapping base class
+  virtual void
+  transform(const ArrayView<const Tensor<1, dim>>                   &input,
+            const MappingKind                                        kind,
+            const typename Mapping<dim, spacedim>::InternalDataBase &internal,
+            const ArrayView<Tensor<1, spacedim>> &output) const override;
+
+  // for documentation, see the Mapping base class
+  virtual void
+  transform(const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
+            const MappingKind                                        kind,
+            const typename Mapping<dim, spacedim>::InternalDataBase &internal,
+            const ArrayView<Tensor<2, spacedim>> &output) const override;
+
+  // for documentation, see the Mapping base class
+  virtual void
+  transform(const ArrayView<const Tensor<2, dim>>                   &input,
+            const MappingKind                                        kind,
+            const typename Mapping<dim, spacedim>::InternalDataBase &internal,
+            const ArrayView<Tensor<2, spacedim>> &output) const override;
+
+  // for documentation, see the Mapping base class
+  virtual void
+  transform(const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
+            const MappingKind                                        kind,
+            const typename Mapping<dim, spacedim>::InternalDataBase &internal,
+            const ArrayView<Tensor<3, spacedim>> &output) const override;
+
+  // for documentation, see the Mapping base class
+  virtual void
+  transform(const ArrayView<const Tensor<3, dim>>                   &input,
+            const MappingKind                                        kind,
+            const typename Mapping<dim, spacedim>::InternalDataBase &internal,
+            const ArrayView<Tensor<3, spacedim>> &output) const override;
+
+  /**
+   * @}
+   */
+
+  /**
+   * @name Interface with FEValues
+   * @{
+   */
+
+  /**
+   * Storage for internal data of the mapping. See Mapping::InternalDataBase
+   * for an extensive description.
+   *
+   * This includes data that is computed once when the object is created (in
+   * get_data()) as well as data the class wants to store from between the
+   * call to fill_fe_values(), fill_fe_face_values(), or
+   * fill_fe_subface_values() until possible later calls from the finite
+   * element to functions such as transform(). The latter class of member
+   * variables are marked as 'mutable'.
+   */
+  class InternalData : public Mapping<dim, spacedim>::InternalDataBase
+  {
+  public:
+    /**
+     * Default constructor.
+     */
+    InternalData() = default;
+
+    /**
+     * Constructor that initializes the object with a quadrature.
+     */
+    InternalData(const Quadrature<dim> &quadrature);
+
+    // Documentation see Mapping::InternalDataBase.
+    virtual void
+    reinit(const UpdateFlags      update_flags,
+           const Quadrature<dim> &quadrature) override;
+
+    /**
+     * Return an estimate (in bytes) for the memory consumption of this object.
+     */
+    virtual std::size_t
+    memory_consumption() const override;
+
+    /**
+     * Extents of the last cell we have seen in the coordinate directions,
+     * i.e., <i>h<sub>x</sub></i>, <i>h<sub>y</sub></i>, <i>h<sub>z</sub></i>.
+     */
+    mutable Tensor<1, dim> cell_extents;
+
+    /**
+     * Traslation term in F(\hat{x})=J\hat{x} + c.
+     */
+    mutable Tensor<1, dim> traslation;
+
+    /**
+     * Reciprocal of the extents of the last cell we have seen in the
+     * coordinate directions, i.e., <i>h<sub>x</sub></i>,
+     * <i>h<sub>y</sub></i>, <i>h<sub>z</sub></i>.
+     */
+    mutable Tensor<1, dim> inverse_cell_extents;
+
+    /**
+     * The volume element
+     */
+    mutable double volume_element;
+
+    /**
+     * Location of quadrature points of faces or subfaces in 3d with all
+     * possible orientations. Can be accessed with the correct offset provided
+     * via QProjector::DataSetDescriptor. Not needed/used for cells.
+     */
+    std::vector<Point<dim>> quadrature_points;
+  };
+
+private:
+  // documentation can be found in Mapping::requires_update_flags()
+  virtual UpdateFlags
+  requires_update_flags(const UpdateFlags update_flags) const override;
+
+  // documentation can be found in Mapping::get_data()
+  virtual std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+  get_data(const UpdateFlags, const Quadrature<dim> &quadrature) const override;
+
+  using Mapping<dim, spacedim>::get_face_data;
+
+  // documentation can be found in Mapping::get_subface_data()
+  virtual std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+  get_subface_data(const UpdateFlags          flags,
+                   const Quadrature<dim - 1> &quadrature) const override;
+
+  // documentation can be found in Mapping::fill_fe_values()
+  virtual CellSimilarity::Similarity
+  fill_fe_values(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const CellSimilarity::Similarity                            cell_similarity,
+    const Quadrature<dim>                                      &quadrature,
+    const typename Mapping<dim, spacedim>::InternalDataBase    &internal_data,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const override;
+
+  using Mapping<dim, spacedim>::fill_fe_face_values;
+
+  // documentation can be found in Mapping::fill_fe_subface_values()
+  virtual void
+  fill_fe_subface_values(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const unsigned int                                          face_no,
+    const unsigned int                                          subface_no,
+    const Quadrature<dim - 1>                                  &quadrature,
+    const typename Mapping<dim, spacedim>::InternalDataBase    &internal_data,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const override;
+
+  // documentation can be found in Mapping::fill_fe_immersed_surface_values()
+  virtual void
+  fill_fe_immersed_surface_values(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const NonMatching::ImmersedSurfaceQuadrature<dim>          &quadrature,
+    const typename Mapping<dim, spacedim>::InternalDataBase    &internal_data,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const override;
+
+  /**
+   * @}
+   */
+
+  /**
+   * Update the cell_extents field of the incoming InternalData object with the
+   * size of the incoming cell.
+   */
+  void
+  update_cell_extents(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const CellSimilarity::Similarity                            cell_similarity,
+    const InternalData                                         &data) const;
+
+  /**
+   * Compute the quadrature points if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   *
+   * Called from fill_fe_values.
+   */
+  void
+  maybe_update_cell_quadrature_points(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const InternalData                                         &data,
+    const ArrayView<const Point<dim>> &unit_quadrature_points,
+    std::vector<Point<dim>>           &quadrature_points) const;
+
+  /**
+   * Compute the normal vectors if the UpdateFlags of the incoming InternalData
+   * object say that they should be updated.
+   */
+  void
+  maybe_update_normal_vectors(
+    const unsigned int           face_no,
+    const InternalData          &data,
+    std::vector<Tensor<1, dim>> &normal_vectors) const;
+
+  /**
+   * Since the Jacobian is constant for this mapping all derivatives of the
+   * Jacobian are identically zero. Fill these quantities with zeros if the
+   * corresponding update flags say that they should be updated.
+   */
+  void
+  maybe_update_jacobian_derivatives(
+    const InternalData              &data,
+    const CellSimilarity::Similarity cell_similarity,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
+
+
+  /**
+   * Compute the volume elements if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   */
+  void
+  maybe_update_volume_elements(const InternalData &data) const;
+
+  /**
+   * Compute the Jacobians if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   */
+  void
+  maybe_update_jacobians(
+    const InternalData              &data,
+    const CellSimilarity::Similarity cell_similarity,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
+
+  /**
+   * Compute the inverse Jacobians if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   */
+  void
+  maybe_update_inverse_jacobians(
+    const InternalData              &data,
+    const CellSimilarity::Similarity cell_similarity,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
+
+  /**
+   * Vector of (local) bounding boxes
+   */
+  std::vector<BoundingBox<dim>> boxes;
+
+  /**
+   * Map from global cell index to bounding box index
+   */
+  std::map<types::global_cell_index, types::global_cell_index>
+    polytope_translator;
+};
+
+/** @} */
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/grid/agglomerator.h
+++ b/include/deal.II/grid/agglomerator.h
@@ -1,0 +1,473 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+#ifndef agglomerator_h
+#define agglomerator_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/bounding_box.h>
+
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+
+namespace dealii
+{
+  template <int dim, int spacedim>
+  class AgglomerationHandler;
+
+  namespace internal
+  {
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    struct Rtree_visitor
+      : public boost::geometry::index::detail::rtree::visitor<
+          Value,
+          typename Options::parameters_type,
+          Box,
+          Allocators,
+          typename Options::node_tag,
+          true>::type
+    {
+      inline Rtree_visitor(
+        const Translator  &translator,
+        const unsigned int target_level,
+        std::vector<std::vector<typename Triangulation<
+          boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+                                                        &agglomerates_,
+        std::vector<types::global_cell_index>           &n_nodes_per_level,
+        std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+                 std::vector<types::global_cell_index>> &parent_to_children);
+
+      /**
+       * An alias that identifies an InternalNode of the tree.
+       */
+      using InternalNode =
+        typename boost::geometry::index::detail::rtree::internal_node<
+          Value,
+          typename Options::parameters_type,
+          Box,
+          Allocators,
+          typename Options::node_tag>::type;
+
+      /**
+       * An alias that identifies a Leaf of the tree.
+       */
+      using Leaf = typename boost::geometry::index::detail::rtree::leaf<
+        Value,
+        typename Options::parameters_type,
+        Box,
+        Allocators,
+        typename Options::node_tag>::type;
+
+      /**
+       * Implements the visitor interface for InternalNode objects. If the node
+       * belongs to the level next to @p target_level, then fill the bounding
+       * box vector for that node.
+       */
+      inline void
+      operator()(const InternalNode &node);
+
+      /**
+       * Implements the visitor interface for Leaf objects.
+       */
+      inline void
+      operator()(const Leaf &);
+
+      /**
+       * Translator interface, required by the boost implementation of the
+       * rtree.
+       */
+      const Translator &translator;
+
+      /**
+       * Store the level we are currently visiting.
+       */
+      size_t level;
+
+      /**
+       * Index used to keep track of the number of different visited nodes
+       * during recursion/
+       */
+      size_t node_counter;
+
+      /**
+       * The level where children are living.
+       * Before: "we want to extract from the RTree object."
+       */
+      const size_t target_level;
+
+      /**
+       * A reference to the input vector of vector of BoundingBox objects. This
+       * vector v has the following property: v[i] = vector with all the mesh
+       * iterators composing the i-th agglomerate.
+       */
+      std::vector<std::vector<typename Triangulation<
+        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+        &agglomerates;
+
+      /**
+       * Store the total number of nodes on each level.
+       */
+      std::vector<types::global_cell_index> &n_nodes_per_level;
+
+      /**
+       * Map that associates to a given node on level l its children, identified
+       * by their integer index.
+       */
+      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+               std::vector<types::global_cell_index>>
+        &parent_node_to_children_nodes;
+    };
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::Rtree_visitor(
+      const Translator  &translator,
+      const unsigned int target_level,
+      std::vector<std::vector<typename Triangulation<
+        boost::geometry::dimension<Box>::value>::active_cell_iterator>>
+                                                      &agglomerates_,
+      std::vector<types::global_cell_index>           &n_nodes_per_level_,
+      std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+               std::vector<types::global_cell_index>> &parent_to_children)
+      : translator(translator)
+      , level(0)
+      , node_counter(0)
+      , target_level(target_level)
+      , agglomerates(agglomerates_)
+      , n_nodes_per_level(n_nodes_per_level_)
+      , parent_node_to_children_nodes(parent_to_children)
+    {}
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    void
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
+      const Rtree_visitor::InternalNode &node)
+    {
+      using elements_type =
+        typename boost::geometry::index::detail::rtree::elements_type<
+          InternalNode>::type; //  pairs of bounding box and pointer to child
+                               //  node
+      const elements_type &elements =
+        boost::geometry::index::detail::rtree::elements(node);
+
+      if (level < target_level)
+        {
+          size_t level_backup = level;
+          ++level;
+
+          for (typename elements_type::const_iterator it = elements.begin();
+               it != elements.end();
+               ++it)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(*this,
+                                                                   *it->second);
+            }
+
+          level = level_backup;
+        }
+      else if (level == target_level)
+        {
+          const auto offset = agglomerates.size();
+          agglomerates.resize(offset + 1);
+          size_t level_backup = level;
+
+          ++level;
+          for (const auto &entry : elements)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(
+                *this, *entry.second);
+            }
+          // Done with node number 'node_counter' on level target_level.
+
+          ++node_counter; // visited all children of an internal node
+          n_nodes_per_level[target_level]++;
+
+          level = level_backup;
+        }
+      else if (level > target_level)
+        {
+          // I am on a child (internal) node on a deeper level.
+
+          // Keep visiting until you go to the leafs.
+          size_t level_backup = level;
+
+          ++level;
+
+          // looping through entries of node
+          for (const auto &entry : elements)
+            {
+              boost::geometry::index::detail::rtree::apply_visitor(
+                *this, *entry.second);
+            }
+          // done with node on level l > target_level (not just
+          // "target_level+1).
+          n_nodes_per_level[level_backup]++;
+          const types::global_cell_index node_idx =
+            n_nodes_per_level[level_backup] - 1; // so to start from 0
+
+          parent_node_to_children_nodes[{n_nodes_per_level[level_backup - 1],
+                                         level_backup - 1}]
+            .push_back(node_idx);
+
+          level = level_backup;
+        }
+    }
+
+
+
+    template <typename Value,
+              typename Options,
+              typename Translator,
+              typename Box,
+              typename Allocators>
+    void
+    Rtree_visitor<Value, Options, Translator, Box, Allocators>::operator()(
+      const Rtree_visitor::Leaf &leaf)
+    {
+      using elements_type =
+        typename boost::geometry::index::detail::rtree::elements_type<
+          Leaf>::type; //  pairs of bounding box and pointer to child node
+      const elements_type &elements =
+        boost::geometry::index::detail::rtree::elements(leaf);
+
+      if (level == target_level)
+        {
+          // If I want to extract from leaf node, i.e. the target_level is the
+          // last one where leafs are grouped together.
+          const auto offset = agglomerates.size();
+          agglomerates.resize(offset + 1);
+
+          for (const auto &it : elements)
+            agglomerates[node_counter].push_back(it.second);
+
+          ++node_counter;
+          n_nodes_per_level[target_level]++;
+        }
+      else
+        {
+          for (const auto &it : elements)
+            agglomerates[node_counter].push_back(it.second);
+
+
+          if (level == target_level + 1)
+            {
+              const unsigned int node_idx = n_nodes_per_level[level];
+
+              parent_node_to_children_nodes[{n_nodes_per_level[level - 1],
+                                             level - 1}]
+                .push_back(node_idx);
+              n_nodes_per_level[level]++;
+            }
+        }
+    }
+  } // namespace internal
+
+
+
+  /**
+   * Helper class which handles agglomeration based on the R-tree data
+   * structure. Notice that the R-tree type is assumed to be an R-star-tree.
+   */
+  template <int dim, typename RtreeType>
+  class CellsAgglomerator
+  {
+  public:
+    template <int, int>
+    friend class AgglomerationHandler;
+
+    /**
+     * Constructor. It takes a given rtree and an integer representing the
+     * index of the level to be extracted.
+     */
+    CellsAgglomerator(const RtreeType   &rtree,
+                      const unsigned int extraction_level);
+
+    /**
+     * Extract agglomerates based on the current tree and the extraction level.
+     * This function returns a reference to
+     */
+    const std::vector<
+      std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+    extract_agglomerates();
+
+    /**
+     * Get total number of levels.
+     */
+    inline unsigned int
+    get_n_levels() const;
+
+    /**
+     * Return the number of nodes present in level @p level.
+     */
+    inline types::global_cell_index
+    get_n_nodes_per_level(const unsigned int level) const;
+
+    /**
+     * This function returns a map which associates to each node on level
+     * @p extraction_level a list of children.
+     */
+    inline const std::map<
+      std::pair<types::global_cell_index, types::global_cell_index>,
+      std::vector<types::global_cell_index>> &
+    get_hierarchy() const;
+
+  private:
+    /**
+     * Raw pointer to the actual R-tree.
+     */
+    RtreeType *rtree;
+
+    /**
+     * Extraction level.
+     */
+    const unsigned int extraction_level;
+
+    /**
+     * Store agglomerates obtained after recursive extraction on nodes of
+     * level @p extraction_level.
+     */
+    std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+      agglomerates_on_level;
+
+    /**
+     * Vector storing the number of nodes (and, ultimately, agglomerates) for
+     * each level.
+     */
+    std::vector<types::global_cell_index> n_nodes_per_level;
+
+    /**
+     * Map which maps a node parent @n on level @p l to a vector of integers
+     * which stores the index of children.
+     */
+    std::map<std::pair<types::global_cell_index, types::global_cell_index>,
+             std::vector<types::global_cell_index>>
+      parent_node_to_children_nodes;
+  };
+
+
+
+  template <int dim, typename RtreeType>
+  CellsAgglomerator<dim, RtreeType>::CellsAgglomerator(
+    const RtreeType   &tree,
+    const unsigned int extraction_level_)
+    : extraction_level(extraction_level_)
+  {
+    rtree = const_cast<RtreeType *>(&tree);
+    Assert(n_levels(*rtree), ExcMessage("At least two levels are needed."));
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  const std::vector<
+    std::vector<typename Triangulation<dim>::active_cell_iterator>> &
+  CellsAgglomerator<dim, RtreeType>::extract_agglomerates()
+  {
+    AssertThrow(extraction_level <= n_levels(*rtree),
+                ExcInternalError("You are trying to extract level " +
+                                 std::to_string(extraction_level) +
+                                 " of the tree, but it only has a total of " +
+                                 std::to_string(n_levels(*rtree)) +
+                                 " levels."));
+    using RtreeView =
+      boost::geometry::index::detail::rtree::utilities::view<RtreeType>;
+    RtreeView rtv(*rtree);
+
+    n_nodes_per_level.resize(rtv.depth() +
+                             1); // store how many nodes we have for each level.
+
+    if (rtv.depth() == 0)
+      {
+        // The below algorithm does not work for `rtv.depth()==0`, which might
+        // happen if the number entries in the tree is too small.
+        agglomerates_on_level.resize(1);
+        agglomerates_on_level[0].resize(1);
+      }
+    else
+      {
+        const unsigned int target_level =
+          std::min<unsigned int>(extraction_level, rtv.depth());
+
+        internal::Rtree_visitor<typename RtreeView::value_type,
+                                typename RtreeView::options_type,
+                                typename RtreeView::translator_type,
+                                typename RtreeView::box_type,
+                                typename RtreeView::allocators_type>
+          extractor_visitor(rtv.translator(),
+                            target_level,
+                            agglomerates_on_level,
+                            n_nodes_per_level,
+                            parent_node_to_children_nodes);
+
+
+        rtv.apply_visitor(extractor_visitor);
+      }
+    return agglomerates_on_level;
+  }
+
+
+
+  // ------------------------------ inline functions -------------------------
+
+
+  template <int dim, typename RtreeType>
+  inline unsigned int
+  CellsAgglomerator<dim, RtreeType>::get_n_levels() const
+  {
+    return n_levels(*rtree);
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  inline types::global_cell_index
+  CellsAgglomerator<dim, RtreeType>::get_n_nodes_per_level(
+    const unsigned int level) const
+  {
+    return n_nodes_per_level[level];
+  }
+
+
+
+  template <int dim, typename RtreeType>
+  inline const std::map<
+    std::pair<types::global_cell_index, types::global_cell_index>,
+    std::vector<types::global_cell_index>> &
+  CellsAgglomerator<dim, RtreeType>::get_hierarchy() const
+  {
+    Assert(parent_node_to_children_nodes.size(),
+           ExcMessage(
+             "The hierarchy has not been computed. Did you forget to call"
+             " extract_agglomerates() first?"));
+    return parent_node_to_children_nodes;
+  }
+} // namespace dealii
+#endif

--- a/source/dofs/CMakeLists.txt
+++ b/source/dofs/CMakeLists.txt
@@ -22,6 +22,7 @@ set(_separate_src
   dof_accessor.cc
   dof_accessor_get.cc
   dof_accessor_set.cc
+  agglomeration_handler.cc
   dof_handler_policy.cc
   dof_renumbering.cc
   dof_tools.cc
@@ -39,6 +40,7 @@ setup_source_list("${_unity_include_src}"
   )
 
 set(_inst
+  agglomeration_handler.inst.in
   block_info.inst.in
   dof_accessor_get.inst.in
   dof_accessor.inst.in

--- a/source/dofs/agglomeration_handler.cc
+++ b/source/dofs/agglomeration_handler.cc
@@ -1,0 +1,1181 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2001 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+#include <deal.II/dofs/agglomeration_handler.h>
+
+#include <deal.II/lac/sparsity_tools.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+template <int dim, int spacedim>
+AgglomerationHandler<dim, spacedim>::AgglomerationHandler(
+  const GridTools::Cache<dim, spacedim> &cache_tria)
+  : cached_tria(std::make_unique<GridTools::Cache<dim, spacedim>>(
+      cache_tria.get_triangulation(),
+      cache_tria.get_mapping()))
+  , communicator(cache_tria.get_triangulation().get_communicator())
+{
+  Assert(dim == spacedim,
+         ExcNotImplemented("Not available with codimension greater than 0"));
+  Assert(dim == 2 || dim == 3, ExcImpossibleInDim(1));
+  Assert((dynamic_cast<const parallel::shared::Triangulation<dim, spacedim> *>(
+            &cached_tria->get_triangulation()) == nullptr),
+         ExcNotImplemented());
+  Assert(cached_tria->get_triangulation().n_active_cells() > 0,
+         ExcMessage(
+           "The triangulation must not be empty upon calling this function."));
+
+  n_agglomerations = 0;
+  hybrid_mesh      = false;
+  initialize_agglomeration_data(cached_tria);
+}
+
+
+
+template <int dim, int spacedim>
+typename AgglomerationHandler<dim, spacedim>::agglomeration_iterator
+AgglomerationHandler<dim, spacedim>::define_agglomerate(
+  const AgglomerationContainer &cells)
+{
+  Assert(cells.size() > 0, ExcMessage("No cells to be agglomerated."));
+
+  if (cells.size() == 1)
+    hybrid_mesh = true; // mesh is made also by classical cells
+
+  // First index drives the selection of the master cell. After that, store the
+  // master cell.
+  const types::global_cell_index global_master_idx =
+    cells[0]->global_active_cell_index();
+  const types::global_cell_index master_idx = cells[0]->active_cell_index();
+  master_cells_container.push_back(cells[0]);
+  master_slave_relationships[global_master_idx] = -1;
+
+  const typename DoFHandler<dim>::active_cell_iterator cell_dh =
+    cells[0]->as_dof_handler_iterator(agglo_dh);
+  cell_dh->set_active_fe_index(CellAgglomerationType::master);
+
+  // Store slave cells and save the relationship with the parent
+  std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
+    slaves;
+  slaves.reserve(cells.size() - 1);
+  // exclude first cell since it's the master cell
+  for (auto it = ++cells.begin(); it != cells.end(); ++it)
+    {
+      slaves.push_back(*it);
+      master_slave_relationships[(*it)->global_active_cell_index()] =
+        global_master_idx; // mark each slave
+      master_slave_relationships_iterators[(*it)->active_cell_index()] =
+        cells[0];
+
+      const typename DoFHandler<dim>::active_cell_iterator cell =
+        (*it)->as_dof_handler_iterator(agglo_dh);
+      cell->set_active_fe_index(CellAgglomerationType::slave); // slave cell
+
+      // If we have a p::d::T, check that all cells are in the same subdomain.
+      // If serial, just check that the subdomain_id is invalid.
+      Assert(((*it)->subdomain_id() == tria->locally_owned_subdomain() ||
+              tria->locally_owned_subdomain() == numbers::invalid_subdomain_id),
+             ExcInternalError());
+    }
+
+  master_slave_relationships_iterators[master_idx] =
+    cells[0]; // set iterator to master cell
+
+  // Store the slaves of each master
+  master2slaves[master_idx] = slaves;
+  // Save to which polygon this agglomerate correspond
+  master2polygon[master_idx] = n_agglomerations;
+
+  ++n_agglomerations; // an agglomeration has been performed, record it
+
+  create_bounding_box(cells); // fill the vector of bboxes
+
+  // Finally, return a polygonal iterator to the polytope just constructed.
+  return {cells[0], this};
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::initialize_fe_values(
+  const Quadrature<dim>     &cell_quadrature,
+  const UpdateFlags         &flags,
+  const Quadrature<dim - 1> &face_quadrature,
+  const UpdateFlags         &face_flags)
+{
+  agglomeration_quad       = cell_quadrature;
+  agglomeration_flags      = flags;
+  agglomeration_face_quad  = face_quadrature;
+  agglomeration_face_flags = face_flags | internal_agglomeration_face_flags;
+
+
+  no_values = std::make_unique<FEValues<dim>>(
+    *mapping,
+    dummy_fe,
+    agglomeration_quad,
+    update_quadrature_points | update_JxW_values); // needed only for quadrature
+  no_face_values = std::make_unique<FEFaceValues<dim>>(
+    *mapping,
+    dummy_fe,
+    agglomeration_face_quad,
+    update_quadrature_points | update_JxW_values |
+      update_normal_vectors); // needed only for quadrature (faces)
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::initialize_agglomeration_data(
+  const std::unique_ptr<GridTools::Cache<dim, spacedim>> &cache_tria)
+{
+  tria    = &cache_tria->get_triangulation();
+  mapping = &cache_tria->get_mapping();
+
+  agglo_dh.reinit(*tria);
+
+  if (const auto parallel_tria = dynamic_cast<
+        const dealii::parallel::TriangulationBase<dim, spacedim> *>(&*tria))
+    {
+      const std::weak_ptr<const Utilities::MPI::Partitioner> cells_partitioner =
+        parallel_tria->global_active_cell_index_partitioner();
+      master_slave_relationships.reinit(
+        cells_partitioner.lock()->locally_owned_range(), communicator);
+    }
+  else
+    {
+      master_slave_relationships.reinit(tria->n_active_cells(), MPI_COMM_SELF);
+    }
+
+  polytope_cache.clear();
+  bboxes.clear();
+
+  // First, update the pointer
+  cached_tria = std::make_unique<GridTools::Cache<dim, spacedim>>(
+    cache_tria->get_triangulation(), cache_tria->get_mapping());
+
+
+  n_agglomerations = 0;
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::distribute_agglomerated_dofs(
+  const FiniteElement<dim> &fe_space)
+{
+  if (dynamic_cast<const FE_DGQ<dim> *>(&fe_space))
+    fe = std::make_unique<FE_DGQ<dim>>(fe_space.degree);
+  else if (dynamic_cast<const FE_SimplexDGP<dim> *>(&fe_space))
+    fe = std::make_unique<FE_SimplexDGP<dim>>(fe_space.degree);
+  else
+    AssertThrow(
+      false,
+      ExcNotImplemented(
+        "Currently, this interface supports only DGQ and DGP bases."));
+
+  box_mapping = std::make_unique<MappingBox<dim>>(
+    bboxes,
+    master2polygon); // construct bounding box mapping
+
+  if (hybrid_mesh)
+    {
+      // the mesh is composed by standard and agglomerate cells. initialize
+      // classes needed for standard cells in order to treat that finite
+      // element space as defined on a standard shape and not on the
+      // BoundingBox.
+      standard_scratch =
+        std::make_unique<ScratchData>(*mapping,
+                                      *fe,
+                                      QGauss<dim>(2 * fe_space.degree + 2),
+                                      internal_agglomeration_flags);
+    }
+
+
+  fe_collection.push_back(*fe); // master
+  fe_collection.push_back(
+    FE_Nothing<dim, spacedim>(fe->reference_cell())); // slave
+
+  initialize_hp_structure();
+
+  // in case the tria is distributed, communicate ghost information with
+  // neighboring ranks
+  const bool needs_ghost_info =
+    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(&*tria) !=
+    nullptr;
+  if (needs_ghost_info)
+    setup_ghost_polytopes();
+
+  setup_connectivity_of_agglomeration();
+
+  if (needs_ghost_info)
+    exchange_interface_values();
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::create_bounding_box(
+  const AgglomerationContainer &polytope)
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+  Assert(dim > 1, ExcNotImplemented());
+
+  std::vector<Point<spacedim>> pts; // store all the vertices
+  for (const auto &cell : polytope)
+    for (const auto i : cell->vertex_indices())
+      pts.push_back(cell->vertex(i));
+
+  bboxes.emplace_back(pts);
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::setup_connectivity_of_agglomeration()
+{
+  Assert(master_cells_container.size() > 0,
+         ExcMessage("No agglomeration has been performed."));
+  Assert(
+    agglo_dh.n_dofs() > 0,
+    ExcMessage(
+      "The DoFHandler associated to the agglomeration has not been initialized."
+      "It's likely that you forgot to distribute the DoFs. You may want"
+      "to check if a call to `initialize_hp_structure()` has been done."));
+
+  number_of_agglomerated_faces.resize(master2polygon.size(), 0);
+  for (const auto &cell : master_cells_container)
+    {
+      internal::AgglomerationHandlerImplementation<dim, spacedim>::
+        setup_master_neighbor_connectivity(cell, *this);
+    }
+
+  if (Utilities::MPI::job_supports_mpi())
+    {
+      // communicate the number of faces
+      recv_n_faces = Utilities::MPI::some_to_some(communicator, local_n_faces);
+
+      // send information about boundaries and neighboring polytopes id
+      recv_bdary_info =
+        Utilities::MPI::some_to_some(communicator, local_bdary_info);
+
+      recv_ghosted_master_id =
+        Utilities::MPI::some_to_some(communicator, local_ghosted_master_id);
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::exchange_interface_values()
+{
+  const unsigned int dofs_per_cell = fe->dofs_per_cell;
+  for (const auto &polytope : polytope_iterators())
+    {
+      if (polytope->is_locally_owned())
+        {
+          const unsigned int n_faces = polytope->n_faces();
+          for (unsigned int f = 0; f < n_faces; ++f)
+            {
+              if (!polytope->at_boundary(f))
+                {
+                  const auto &neigh_polytope = polytope->neighbor(f);
+                  if (!neigh_polytope->is_locally_owned())
+                    {
+                      // Neighboring polytope is ghosted.
+
+                      // Compute shape functions at the interface
+                      const auto &current_fe = reinit(polytope, f);
+
+                      std::vector<Point<spacedim>> qpoints_to_send =
+                        current_fe.get_quadrature_points();
+
+                      const std::vector<double> &jxws_to_send =
+                        current_fe.get_JxW_values();
+
+                      const std::vector<Tensor<1, spacedim>> &normals_to_send =
+                        current_fe.get_normal_vectors();
+
+
+                      const types::subdomain_id neigh_rank =
+                        neigh_polytope->subdomain_id();
+
+                      std::pair<CellId, unsigned int> cell_and_face{
+                        polytope->id(), f};
+                      // Prepare data to send
+                      local_qpoints[neigh_rank].emplace(cell_and_face,
+                                                        qpoints_to_send);
+
+                      local_jxws[neigh_rank].emplace(cell_and_face,
+                                                     jxws_to_send);
+
+                      local_normals[neigh_rank].emplace(cell_and_face,
+                                                        normals_to_send);
+
+
+                      const unsigned int n_qpoints = qpoints_to_send.size();
+
+                      // TODO: check `agglomeration_flags` before computing
+                      // values and gradients.
+                      std::vector<std::vector<double>> values_per_qpoints(
+                        dofs_per_cell);
+
+                      std::vector<std::vector<Tensor<1, spacedim>>>
+                        gradients_per_qpoints(dofs_per_cell);
+
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        {
+                          values_per_qpoints[i].resize(n_qpoints);
+                          gradients_per_qpoints[i].resize(n_qpoints);
+                          for (unsigned int q = 0; q < n_qpoints; ++q)
+                            {
+                              values_per_qpoints[i][q] =
+                                current_fe.shape_value(i, q);
+                              gradients_per_qpoints[i][q] =
+                                current_fe.shape_grad(i, q);
+                            }
+                        }
+
+                      local_values[neigh_rank].emplace(cell_and_face,
+                                                       values_per_qpoints);
+                      local_gradients[neigh_rank].emplace(
+                        cell_and_face, gradients_per_qpoints);
+                    }
+                }
+            }
+        }
+    }
+
+  // Finally, exchange with neighboring ranks
+  recv_qpoints   = Utilities::MPI::some_to_some(communicator, local_qpoints);
+  recv_jxws      = Utilities::MPI::some_to_some(communicator, local_jxws);
+  recv_normals   = Utilities::MPI::some_to_some(communicator, local_normals);
+  recv_values    = Utilities::MPI::some_to_some(communicator, local_values);
+  recv_gradients = Utilities::MPI::some_to_some(communicator, local_gradients);
+}
+
+
+
+template <int dim, int spacedim>
+Quadrature<dim>
+AgglomerationHandler<dim, spacedim>::agglomerated_quadrature(
+  const typename AgglomerationHandler<dim, spacedim>::AgglomerationContainer
+    &cells,
+  const typename Triangulation<dim, spacedim>::active_cell_iterator
+    &master_cell) const
+{
+  Assert(is_master_cell(master_cell),
+         ExcMessage("This must be a master cell."));
+
+  std::vector<Point<dim>> vec_pts;
+  std::vector<double>     vec_JxWs;
+  for (const auto &dummy_cell : cells)
+    {
+      no_values->reinit(dummy_cell);
+      auto        q_points = no_values->get_quadrature_points(); // real qpoints
+      const auto &JxWs     = no_values->get_JxW_values();
+
+      std::transform(q_points.begin(),
+                     q_points.end(),
+                     std::back_inserter(vec_pts),
+                     [&](const Point<spacedim> &p) { return p; });
+      std::transform(JxWs.begin(),
+                     JxWs.end(),
+                     std::back_inserter(vec_JxWs),
+                     [&](const double w) { return w; });
+    }
+
+  // Map back each point in real space by using the map associated to the
+  // bounding box.
+  std::vector<Point<dim>> unit_points(vec_pts.size());
+  const auto             &bbox =
+    bboxes[master2polygon.at(master_cell->active_cell_index())];
+  unit_points.reserve(vec_pts.size());
+
+  for (unsigned int i = 0; i < vec_pts.size(); i++)
+    unit_points[i] = bbox.real_to_unit(vec_pts[i]);
+
+  return Quadrature<dim>(unit_points, vec_JxWs);
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::initialize_hp_structure()
+{
+  Assert(agglo_dh.get_triangulation().n_cells() > 0,
+         ExcMessage(
+           "Triangulation must not be empty upon calling this function."));
+  Assert(n_agglomerations > 0,
+         ExcMessage("No agglomeration has been performed."));
+
+  agglo_dh.distribute_dofs(fe_collection);
+}
+
+
+
+template <int dim, int spacedim>
+const FEValues<dim, spacedim> &
+AgglomerationHandler<dim, spacedim>::reinit(
+  const AgglomerationIterator<dim, spacedim> &polytope) const
+{
+  const auto &deal_cell = polytope->as_dof_handler_iterator(agglo_dh);
+
+  const auto &agglo_cells = polytope->get_agglomerate();
+
+  Quadrature<dim> agglo_quad = agglomerated_quadrature(agglo_cells, deal_cell);
+
+  agglomerated_scratch = std::make_unique<ScratchData>(*box_mapping,
+                                                       fe_collection[0],
+                                                       agglo_quad,
+                                                       agglomeration_flags);
+  return agglomerated_scratch->reinit(deal_cell);
+}
+
+
+
+template <int dim, int spacedim>
+const FEValuesBase<dim, spacedim> &
+AgglomerationHandler<dim, spacedim>::reinit_master(
+  const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+  const unsigned int                                              face_index,
+  std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
+    &agglo_isv_ptr) const
+{
+  return internal::AgglomerationHandlerImplementation<dim, spacedim>::
+    reinit_master(cell, face_index, agglo_isv_ptr, *this);
+}
+
+
+
+template <int dim, int spacedim>
+const FEValuesBase<dim, spacedim> &
+AgglomerationHandler<dim, spacedim>::reinit(
+  const AgglomerationIterator<dim, spacedim> &polytope,
+  const unsigned int                          face_index) const
+{
+  const auto &deal_cell = polytope->as_dof_handler_iterator(agglo_dh);
+  Assert(is_master_cell(deal_cell), ExcMessage("This should be true."));
+
+  return internal::AgglomerationHandlerImplementation<dim, spacedim>::
+    reinit_master(deal_cell, face_index, agglomerated_isv_bdary, *this);
+}
+
+
+
+template <int dim, int spacedim>
+std::pair<const FEValuesBase<dim, spacedim> &,
+          const FEValuesBase<dim, spacedim> &>
+AgglomerationHandler<dim, spacedim>::reinit_interface(
+  const AgglomerationIterator<dim, spacedim> &polytope_in,
+  const AgglomerationIterator<dim, spacedim> &neigh_polytope,
+  const unsigned int                          local_in,
+  const unsigned int                          local_neigh) const
+{
+  // If current and neighboring polytopes are both locally owned, then compute
+  // the jump in the classical way without needing information about ghosted
+  // entities.
+  if (polytope_in->is_locally_owned() && neigh_polytope->is_locally_owned())
+    {
+      const auto &cell_in = polytope_in->as_dof_handler_iterator(agglo_dh);
+      const auto &neigh_cell =
+        neigh_polytope->as_dof_handler_iterator(agglo_dh);
+
+      const auto &fe_in =
+        internal::AgglomerationHandlerImplementation<dim, spacedim>::
+          reinit_master(cell_in, local_in, agglomerated_isv, *this);
+      const auto &fe_out =
+        internal::AgglomerationHandlerImplementation<dim, spacedim>::
+          reinit_master(neigh_cell, local_neigh, agglomerated_isv_neigh, *this);
+      std::pair<const FEValuesBase<dim, spacedim> &,
+                const FEValuesBase<dim, spacedim> &>
+        my_p(fe_in, fe_out);
+
+      return my_p;
+    }
+  else
+    {
+      Assert((polytope_in->is_locally_owned() &&
+              !neigh_polytope->is_locally_owned()),
+             ExcInternalError());
+
+      const auto &cell = polytope_in->as_dof_handler_iterator(agglo_dh);
+      const auto &bbox = bboxes[master2polygon.at(cell->active_cell_index())];
+      // const double bbox_measure = bbox.volume();
+
+      const unsigned int neigh_rank = neigh_polytope->subdomain_id();
+      const CellId      &neigh_id   = neigh_polytope->id();
+
+      // Retrieve qpoints,JxWs, normals sent previously from the neighboring
+      // rank.
+      std::vector<Point<spacedim>> &real_qpoints =
+        recv_qpoints.at(neigh_rank).at({neigh_id, local_neigh});
+
+      const auto &JxWs = recv_jxws.at(neigh_rank).at({neigh_id, local_neigh});
+
+      std::vector<Tensor<1, spacedim>> &normals =
+        recv_normals.at(neigh_rank).at({neigh_id, local_neigh});
+
+      // Apply the necessary scalings due to the fact that functions are defined
+      // on a bbox.
+      std::vector<Point<spacedim>> final_unit_q_points;
+      std::transform(real_qpoints.begin(),
+                     real_qpoints.end(),
+                     std::back_inserter(final_unit_q_points),
+                     [&](const Point<spacedim> &p) {
+                       return bbox.real_to_unit(p);
+                     });
+
+      // Since we received normal vectors from a neighbor, we have to swap
+      // the
+      // // sign of the vector in order to have outward normals.
+      for (unsigned int q = 0; q < final_unit_q_points.size(); ++q)
+        normals[q] *= -1;
+
+
+      NonMatching::ImmersedSurfaceQuadrature<dim, spacedim> surface_quad(
+        final_unit_q_points, JxWs, normals);
+
+      agglomerated_isv =
+        std::make_unique<NonMatching::FEImmersedSurfaceValues<spacedim>>(
+          *box_mapping, *fe, surface_quad, agglomeration_face_flags);
+
+
+      agglomerated_isv->reinit(cell);
+
+      std::pair<const FEValuesBase<dim, spacedim> &,
+                const FEValuesBase<dim, spacedim> &>
+        my_p(*agglomerated_isv, *agglomerated_isv);
+
+      return my_p;
+    }
+}
+
+
+
+template <int dim, int spacedim>
+template <typename SparsityPatternType, typename Number>
+void
+AgglomerationHandler<dim, spacedim>::create_agglomeration_sparsity_pattern(
+  SparsityPatternType             &dsp,
+  const AffineConstraints<Number> &constraints,
+  const bool                       keep_constrained_dofs,
+  const types::subdomain_id        subdomain_id)
+{
+  Assert(n_agglomerations > 0,
+         ExcMessage("The agglomeration has not been set up correctly."));
+  Assert(dsp.empty(),
+         ExcMessage(
+           "The Sparsity pattern must be empty upon calling this function."));
+
+  const IndexSet &locally_owned_dofs = agglo_dh.locally_owned_dofs();
+  const IndexSet  locally_relevant_dofs =
+    DoFTools::extract_locally_relevant_dofs(agglo_dh);
+
+  if constexpr (std::is_same_v<SparsityPatternType, DynamicSparsityPattern>)
+    dsp.reinit(locally_owned_dofs.size(),
+               locally_owned_dofs.size(),
+               locally_relevant_dofs);
+  else if constexpr (std::is_same_v<SparsityPatternType,
+                                    TrilinosWrappers::SparsityPattern>)
+    dsp.reinit(locally_owned_dofs, communicator);
+  else
+    AssertThrow(false, ExcNotImplemented());
+
+  // Create the sparsity pattern corresponding only to volumetric terms. The
+  // fluxes needed by DG methods will be filled later.
+  DoFTools::make_sparsity_pattern(
+    agglo_dh, dsp, constraints, keep_constrained_dofs, subdomain_id);
+
+
+  const unsigned int dofs_per_cell = agglo_dh.get_fe(0).n_dofs_per_cell();
+  std::vector<types::global_dof_index> current_dof_indices(dofs_per_cell);
+  std::vector<types::global_dof_index> neighbor_dof_indices(dofs_per_cell);
+
+  // Loop over all locally owned polytopes, find the neighbor (also ghosted)
+  // and add fluxes to the sparsity pattern.
+  for (const auto &polytope : polytope_iterators())
+    {
+      if (polytope->is_locally_owned())
+        {
+          const unsigned int n_current_faces = polytope->n_faces();
+          polytope->get_dof_indices(current_dof_indices);
+          for (unsigned int f = 0; f < n_current_faces; ++f)
+            {
+              const auto &neigh_polytope = polytope->neighbor(f);
+              if (neigh_polytope.state() == IteratorState::valid)
+                {
+                  neigh_polytope->get_dof_indices(neighbor_dof_indices);
+                  constraints.add_entries_local_to_global(current_dof_indices,
+                                                          neighbor_dof_indices,
+                                                          dsp,
+                                                          keep_constrained_dofs,
+                                                          {});
+                }
+            }
+        }
+    }
+
+
+
+  if constexpr (std::is_same_v<SparsityPatternType,
+                               TrilinosWrappers::SparsityPattern>)
+    dsp.compress();
+}
+
+
+
+template <int dim, int spacedim>
+void
+AgglomerationHandler<dim, spacedim>::setup_ghost_polytopes()
+{
+  [[maybe_unused]] const auto parallel_triangulation =
+    dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(&*tria);
+  Assert(parallel_triangulation != nullptr, ExcInternalError());
+
+  const unsigned int                   n_dofs_per_cell = fe->dofs_per_cell;
+  std::vector<types::global_dof_index> global_dof_indices(n_dofs_per_cell);
+  for (const auto &polytope : polytope_iterators())
+    if (polytope->is_locally_owned())
+      {
+        const CellId &master_cell_id = polytope->id();
+
+        const auto polytope_dh = polytope->as_dof_handler_iterator(agglo_dh);
+        polytope_dh->get_dof_indices(global_dof_indices);
+
+
+        const auto &agglomerate = polytope->get_agglomerate();
+
+        for (const auto &cell : agglomerate)
+          {
+            // interior, locally owned, cell
+            for (const auto &f : cell->face_indices())
+              {
+                if (!cell->at_boundary(f))
+                  {
+                    const auto &neighbor = cell->neighbor(f);
+                    if (neighbor->is_ghost())
+                      {
+                        // key of the map: the rank to which send the data
+                        const types::subdomain_id neigh_rank =
+                          neighbor->subdomain_id();
+
+                        // inform the "standard" neighbor about the neighboring
+                        // id and its master cell
+                        local_cell_ids_neigh_cell[neigh_rank].emplace(
+                          cell->id(), master_cell_id);
+
+                        // inform the neighboring rank that this master cell
+                        // (hence polytope) has the following DoF indices
+                        local_ghost_dofs[neigh_rank].emplace(
+                          master_cell_id, global_dof_indices);
+
+                        // ...same for bounding boxes
+                        const auto &bbox = bboxes[polytope->index()];
+                        local_ghosted_bbox[neigh_rank].emplace(master_cell_id,
+                                                               bbox);
+                      }
+                  }
+              }
+          }
+      }
+
+  recv_cell_ids_neigh_cell =
+    Utilities::MPI::some_to_some(communicator, local_cell_ids_neigh_cell);
+
+  // Exchange with neighboring ranks the neighboring bounding boxes
+  recv_ghosted_bbox =
+    Utilities::MPI::some_to_some(communicator, local_ghosted_bbox);
+
+  // Exchange with neighboring ranks the neighboring ghosted DoFs
+  recv_ghost_dofs =
+    Utilities::MPI::some_to_some(communicator, local_ghost_dofs);
+}
+
+
+
+namespace internal
+{
+  template <int dim, int spacedim>
+  class AgglomerationHandlerImplementation
+  {
+  public:
+    static const FEValuesBase<dim, spacedim> &
+    reinit_master(
+      const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+      const unsigned int face_index,
+      std::unique_ptr<NonMatching::FEImmersedSurfaceValues<spacedim>>
+                                                &agglo_isv_ptr,
+      const AgglomerationHandler<dim, spacedim> &handler)
+    {
+      Assert(handler.is_master_cell(cell),
+             ExcMessage("This cell must be a master one."));
+
+      AgglomerationIterator<dim, spacedim> it{cell, &handler};
+      const auto &neigh_polytope = it->neighbor(face_index);
+
+      const CellId polytope_in_id = cell->id();
+
+      // Retrieve the bounding box of the agglomeration
+      const auto &bbox =
+        handler.bboxes[handler.master2polygon.at(cell->active_cell_index())];
+
+      CellId polytope_out_id;
+      if (neigh_polytope.state() == IteratorState::valid)
+        polytope_out_id = neigh_polytope->id();
+      else
+        polytope_out_id = polytope_in_id; // on the boundary. Same id
+
+      const auto &common_face =
+        handler.polytope_cache.interface.at({polytope_in_id, polytope_out_id});
+
+      std::vector<Point<spacedim>> final_unit_q_points;
+      std::vector<double>          final_weights;
+      std::vector<Tensor<1, dim>>  final_normals;
+
+      const unsigned int expected_qpoints =
+        common_face.size() * handler.agglomeration_face_quad.size();
+      final_unit_q_points.reserve(expected_qpoints);
+      final_weights.reserve(expected_qpoints);
+      final_normals.reserve(expected_qpoints);
+
+
+      for (const auto &[deal_cell, local_face_idx] : common_face)
+        {
+          handler.no_face_values->reinit(deal_cell, local_face_idx);
+
+          const auto &q_points =
+            handler.no_face_values->get_quadrature_points();
+          const auto &JxWs    = handler.no_face_values->get_JxW_values();
+          const auto &normals = handler.no_face_values->get_normal_vectors();
+
+          const unsigned int n_qpoints_agglo = q_points.size();
+
+          for (unsigned int q = 0; q < n_qpoints_agglo; ++q)
+            {
+              final_unit_q_points.push_back(bbox.real_to_unit(q_points[q]));
+              final_weights.push_back(JxWs[q]);
+              final_normals.push_back(normals[q]);
+            }
+        }
+
+      NonMatching::ImmersedSurfaceQuadrature<dim, spacedim> surface_quad(
+        final_unit_q_points, final_weights, final_normals);
+
+      agglo_isv_ptr =
+        std::make_unique<NonMatching::FEImmersedSurfaceValues<spacedim>>(
+          *(handler.box_mapping),
+          *(handler.fe),
+          surface_quad,
+          handler.agglomeration_face_flags);
+
+      agglo_isv_ptr->reinit(cell);
+
+      return *agglo_isv_ptr;
+    }
+
+
+
+    /**
+     * Given an agglomeration described by the master cell `master_cell`,
+     * this function:
+     * - enumerates the faces of the agglomeration
+     * - stores who is the neighbor, the local face indices from outside and
+     * inside*/
+    static void
+    setup_master_neighbor_connectivity(
+      const typename Triangulation<dim, spacedim>::active_cell_iterator
+                                                &master_cell,
+      const AgglomerationHandler<dim, spacedim> &handler)
+    {
+      Assert(
+        handler.master_slave_relationships[master_cell
+                                             ->global_active_cell_index()] ==
+          -1,
+        ExcMessage("The present cell with index " +
+                   std::to_string(master_cell->global_active_cell_index()) +
+                   "is not a master one."));
+
+      const auto &agglomeration = handler.get_agglomerate(master_cell);
+      const types::global_cell_index current_polytope_index =
+        handler.master2polygon.at(master_cell->active_cell_index());
+
+      CellId current_polytope_id = master_cell->id();
+
+
+      std::set<types::global_cell_index> visited_polygonal_neighbors;
+
+      std::map<unsigned int, CellId> face_to_neigh_id;
+
+      std::map<unsigned int, bool> is_face_at_boundary;
+
+      // same as above, but with CellId
+      std::set<CellId> visited_polygonal_neighbors_id;
+      unsigned int     ghost_counter = 0;
+
+      for (const auto &cell : agglomeration)
+        {
+          const types::global_cell_index cell_index = cell->active_cell_index();
+
+          const CellId cell_id = cell->id();
+
+          for (const auto f : cell->face_indices())
+            {
+              const auto &neighboring_cell = cell->neighbor(f);
+
+              const bool valid_neighbor =
+                neighboring_cell.state() == IteratorState::valid;
+
+              if (valid_neighbor)
+                {
+                  if (neighboring_cell->is_locally_owned() &&
+                      !handler.are_cells_agglomerated(cell, neighboring_cell))
+                    {
+                      // - cell is not on the boundary,
+                      // - it's not agglomerated with the neighbor. If so,
+                      // it's a neighbor of the present agglomeration
+
+                      // a new face of the agglomeration has been
+                      // discovered.
+                      handler.polygon_boundary[master_cell].push_back(
+                        cell->face(f));
+
+                      // global index of neighboring deal.II cell
+                      const types::global_cell_index neighboring_cell_index =
+                        neighboring_cell->active_cell_index();
+
+                      // master cell for the neighboring polytope
+                      const auto &master_of_neighbor =
+                        handler.master_slave_relationships_iterators.at(
+                          neighboring_cell_index);
+
+                      const auto nof = cell->neighbor_of_neighbor(f);
+
+                      if (handler.is_slave_cell(neighboring_cell))
+                        {
+                          // index of the neighboring polytope
+                          const types::global_cell_index
+                            neighbor_polytope_index = handler.master2polygon.at(
+                              master_of_neighbor->active_cell_index());
+
+                          CellId neighbor_polytope_id =
+                            master_of_neighbor->id();
+
+                          if (visited_polygonal_neighbors.find(
+                                neighbor_polytope_index) ==
+                              std::end(visited_polygonal_neighbors))
+                            {
+                              // found a neighbor
+
+                              const unsigned int n_face =
+                                handler.number_of_agglomerated_faces
+                                  [current_polytope_index];
+
+                              handler.polytope_cache.cell_face_at_boundary[{
+                                current_polytope_index, n_face}] = {
+                                false, master_of_neighbor};
+
+                              is_face_at_boundary[n_face] = true;
+
+                              ++handler.number_of_agglomerated_faces
+                                  [current_polytope_index];
+
+                              visited_polygonal_neighbors.insert(
+                                neighbor_polytope_index);
+                            }
+
+
+                          if (handler.polytope_cache.visited_cell_and_faces
+                                .find({cell_index, f}) ==
+                              std::end(
+                                handler.polytope_cache.visited_cell_and_faces))
+                            {
+                                handler.polytope_cache
+                                  .interface[{
+                                  current_polytope_id, neighbor_polytope_id}]
+                                  .emplace_back(cell, f);
+
+                                handler.polytope_cache.visited_cell_and_faces
+                                  .insert({cell_index, f});
+                            }
+
+
+                          if (handler.polytope_cache.visited_cell_and_faces
+                                .find({neighboring_cell_index, nof}) ==
+                              std::end(
+                                handler.polytope_cache.visited_cell_and_faces))
+                            {
+                                handler.polytope_cache
+                                  .interface[{
+                                  neighbor_polytope_id, current_polytope_id}]
+                                  .emplace_back(neighboring_cell, nof);
+
+                                handler.polytope_cache.visited_cell_and_faces
+                                  .insert({neighboring_cell_index, nof});
+                            }
+                        }
+                      else
+                        {
+                          // neighboring cell is a master
+
+                          // save the pair of neighboring cells
+                          const types::global_cell_index
+                            neighbor_polytope_index =
+                              handler.master2polygon.at(neighboring_cell_index);
+
+                          CellId neighbor_polytope_id = neighboring_cell->id();
+
+                          if (visited_polygonal_neighbors.find(
+                                neighbor_polytope_index) ==
+                              std::end(visited_polygonal_neighbors))
+                            {
+                                // found a neighbor
+                                const unsigned int n_face =
+                                  handler.number_of_agglomerated_faces
+                                    [current_polytope_index];
+
+
+                                handler.polytope_cache.cell_face_at_boundary[{
+                                  current_polytope_index, n_face}] = {
+                                  false, neighboring_cell};
+
+                                is_face_at_boundary[n_face] = true;
+
+                                ++handler.number_of_agglomerated_faces
+                                    [current_polytope_index];
+
+                                visited_polygonal_neighbors.insert(
+                                  neighbor_polytope_index);
+                            }
+
+
+
+                          if (handler.polytope_cache.visited_cell_and_faces
+                                .find({cell_index, f}) ==
+                              std::end(
+                                handler.polytope_cache.visited_cell_and_faces))
+                            {
+                                handler.polytope_cache
+                                  .interface[{
+                                  current_polytope_id, neighbor_polytope_id}]
+                                  .emplace_back(cell, f);
+
+                                handler.polytope_cache.visited_cell_and_faces
+                                  .insert({cell_index, f});
+                            }
+
+                          if (handler.polytope_cache.visited_cell_and_faces
+                                .find({neighboring_cell_index, nof}) ==
+                              std::end(
+                                handler.polytope_cache.visited_cell_and_faces))
+                            {
+                                handler.polytope_cache
+                                  .interface[{
+                                  neighbor_polytope_id, current_polytope_id}]
+                                  .emplace_back(neighboring_cell, nof);
+
+                                handler.polytope_cache.visited_cell_and_faces
+                                  .insert({neighboring_cell_index, nof});
+                            }
+                        }
+                    }
+                  else if (neighboring_cell->is_ghost())
+                    {
+                      const auto nof = cell->neighbor_of_neighbor(f);
+
+                      // from neighboring rank,receive the association
+                      // between standard cell ids and neighboring polytope.
+                      // This tells to the current rank that the
+                      // neighboring cell has the following CellId as master
+                      // cell.
+                      const auto &check_neigh_poly_ids =
+                        handler.recv_cell_ids_neigh_cell.at(
+                          neighboring_cell->subdomain_id());
+
+                      const CellId neighboring_cell_id = neighboring_cell->id();
+
+                      const CellId &check_neigh_polytope_id =
+                        check_neigh_poly_ids.at(neighboring_cell_id);
+
+                      // const auto master_index =
+                      // master_indices[ghost_counter];
+
+                      if (visited_polygonal_neighbors_id.find(
+                            check_neigh_polytope_id) ==
+                          std::end(visited_polygonal_neighbors_id))
+                        {
+                          handler.polytope_cache.cell_face_at_boundary[{
+                            current_polytope_index,
+                            handler.number_of_agglomerated_faces
+                              [current_polytope_index]}] = {false,
+                                                            neighboring_cell};
+
+
+                          // record the cell id of the neighboring polytope
+                          handler.polytope_cache.ghosted_master_id[{
+                            current_polytope_id,
+                            handler.number_of_agglomerated_faces
+                              [current_polytope_index]}] =
+                            check_neigh_polytope_id;
+
+
+                          const unsigned int n_face =
+                            handler.number_of_agglomerated_faces
+                              [current_polytope_index];
+
+                          face_to_neigh_id[n_face] = check_neigh_polytope_id;
+
+                          is_face_at_boundary[n_face] = false;
+
+
+                          // increment number of faces
+                          ++handler.number_of_agglomerated_faces
+                              [current_polytope_index];
+
+                          visited_polygonal_neighbors_id.insert(
+                            check_neigh_polytope_id);
+
+                          // ghosted polytope has been found, increment
+                          // ghost counter
+                          ++ghost_counter;
+                        }
+
+
+
+                      if (handler.polytope_cache.visited_cell_and_faces_id.find(
+                            {cell_id, f}) ==
+                          std::end(
+                            handler.polytope_cache.visited_cell_and_faces_id))
+                        {
+                            handler.polytope_cache
+                              .interface[{
+                              current_polytope_id, check_neigh_polytope_id}]
+                              .emplace_back(cell, f);
+
+                            handler.polytope_cache.visited_cell_and_faces_id
+                              .insert({cell_id, f});
+                        }
+
+
+                      if (handler.polytope_cache.visited_cell_and_faces_id.find(
+                            {neighboring_cell_id, nof}) ==
+                          std::end(
+                            handler.polytope_cache.visited_cell_and_faces_id))
+                        {
+                            handler.polytope_cache
+                              .interface[{
+                              check_neigh_polytope_id, current_polytope_id}]
+                              .emplace_back(neighboring_cell, nof);
+
+                            handler.polytope_cache.visited_cell_and_faces_id
+                              .insert({neighboring_cell_id, nof});
+                        }
+                    }
+                }
+              else if (cell->face(f)->at_boundary())
+                {
+                  // Boundary face of a boundary cell.
+                  // Note that the neighboring cell must be invalid.
+
+                  handler.polygon_boundary[master_cell].push_back(
+                    cell->face(f));
+
+                  if (visited_polygonal_neighbors.find(
+                        std::numeric_limits<unsigned int>::max()) ==
+                      std::end(visited_polygonal_neighbors))
+                    {
+                      // boundary face. Notice that `neighboring_cell` is
+                      // invalid here.
+                      handler.polytope_cache.cell_face_at_boundary[{
+                        current_polytope_index,
+                        handler.number_of_agglomerated_faces
+                          [current_polytope_index]}] = {true, neighboring_cell};
+
+                      const unsigned int n_face =
+                        handler
+                          .number_of_agglomerated_faces[current_polytope_index];
+
+                      is_face_at_boundary[n_face] = true;
+
+                      ++handler
+                          .number_of_agglomerated_faces[current_polytope_index];
+
+                      visited_polygonal_neighbors.insert(
+                        std::numeric_limits<unsigned int>::max());
+                    }
+
+
+
+                  if (handler.polytope_cache.visited_cell_and_faces.find(
+                        {cell_index, f}) ==
+                      std::end(handler.polytope_cache.visited_cell_and_faces))
+                    {
+                        handler.polytope_cache
+                          .interface[{
+                          current_polytope_id, current_polytope_id}]
+                          .emplace_back(cell, f);
+
+                        handler.polytope_cache.visited_cell_and_faces.insert(
+                          {cell_index, f});
+                    }
+                }
+            } // loop over faces
+        }     // loop over all cells of agglomerate
+
+
+
+      if (ghost_counter > 0)
+        {
+          const auto parallel_triangulation = dynamic_cast<
+            const dealii::parallel::TriangulationBase<dim, spacedim> *>(
+            &(*handler.tria));
+
+          const unsigned int n_faces_current_poly =
+            handler.number_of_agglomerated_faces[current_polytope_index];
+
+          // Communicate to neighboring ranks that current_polytope_id has
+          // a number of faces equal to n_faces_current_poly faces:
+          // current_polytope_id -> n_faces_current_poly
+          for (const unsigned int neigh_rank :
+               parallel_triangulation->ghost_owners())
+            {
+              handler.local_n_faces[neigh_rank].emplace(current_polytope_id,
+                                                        n_faces_current_poly);
+
+              handler.local_bdary_info[neigh_rank].emplace(current_polytope_id,
+                                                           is_face_at_boundary);
+
+              handler.local_ghosted_master_id[neigh_rank].emplace(
+                current_polytope_id, face_to_neigh_id);
+            }
+        }
+    }
+  };
+
+
+
+} // namespace internal
+
+
+// explicit instantiations
+#include "dofs/agglomeration_handler.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/dofs/agglomeration_handler.inst.in
+++ b/source/dofs/agglomeration_handler.inst.in
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+    template class AgglomerationHandler<deal_II_dimension>;
+
+    template void
+    AgglomerationHandler<deal_II_dimension>::
+      create_agglomeration_sparsity_pattern(
+        DynamicSparsityPattern          &sparsity_pattern,
+        const AffineConstraints<double> &constraints,
+        const bool                       keep_constrained_dofs,
+        const types::subdomain_id        subdomain_id);
+
+#ifdef DEAL_II_WITH_TRILINOS
+    template void
+    AgglomerationHandler<deal_II_dimension>::
+      create_agglomeration_sparsity_pattern(
+        TrilinosWrappers::SparsityPattern &sparsity_pattern,
+        const AffineConstraints<double>   &constraints,
+        const bool                         keep_constrained_dofs,
+        const types::subdomain_id          subdomain_id);
+#endif
+  }

--- a/source/fe/CMakeLists.txt
+++ b/source/fe/CMakeLists.txt
@@ -57,6 +57,7 @@ set(_unity_include_src
   mapping_c1.cc
   mapping_cartesian.cc
   mapping.cc
+  mapping_box.cc
   mapping_fe.cc
   mapping_p1.cc
   mapping_q1.cc
@@ -136,6 +137,7 @@ set(_inst
   mapping_c1.inst.in
   mapping_cartesian.inst.in
   mapping.inst.in
+  mapping_box.inst.in
   mapping_fe.inst.in
   mapping_fe_field.inst.in
   mapping_p1.inst.in

--- a/source/fe/mapping_box.cc
+++ b/source/fe/mapping_box.cc
@@ -1,0 +1,990 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2001 - 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+#include <deal.II/base/array_view.h>
+#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/qprojector.h>
+#include <deal.II/base/quadrature.h>
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/tensor.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_box.h>
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/full_matrix.h>
+
+#include <algorithm>
+
+
+
+DEAL_II_NAMESPACE_OPEN
+
+DeclExceptionMsg(
+  ExcCellNotAssociatedWithBox,
+  "You are using MappingBox, but the incoming element is not associated with a"
+  "Bounding Box.");
+
+
+
+/**
+ * Return whether the incoming element has a BoundingBox associated to it.
+ * Simplicial and quad-hex meshes are supported.
+ */
+template <typename CellType>
+bool
+has_box(const CellType &cell,
+        const std::map<types::global_cell_index, types::global_cell_index>
+          &translator)
+{
+  Assert((cell->reference_cell().is_hyper_cube() ||
+          cell->reference_cell().is_simplex()),
+         ExcNotImplemented());
+  Assert((translator.find(cell->active_cell_index()) != translator.cend()),
+         ExcCellNotAssociatedWithBox());
+
+  return true;
+}
+
+
+
+template <int dim, int spacedim>
+MappingBox<dim, spacedim>::MappingBox(
+  const std::vector<BoundingBox<dim>> &input_boxes,
+  const std::map<types::global_cell_index, types::global_cell_index>
+    &global_to_polytope)
+{
+  Assert(input_boxes.size() > 0,
+         ExcMessage("Invalid number of bounding boxes."));
+
+  // copy boxes and map
+  boxes.resize(input_boxes.size());
+  for (unsigned int i = 0; i < input_boxes.size(); ++i)
+    boxes[i] = input_boxes[i];
+  polytope_translator = global_to_polytope;
+}
+
+
+
+template <int dim, int spacedim>
+MappingBox<dim, spacedim>::InternalData::InternalData(const Quadrature<dim> &q)
+  : cell_extents(numbers::signaling_nan<Tensor<1, dim>>())
+  , traslation(numbers::signaling_nan<Tensor<1, dim>>())
+  , inverse_cell_extents(numbers::signaling_nan<Tensor<1, dim>>())
+  , volume_element(numbers::signaling_nan<double>())
+  , quadrature_points(q.get_points())
+{}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::InternalData::reinit(const UpdateFlags update_flags,
+                                                const Quadrature<dim> &)
+{
+  // store the flags in the internal data object so we can access them
+  // in fill_fe_*_values(). use the transitive hull of the required
+  // flags
+  this->update_each = update_flags;
+}
+
+
+
+template <int dim, int spacedim>
+std::size_t
+MappingBox<dim, spacedim>::InternalData::memory_consumption() const
+{
+  return (Mapping<dim, spacedim>::InternalDataBase::memory_consumption() +
+          MemoryConsumption::memory_consumption(cell_extents) +
+          MemoryConsumption::memory_consumption(traslation) +
+          MemoryConsumption::memory_consumption(inverse_cell_extents) +
+          MemoryConsumption::memory_consumption(volume_element));
+}
+
+
+
+template <int dim, int spacedim>
+bool
+MappingBox<dim, spacedim>::preserves_vertex_locations() const
+{
+  return true;
+}
+
+
+
+template <int dim, int spacedim>
+bool
+#if DEAL_II_VERSION_GTE(9, 8, 0)
+MappingBox<dim, spacedim>::is_compatible_with(
+  const ReferenceCell<dim> &reference_cell) const
+#else
+MappingBox<dim, spacedim>::is_compatible_with(
+  const ReferenceCell &reference_cell) const
+#endif
+{
+  Assert(dim == reference_cell.get_dimension(),
+         ExcMessage("The dimension of your mapping (" +
+                    Utilities::to_string(dim) +
+                    ") and the reference cell cell_type (" +
+                    Utilities::to_string(reference_cell.get_dimension()) +
+                    " ) do not agree."));
+
+  return reference_cell.is_hyper_cube() || reference_cell.is_simplex();
+}
+
+
+
+template <int dim, int spacedim>
+UpdateFlags
+MappingBox<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
+{
+  // this mapping is pretty simple in that it can basically compute
+  // every piece of information wanted by FEValues without requiring
+  // computing any other quantities. boundary forms are one exception
+  // since they can be computed from the normal vectors without much
+  // further ado
+  UpdateFlags out = in;
+  if (out & update_boundary_forms)
+    out |= update_normal_vectors;
+
+  return out;
+}
+
+
+
+template <int dim, int spacedim>
+std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+MappingBox<dim, spacedim>::get_data(const UpdateFlags      update_flags,
+                                    const Quadrature<dim> &q) const
+{
+  std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
+    std::make_unique<InternalData>();
+  data_ptr->reinit(requires_update_flags(update_flags), q);
+
+  return data_ptr;
+}
+
+
+
+template <int dim, int spacedim>
+std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>
+MappingBox<dim, spacedim>::get_subface_data(
+  const UpdateFlags          update_flags,
+  const Quadrature<dim - 1> &quadrature) const
+{
+  (void)update_flags;
+  (void)quadrature;
+  DEAL_II_NOT_IMPLEMENTED();
+  return {};
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::update_cell_extents(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const CellSimilarity::Similarity                            cell_similarity,
+  const InternalData                                         &data) const
+{
+  // Compute start point and sizes along axes. The vertices to be looked at
+  // are 1, 2, 4 compared to the base vertex 0.
+  if (cell_similarity != CellSimilarity::translation)
+    {
+      const BoundingBox<dim> &current_box =
+        boxes[polytope_translator.at(cell->active_cell_index())];
+      const std::pair<Point<dim>, Point<dim>> &bdary_points =
+        current_box.get_boundary_points();
+
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          const double cell_extent_d = current_box.side_length(d);
+          data.cell_extents[d]       = cell_extent_d;
+
+          data.traslation[d] =
+            .5 * (bdary_points.first[d] +
+                  bdary_points.second[d]); // midpoint of each interval
+
+          Assert(cell_extent_d != 0.,
+                 ExcMessage("Cell does not appear to be Cartesian!"));
+          data.inverse_cell_extents[d] = 1. / cell_extent_d;
+        }
+    }
+}
+
+
+
+namespace
+{
+  template <int dim>
+  void
+  transform_quadrature_points(
+    const BoundingBox<dim>            &box,
+    const ArrayView<const Point<dim>> &unit_quadrature_points,
+    std::vector<Point<dim>>           &quadrature_points)
+  {
+    for (unsigned int i = 0; i < quadrature_points.size(); ++i)
+      quadrature_points[i] = box.unit_to_real(unit_quadrature_points[i]);
+  }
+} // namespace
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::maybe_update_cell_quadrature_points(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const InternalData                                         &data,
+  const ArrayView<const Point<dim>> &unit_quadrature_points,
+  std::vector<Point<dim>>           &quadrature_points) const
+{
+  if (data.update_each & update_quadrature_points)
+    transform_quadrature_points(
+      boxes[polytope_translator.at(cell->active_cell_index())],
+      unit_quadrature_points,
+      quadrature_points);
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::maybe_update_normal_vectors(
+  const unsigned int           face_no,
+  const InternalData          &data,
+  std::vector<Tensor<1, dim>> &normal_vectors) const
+{
+  // compute normal vectors. All normals on a face have the same value.
+  if (data.update_each & update_normal_vectors)
+    {
+      Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
+      std::fill(normal_vectors.begin(),
+                normal_vectors.end(),
+                GeometryInfo<dim>::unit_normal_vector[face_no]);
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::maybe_update_jacobian_derivatives(
+  const InternalData              &data,
+  const CellSimilarity::Similarity cell_similarity,
+  internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &output_data) const
+{
+  if (cell_similarity != CellSimilarity::translation)
+    {
+      if (data.update_each & update_jacobian_grads)
+        for (unsigned int i = 0; i < output_data.jacobian_grads.size(); ++i)
+          output_data.jacobian_grads[i] = DerivativeForm<2, dim, spacedim>();
+
+      if (data.update_each & update_jacobian_pushed_forward_grads)
+        for (unsigned int i = 0;
+             i < output_data.jacobian_pushed_forward_grads.size();
+             ++i)
+          output_data.jacobian_pushed_forward_grads[i] = Tensor<3, spacedim>();
+
+      if (data.update_each & update_jacobian_2nd_derivatives)
+        for (unsigned int i = 0;
+             i < output_data.jacobian_2nd_derivatives.size();
+             ++i)
+          output_data.jacobian_2nd_derivatives[i] =
+            DerivativeForm<3, dim, spacedim>();
+
+      if (data.update_each & update_jacobian_pushed_forward_2nd_derivatives)
+        for (unsigned int i = 0;
+             i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
+             ++i)
+          output_data.jacobian_pushed_forward_2nd_derivatives[i] =
+            Tensor<4, spacedim>();
+
+      if (data.update_each & update_jacobian_3rd_derivatives)
+        for (unsigned int i = 0;
+             i < output_data.jacobian_3rd_derivatives.size();
+             ++i)
+          output_data.jacobian_3rd_derivatives[i] =
+            DerivativeForm<4, dim, spacedim>();
+
+      if (data.update_each & update_jacobian_pushed_forward_3rd_derivatives)
+        for (unsigned int i = 0;
+             i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
+             ++i)
+          output_data.jacobian_pushed_forward_3rd_derivatives[i] =
+            Tensor<5, spacedim>();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::maybe_update_volume_elements(
+  const InternalData &data) const
+{
+  if (data.update_each & update_volume_elements)
+    {
+      double volume = data.cell_extents[0];
+      for (unsigned int d = 1; d < dim; ++d)
+        volume *= data.cell_extents[d];
+      data.volume_element = volume;
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::maybe_update_jacobians(
+  const InternalData              &data,
+  const CellSimilarity::Similarity cell_similarity,
+  internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &output_data) const
+{
+  // "compute" Jacobian at the quadrature points, which are all the
+  // same
+  if (data.update_each & update_jacobians)
+    if (cell_similarity != CellSimilarity::translation)
+      for (unsigned int i = 0; i < output_data.jacobians.size(); ++i)
+        {
+          output_data.jacobians[i] = DerivativeForm<1, dim, spacedim>();
+          for (unsigned int j = 0; j < dim; ++j)
+            output_data.jacobians[i][j][j] = data.cell_extents[j];
+        }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::maybe_update_inverse_jacobians(
+  const InternalData              &data,
+  const CellSimilarity::Similarity cell_similarity,
+  internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &output_data) const
+{
+  // "compute" inverse Jacobian at the quadrature points, which are
+  // all the same
+  if (data.update_each & update_inverse_jacobians)
+    if (cell_similarity != CellSimilarity::translation)
+      for (unsigned int i = 0; i < output_data.inverse_jacobians.size(); ++i)
+        {
+          output_data.inverse_jacobians[i] = Tensor<2, dim>();
+          for (unsigned int j = 0; j < dim; ++j)
+            output_data.inverse_jacobians[i][j][j] =
+              data.inverse_cell_extents[j];
+        }
+}
+
+
+
+template <int dim, int spacedim>
+CellSimilarity::Similarity
+MappingBox<dim, spacedim>::fill_fe_values(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const CellSimilarity::Similarity                            cell_similarity,
+  const Quadrature<dim>                                      &quadrature,
+  const typename Mapping<dim, spacedim>::InternalDataBase    &internal_data,
+  internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &output_data) const
+{
+  Assert(has_box(cell, polytope_translator), ExcCellNotAssociatedWithBox());
+
+  // convert data object to internal data for this class. fails with
+  // an exception if that is not possible
+  Assert(dynamic_cast<const InternalData *>(&internal_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(internal_data);
+
+
+  update_cell_extents(cell, cell_similarity, data);
+
+  maybe_update_cell_quadrature_points(cell,
+                                      data,
+                                      quadrature.get_points(),
+                                      output_data.quadrature_points);
+
+  // compute Jacobian determinant. all values are equal and are the
+  // product of the local lengths in each coordinate direction
+  if (data.update_each & (update_JxW_values | update_volume_elements))
+    if (cell_similarity != CellSimilarity::translation)
+      {
+        double J = data.cell_extents[0];
+        for (unsigned int d = 1; d < dim; ++d)
+          J *= data.cell_extents[d];
+        data.volume_element = J;
+        if (data.update_each & update_JxW_values)
+          for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
+            output_data.JxW_values[i] = quadrature.weight(i);
+      }
+
+
+  maybe_update_jacobians(data, cell_similarity, output_data);
+  maybe_update_jacobian_derivatives(data, cell_similarity, output_data);
+  maybe_update_inverse_jacobians(data, cell_similarity, output_data);
+
+  return cell_similarity;
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::fill_fe_subface_values(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const unsigned int                                          face_no,
+  const unsigned int                                          subface_no,
+  const Quadrature<dim - 1>                                  &quadrature,
+  const typename Mapping<dim, spacedim>::InternalDataBase    &internal_data,
+  internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &output_data) const
+{
+  (void)cell;
+  (void)face_no;
+  (void)subface_no;
+  (void)quadrature;
+  (void)internal_data;
+  (void)output_data;
+  DEAL_II_NOT_IMPLEMENTED();
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::fill_fe_immersed_surface_values(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const NonMatching::ImmersedSurfaceQuadrature<dim>          &quadrature,
+  const typename Mapping<dim, spacedim>::InternalDataBase    &internal_data,
+  internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+    &output_data) const
+{
+  AssertDimension(dim, spacedim);
+  Assert(has_box(cell, polytope_translator), ExcCellNotAssociatedWithBox());
+
+  // Convert data object to internal data for this class. Fails with an
+  // exception if that is not possible.
+  Assert(dynamic_cast<const InternalData *>(&internal_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(internal_data);
+
+
+  update_cell_extents(cell, CellSimilarity::none, data);
+
+  maybe_update_cell_quadrature_points(cell,
+                                      data,
+                                      quadrature.get_points(),
+                                      output_data.quadrature_points);
+
+  if (data.update_each & update_normal_vectors)
+    for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
+      output_data.normal_vectors[i] = quadrature.normal_vector(i);
+
+  if (data.update_each & update_JxW_values)
+    for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
+      output_data.JxW_values[i] = quadrature.weight(i);
+
+  maybe_update_volume_elements(data);
+  maybe_update_jacobians(data, CellSimilarity::none, output_data);
+  maybe_update_jacobian_derivatives(data, CellSimilarity::none, output_data);
+  maybe_update_inverse_jacobians(data, CellSimilarity::none, output_data);
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::transform(
+  const ArrayView<const Tensor<1, dim>>                   &input,
+  const MappingKind                                        mapping_kind,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const ArrayView<Tensor<1, spacedim>>                    &output) const
+{
+  AssertDimension(input.size(), output.size());
+  Assert(dynamic_cast<const InternalData *>(&mapping_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+
+  switch (mapping_kind)
+    {
+      case mapping_covariant:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d = 0; d < dim; ++d)
+              output[i][d] = input[i][d] * data.inverse_cell_extents[d];
+          return;
+        }
+
+      case mapping_contravariant:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d = 0; d < dim; ++d)
+              output[i][d] = input[i][d] * data.cell_extents[d];
+          return;
+        }
+      case mapping_piola:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+          Assert(data.update_each & update_volume_elements,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_volume_elements"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d = 0; d < dim; ++d)
+              output[i][d] =
+                input[i][d] * data.cell_extents[d] / data.volume_element;
+          return;
+        }
+      default:
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::transform(
+  const ArrayView<const DerivativeForm<1, dim, spacedim>> &input,
+  const MappingKind                                        mapping_kind,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const ArrayView<Tensor<2, spacedim>>                    &output) const
+{
+  AssertDimension(input.size(), output.size());
+  Assert(dynamic_cast<const InternalData *>(&mapping_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+
+  switch (mapping_kind)
+    {
+      case mapping_covariant:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] =
+                  input[i][d1][d2] * data.inverse_cell_extents[d2];
+          return;
+        }
+
+      case mapping_contravariant:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2];
+          return;
+        }
+
+      case mapping_covariant_gradient:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] *
+                                    data.inverse_cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
+          return;
+        }
+
+      case mapping_contravariant_gradient:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
+          return;
+        }
+
+      case mapping_piola:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+          Assert(data.update_each & update_volume_elements,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_volume_elements"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] /
+                                    data.volume_element;
+          return;
+        }
+
+      case mapping_piola_gradient:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+          Assert(data.update_each & update_volume_elements,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_volume_elements"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1] /
+                                    data.volume_element;
+          return;
+        }
+
+      default:
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::transform(
+  const ArrayView<const Tensor<2, dim>>                   &input,
+  const MappingKind                                        mapping_kind,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const ArrayView<Tensor<2, spacedim>>                    &output) const
+{
+  AssertDimension(input.size(), output.size());
+  Assert(dynamic_cast<const InternalData *>(&mapping_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+
+  switch (mapping_kind)
+    {
+      case mapping_covariant:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] =
+                  input[i][d1][d2] * data.inverse_cell_extents[d2];
+          return;
+        }
+
+      case mapping_contravariant:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2];
+          return;
+        }
+
+      case mapping_covariant_gradient:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] *
+                                    data.inverse_cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
+          return;
+        }
+
+      case mapping_contravariant_gradient:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1];
+          return;
+        }
+
+      case mapping_piola:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+          Assert(data.update_each & update_volume_elements,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_volume_elements"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] /
+                                    data.volume_element;
+          return;
+        }
+
+      case mapping_piola_gradient:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+          Assert(data.update_each & update_volume_elements,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_volume_elements"));
+
+          for (unsigned int i = 0; i < output.size(); ++i)
+            for (unsigned int d1 = 0; d1 < dim; ++d1)
+              for (unsigned int d2 = 0; d2 < dim; ++d2)
+                output[i][d1][d2] = input[i][d1][d2] * data.cell_extents[d2] *
+                                    data.inverse_cell_extents[d1] /
+                                    data.volume_element;
+          return;
+        }
+
+      default:
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::transform(
+  const ArrayView<const DerivativeForm<2, dim, spacedim>> &input,
+  const MappingKind                                        mapping_kind,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const ArrayView<Tensor<3, spacedim>>                    &output) const
+{
+  AssertDimension(input.size(), output.size());
+  Assert(dynamic_cast<const InternalData *>(&mapping_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+
+  switch (mapping_kind)
+    {
+      case mapping_covariant_gradient:
+        {
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int q = 0; q < output.size(); ++q)
+            for (unsigned int i = 0; i < spacedim; ++i)
+              for (unsigned int j = 0; j < spacedim; ++j)
+                for (unsigned int k = 0; k < spacedim; ++k)
+                  {
+                    output[q][i][j][k] = input[q][i][j][k] *
+                                         data.inverse_cell_extents[j] *
+                                         data.inverse_cell_extents[k];
+                  }
+          return;
+        }
+      default:
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::transform(
+  const ArrayView<const Tensor<3, dim>>                   &input,
+  const MappingKind                                        mapping_kind,
+  const typename Mapping<dim, spacedim>::InternalDataBase &mapping_data,
+  const ArrayView<Tensor<3, spacedim>>                    &output) const
+{
+  AssertDimension(input.size(), output.size());
+  Assert(dynamic_cast<const InternalData *>(&mapping_data) != nullptr,
+         ExcInternalError());
+  const InternalData &data = static_cast<const InternalData &>(mapping_data);
+
+  switch (mapping_kind)
+    {
+      case mapping_contravariant_hessian:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+
+          for (unsigned int q = 0; q < output.size(); ++q)
+            for (unsigned int i = 0; i < spacedim; ++i)
+              for (unsigned int j = 0; j < spacedim; ++j)
+                for (unsigned int k = 0; k < spacedim; ++k)
+                  {
+                    output[q][i][j][k] = input[q][i][j][k] *
+                                         data.cell_extents[i] *
+                                         data.inverse_cell_extents[j] *
+                                         data.inverse_cell_extents[k];
+                  }
+          return;
+        }
+
+      case mapping_covariant_hessian:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+
+          for (unsigned int q = 0; q < output.size(); ++q)
+            for (unsigned int i = 0; i < spacedim; ++i)
+              for (unsigned int j = 0; j < spacedim; ++j)
+                for (unsigned int k = 0; k < spacedim; ++k)
+                  {
+                    output[q][i][j][k] = input[q][i][j][k] *
+                                         (data.inverse_cell_extents[i] *
+                                          data.inverse_cell_extents[j]) *
+                                         data.inverse_cell_extents[k];
+                  }
+
+          return;
+        }
+
+      case mapping_piola_hessian:
+        {
+          Assert(data.update_each & update_covariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_covariant_transformation"));
+          Assert(data.update_each & update_contravariant_transformation,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_contravariant_transformation"));
+          Assert(data.update_each & update_volume_elements,
+                 typename FEValuesBase<dim>::ExcAccessToUninitializedField(
+                   "update_volume_elements"));
+
+          for (unsigned int q = 0; q < output.size(); ++q)
+            for (unsigned int i = 0; i < spacedim; ++i)
+              for (unsigned int j = 0; j < spacedim; ++j)
+                for (unsigned int k = 0; k < spacedim; ++k)
+                  {
+                    output[q][i][j][k] =
+                      input[q][i][j][k] *
+                      (data.cell_extents[i] / data.volume_element *
+                       data.inverse_cell_extents[j]) *
+                      data.inverse_cell_extents[k];
+                  }
+
+          return;
+        }
+
+      default:
+        DEAL_II_NOT_IMPLEMENTED();
+    }
+}
+
+
+
+template <int dim, int spacedim>
+Point<spacedim>
+MappingBox<dim, spacedim>::transform_unit_to_real_cell(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const Point<dim>                                           &p) const
+{
+  Assert(has_box(cell, polytope_translator), ExcCellNotAssociatedWithBox());
+  Assert(dim == spacedim, ExcNotImplemented());
+
+  return boxes[polytope_translator.at(cell->active_cell_index())].unit_to_real(
+    p);
+}
+
+
+
+template <int dim, int spacedim>
+Point<dim>
+MappingBox<dim, spacedim>::transform_real_to_unit_cell(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const Point<spacedim>                                      &p) const
+{
+  Assert(has_box(cell, polytope_translator), ExcCellNotAssociatedWithBox());
+  Assert(dim == spacedim, ExcNotImplemented());
+
+  return boxes[polytope_translator.at(cell->active_cell_index())].real_to_unit(
+    p);
+}
+
+
+
+template <int dim, int spacedim>
+void
+MappingBox<dim, spacedim>::transform_points_real_to_unit_cell(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const ArrayView<const Point<spacedim>>                     &real_points,
+  const ArrayView<Point<dim>>                                &unit_points) const
+{
+  Assert(has_box(cell, polytope_translator), ExcCellNotAssociatedWithBox());
+  AssertDimension(real_points.size(), unit_points.size());
+
+  if (dim != spacedim)
+    DEAL_II_NOT_IMPLEMENTED();
+  for (unsigned int i = 0; i < real_points.size(); ++i)
+    unit_points[i] =
+      boxes[polytope_translator.at(cell->active_cell_index())].real_to_unit(
+        real_points[i]);
+}
+
+
+
+template <int dim, int spacedim>
+std::unique_ptr<Mapping<dim, spacedim>>
+MappingBox<dim, spacedim>::clone() const
+{
+  return std::make_unique<MappingBox<dim, spacedim>>(*this);
+}
+
+
+//---------------------------------------------------------------------------
+// explicit instantiations
+#include "fe/mapping_box.inst"
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/fe/mapping_box.inst.in
+++ b/source/fe/mapping_box.inst.in
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2024 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Part of the source code is dual licensed under Apache-2.0 WITH
+// LLVM-exception OR LGPL-2.1-or-later. Detailed license information
+// governing the source code and code contributions can be found in
+// LICENSE.md and CONTRIBUTING.md at the top level directory of deal.II.
+//
+// ------------------------------------------------------------------------
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+    template class MappingBox<deal_II_dimension>;
+  }

--- a/tests/agglomeration/3DRtree.cc
+++ b/tests/agglomeration/3DRtree.cc
@@ -1,0 +1,152 @@
+#include <deal.II/dofs/agglomeration_handler.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/poly_utils.h>
+#include <deal.II/grid/reference_cell.h>
+
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <algorithm>
+
+using namespace dealii;
+
+// Check that the R-tree based agglomeration works also in 3D.
+
+
+enum class GridType
+{
+  grid_generator,
+  unstructured
+};
+
+enum class PartitionerType
+{
+  metis,
+  rtree
+};
+
+
+template <int dim>
+class Poisson
+{
+private:
+  void
+  make_agglomerated_grid();
+  void
+  setup_agglomeration();
+
+  Triangulation<dim>                         tria;
+  MappingQ<dim>                              mapping;
+  std::unique_ptr<AgglomerationHandler<dim>> ah;
+  std::unique_ptr<GridTools::Cache<dim>>     cached_tria;
+
+public:
+  Poisson(const GridType        &grid_type        = GridType::grid_generator,
+          const PartitionerType &partitioner_type = PartitionerType::rtree,
+          const unsigned int     extraction_level = 2);
+  void
+  run();
+
+  double          penalty_constant = 10.;
+  GridType        grid_type;
+  PartitionerType partitioner_type;
+  unsigned int    extraction_level;
+};
+
+
+
+template <int dim>
+Poisson<dim>::Poisson(const GridType        &grid_type,
+                      const PartitionerType &partitioner_type,
+                      const unsigned int     extraction_level)
+  : mapping(1)
+  , grid_type(grid_type)
+  , partitioner_type(partitioner_type)
+  , extraction_level(extraction_level)
+{}
+
+template <int dim>
+void
+Poisson<dim>::make_agglomerated_grid()
+{
+  GridIn<dim> grid_in;
+  if (grid_type == GridType::unstructured)
+    {
+      // This test does not read an external grid
+      DEAL_II_NOT_IMPLEMENTED();
+    }
+  else
+    {
+      GridGenerator::hyper_ball(tria);
+      tria.refine_global(3); // 6
+    }
+  std::cout << "Size of tria: " << tria.n_active_cells() << std::endl;
+  cached_tria = std::make_unique<GridTools::Cache<dim>>(tria, mapping);
+  ah          = std::make_unique<AgglomerationHandler<dim>>(*cached_tria);
+
+
+  if (partitioner_type == PartitionerType::metis)
+    {
+      // Not done in this test
+      DEAL_II_NOT_IMPLEMENTED();
+    }
+  else if (partitioner_type == PartitionerType::rtree)
+    {
+      // Partition with Rtree
+
+      namespace bgi                                   = boost::geometry::index;
+      static constexpr unsigned int max_elem_per_node = 8; // 2
+      std::vector<std::pair<BoundingBox<dim>,
+                            typename Triangulation<dim>::active_cell_iterator>>
+                   boxes(tria.n_active_cells());
+      unsigned int i = 0;
+      for (const auto &cell : tria.active_cell_iterators())
+        boxes[i++] = std::make_pair(mapping.get_bounding_box(cell), cell);
+
+      auto tree = pack_rtree<bgi::rstar<max_elem_per_node>>(boxes);
+      std::cout << "Total number of levels in the tree: " << n_levels(tree)
+                << std::endl;
+
+      CellsAgglomerator<dim, decltype(tree)> agglomerator{tree,
+                                                          extraction_level};
+      const auto vec_agglomerates = agglomerator.extract_agglomerates();
+      // Flag elements for agglomeration
+      for (const auto &agglo : vec_agglomerates)
+        {
+          ah->define_agglomerate(agglo);
+        }
+
+
+      std::cout << "N subdomains = " << ah->n_agglomerates() << std::endl;
+    }
+}
+
+template <int dim>
+void
+Poisson<dim>::run()
+{
+  make_agglomerated_grid();
+}
+
+int
+main()
+{
+  {
+    Poisson<3> poisson_problem{GridType::grid_generator,
+                               PartitionerType::rtree,
+                               2};
+    poisson_problem.run();
+  }
+
+
+
+  return 0;
+}

--- a/tests/agglomeration/3DRtree.output
+++ b/tests/agglomeration/3DRtree.output
@@ -1,0 +1,3 @@
+Size of tria: 3584
+Total number of levels in the tree: 3
+N subdomains = 56

--- a/tests/agglomeration/CMakeLists.txt
+++ b/tests/agglomeration/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.13.4)
+include(../scripts/setup_testsubproject.cmake)
+project(testsuite CXX)
+deal_ii_pickup_tests()

--- a/tests/agglomeration/fe_space_on_bbox.cc
+++ b/tests/agglomeration/fe_space_on_bbox.cc
@@ -1,0 +1,161 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2009 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+// Agglomerate some cells in a grid, and create a finite element space on the
+// bounding box of an agglomeration. To check the correctness, compute the area
+// of the agglomerated cells using the weights of a custom quadrature rule over
+// the agglomerated element.
+
+#include <deal.II/dofs/agglomeration_handler.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/poly_utils.h>
+
+using namespace dealii;
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, -1, 1);
+  MappingQ<dim> mapping(1);
+  tria.refine_global(3);
+  GridTools::Cache<dim>     cached_tria(tria, mapping);
+  AgglomerationHandler<dim> ah(cached_tria);
+
+  std::vector<typename Triangulation<dim>::active_cell_iterator>
+    cells; // each cell = an agglomerate
+  for (const auto &cell : tria.active_cell_iterators())
+    cells.push_back(cell);
+
+  std::vector<types::global_cell_index> flagged_cells;
+  const auto                            store_flagged_cells =
+    [&flagged_cells](
+      const std::vector<types::global_cell_index> &idxs_to_be_agglomerated) {
+      for (const int idx : idxs_to_be_agglomerated)
+        flagged_cells.push_back(idx);
+    };
+
+
+  if constexpr (dim == 2)
+    {
+      std::vector<types::global_cell_index> idxs_to_be_agglomerated = {
+        3, 6, 9, 12, 13};
+      store_flagged_cells(idxs_to_be_agglomerated);
+
+      std::vector<typename Triangulation<dim>::active_cell_iterator>
+        cells_to_be_agglomerated;
+      PolyUtils::collect_cells_for_agglomeration(tria,
+                                                 idxs_to_be_agglomerated,
+                                                 cells_to_be_agglomerated);
+
+      std::vector<types::global_cell_index> idxs_to_be_agglomerated2 = {15,
+                                                                        36,
+                                                                        37};
+      store_flagged_cells(idxs_to_be_agglomerated2);
+
+      std::vector<typename Triangulation<dim>::active_cell_iterator>
+        cells_to_be_agglomerated2;
+      PolyUtils::collect_cells_for_agglomeration(tria,
+                                                 idxs_to_be_agglomerated2,
+                                                 cells_to_be_agglomerated2);
+
+      std::vector<types::global_cell_index> idxs_to_be_agglomerated3 = {57,
+                                                                        60,
+                                                                        54};
+      store_flagged_cells(idxs_to_be_agglomerated3);
+      std::vector<typename Triangulation<dim>::active_cell_iterator>
+        cells_to_be_agglomerated3;
+      PolyUtils::collect_cells_for_agglomeration(tria,
+                                                 idxs_to_be_agglomerated3,
+                                                 cells_to_be_agglomerated3);
+
+      std::vector<types::global_cell_index> idxs_to_be_agglomerated4 = {25,
+                                                                        19,
+                                                                        22};
+      store_flagged_cells(idxs_to_be_agglomerated4);
+
+      std::vector<typename Triangulation<dim>::active_cell_iterator>
+        cells_to_be_agglomerated4;
+      PolyUtils::collect_cells_for_agglomeration(tria,
+                                                 idxs_to_be_agglomerated4,
+                                                 cells_to_be_agglomerated4);
+
+      // Agglomerate the cells just stored
+      ah.define_agglomerate(cells_to_be_agglomerated);
+      ah.define_agglomerate(cells_to_be_agglomerated2);
+      ah.define_agglomerate(cells_to_be_agglomerated3);
+      ah.define_agglomerate(cells_to_be_agglomerated4);
+    }
+  else if constexpr (dim == 3)
+    {
+      std::vector<types::global_cell_index> idxs_to_be_agglomerated = {463,
+                                                                       459};
+      store_flagged_cells(idxs_to_be_agglomerated);
+
+      std::vector<typename Triangulation<dim>::active_cell_iterator>
+        cells_to_be_agglomerated;
+      PolyUtils::collect_cells_for_agglomeration(tria,
+                                                 idxs_to_be_agglomerated,
+                                                 cells_to_be_agglomerated);
+
+      ah.define_agglomerate(cells_to_be_agglomerated);
+    }
+
+  for (std::size_t i = 0; i < tria.n_active_cells(); ++i)
+    {
+      // If not present, agglomerate all the singletons
+      if (std::find(flagged_cells.begin(),
+                    flagged_cells.end(),
+                    cells[i]->active_cell_index()) == std::end(flagged_cells))
+        ah.define_agglomerate({cells[i]});
+    }
+
+  FE_DGQ<dim> fe_dg(1);
+  ah.distribute_agglomerated_dofs(fe_dg);
+  ah.initialize_fe_values(QGauss<dim>(1), update_JxW_values);
+
+  // prints
+  const auto fu = [&](const types::global_cell_index given_index) {
+    for (const auto &polytope : ah.polytope_iterators())
+      {
+        if (polytope->index() <= given_index)
+          {
+            const auto &fev = ah.reinit(polytope);
+            double      sum = 0.;
+            for (const double weight : fev.get_JxW_values())
+              sum += weight;
+            std::cout << "Sum is: " << sum << std::endl;
+          }
+      }
+  };
+
+  if constexpr (dim == 2)
+    {
+      fu(3);
+    }
+  else if constexpr (dim == 3)
+    {
+      fu(0);
+    }
+}
+
+
+int
+main()
+{
+  test<2>();
+  test<3>();
+  return 0;
+}

--- a/tests/agglomeration/fe_space_on_bbox.output
+++ b/tests/agglomeration/fe_space_on_bbox.output
@@ -1,0 +1,5 @@
+Sum is: 0.3125
+Sum is: 0.1875
+Sum is: 0.1875
+Sum is: 0.1875
+Sum is: 0.03125

--- a/tests/agglomeration/poisson_sanity_check_01.cc
+++ b/tests/agglomeration/poisson_sanity_check_01.cc
@@ -1,0 +1,438 @@
+#include <deal.II/dofs/agglomeration_handler.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
+
+#include <deal.II/lac/linear_operator.h>
+#include <deal.II/lac/linear_operator_tools.h>
+#include <deal.II/lac/sparse_direct.h>
+#include <deal.II/lac/sparse_matrix.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools_integrate_difference.h>
+#include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <algorithm>
+
+/*
+ * Sanity check: test that the SIPDG matrix is assembled correctly on an
+ * agglomerated mesh by inserting in the bilinear form linear and constant
+ * functions.
+ */
+using namespace dealii;
+
+template <int dim>
+class LinearFunction : public Function<dim>
+{
+public:
+  LinearFunction(const std::vector<int> &coeffs)
+  {
+    Assert(coeffs.size() <= dim, ExcMessage("Wrong size!"));
+    coefficients.resize(coeffs.size());
+    for (size_t i = 0; i < coeffs.size(); i++)
+      coefficients[i] = coeffs[i];
+  }
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const override;
+  std::vector<int> coefficients;
+};
+
+template <int dim>
+double
+LinearFunction<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  double value = 0.;
+  for (size_t i = 0; i < coefficients.size(); i++)
+    value += coefficients[i] * p[i];
+  return value;
+}
+
+
+template <int dim>
+class LaplaceOperator
+{
+private:
+  void
+  make_grid();
+  void
+  setup_agglomeration();
+  void
+  assemble_system();
+  void
+  solve();
+  void
+  perform_sanity_check();
+
+
+  Triangulation<dim>                         tria;
+  MappingQ<dim>                              mapping;
+  FE_DGQ<dim>                                dg_fe;
+  std::unique_ptr<AgglomerationHandler<dim>> ah;
+  AffineConstraints<double>                  constraints;
+  SparsityPattern                            sparsity;
+  DynamicSparsityPattern                     dsp;
+  SparseMatrix<double>                       system_matrix;
+  Vector<double>                             solution;
+  Vector<double>                             system_rhs;
+  std::unique_ptr<GridTools::Cache<dim>>     cached_tria;
+
+public:
+  LaplaceOperator(const unsigned int, const unsigned int fe_degree = 1);
+  void
+  run();
+
+  double       penalty_constant = 10.;
+  unsigned int n_subdomains;
+};
+
+
+
+template <int dim>
+LaplaceOperator<dim>::LaplaceOperator(const unsigned int n_subdomains,
+                                      const unsigned int fe_degree)
+  : mapping(1)
+  , dg_fe(fe_degree)
+  , n_subdomains(n_subdomains)
+{}
+
+template <int dim>
+void
+LaplaceOperator<dim>::make_grid()
+{
+  GridGenerator::hyper_cube(tria, 0., 1.);
+  tria.refine_global(6); // 3
+  cached_tria = std::make_unique<GridTools::Cache<dim>>(tria, mapping);
+
+  GridTools::partition_triangulation(n_subdomains,
+                                     tria,
+                                     SparsityTools::Partitioner::metis);
+  std::cout << "N subdomains: " << n_subdomains << std::endl;
+  constraints.close();
+
+
+#ifdef FALSE
+  // Check number of agglomerates
+  {
+    GridOut           grid_out_svg;
+    GridOutFlags::Svg svg_flags;
+    svg_flags.label_subdomain_id = true;
+    svg_flags.coloring           = GridOutFlags::Svg::subdomain_id;
+    grid_out_svg.set_flags(svg_flags);
+    std::string   grid_type = "agglomerated_grid";
+    std::ofstream out(grid_type + ".svg");
+    grid_out_svg.write_svg(tria, out);
+  }
+#endif
+}
+
+
+
+template <int dim>
+void
+LaplaceOperator<dim>::setup_agglomeration()
+{
+  ah = std::make_unique<AgglomerationHandler<dim>>(*cached_tria);
+
+  std::vector<std::vector<typename Triangulation<dim>::active_cell_iterator>>
+    cells_per_subdomain(n_subdomains);
+  for (const auto &cell : tria.active_cell_iterators())
+    cells_per_subdomain[cell->subdomain_id()].push_back(cell);
+
+  for (std::size_t i = 0; i < cells_per_subdomain.size(); ++i)
+    ah->define_agglomerate(cells_per_subdomain[i]);
+
+
+  ah->distribute_agglomerated_dofs(dg_fe);
+  ah->create_agglomeration_sparsity_pattern(dsp);
+  sparsity.copy_from(dsp);
+}
+
+
+
+template <int dim>
+void
+LaplaceOperator<dim>::assemble_system()
+{
+  system_matrix.reinit(sparsity);
+  solution.reinit(ah->n_dofs());
+  system_rhs.reinit(ah->n_dofs());
+
+  const unsigned int quadrature_degree      = 2 * dg_fe.get_degree() + 1;
+  const unsigned int face_quadrature_degree = 2 * dg_fe.get_degree() + 1;
+  ah->initialize_fe_values(QGauss<dim>(quadrature_degree),
+                           update_gradients | update_JxW_values |
+                             update_quadrature_points | update_JxW_values |
+                             update_values,
+                           QGauss<dim - 1>(face_quadrature_degree));
+
+  const unsigned int dofs_per_cell = ah->n_dofs_per_cell();
+
+  FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+  Vector<double>     cell_rhs(dofs_per_cell);
+
+  // Next, we define the four dofsxdofs matrices needed to assemble jumps and
+  // averages.
+  FullMatrix<double> M11(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M12(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M21(dofs_per_cell, dofs_per_cell);
+  FullMatrix<double> M22(dofs_per_cell, dofs_per_cell);
+
+  std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+  for (const auto &polytope : ah->polytope_iterators())
+    {
+      cell_matrix              = 0;
+      cell_rhs                 = 0;
+      const auto &agglo_values = ah->reinit(polytope);
+
+      const auto         &q_points  = agglo_values.get_quadrature_points();
+      const unsigned int  n_qpoints = q_points.size();
+      std::vector<double> rhs(n_qpoints);
+
+      for (unsigned int q_index : agglo_values.quadrature_point_indices())
+        {
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            {
+              for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                {
+                  cell_matrix(i, j) += agglo_values.shape_grad(i, q_index) *
+                                       agglo_values.shape_grad(j, q_index) *
+                                       agglo_values.JxW(q_index);
+                }
+              cell_rhs(i) += agglo_values.shape_value(i, q_index) *
+                             rhs[q_index] * agglo_values.JxW(q_index);
+            }
+        }
+
+      polytope->get_dof_indices(local_dof_indices);
+      constraints.distribute_local_to_global(
+        cell_matrix, cell_rhs, local_dof_indices, system_matrix, system_rhs);
+
+      // Face terms
+      const unsigned int n_faces = polytope->n_faces();
+
+      for (unsigned int f = 0; f < n_faces; ++f)
+        {
+          const double current_element_diameter =
+            std::fabs(polytope->diameter());
+
+          if (polytope->at_boundary(f))
+            {
+              const auto &fe_face = ah->reinit(polytope, f);
+
+              const unsigned int dofs_per_cell = fe_face.dofs_per_cell;
+              std::vector<types::global_dof_index> local_dof_indices_bdary_cell(
+                dofs_per_cell);
+
+              // Get normal vectors seen from each agglomeration.
+              cell_matrix = 0.;
+              for ([[maybe_unused]] unsigned int q_index :
+                   fe_face.quadrature_point_indices())
+                {
+                  for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                    {
+                      for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                        {
+                          cell_matrix(i, j) +=
+                            0.; // zero out, for this sanity check we need to
+                                // neglect boundary contributions
+                        }
+                    }
+                }
+
+              // distribute DoFs
+              polytope->get_dof_indices(local_dof_indices_bdary_cell);
+              constraints.distribute_local_to_global(
+                cell_matrix, local_dof_indices_bdary_cell, system_matrix);
+            }
+          else
+            {
+              const auto &neigh_polytope = polytope->neighbor(f);
+
+              const double neigh_element_diameter =
+                std::fabs(neigh_polytope->diameter());
+              const double penalty =
+                penalty_constant *
+                std::max(1. / current_element_diameter,
+                         1. / neigh_element_diameter); // Cinv still missing
+
+              // This is necessary to loop over internal faces only once.
+              if (polytope->index() < neigh_polytope->index())
+                {
+                  unsigned int nofn =
+                    polytope->neighbor_of_agglomerated_neighbor(f);
+                  // ah->neighbor_of_agglomerated_neighbor(cell, f);
+
+                  const auto &fe_faces =
+                    ah->reinit_interface(polytope, neigh_polytope, f, nofn);
+
+                  const auto &fe_faces0 = fe_faces.first;
+                  const auto &fe_faces1 = fe_faces.second;
+
+                  Assert((neigh_polytope->neighbor(nofn)->index() ==
+                          polytope->index()),
+                         ExcMessage("Mismatch!"));
+#ifdef FALSE
+                  // Check that face qpoints match at the interface
+                  const auto &points0 = fe_faces0.get_quadrature_points();
+                  const auto &points1 = fe_faces1.get_quadrature_points();
+                  for (size_t i = 0;
+                       i < fe_faces1.get_quadrature_points().size();
+                       ++i)
+                    {
+                      double d = (points0[i] - points1[i]).norm();
+                      Assert(d < 1e-15,
+                             ExcMessage(
+                               "Face qpoints at the interface do not match!"));
+                    }
+#endif
+                  std::vector<types::global_dof_index>
+                    local_dof_indices_neighbor(dofs_per_cell);
+
+                  M11 = 0.;
+                  M12 = 0.;
+                  M21 = 0.;
+                  M22 = 0.;
+
+                  const auto &normals = fe_faces0.get_normal_vectors();
+                  // M11
+                  for (unsigned int q_index :
+                       fe_faces0.quadrature_point_indices())
+                    {
+                      for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                        {
+                          for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                            {
+                              M11(i, j) +=
+                                (-0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) -
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) +
+                                 (penalty)*fe_faces0.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces0.JxW(q_index);
+
+                              M12(i, j) +=
+                                (0.5 * fe_faces0.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) -
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(i, q_index) -
+                                 (penalty)*fe_faces0.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+
+                              // A10
+                              M21(i, j) +=
+                                (-0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces0.shape_value(j, q_index) +
+                                 0.5 * fe_faces0.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) -
+                                 (penalty)*fe_faces1.shape_value(i, q_index) *
+                                   fe_faces0.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+
+                              // A11
+                              M22(i, j) +=
+                                (0.5 * fe_faces1.shape_grad(i, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(j, q_index) +
+                                 0.5 * fe_faces1.shape_grad(j, q_index) *
+                                   normals[q_index] *
+                                   fe_faces1.shape_value(i, q_index) +
+                                 (penalty)*fe_faces1.shape_value(i, q_index) *
+                                   fe_faces1.shape_value(j, q_index)) *
+                                fe_faces1.JxW(q_index);
+                            }
+                        }
+                    }
+
+                  // distribute DoFs
+                  neigh_polytope->get_dof_indices(local_dof_indices_neighbor);
+
+                  constraints.distribute_local_to_global(M11,
+                                                         local_dof_indices,
+                                                         system_matrix);
+                  constraints.distribute_local_to_global(
+                    M12,
+                    local_dof_indices,
+                    local_dof_indices_neighbor,
+                    system_matrix);
+                  constraints.distribute_local_to_global(
+                    M21,
+                    local_dof_indices_neighbor,
+                    local_dof_indices,
+                    system_matrix);
+                  constraints.distribute_local_to_global(
+                    M22, local_dof_indices_neighbor, system_matrix);
+                } // Loop only once trough internal faces
+            }
+        } // Loop over faces of current cell
+    }     // Loop over cells
+}
+
+
+
+template <int dim>
+void
+LaplaceOperator<dim>::perform_sanity_check()
+{
+  {
+    // Sanity check: v(x,y)=x
+    Vector<double>      interpx(ah->get_dof_handler().n_dofs());
+    Vector<double>      interpxplusy(ah->get_dof_handler().n_dofs());
+    Vector<double>      interpone(ah->get_dof_handler().n_dofs());
+    LinearFunction<dim> xfunction{{1, 0}};
+    LinearFunction<dim> xplusfunction{{1, 1}};
+    VectorTools::interpolate(ah->get_agglomeration_mapping(),
+                             ah->get_dof_handler(),
+                             xfunction,
+                             interpx);
+    VectorTools::interpolate(ah->get_agglomeration_mapping(),
+                             ah->get_dof_handler(),
+                             xplusfunction,
+                             interpxplusy);
+    const double valuex = system_matrix.matrix_scalar_product(interpx, interpx);
+    const double valuexplusy =
+      system_matrix.matrix_scalar_product(interpxplusy, interpxplusy);
+    std::cout << "Test with f(x,y)=x:" << valuex
+              << std::endl; // expected result is 1
+    std::cout << "Test with f(x,y)=x+y:" << valuexplusy
+              << std::endl; // expected result is 2
+
+    interpone = 1.;
+    double value_one =
+      system_matrix.matrix_scalar_product(interpone, interpone);
+    std::cout << "Test with 1: " << value_one
+              << std::endl; // expected result is 0
+  }
+}
+
+template <int dim>
+void
+LaplaceOperator<dim>::run()
+{
+  make_grid();
+  setup_agglomeration();
+  assemble_system();
+  perform_sanity_check();
+}
+
+int
+main()
+{
+  for (const unsigned int n_agglomerates : {50, 100, 120})
+    {
+      LaplaceOperator<2> sanity_check{n_agglomerates};
+      sanity_check.run();
+    }
+
+  return 0;
+}

--- a/tests/agglomeration/poisson_sanity_check_01.output
+++ b/tests/agglomeration/poisson_sanity_check_01.output
@@ -1,0 +1,12 @@
+N subdomains: 50
+Test with f(x,y)=x:1
+Test with f(x,y)=x+y:2
+Test with 1: 5.70461e-14
+N subdomains: 100
+Test with f(x,y)=x:1
+Test with f(x,y)=x+y:2
+Test with 1: -1.42813e-14
+N subdomains: 120
+Test with f(x,y)=x:1
+Test with f(x,y)=x+y:2
+Test with 1: 4.44953e-14


### PR DESCRIPTION
This PR introduces the infrastructure for discontinuous Galerkin methods on agglomerated (polyhedral) meshes, where patches of standard deal.II cells are merged into larger polygonal/polyhedral elements.

The primary motivation is not just the ability to solve PDEs on polyhedral meshes, but rather the use of agglomerates to build coarser levels in multigrid preconditioners. To this end, the PR includes an agglomeration algorithm that constructs a hierarchy of coarser meshes starting from an existing _fine_ triangulation. 

The agglomeration strategy implemented here is described in:
https://www.sciencedirect.com/science/article/abs/pii/S0021999125000567,
and we have recently exploited such coarsening strategy to build a preconditioner for DG discretizations of electrophysiology (https://arxiv.org/pdf/2602.16312).

The functionality proposed here originates from the [polyDEAL](https://github.com/fdrmrc/Polydeal/) library, a deal.II-based project I developed during my PhD. It additionally contains distributed-memory agglomerated multigrid capabilities, while this PR focuses on some related infrastructure required to represent and operate on agglomerated meshes within deal.II.  We support `p::f::T` trias.

Let me summarize here the main classes:

- **`AgglomerationHandler`**. It plays a role analogous to a standard deal.II DoFHandler, and stores the agglomeration topology via master/slave cell relationships, distributes DoFs on the polytopal mesh (`distribute_agglomerated_dofs()`), and allows the creation of DG sparsity patterns.

- **`AgglomerationAccessor`** and **`AgglomerationIterator`**: iterator and accessor patterns (following deal.II conventions) to loop over polytopes, query geometric data, neighbors, and retrieve DoF indices. Indeed, the following snippet shows how one can loop over elements (polyhedra) in the same way as cells

```
for (const auto &polytope : handler->polytope_iterators())
    {
      cell_matrix              = 0;
      cell_rhs                 = 0;
      polytope->get_dof_indices(local_dof_indices);
      // evaluate shape functions at qpoints, fill cell_matrix, cell_rhs, and so on...
}
```

- **`CellsAgglomerator`**: class that drives agglomeration based on the R-tree from boost.

- **`MappingBox`**: essentially, a `MappingCartesian` which is agglomeration-aware. It provides efficient affine (axis-aligned bounding box) mapping from the reference cell to each polytope. It is parameterized by a vector of `BoundingBox` objects and is used internally by `AgglomerationHandler` for quadrature and shape-function evaluations on polytopes.

Concerning the main design choices:

- We distinguish beteween "slave" and "master" cells in the code. Slave cells carry no DoFs (`FE_Nothing`), while the master cell of each agglomerate holds DoFs. An internal hp-structure automates this assignment.
- Quadrature rules on polyhedra are built by collecting standard quadrature rules from all subcells and mapping their points to the bounding-box reference frame.
- The interface between two neighboring polytopes is described as the collection of deal.II faces separating them, allowing standard DG flux integrals to be assembled face-by-face.




I recognize that this is a relatively large PR, so I am happy to split it into smaller PRs to simplify the review process. I am also very open to suggestions and discussions regarding both the overall design and the preferred integration strategy.