### PR TITLE
Deprecate other now-unused parts of MeshWorker.

### DIFF
--- a/doc/news/changes/major/20260616Bangerth
+++ b/doc/news/changes/major/20260616Bangerth
@@ -1,0 +1,53 @@
+Deprecated: deal.II has had a long list of classes in namespace
+MeshWorker that were developed decades ago when we had a different
+programming style and that were intended to hide some of the
+complexity of assembling linear systems as well as evaluating and
+postprocessing solutions. Many parts of the MeshWorker framework
+worked well for a specific purpose, but turned out to be very
+difficult to adapt to other tasks -- say, converting the assembly of a
+term to a term that nonlinearly depends on coefficients that
+themselves depend on the current solution. The framework also dates
+back to a time when deal.II had substantially poorer test coverage and
+documentation, and as a consequence corner cases were often found to
+not actually work as expected, and/or not well documented.
+
+As a consequence, we have over time developed other, better, better
+documented, and better tested tools for all of these tasks. The only
+remaining hold-out that used the old MeshWorker framework was step-39,
+and with the conversion of step-39 from the old MeshWorker::loop()
+function to the newer MeshWorker::mesh_loop() function, many of the
+old classes have become unused in the tutorial and have been
+deprecated (and will consequently be removed in the second-next
+release). Specifically, these classes and functions are:
+
+- MeshWorker::DoFInfo
+- MeshWorker::IntegrationInfo
+- MeshWorker::IntegrationInfoBox
+- MeshWorker::loop().
+
+This has also led to many other classes that were previously only used
+within the classes and functions mentioned above, and that are now
+also deprecated:
+
+- MeshWorker::Assembler::Functional
+- MeshWorker::Assembler::ResidualLocalBlocksToGlobalBlocks
+- MeshWorker::Assembler::MatrixLocalBlocksToGlobalBlocks
+- MeshWorker::Assembler::MGMatrixLocalBlocksToGlobalBlocks
+- MeshWorker::Assembler::ResidualSimple
+- MeshWorker::Assembler::MatrixSimple
+- MeshWorker::Assembler::MGMatrixSimple
+- MeshWorker::Assembler::SystemSimple
+- MeshWorker::Assembler::CellsAndFaces
+- MeshWorker::Assembler::GnuplotPatch
+- MeshWorker::VectorSelector
+- MeshWorker::VectorDataBase
+- MeshWorker::VectorData
+- MeshWorker::MGVectorData
+- MeshWorker::LocalResults
+- MeshWorker::LoopControl
+- MeshWorker::cell_action()
+
+All of these classes will disappear in a future release.
+
+<br>
+(Wolfgang Bangerth, 2026/06/16)

--- a/include/deal.II/meshworker/assembler.h
+++ b/include/deal.II/meshworker/assembler.h
@@ -106,7 +106,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename VectorType>
-    class ResidualLocalBlocksToGlobalBlocks
+    class DEAL_II_DEPRECATED_EARLY ResidualLocalBlocksToGlobalBlocks
     {
     public:
       /**
@@ -205,7 +205,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename MatrixType, typename number = double>
-    class MatrixLocalBlocksToGlobalBlocks
+    class DEAL_II_DEPRECATED_EARLY MatrixLocalBlocksToGlobalBlocks
     {
     public:
       /**
@@ -320,7 +320,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename MatrixType, typename number = double>
-    class MGMatrixLocalBlocksToGlobalBlocks
+    class DEAL_II_DEPRECATED_EARLY MGMatrixLocalBlocksToGlobalBlocks
     {
     public:
       using MatrixPtrVector = MGMatrixBlockVector<MatrixType>;

--- a/include/deal.II/meshworker/functional.h
+++ b/include/deal.II/meshworker/functional.h
@@ -100,7 +100,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename number = double>
-    class CellsAndFaces
+    class DEAL_II_DEPRECATED_EARLY CellsAndFaces
     {
     public:
       /**

--- a/include/deal.II/meshworker/local_results.h
+++ b/include/deal.II/meshworker/local_results.h
@@ -76,7 +76,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <typename number>
-  class LocalResults
+  class DEAL_II_DEPRECATED_EARLY LocalResults
   {
   public:
     /**

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -200,7 +200,7 @@ namespace MeshWorker
   /**
    * Collection of parameters to control the execution of MeshWorker loops.
    */
-  class LoopControl
+  class DEAL_II_DEPRECATED_EARLY LoopControl
   {
   public:
     /**
@@ -310,7 +310,7 @@ namespace MeshWorker
             int dim,
             int spacedim,
             typename IteratorType>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   cell_action(
     IteratorType              cell,
     DoFInfoBox<dim, DOFINFO> &dof_info,

--- a/include/deal.II/meshworker/output.h
+++ b/include/deal.II/meshworker/output.h
@@ -51,7 +51,7 @@ namespace MeshWorker
      *
      * @note In the current implementation, only cell data can be written.
      */
-    class GnuplotPatch
+    class DEAL_II_DEPRECATED_EARLY GnuplotPatch
     {
     public:
       /**

--- a/include/deal.II/meshworker/simple.h
+++ b/include/deal.II/meshworker/simple.h
@@ -53,7 +53,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename VectorType>
-    class ResidualSimple
+    class DEAL_II_DEPRECATED_EARLY ResidualSimple
     {
     public:
       /**
@@ -146,7 +146,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename MatrixType>
-    class MatrixSimple
+    class DEAL_II_DEPRECATED_EARLY MatrixSimple
     {
     public:
       /**
@@ -248,7 +248,7 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename MatrixType>
-    class MGMatrixSimple
+    class DEAL_II_DEPRECATED_EARLY MGMatrixSimple
     {
     public:
       /**
@@ -431,8 +431,9 @@ namespace MeshWorker
      * @ingroup MeshWorker
      */
     template <typename MatrixType, typename VectorType>
-    class SystemSimple : private MatrixSimple<MatrixType>,
-                         private ResidualSimple<VectorType>
+    class DEAL_II_DEPRECATED_EARLY SystemSimple
+      : private MatrixSimple<MatrixType>,
+        private ResidualSimple<VectorType>
     {
     public:
       /**

--- a/include/deal.II/meshworker/vector_selector.h
+++ b/include/deal.II/meshworker/vector_selector.h
@@ -44,7 +44,7 @@ namespace MeshWorker
    *
    * @ingroup MeshWorker
    */
-  class VectorSelector : public EnableObserverPointer
+  class DEAL_II_DEPRECATED_EARLY VectorSelector : public EnableObserverPointer
   {
   public:
     /**
@@ -187,7 +187,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <int dim, int spacedim = dim, typename Number = double>
-  class VectorDataBase : public VectorSelector
+  class DEAL_II_DEPRECATED_EARLY VectorDataBase : public VectorSelector
   {
   public:
     /**
@@ -299,7 +299,7 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <typename VectorType, int dim, int spacedim = dim>
-  class VectorData
+  class DEAL_II_DEPRECATED_EARLY VectorData
     : public VectorDataBase<dim, spacedim, typename VectorType::value_type>
   {
   public:
@@ -379,7 +379,8 @@ namespace MeshWorker
    * @ingroup MeshWorker
    */
   template <typename VectorType, int dim, int spacedim = dim>
-  class MGVectorData : public VectorData<VectorType, dim, spacedim>
+  class DEAL_II_DEPRECATED_EARLY MGVectorData
+    : public VectorData<VectorType, dim, spacedim>
   {
   public:
     /**


### PR DESCRIPTION
Blocked by #19863 and #19893. If we deprecate those `MeshWorker` classes that are currently only used by step-39 (but won't any more after #19863), then that leads to a whole collection of other classes that are also becoming unused and that we can also early-deprecate. Specifically, these are:
 - MeshWorker::Assembler::Functional
 - MeshWorker::Assembler::ResidualLocalBlocksToGlobalBlocks
 - MeshWorker::Assembler::MatrixLocalBlocksToGlobalBlocks
 - MeshWorker::Assembler::MGMatrixLocalBlocksToGlobalBlocks
 - MeshWorker::Assembler::ResidualSimple
 - MeshWorker::Assembler::MatrixSimple
 - MeshWorker::Assembler::MGMatrixSimple
 - MeshWorker::Assembler::SystemSimple
 - MeshWorker::Assembler::CellsAndFaces
 - MeshWorker::Assembler::GnuplotPatch
 - MeshWorker::VectorSelector
 - MeshWorker::VectorDataBase
 - MeshWorker::VectorData
 - MeshWorker::MGVectorData
 - MeshWorker::LocalResults
 - MeshWorker::LoopControl
 - MeshWorker::cell_action()

So these can now also go, and this patch marks them as well. Fixes #15839.