### PR TITLE
Revert "Use set of pairs for hp_quad_dof_identities"

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -352,14 +352,11 @@ namespace hp
     /**
      * Same as hp_vertex_dof_indices(), except that the function treats degrees
      * of freedom on quads.
-     *
-     * The function takes the set of pairs `fes_and_faces` as an argument,
-     * where the first entry in each pair identifies the `fe_index` and
-     * the second entry is the corresponding `face_no`.
      */
     std::vector<std::map<unsigned int, unsigned int>>
-    hp_quad_dof_identities(const std::set<std::pair<unsigned int, unsigned int>>
-                             &fes_and_faces) const;
+    hp_quad_dof_identities(const std::set<unsigned int> &fes,
+                           const unsigned int            face_no = 0) const;
+
 
     /**
      * Return the indices of finite elements in this FECollection that dominate

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -83,9 +83,7 @@ namespace internal
           const unsigned int face_no          = numbers::invalid_unsigned_int,
           const unsigned int face_no_neighbor = numbers::invalid_unsigned_int)
         {
-          Assert(structdim == 2 ||
-                   (face_no == numbers::invalid_unsigned_int &&
-                    face_no_neighbor == numbers::invalid_unsigned_int),
+          Assert(structdim == 2 || face_no == numbers::invalid_unsigned_int,
                  ExcInternalError());
           Assert((face_no == numbers::invalid_unsigned_int &&
                   face_no_neighbor == numbers::invalid_unsigned_int) ||
@@ -123,14 +121,9 @@ namespace internal
                   case 2:
                     {
                       // TODO: Change set to types::fe_index
-                      std::pair<unsigned int, unsigned int> p1{fe_index_1,
-                                                               face_no};
-                      std::pair<unsigned int, unsigned int> p2{
-                        fe_index_2, face_no_neighbor};
-
                       complete_identities = fes.hp_quad_dof_identities(
-                        std::set<std::pair<unsigned int, unsigned int>>{p1,
-                                                                        p2});
+                        std::set<unsigned int>{fe_index_1, fe_index_2},
+                        face_no);
                       break;
                     }
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -560,29 +560,16 @@ namespace hp
   template <int dim, int spacedim>
   std::vector<std::map<unsigned int, unsigned int>>
   FECollection<dim, spacedim>::hp_quad_dof_identities(
-    const std::set<std::pair<unsigned int, unsigned int>> &fes_and_faces) const
+    const std::set<unsigned int> &fes,
+    const unsigned int            face_no) const
   {
-    // first entry in the pair is the fe_index, the second entry is the face_no
-    std::pair<unsigned int, unsigned int> fe_and_face_1 =
-      *fes_and_faces.begin();
-    std::pair<unsigned int, unsigned int> fe_and_face_2 =
-      *(++fes_and_faces.begin());
-
-    auto query_quad_dof_identities =
-      [this, &fe_and_face_1, &fe_and_face_2](const unsigned int fe_index_1,
-                                             const unsigned int fe_index_2) {
-        // check if fe_index_1 is the same fe index as in fe_and_face_1
-        // then use the corresponding face
-        const unsigned int face_no = fe_index_1 == fe_and_face_1.first ?
-                                       fe_and_face_1.second :
-                                       fe_and_face_2.second;
-        return (*this)[fe_index_1].hp_quad_dof_identities((*this)[fe_index_2],
-                                                          face_no);
-      };
-
-    return compute_hp_dof_identities(
-      std::set<unsigned int>{fe_and_face_1.first, fe_and_face_2.first},
-      query_quad_dof_identities);
+    auto query_quad_dof_identities = [this,
+                                      face_no](const unsigned int fe_index_1,
+                                               const unsigned int fe_index_2) {
+      return (*this)[fe_index_1].hp_quad_dof_identities((*this)[fe_index_2],
+                                                        face_no);
+    };
+    return compute_hp_dof_identities(fes, query_quad_dof_identities);
   }
 
 


### PR DESCRIPTION
This reverts commit 6cdf7d2703ec6fb37c6566d05a21bd0b89336ada, #19291, due to the failures discussed there. I don't know how it tested correctly there before I merged, but regardless, I would appreciate prompt merging of this to get everything else unstuck.