### PR TITLE
Unify the CG solver classes used in step-45 and step-32

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -261,7 +261,7 @@ namespace Step32
         if (do_solve_A == true)
           {
             SolverControl solver_control(5000, utmp.l2_norm() * 1e-2);
-            TrilinosWrappers::SolverCG solver(solver_control);
+            SolverCG<TrilinosWrappers::MPI::Vector> solver(solver_control);
             solver.solve(stokes_matrix->block(0, 0),
                          dst.block(0),
                          utmp,

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -223,9 +223,10 @@ namespace Step45
     TrilinosWrappers::MPI::Vector       &dst,
     const TrilinosWrappers::MPI::Vector &src) const
   {
-    SolverControl              solver_control(src.size(), 1e-6 * src.l2_norm());
-    TrilinosWrappers::SolverCG cg(solver_control,
-                                  TrilinosWrappers::SolverCG::AdditionalData());
+    SolverControl solver_control(src.size(), 1e-6 * src.l2_norm());
+    SolverCG<TrilinosWrappers::MPI::Vector> cg(
+      solver_control,
+      SolverCG<TrilinosWrappers::MPI::Vector>::AdditionalData());
 
     tmp = 0.;
     cg.solve(*matrix, tmp, src, *preconditioner);


### PR DESCRIPTION
step-32 and step-45 are a bit peculiar, because they use the Trilinos CG solver in one place, but the deal.II solver in two other places. This is not documented or explained and I can only assume it was an accident. The Trilinos CG solver is not yet available with the Tpetrawrapper classes (it would be a Belos solver). It would be easiest to just consistently use the deal.II CG solver in these tutorials.

I have checked that the tests for both steps pass with Trilinos-16-2. So far I cannot check with 17, because both steps require #19403, which I need to finish first.