### PR TITLE
Simplify interface to vector access with hanging node constraints 

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2916,28 +2916,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
       if (mask[v] == false)
         cells[v] = numbers::invalid_unsigned_int;
 
-  bool has_hn_constraints = false;
-
-  if (is_face == false)
-    {
-      if (!dof_info.hanging_node_constraint_masks.empty() &&
-          !dof_info.hanging_node_constraint_masks_comp.empty() &&
-          dof_info
-            .hanging_node_constraint_masks_comp[this->active_fe_index]
-                                               [this->first_selected_component])
-        for (unsigned int v = 0; v < n_lanes; ++v)
-          if (cells[v] != numbers::invalid_unsigned_int &&
-              dof_info.hanging_node_constraint_masks[cells[v]] !=
-                internal::MatrixFreeFunctions::
-                  unconstrained_compressed_constraint_kind)
-            has_hn_constraints = true;
-    }
-
   std::bool_constant<internal::is_vectorizable<VectorType, Number>::value>
     vector_selector;
 
   const bool use_vectorized_path =
-    !(masking_is_active || has_hn_constraints || accesses_exterior_dofs);
+    !(masking_is_active || accesses_exterior_dofs);
 
   const std::size_t dofs_per_component = this->data->dofs_per_component_on_cell;
 
@@ -3045,15 +3028,6 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
           if (my_index_start[n_components_read].second !=
               my_index_start[0].second)
             has_constraints = true;
-
-          if (dof_info.hanging_node_constraint_masks.size() > 0 &&
-              dof_info.hanging_node_constraint_masks_comp.size() > 0 &&
-              dof_info.hanging_node_constraint_masks[cells[v]] !=
-                internal::MatrixFreeFunctions::
-                  unconstrained_compressed_constraint_kind &&
-              dof_info.hanging_node_constraint_masks_comp
-                [this->active_fe_index][this->first_selected_component])
-            has_hn_constraints = true;
 
           Assert(my_index_start[n_components_read].first ==
                      my_index_start[0].first ||

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -718,18 +718,9 @@ namespace internal
         }
       else
         {
-#if DEAL_II_VECTORIZATION_WIDTH_IN_BITS < 512 || \
-  !defined(DEAL_II_USE_VECTORIZATION_GATHER)
           for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
             if (indices[v] != numbers::invalid_unsigned_int)
               vec_ptr[indices[v]] += res[v];
-#else
-          // only use gather in case there is also scatter.
-          VectorizedArrayType tmp;
-          tmp.gather(vec_ptr, indices);
-          tmp += res;
-          tmp.scatter(indices, vec_ptr);
-#endif
         }
     }
 

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -693,50 +693,12 @@ namespace internal
                     }
                   else
                     {
-                      const unsigned int *dof_indices =
-                        this->dof_indices.data() +
-                        row_starts[i * vectorization_length * n_components]
-                          .first;
                       if (n_lanes_filled == vectorization_length)
                         index_storage_variants[dof_access_cell][i] =
                           IndexStorageVariants::interleaved;
                       else
                         index_storage_variants[dof_access_cell][i] =
                           IndexStorageVariants::full;
-
-                      // do not use interleaved storage if two entries within
-                      // vectorized array point to the same index (scatter not
-                      // possible due to race condition)
-                      for (const unsigned int *indices = dof_indices;
-                           indices != dof_indices + ndofs;
-                           ++indices)
-                        {
-                          bool         is_sorted = true;
-                          unsigned int previous  = indices[0];
-                          for (unsigned int l = 1; l < n_lanes_filled; ++l)
-                            {
-                              const unsigned int current = indices[l * ndofs];
-                              if (current == numbers::invalid_unsigned_int)
-                                continue;
-
-                              if (current <= previous)
-                                is_sorted = false;
-
-                              // the simple check failed, must compare all
-                              // indices manually - due to short sizes this
-                              // O(n^2) algorithm is better than sorting
-                              if (!is_sorted)
-                                for (unsigned int j = 0; j < l; ++j)
-                                  if (indices[j * ndofs] == current)
-                                    {
-                                      index_storage_variants
-                                        [dof_access_cell][i] =
-                                          IndexStorageVariants::full;
-                                      break;
-                                    }
-                              previous = current;
-                            }
-                        }
                     }
                 }
               else // ndofs == 0


### PR DESCRIPTION
This PR, currently sitting on top of #14324 that is waiting for another review, exploits some of the simplifications enabled by #14324: We can now also use the fast read function in case of hanging-node constraints, which allows me to simplify the code. It is logically separate from the other PR, thus the separate pull request. Only the last commit https://github.com/dealii/dealii/commit/f44f15815caf25160aa0e12ab4d4217d030acd99 is relevant, modifying 1 line and removing 73 lines. The summary is that with the new code does not need to check whether we have hanging nodes before deciding how to access the indices. On this path, I have to avoid the vectorized `scatter` functions that would lead to undefined behavior, but that instruction is often more expensive than the scalar-ized version.