### PR TITLE
DerivativeApproximation: use type erasure.

### DIFF
--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -983,19 +983,29 @@ namespace DerivativeApproximation
         Iterators(dof_handler.begin_active(), derivative_norm.begin())),
         end(Iterators(dof_handler.end(), derivative_norm.end()));
 
+      // Use type erasure to prevent workstream from seeing this function's type
+      // (which in turn prevents it from instantiating for every possible
+      // InputVector type)
+      std::function<void(const SynchronousIterators<Iterators> &cell,
+                         const Assembler::Scratch &,
+                         Assembler::CopyData &)>
+        worker = [&mapping,
+                  &dof_handler,
+                  &solution,
+                  component](const SynchronousIterators<Iterators> &cell,
+                             const Assembler::Scratch &,
+                             Assembler::CopyData &) {
+          approximate<DerivativeDescription, dim, InputVector, spacedim>(
+            cell, mapping, dof_handler, solution, component);
+        };
+
       // There is no need for a copier because there is no conflict between
       // threads to write in derivative_norm. Scratch and CopyData are also
       // useless.
       WorkStream::run(
         begin,
         end,
-        [&mapping, &dof_handler, &solution, component](
-          const SynchronousIterators<Iterators> &cell,
-          const Assembler::Scratch &,
-          Assembler::CopyData &) {
-          approximate<DerivativeDescription, dim, InputVector, spacedim>(
-            cell, mapping, dof_handler, solution, component);
-        },
+        worker,
         std::function<void(const internal::Assembler::CopyData &)>(),
         internal::Assembler::Scratch(),
         internal::Assembler::CopyData());


### PR DESCRIPTION
This prevents WorkStream::run() from seeing the type of the calling function (which includes the vector type), which in turn prevents it from instantiating a copy of itself for every vector type (and dim, and spacedim, etc.) used by the calling function. In practice, this dramatically lowers the size of the object file (89 MB to 24 MB).

Since the worker function sets up an hp::FEValues object, examines neighboring cells, etc. converting this from a normal function call to a virtual one is not a measurable amount of overhead (TaskFlow can't inline the function call anyway since it is ultimately stored as std::function<void()> in its task graph).

I am pleased to report that this patch, combined with some changes to `MatrixCreator`, lowers the library size on my laptop (in debug mode) by 21% (1.4 GB to 1.1 GB). As long as MSVC implements type erasure in a similar way this should fix the problems in #19829.