### PR TITLE
Make a Tpetra vector function const

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -957,7 +957,7 @@ namespace LinearAlgebra
        * that sets the parallel partitioning of the vector.
        */
       const TpetraTypes::MapType<MemorySpace> &
-      trilinos_partitioner();
+      trilinos_partitioner() const;
 
       /**
        * Return a const Teuchos::RCP to the underlying Trilinos

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1573,7 +1573,7 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     const TpetraTypes::MapType<MemorySpace> &
-    Vector<Number, MemorySpace>::trilinos_partitioner()
+    Vector<Number, MemorySpace>::trilinos_partitioner() const
     {
       return *vector->getMap();
     }


### PR DESCRIPTION
This function returns a const reference to vector internals, therefore it can be const. More importantly the corresponding function in TrilinosWrappers vector is const, so letting them behave the same makes porting code simpler.