### PR TITLE
Fix GridIn::read() for abaqus input files

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -5151,9 +5151,8 @@ GridIn<dim, spacedim>::parse_format(const std::string &format_name)
   if (format_name == "vtu")
     return vtu;
 
-  // This is also the typical extension of Abaqus input files.
   if (format_name == "inp")
-    return ucd;
+    return abaqus;
 
   if (format_name == "ucd")
     return ucd;


### PR DESCRIPTION
When `GridIn::read(filename)` is used with automatic format detection based on the file extension, Abaqus input files (`*.inp`) were mistakenly classified as UCD files. As a result, the wrong reader was selected. This patch fixes the format detection and correctly maps `.inp` files to the Abaqus format.