### PR TITLE
Make step-90 compatible with TpetraWrappers

### DIFF
--- a/include/deal.II/lac/trilinos_solver.h
+++ b/include/deal.II/lac/trilinos_solver.h
@@ -16,14 +16,17 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+#ifndef DEAL_II_TRILINOS_WITH_EPETRA
+#  include <deal.II/lac/trilinos_tpetra_solver_direct.h>
+#  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
+#endif
 
+#ifdef DEAL_II_TRILINOS_WITH_EPETRA
 #  include <deal.II/base/template_constraints.h>
 
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/la_parallel_vector.h>
 #  include <deal.II/lac/solver_control.h>
-#  include <deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h>
 #  include <deal.II/lac/vector.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS

--- a/include/deal.II/lac/trilinos_tpetra_solver_direct.h
+++ b/include/deal.II/lac/trilinos_tpetra_solver_direct.h
@@ -193,7 +193,7 @@ namespace LinearAlgebra
        */
       struct AdditionalData
       {
-        AdditionalData(const std::string &solver_name);
+        AdditionalData(const std::string &solver_name = "KLU2");
 
 
         /**

--- a/include/deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h
+++ b/include/deal.II/lac/trilinos_tpetra_to_trilinos_wrappers.h
@@ -86,6 +86,9 @@ namespace LinearAlgebra::TpetraWrappers
 
   template <typename Number, typename MemorySpace>
   class PreconditionAMGMueLu;
+
+  template <typename Number, typename MemorySpace>
+  class SolverDirect;
 } // namespace LinearAlgebra::TpetraWrappers
 #  endif
 
@@ -177,6 +180,13 @@ namespace TrilinosWrappers
   class PreconditionBlockSOR;
   class PreconditionBlockSSOR;
   class PreconditionAMG;
+#  endif
+
+#  ifndef DEAL_II_TRILINOS_WITH_EPETRA
+  using SolverDirect = ::dealii::LinearAlgebra::TpetraWrappers::
+    SolverDirect<double, ::dealii::MemorySpace::Host>;
+#  else
+  class SolverDirect;
 #  endif
 } // namespace TrilinosWrappers
 


### PR DESCRIPTION
These are fixes necessary to let step-90 run without Trilinos Epetra packages (ie let it run with a Tpetra vector and solver).

Necessary fixes:
- `trilinos_solver.h` did not correctly include `trilinos_tpetra_to_trilinos_wrappers.h` if Epetra is not available. Fixed so that the includes work like for the other Tpetra wrapper classes (e.g. `trilinos_sparse_matrix.h`)
- `LinearAlgebra::TpetraWrappers::SolverDirect::AdditionalData` did not specify a default solver, although `TrilinosWrappers::SolverDirect` did. The old default was `Amesos_Klu`, as far as I could tell `KLU2` is the equivalent in Amesos2. This is mostly important to be able to default construct an `AdditionalData` object (which is done in step-90).
- added `SolverDirect` as one of the compatibility class names provided by `trilinos_tpetra_to_trilinos_wrappers.h`, so that users of the old Amesos solvers will automatically use the new solvers as long as they didnt specify a solver name that is no longer available

With these changes step-90 runs successfully with Trilinos 17.