### PR TITLE
Deprecate those classes that were only used in step-39.

### DIFF
--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -69,7 +69,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <int dim, int spacedim = dim, typename number = double>
-  class DoFInfo : public LocalResults<number>
+  class DEAL_II_DEPRECATED_EARLY DoFInfo : public LocalResults<number>
   {
   public:
     /// The current cell
@@ -215,7 +215,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <int dim, class DOFINFO>
-  class DoFInfoBox
+  class DEAL_II_DEPRECATED_EARLY DoFInfoBox
   {
   public:
     /**

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -71,7 +71,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <int dim, int spacedim = dim>
-  class IntegrationInfo
+  class DEAL_II_DEPRECATED_EARLY IntegrationInfo
   {
   private:
     /// vector of FEValues objects
@@ -291,7 +291,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <int dim, int spacedim = dim>
-  class IntegrationInfoBox
+  class DEAL_II_DEPRECATED_EARLY IntegrationInfoBox
   {
   public:
     /**

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -558,7 +558,7 @@ namespace MeshWorker
             class INFOBOX,
             typename AssemblerType,
             typename IteratorType>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   loop(IteratorType                                             begin,
        std_cxx20::type_identity_t<IteratorType>                 end,
        DOFINFO                                                 &dinfo,


### PR DESCRIPTION
Blocked by #19863. This PR early-deprecates the `MeshWorker` classes that were only directly used by step-39. 

Fixes #17696.