### PR TITLE
Choose more efficient way of asking whether a vector is zero.

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2503,7 +2503,7 @@ namespace internal
         // starting guess for a power iteration, but in neither case a
         // zero vector yields anything useful. So skip the following code and
         // instead use the fallback below if temp_vector1 is the zero vector.
-        if (temp_vector1.l2_norm() != 0.0)
+        if (temp_vector1.all_zero() == false)
           {
             if (data.eigenvalue_algorithm ==
                 internal::EigenvalueAlgorithm::lanczos)


### PR DESCRIPTION
#18178 had one outstanding issue, namely using `v.all_zero() == false` over `v.l2_norm() != 0`, see https://github.com/dealii/dealii/pull/18178#pullrequestreview-2669268797. This patch makes that change.