### PR TITLE
Don't mark functions in anonymous spaces as inline.

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -827,7 +827,7 @@ namespace
   // is a dim-dimensional integer vector. If the points are
   // saved in the patch.data member, return the saved point instead.
   template <int dim, int spacedim>
-  inline Point<spacedim>
+  Point<spacedim>
   get_equispaced_location(
     const DataOutBase::Patch<dim, spacedim>   &patch,
     const std::initializer_list<unsigned int> &lattice_location,
@@ -918,7 +918,7 @@ namespace
   // If the points are saved in the patch.data member, return the saved point
   // instead.
   template <int dim, int spacedim>
-  inline Point<spacedim>
+  Point<spacedim>
   get_node_location(const DataOutBase::Patch<dim, spacedim> &patch,
                     const unsigned int                       node_index)
   {
@@ -1484,7 +1484,7 @@ namespace
 
 
   template <typename data>
-  inline void
+  void
   DXStream::write_dataset(const unsigned int, const std::vector<data> &values)
   {
     if (flags.data_binary)
@@ -1689,7 +1689,7 @@ namespace
 
 
   template <typename data>
-  inline void
+  void
   UcdStream::write_dataset(const unsigned int       index,
                            const std::vector<data> &values)
   {

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -725,7 +725,7 @@ namespace Utilities
           index_type
           operator[](const std::size_t index) const;
 
-          bool
+          [[maybe_unused]] bool
           entry_has_been_set(const std::size_t index) const;
 
         private:
@@ -1177,7 +1177,7 @@ namespace Utilities
 
 
 
-        inline bool
+        inline [[maybe_unused]] bool
         FlexibleIndexStorage::entry_has_been_set(const std::size_t index) const
         {
           AssertIndexRange(index, size);

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1037,9 +1037,9 @@ namespace Utilities
             unsigned int                 &owner_index_guess);
         };
 
-        /* ------------------------- inline functions ----------------------- */
 
-        inline unsigned int
+
+        unsigned int
         Dictionary::dof_to_dict_rank(const types::global_dof_index i)
         {
           // note: this formula is also explicitly used in
@@ -1048,7 +1048,7 @@ namespace Utilities
         }
 
 
-        inline types::global_dof_index
+        types::global_dof_index
         Dictionary::get_index_offset(const unsigned int rank)
         {
           return std::min(dofs_per_process *
@@ -1060,7 +1060,7 @@ namespace Utilities
 
 
 
-        inline unsigned int
+        unsigned int
         Dictionary::get_owning_rank_index(
           const unsigned int rank_in_owned_indices,
           const unsigned int guess)
@@ -1177,7 +1177,7 @@ namespace Utilities
 
 
 
-        inline [[maybe_unused]] bool
+        [[maybe_unused]] bool
         FlexibleIndexStorage::entry_has_been_set(const std::size_t index) const
         {
           AssertIndexRange(index, size);

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -28,7 +28,7 @@ namespace
    * Elemental default grid: El::Grid::Grid(mpi_comm,...)
    * https://github.com/elemental/Elemental/blob/master/src/core/Grid.cpp#L67-L91
    */
-  inline std::pair<int, int>
+  std::pair<int, int>
   compute_processor_grid_sizes(const MPI_Comm     mpi_comm,
                                const unsigned int m,
                                const unsigned int n,

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -33,7 +33,7 @@ namespace internal
   namespace
   {
     template <std::size_t dim>
-    inline void
+    void
     compute_tensor_index(const unsigned int,
                          const unsigned int,
                          const unsigned int,
@@ -42,7 +42,7 @@ namespace internal
       DEAL_II_NOT_IMPLEMENTED();
     }
 
-    inline void
+    void
     compute_tensor_index(const unsigned int n,
                          const unsigned int,
                          const unsigned int,
@@ -51,7 +51,7 @@ namespace internal
       indices[0] = n;
     }
 
-    inline void
+    void
     compute_tensor_index(const unsigned int n,
                          const unsigned int n_pols_0,
                          const unsigned int,
@@ -61,7 +61,7 @@ namespace internal
       indices[1] = n / n_pols_0;
     }
 
-    inline void
+    void
     compute_tensor_index(const unsigned int           n,
                          const unsigned int           n_pols_0,
                          const unsigned int           n_pols_1,

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -51,7 +51,7 @@ namespace
   }
 
   template <typename number>
-  inline number
+  number
   max_element(const dealii::Vector<number> &criteria)
   {
     return (criteria.size() > 0) ?
@@ -62,7 +62,7 @@ namespace
 
 
   template <typename number>
-  inline number
+  number
   min_element(const dealii::Vector<number> &criteria)
   {
     return (criteria.size() > 0) ?

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1551,7 +1551,7 @@ namespace
    * the @p tree by @p idx.
    */
   template <int dim, int spacedim>
-  inline void
+  void
   add_single_cell_relation(
     std::vector<cell_relation_t<dim, spacedim>>                &cell_rel,
     const typename dealii::internal::p4est::types<dim>::tree   &tree,

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -55,7 +55,7 @@ namespace DoFTools
   {
     namespace
     {
-      inline bool
+      bool
       check_primary_dof_list(
         const FullMatrix<double>                   &face_interpolation_matrix,
         const std::vector<types::global_dof_index> &primary_dof_list)

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -49,7 +49,7 @@ namespace internal
       // tensorization on inner loops for performance reasons. this clears a
       // dim-array
       template <int dim>
-      inline void
+      void
       zero_indices(unsigned int (&indices)[dim])
       {
         for (unsigned int d = 0; d < dim; ++d)
@@ -62,7 +62,7 @@ namespace internal
       // tensorization on inner loops for performance reasons. this increments
       // tensor product indices
       template <int dim>
-      inline void
+      void
       increment_indices(unsigned int (&indices)[dim], const unsigned int dofs1d)
       {
         ++indices[0];

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -41,7 +41,7 @@ namespace internal
     namespace
     {
       template <int dim, int spacedim>
-      inline void
+      void
       compute_embedding_matrices(
         const dealii::FE_Q_Bubbles<dim, spacedim>    &fe,
         std::vector<std::vector<FullMatrix<double>>> &matrices,

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -35,7 +35,7 @@ namespace internal
       /**
        * A function which maps  in[i] to i,i.e. output[in[i]] = i;
        */
-      inline std::vector<unsigned int>
+      std::vector<unsigned int>
       invert_numbering(const std::vector<unsigned int> &in)
       {
         std::vector<unsigned int> out(in.size());

--- a/source/fe/fe_values_views.cc
+++ b/source/fe/fe_values_views.cc
@@ -38,7 +38,7 @@ namespace internal
   namespace
   {
     template <int dim, int spacedim>
-    inline std::vector<unsigned int>
+    std::vector<unsigned int>
     make_shape_function_to_row_table(const FiniteElement<dim, spacedim> &fe)
     {
       std::vector<unsigned int> shape_function_to_row_table(

--- a/source/grid/grid_generator_pipe_junction.cc
+++ b/source/grid/grid_generator_pipe_junction.cc
@@ -50,7 +50,7 @@ namespace
      * Calculate the height of a pipe segment, depending on the location in the
      * x-y plane.
      */
-    inline double
+    double
     compute_z_expansion(const double          x,
                         const double          y,
                         const AdditionalData &data)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1601,7 +1601,7 @@ namespace
    * manifold with a twist.
    */
   template <class TRIANGULATION>
-  inline typename TRIANGULATION::DistortedCellList
+  typename TRIANGULATION::DistortedCellList
   collect_distorted_coarse_cells(const TRIANGULATION &)
   {
     return typename TRIANGULATION::DistortedCellList();
@@ -1618,7 +1618,7 @@ namespace
    * for the case dim==spacedim.
    */
   template <int dim>
-  inline typename Triangulation<dim, dim>::DistortedCellList
+  typename Triangulation<dim, dim>::DistortedCellList
   collect_distorted_coarse_cells(const Triangulation<dim, dim> &triangulation)
   {
     typename Triangulation<dim, dim>::DistortedCellList distorted_cells;

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -40,7 +40,7 @@ namespace
   // (subface_no), return the number of the
   // subface concerning the FaceRefineCase of
   // the face
-  inline unsigned int
+  unsigned int
   translate_subface_no(const TriaIterator<TriaAccessor<2, 3, 3>> &face,
                        const unsigned int                         subface_no)
   {
@@ -82,7 +82,7 @@ namespace
   // (subsubface_no), return the number of the
   // subface concerning the FaceRefineCase of
   // the face
-  inline unsigned int
+  unsigned int
   translate_subface_no(const TriaIterator<TriaAccessor<2, 3, 3>> &face,
                        const unsigned int                         subface_no,
                        const unsigned int                         subsubface_no)

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -55,7 +55,7 @@ DEAL_II_NAMESPACE_OPEN
 namespace
 {
   template <typename T>
-  inline T
+  T
   sqr(const T t)
   {
     return t * t;


### PR DESCRIPTION
While reading up on MSVC I learned about the [`/Zc:inline` flag](https://learn.microsoft.com/en-us/cpp/build/reference/zc-inline-remove-unreferenced-comdat?view=msvc-170): I haven't tried it yet but I'm reasonably sure this will significantly decrease the size of our MSVC archives (and more-or-less permanently solve the problem: we are at about 3.8/4 GB right now so it will be an issue again soon). That flag essentially enables standards-conforming behavior w.r.t. the `inline` keyword in MSVC.

I think these `inline`s are harmless but I want to be sure that MSVC does the correct thing, so before I switch that flag on I'm reviewing our uses of `inline` in `.cc` files and fixing any that are confusing or unnecessary. I checked and all of these are in anonymous namespaces in source files so we really don't need `inline` here.