### PR TITLE
Fix initialization of hessians_quad_submitted in FEEvaluationData

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -1098,6 +1098,7 @@ inline FEEvaluationData<dim, Number, is_face>::FEEvaluationData(
   , hessians_quad_initialized(false)
   , values_quad_submitted(false)
   , gradients_quad_submitted(false)
+  , hessians_quad_submitted(false)
 #  endif
   , cell(numbers::invalid_unsigned_int)
   , interior_face(is_interior_face)
@@ -1187,6 +1188,7 @@ FEEvaluationData<dim, Number, is_face>::operator=(const FEEvaluationData &other)
       values_quad_initialized    = false;
       gradients_quad_initialized = false;
       hessians_quad_initialized  = false;
+      hessians_quad_submitted    = false;
       values_quad_submitted      = false;
       gradients_quad_submitted   = false;
     }


### PR DESCRIPTION
The debug-only member `hessians_quad_submitted` was not initialized in the constructor and not reset in the assignment operator, unlike the corresponding value and gradient flags. This could lead to undefined behavior when copying `FEEvaluationData` objects, triggering warnings such as

```text
runtime error: load of value XXX, which is not a valid value for type 'bool'
```

This patch initializes and resets `hessians_quad_submitted` consistently with the other debug state flags.
