### PR TITLE
Don't mark member functions in source files as inline.

### DIFF
--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -511,7 +511,7 @@ namespace Functions
   {}
 
 
-  inline double
+  double
   StokesLSingularity::Psi(double phi) const
   {
     return coslo * (std::sin(lp * phi) / lp - std::sin(lm * phi) / lm) -
@@ -519,7 +519,7 @@ namespace Functions
   }
 
 
-  inline double
+  double
   StokesLSingularity::Psi_1(double phi) const
   {
     return coslo * (std::cos(lp * phi) - std::cos(lm * phi)) +
@@ -527,7 +527,7 @@ namespace Functions
   }
 
 
-  inline double
+  double
   StokesLSingularity::Psi_2(double phi) const
   {
     return coslo * (lm * std::sin(lm * phi) - lp * std::sin(lp * phi)) +
@@ -535,7 +535,7 @@ namespace Functions
   }
 
 
-  inline double
+  double
   StokesLSingularity::Psi_3(double phi) const
   {
     return coslo *
@@ -545,7 +545,7 @@ namespace Functions
   }
 
 
-  inline double
+  double
   StokesLSingularity::Psi_4(double phi) const
   {
     return coslo * (lp * lp * lp * std::sin(lp * phi) -

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -283,7 +283,7 @@ ParameterAcceptor::leave_my_subsection(
 
 
 
-inline unsigned int
+unsigned int
 ParameterAcceptor::get_acceptor_id() const
 {
   return acceptor_id;

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -148,7 +148,7 @@ DoFCellAccessor<dim, spacedim, lda>::periodic_neighbor_child_on_subface(
 
 
 template <int dim, int spacedim, bool lda>
-inline TriaIterator<DoFCellAccessor<dim, spacedim, lda>>
+TriaIterator<DoFCellAccessor<dim, spacedim, lda>>
 DoFCellAccessor<dim, spacedim, lda>::periodic_neighbor(
   const unsigned int face) const
 {
@@ -161,7 +161,7 @@ DoFCellAccessor<dim, spacedim, lda>::periodic_neighbor(
 
 
 template <int dim, int spacedim, bool lda>
-inline TriaIterator<DoFCellAccessor<dim, spacedim, lda>>
+TriaIterator<DoFCellAccessor<dim, spacedim, lda>>
 DoFCellAccessor<dim, spacedim, lda>::neighbor_or_periodic_neighbor(
   const unsigned int face) const
 {
@@ -174,7 +174,7 @@ DoFCellAccessor<dim, spacedim, lda>::neighbor_or_periodic_neighbor(
 
 
 template <int structdim, int dim, int spacedim, bool level_dof_access>
-inline void
+void
 DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
   std::vector<types::global_dof_index> &dof_indices,
   const types::fe_index                 fe_index_) const
@@ -211,7 +211,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
 
 
 template <int structdim, int dim, int spacedim, bool level_dof_access>
-inline void
+void
 DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
   const int                             level,
   std::vector<types::global_dof_index> &dof_indices,
@@ -233,7 +233,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
 
 
 template <int structdim, int dim, int spacedim, bool level_dof_access>
-inline void
+void
 DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
   const int                                   level,
   const std::vector<types::global_dof_index> &dof_indices,
@@ -276,7 +276,7 @@ namespace internal
 
 
 template <int dimension_, int space_dimension_, bool level_dof_access>
-inline void
+void
 DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   get_dof_indices(std::vector<types::global_dof_index> &dof_indices) const
 {
@@ -293,7 +293,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 
 
 template <int dimension_, int space_dimension_, bool level_dof_access>
-inline void
+void
 DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   get_mg_dof_indices(std::vector<types::global_dof_index> &dof_indices) const
 {
@@ -307,7 +307,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 
 
 template <int dimension_, int space_dimension_, bool level_dof_access>
-inline void
+void
 DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   set_mg_dof_indices(const std::vector<types::global_dof_index> &dof_indices)
 {

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1348,7 +1348,7 @@ FiniteElement<dim, spacedim>::get_face_data(
 
 
 template <int dim, int spacedim>
-inline void
+void
 FiniteElement<dim, spacedim>::fill_fe_face_values(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const unsigned int                                          face_no,
@@ -1377,7 +1377,7 @@ FiniteElement<dim, spacedim>::fill_fe_face_values(
 
 
 template <int dim, int spacedim>
-inline void
+void
 FiniteElement<dim, spacedim>::fill_fe_face_values(
   const typename Triangulation<dim, spacedim>::cell_iterator & /* cell */,
   const unsigned int /* face_no */,

--- a/source/fe/fe_poly.cc
+++ b/source/fe/fe_poly.cc
@@ -517,7 +517,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
 
 
 template <int dim, int spacedim>
-inline void
+void
 FE_Poly<dim, spacedim>::correct_hessians(
   internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
     &output_data,
@@ -536,7 +536,7 @@ FE_Poly<dim, spacedim>::correct_hessians(
 
 
 template <int dim, int spacedim>
-inline void
+void
 FE_Poly<dim, spacedim>::correct_third_derivatives(
   internal::FEValuesImplementation::FiniteElementRelatedData<dim, spacedim>
     &output_data,
@@ -567,7 +567,7 @@ FE_Poly<dim, spacedim>::correct_third_derivatives(
 
 
 template <int dim, int spacedim>
-inline const ScalarPolynomialsBase<dim> &
+const ScalarPolynomialsBase<dim> &
 FE_Poly<dim, spacedim>::get_poly_space() const
 {
   return *poly_space;

--- a/source/fe/fe_series_fourier.cc
+++ b/source/fe/fe_series_fourier.cc
@@ -223,7 +223,7 @@ namespace FESeries
 
 
   template <int dim, int spacedim>
-  inline bool
+  bool
   Fourier<dim, spacedim>::operator==(
     const Fourier<dim, spacedim> &fourier) const
   {

--- a/source/fe/fe_series_legendre.cc
+++ b/source/fe/fe_series_legendre.cc
@@ -229,7 +229,7 @@ namespace FESeries
 
 
   template <int dim, int spacedim>
-  inline bool
+  bool
   Legendre<dim, spacedim>::operator==(
     const Legendre<dim, spacedim> &legendre) const
   {

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -1411,7 +1411,7 @@ FEValuesBase<dim, spacedim>::maybe_invalidate_previous_present_cell(
 
 
 template <int dim, int spacedim>
-inline void
+void
 FEValuesBase<dim, spacedim>::check_cell_similarity(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell)
 {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2383,13 +2383,13 @@ namespace internal
                    ExcInternalError());
       }
 
-      inline const std::set<ReferenceCell<dim>> &
+      const std::set<ReferenceCell<dim>> &
       all_reference_cells() const
       {
         return all_reference_cells_;
       }
 
-      inline std::vector<types::geometric_orientation> &
+      std::vector<types::geometric_orientation> &
       entity_orientations(const unsigned int structdim)
       {
         if (structdim == 1)
@@ -2400,7 +2400,7 @@ namespace internal
         return quad_orientation;
       }
 
-      inline const std::vector<types::geometric_orientation> &
+      const std::vector<types::geometric_orientation> &
       entity_orientations(const unsigned int structdim) const
       {
         if (structdim == 1)
@@ -2412,7 +2412,7 @@ namespace internal
       }
 
       template <int structdim>
-      inline std::vector<ReferenceCell<structdim>> &
+      std::vector<ReferenceCell<structdim>> &
       entity_types()
       {
         if constexpr (structdim == dim)
@@ -2428,7 +2428,7 @@ namespace internal
       }
 
       template <int structdim>
-      inline const std::vector<ReferenceCell<structdim>> &
+      const std::vector<ReferenceCell<structdim>> &
       entity_types() const
       {
         if constexpr (structdim == dim)
@@ -2443,7 +2443,7 @@ namespace internal
           DEAL_II_ASSERT_UNREACHABLE();
       }
 
-      inline ArrayOfArrays &
+      ArrayOfArrays &
       entity_to_entities(const unsigned int from, const unsigned int to)
       {
         if (from == dim && to == dim)
@@ -2462,7 +2462,7 @@ namespace internal
         return cell_entities;
       }
 
-      inline const ArrayOfArrays &
+      const ArrayOfArrays &
       entity_to_entities(const unsigned int from, const unsigned int to) const
       {
         if (from == dim && to == dim)

--- a/source/lac/psblas_sparsity_pattern.cc
+++ b/source/lac/psblas_sparsity_pattern.cc
@@ -73,7 +73,7 @@ namespace PSCToolkitWrappers
 
 
   template <typename ForwardIterator>
-  inline void
+  void
   SparsityPattern::add_entries(
     const PSCToolkitWrappers::SparsityPattern::size_type row,
     ForwardIterator                                      begin,

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -800,7 +800,7 @@ namespace TrilinosWrappers
 
 
   template <typename SparsityPatternType>
-  inline std::enable_if_t<
+  std::enable_if_t<
     !std::is_same_v<SparsityPatternType, dealii::SparseMatrix<double>>>
   SparseMatrix::reinit(const IndexSet            &row_parallel_partitioning,
                        const IndexSet            &col_parallel_partitioning,
@@ -877,7 +877,7 @@ namespace TrilinosWrappers
 
 
   template <typename number>
-  inline void
+  void
   SparseMatrix::reinit(
     const IndexSet                       &row_parallel_partitioning,
     const IndexSet                       &col_parallel_partitioning,

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -170,7 +170,7 @@ namespace NonMatching
 
 
   template <int dim>
-  inline void
+  void
   FEImmersedSurfaceValues<dim>::initialize(const UpdateFlags update_flags)
   {
     UpdateFlags flags = this->compute_update_flags(update_flags);

--- a/source/non_matching/immersed_surface_quadrature.cc
+++ b/source/non_matching/immersed_surface_quadrature.cc
@@ -51,7 +51,7 @@ namespace NonMatching
 
 
   template <int dim, int spacedim>
-  inline void
+  void
   ImmersedSurfaceQuadrature<dim, spacedim>::clear()
   {
     this->quadrature_points.clear();

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -644,7 +644,7 @@ namespace NonMatching
 
 
       template <int dim>
-      inline void
+      void
       ExtendableQuadrature<dim>::clear()
       {
         this->quadrature_points.clear();


### PR DESCRIPTION
Like the other PR (#19922) I don't think this is wrong but it is unnecessary.