### PR TITLE
Re-apply #19291.

### DIFF
--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -352,11 +352,14 @@ namespace hp
     /**
      * Same as hp_vertex_dof_indices(), except that the function treats degrees
      * of freedom on quads.
+     *
+     * The function takes the set of pairs `fes_and_faces` as an argument,
+     * where the first entry in each pair identifies the `fe_index` and
+     * the second entry is the corresponding `face_no`.
      */
     std::vector<std::map<unsigned int, unsigned int>>
-    hp_quad_dof_identities(const std::set<unsigned int> &fes,
-                           const unsigned int            face_no = 0) const;
-
+    hp_quad_dof_identities(const std::set<std::pair<unsigned int, unsigned int>>
+                             &fes_and_faces) const;
 
     /**
      * Return the indices of finite elements in this FECollection that dominate

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -83,7 +83,9 @@ namespace internal
           const unsigned int face_no          = numbers::invalid_unsigned_int,
           const unsigned int face_no_neighbor = numbers::invalid_unsigned_int)
         {
-          Assert(structdim == 2 || face_no == numbers::invalid_unsigned_int,
+          Assert(structdim == 2 ||
+                   (face_no == numbers::invalid_unsigned_int &&
+                    face_no_neighbor == numbers::invalid_unsigned_int),
                  ExcInternalError());
           Assert((face_no == numbers::invalid_unsigned_int &&
                   face_no_neighbor == numbers::invalid_unsigned_int) ||
@@ -121,9 +123,14 @@ namespace internal
                   case 2:
                     {
                       // TODO: Change set to types::fe_index
+                      std::pair<unsigned int, unsigned int> p1{fe_index_1,
+                                                               face_no};
+                      std::pair<unsigned int, unsigned int> p2{
+                        fe_index_2, face_no_neighbor};
+
                       complete_identities = fes.hp_quad_dof_identities(
-                        std::set<unsigned int>{fe_index_1, fe_index_2},
-                        face_no);
+                        std::set<std::pair<unsigned int, unsigned int>>{p1,
+                                                                        p2});
                       break;
                     }
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -580,9 +580,16 @@ namespace hp
                                                           face_no);
       };
 
-    return compute_hp_dof_identities(
-      std::set<unsigned int>{fe_and_face_1.first, fe_and_face_2.first},
-      query_quad_dof_identities);
+    // Extract only the FE indices from the pairs we got as inputs
+    std::set<unsigned int> fe_indices_only;
+    for (const auto &[fe_index, face_index] : fes_and_faces)
+      {
+        fe_indices_only.insert(fe_index);
+        (void)face_index;
+      }
+
+    return compute_hp_dof_identities(fe_indices_only,
+                                     query_quad_dof_identities);
   }
 
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -560,16 +560,29 @@ namespace hp
   template <int dim, int spacedim>
   std::vector<std::map<unsigned int, unsigned int>>
   FECollection<dim, spacedim>::hp_quad_dof_identities(
-    const std::set<unsigned int> &fes,
-    const unsigned int            face_no) const
+    const std::set<std::pair<unsigned int, unsigned int>> &fes_and_faces) const
   {
-    auto query_quad_dof_identities = [this,
-                                      face_no](const unsigned int fe_index_1,
-                                               const unsigned int fe_index_2) {
-      return (*this)[fe_index_1].hp_quad_dof_identities((*this)[fe_index_2],
-                                                        face_no);
-    };
-    return compute_hp_dof_identities(fes, query_quad_dof_identities);
+    // first entry in the pair is the fe_index, the second entry is the face_no
+    std::pair<unsigned int, unsigned int> fe_and_face_1 =
+      *fes_and_faces.begin();
+    std::pair<unsigned int, unsigned int> fe_and_face_2 =
+      *(++fes_and_faces.begin());
+
+    auto query_quad_dof_identities =
+      [this, &fe_and_face_1, &fe_and_face_2](const unsigned int fe_index_1,
+                                             const unsigned int fe_index_2) {
+        // check if fe_index_1 is the same fe index as in fe_and_face_1
+        // then use the corresponding face
+        const unsigned int face_no = fe_index_1 == fe_and_face_1.first ?
+                                       fe_and_face_1.second :
+                                       fe_and_face_2.second;
+        return (*this)[fe_index_1].hp_quad_dof_identities((*this)[fe_index_2],
+                                                          face_no);
+      };
+
+    return compute_hp_dof_identities(
+      std::set<unsigned int>{fe_and_face_1.first, fe_and_face_2.first},
+      query_quad_dof_identities);
   }
 
 

--- a/tests/hp/hp_quad_dof_identities_mixed_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_mixed_multiway.cc
@@ -41,9 +41,9 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<std::pair<unsigned int, unsigned int>> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
-    fe_indices.emplace(i);
+    fe_indices.emplace(i, 0);
 
   const auto identities = fe_collection.hp_quad_dof_identities(fe_indices);
 

--- a/tests/hp/hp_quad_dof_identities_q_equidistant_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_q_equidistant_multiway.cc
@@ -45,9 +45,9 @@ test()
     }
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<std::pair<unsigned int, unsigned int>> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
-    fe_indices.emplace(i);
+    fe_indices.emplace(i, 0);
 
   const auto identities = fe_collection.hp_quad_dof_identities(fe_indices);
 

--- a/tests/hp/hp_quad_dof_identities_q_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_q_multiway.cc
@@ -35,9 +35,9 @@ test()
     fe_collection.push_back(FE_Q<dim>(i));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<std::pair<unsigned int, unsigned int>> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
-    fe_indices.emplace(i);
+    fe_indices.emplace(i, 0);
 
   const auto identities = fe_collection.hp_quad_dof_identities(fe_indices);
 

--- a/tests/hp/hp_quad_dof_identities_q_system_multiway.cc
+++ b/tests/hp/hp_quad_dof_identities_q_system_multiway.cc
@@ -37,9 +37,9 @@ test()
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(i), 2));
 
   // construct the complete set of fe indices
-  std::set<unsigned int> fe_indices;
+  std::set<std::pair<unsigned int, unsigned int>> fe_indices;
   for (unsigned int i = 0; i < fe_collection.size(); ++i)
-    fe_indices.emplace(i);
+    fe_indices.emplace(i, 0u);
 
   const auto identities = fe_collection.hp_quad_dof_identities(fe_indices);
 


### PR DESCRIPTION
This PR re-applies #19291, plus the changes mentioned in that PR to the four tests that didn't compile, plus a commit that fixes these tests. The issue with the failing tests (once modified to compile correctly) was that #19291 had this piece of code:
```
 return compute_hp_dof_identities(
      std::set<unsigned int>{fe_and_face_1.first, fe_and_face_2.first},
      query_quad_dof_identities);
```
This assumes that there are exactly two finite elements and corresponding face indices on which we want to compute which DoFs match each other. This is of course true in actual practice because in 3d, only two finite elements can come together to form a quad (which is what we are considering in this function). The issue was that in the test suite, we also have cases where we compute DoF identities on quads for more than 2 finite elements -- a case that would be relevant if we were in 4d (because there, just like for lines in 3d, more than two cells can come together at a quad). In other words, the original patch works for all cases we *really* care about, just not for the four tests in the test suite that check contrived cases.

Anyway, it was easy to fix. We just need to replace the two-element set by the set of first elements of the input:
```
    // Extract only the FE indices from the pairs we got as inputs
    std::set<unsigned int> fe_indices_only;
    for (const auto &[fe_index, face_index] : fes_and_faces)
      {
        fe_indices_only.insert(fe_index);
        (void)face_index;
      }

    return compute_hp_dof_identities(fe_indices_only,
                                     query_quad_dof_identities);
```

@dominiktassilostill FYI.

Fixes #19903.