### PR TITLE
Use `ScalarLagrangePolynomialSimplex` in `FE_SimplexP`

### DIFF
--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -17,6 +17,7 @@
 
 #include <deal.II/base/mutex.h>
 #include <deal.II/base/polynomials_barycentric.h>
+#include <deal.II/base/polynomials_simplex.h>
 #include <deal.II/base/types.h>
 
 #include <deal.II/fe/fe_poly.h>
@@ -37,6 +38,18 @@ class FE_SimplexPoly : public dealii::FE_Poly<dim, spacedim>
 public:
   /**
    * Constructor.
+   */
+  FE_SimplexPoly(
+    const ScalarLagrangePolynomialSimplex<dim>    &polynomials,
+    const FiniteElementData<dim>                  &fe_data,
+    const bool                                     prolongation_is_additive,
+    const std::vector<Point<dim>>                 &unit_support_points,
+    const std::vector<std::vector<Point<dim - 1>>> unit_face_support_points,
+    const FullMatrix<double>                      &interface_constraints);
+
+  /**
+   * Similar to the other constructor but takes barycentric polynomials as an
+   * argument. Needed for FE_SimplexP_Bubbles.
    */
   FE_SimplexPoly(
     const BarycentricPolynomials<dim>              polynomials,

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -14,6 +14,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/polynomials_barycentric.h>
+#include <deal.II/base/polynomials_simplex.h>
 #include <deal.II/base/qprojector.h>
 #include <deal.II/base/types.h>
 
@@ -250,7 +251,8 @@ namespace
     FullMatrix<double> interface_constraints(n_dofs_constrained,
                                              n_dofs_per_face);
 
-    const auto poly = BarycentricPolynomials<dim - 1>::get_fe_p_basis(degree);
+    const ScalarLagrangePolynomialSimplex<dim - 1> poly(
+      degree, unit_support_points_fe_p<dim - 1>(degree));
 
     for (unsigned int i = 0; i < n_dofs_constrained; ++i)
       for (unsigned int j = 0; j < n_dofs_per_face; ++j)
@@ -324,6 +326,28 @@ namespace
       }
   }
 } // namespace
+
+
+
+template <int dim, int spacedim>
+FE_SimplexPoly<dim, spacedim>::FE_SimplexPoly(
+  const ScalarLagrangePolynomialSimplex<dim>    &polynomials,
+  const FiniteElementData<dim>                  &fe_data,
+  const bool                                     prolongation_is_additive,
+  const std::vector<Point<dim>>                 &unit_support_points,
+  const std::vector<std::vector<Point<dim - 1>>> unit_face_support_points,
+  const FullMatrix<double>                      &interface_constraints)
+  : dealii::FE_Poly<dim, spacedim>(
+      polynomials,
+      fe_data,
+      std::vector<bool>(fe_data.dofs_per_cell, prolongation_is_additive),
+      std::vector<ComponentMask>(fe_data.dofs_per_cell,
+                                 ComponentMask(std::vector<bool>(1, true))))
+{
+  this->unit_support_points      = unit_support_points;
+  this->unit_face_support_points = unit_face_support_points;
+  this->interface_constraints    = interface_constraints;
+}
 
 
 
@@ -761,7 +785,9 @@ FE_SimplexPoly<dim, spacedim>::
 template <int dim, int spacedim>
 FE_SimplexP<dim, spacedim>::FE_SimplexP(const unsigned int degree)
   : FE_SimplexPoly<dim, spacedim>(
-      BarycentricPolynomials<dim>::get_fe_p_basis(degree),
+      ScalarLagrangePolynomialSimplex<dim>(degree,
+                                           unit_support_points_fe_p<dim>(
+                                             degree)),
       FiniteElementData<dim>(get_dpo_vector_fe_p(dim, degree),
                              ReferenceCells::get_simplex<dim>(),
                              1,
@@ -1016,7 +1042,9 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
 template <int dim, int spacedim>
 FE_SimplexDGP<dim, spacedim>::FE_SimplexDGP(const unsigned int degree)
   : FE_SimplexPoly<dim, spacedim>(
-      BarycentricPolynomials<dim>::get_fe_p_basis(degree),
+      ScalarLagrangePolynomialSimplex<dim>(degree,
+                                           unit_support_points_fe_p<dim>(
+                                             degree)),
       FiniteElementData<dim>(get_dpo_vector_fe_dgp(dim, degree),
                              ReferenceCells::get_simplex<dim>(),
                              1,


### PR DESCRIPTION
This PR changes the basis of `FE_SimplexP` and `FE_SimplexDGP` from barycentric polynomials to `ScalarLagrangePolynomialSimplex`. In connection with #19881 it enables to higher order simplex elements.

To really use a high order polynomial basis the adoption of the support points from equidistant support to something more optimized is missing.

@drwells  I see some tests failing, but maybe it helps for checking #19881.