### PR TITLE
Implement a partition method that takes a zoltan object as argument.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -56,6 +56,10 @@
 #  include <boost/iostreams/stream.hpp>
 #endif
 
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+#  include <zoltan_cpp.h>
+#endif
+
 #include <optional>
 #include <set>
 
@@ -1978,6 +1982,41 @@ namespace GridTools
                           Triangulation<dim, spacedim> &triangulation,
                           const SparsityTools::Partitioner partitioner =
                             SparsityTools::Partitioner::metis);
+
+
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int            n_partitions,
+                          Triangulation<dim, spacedim> &triangulation,
+                          std::unique_ptr<Zoltan>      &zz);
+
+
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int               n_partitions,
+                          const std::vector<unsigned int> &cell_weights,
+                          Triangulation<dim, spacedim>    &triangulation,
+                          std::unique_ptr<Zoltan>         &zz);
+
+
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int            n_partitions,
+                          const SparsityPattern        &cell_connection_graph,
+                          Triangulation<dim, spacedim> &triangulation,
+                          std::unique_ptr<Zoltan>      &zz);
+
+
+
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int               n_partitions,
+                          const std::vector<unsigned int> &cell_weights,
+                          const SparsityPattern        &cell_connection_graph,
+                          Triangulation<dim, spacedim> &triangulation,
+                          std::unique_ptr<Zoltan>      &zz);
+#endif
 
   /**
    * Generates a partitioning of the active cells making up the entire domain

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -24,6 +24,10 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 #include <deal.II/lac/sparsity_pattern.h>
 
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+#  include <zoltan_cpp.h>
+#endif
+
 #include <memory>
 #include <vector>
 
@@ -98,7 +102,8 @@ namespace SparsityTools
   partition(const SparsityPattern     &sparsity_pattern,
             const unsigned int         n_partitions,
             std::vector<unsigned int> &partition_indices,
-            const Partitioner          partitioner = Partitioner::metis);
+            const Partitioner          partitioner = Partitioner::metis,
+            std::unique_ptr<Zoltan>    zz          = nullptr);
 
 
   /**
@@ -117,6 +122,23 @@ namespace SparsityTools
             const unsigned int               n_partitions,
             std::vector<unsigned int>       &partition_indices,
             const Partitioner                partitioner = Partitioner::metis);
+
+
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+  void
+  partition(const SparsityPattern     &sparsity_pattern,
+            const unsigned int         n_partitions,
+            std::vector<unsigned int> &partition_indices,
+            std::unique_ptr<Zoltan>   &zz);
+
+
+  void
+  partition(const SparsityPattern           &sparsity_pattern,
+            const std::vector<unsigned int> &cell_weights,
+            const unsigned int               n_partitions,
+            std::vector<unsigned int>       &partition_indices,
+            std::unique_ptr<Zoltan>         &zz);
+#endif
 
   /**
    * Using a coloring algorithm provided by ZOLTAN to color nodes whose

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1991,6 +1991,203 @@ namespace GridTools
   }
 
 
+
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int            n_partitions,
+                          Triangulation<dim, spacedim> &triangulation,
+                          std::unique_ptr<Zoltan>      &zz)
+  {
+    Assert((dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+              &triangulation) == nullptr),
+           ExcMessage("Objects of type parallel::distributed::Triangulation "
+                      "are already partitioned implicitly and can not be "
+                      "partitioned again explicitly."));
+
+    std::vector<unsigned int> cell_weights;
+
+    // Get cell weighting if a signal has been attached to the triangulation
+    if (!triangulation.signals.weight.empty())
+      {
+        cell_weights.resize(triangulation.n_active_cells(), 0U);
+
+        // In a first step, obtain the weights of the locally owned
+        // cells. For all others, the weight remains at the zero the
+        // vector was initialized with above.
+        for (const auto &cell : triangulation.active_cell_iterators())
+          if (cell->is_locally_owned())
+            cell_weights[cell->active_cell_index()] =
+              triangulation.signals.weight(cell, CellStatus::cell_will_persist);
+
+        // If this is a parallel triangulation, we then need to also
+        // get the weights for all other cells. We have asserted above
+        // that this function can't be used for
+        // parallel::distributed::Triangulation objects, so the only
+        // ones we have to worry about here are
+        // parallel::shared::Triangulation
+        if (const auto shared_tria =
+              dynamic_cast<parallel::shared::Triangulation<dim, spacedim> *>(
+                &triangulation))
+          Utilities::MPI::sum(cell_weights,
+                              shared_tria->get_communicator(),
+                              cell_weights);
+
+        // verify that the global sum of weights is larger than 0
+        Assert(std::accumulate(cell_weights.begin(),
+                               cell_weights.end(),
+                               std::uint64_t(0)) > 0,
+               ExcMessage("The global sum of weights over all active cells "
+                          "is zero. Please verify how you generate weights."));
+      }
+
+    // Call the other more general function
+    partition_triangulation(n_partitions, cell_weights, triangulation, zz);
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int               n_partitions,
+                          const std::vector<unsigned int> &cell_weights,
+                          Triangulation<dim, spacedim>    &triangulation,
+                          std::unique_ptr<Zoltan>         &zz)
+  {
+    Assert((dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+              &triangulation) == nullptr),
+           ExcMessage("Objects of type parallel::distributed::Triangulation "
+                      "are already partitioned implicitly and can not be "
+                      "partitioned again explicitly."));
+    Assert(n_partitions > 0, ExcInvalidNumberOfPartitions(n_partitions));
+
+    // check for an easy return
+    if (n_partitions == 1)
+      {
+        for (const auto &cell : triangulation.active_cell_iterators())
+          cell->set_subdomain_id(0);
+        return;
+      }
+
+    // we decompose the domain by first
+    // generating the connection graph of all
+    // cells with their neighbors, and then
+    // passing this graph off to METIS.
+    // finally defer to the other function for
+    // partitioning and assigning subdomain ids
+    DynamicSparsityPattern cell_connectivity;
+    get_face_connectivity_of_cells(triangulation, cell_connectivity);
+
+    SparsityPattern sp_cell_connectivity;
+    sp_cell_connectivity.copy_from(cell_connectivity);
+    partition_triangulation(
+      n_partitions, cell_weights, sp_cell_connectivity, triangulation, zz);
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int            n_partitions,
+                          const SparsityPattern        &cell_connection_graph,
+                          Triangulation<dim, spacedim> &triangulation,
+                          std::unique_ptr<Zoltan>      &zz)
+  {
+    Assert((dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+              &triangulation) == nullptr),
+           ExcMessage("Objects of type parallel::distributed::Triangulation "
+                      "are already partitioned implicitly and can not be "
+                      "partitioned again explicitly."));
+
+    std::vector<unsigned int> cell_weights;
+
+    // Get cell weighting if a signal has been attached to the triangulation
+    if (!triangulation.signals.weight.empty())
+      {
+        cell_weights.resize(triangulation.n_active_cells(), 0U);
+
+        // In a first step, obtain the weights of the locally owned
+        // cells. For all others, the weight remains at the zero the
+        // vector was initialized with above.
+        for (const auto &cell : triangulation.active_cell_iterators() |
+                                  IteratorFilters::LocallyOwnedCell())
+          cell_weights[cell->active_cell_index()] =
+            triangulation.signals.weight(cell, CellStatus::cell_will_persist);
+
+        // If this is a parallel triangulation, we then need to also
+        // get the weights for all other cells. We have asserted above
+        // that this function can't be used for
+        // parallel::distribute::Triangulation objects, so the only
+        // ones we have to worry about here are
+        // parallel::shared::Triangulation
+        if (const auto shared_tria =
+              dynamic_cast<parallel::shared::Triangulation<dim, spacedim> *>(
+                &triangulation))
+          Utilities::MPI::sum(cell_weights,
+                              shared_tria->get_communicator(),
+                              cell_weights);
+
+        // verify that the global sum of weights is larger than 0
+        Assert(std::accumulate(cell_weights.begin(),
+                               cell_weights.end(),
+                               std::uint64_t(0)) > 0,
+               ExcMessage("The global sum of weights over all active cells "
+                          "is zero. Please verify how you generate weights."));
+      }
+
+    // Call the other more general function
+    partition_triangulation(
+      n_partitions, cell_weights, cell_connection_graph, triangulation, zz);
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  partition_triangulation(const unsigned int               n_partitions,
+                          const std::vector<unsigned int> &cell_weights,
+                          const SparsityPattern        &cell_connection_graph,
+                          Triangulation<dim, spacedim> &triangulation,
+                          std::unique_ptr<Zoltan>      &zz)
+  {
+    Assert((dynamic_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
+              &triangulation) == nullptr),
+           ExcMessage("Objects of type parallel::distributed::Triangulation "
+                      "are already partitioned implicitly and can not be "
+                      "partitioned again explicitly."));
+    Assert(n_partitions > 0, ExcInvalidNumberOfPartitions(n_partitions));
+    Assert(cell_connection_graph.n_rows() == triangulation.n_active_cells(),
+           ExcMessage("Connectivity graph has wrong size"));
+    Assert(cell_connection_graph.n_cols() == triangulation.n_active_cells(),
+           ExcMessage("Connectivity graph has wrong size"));
+
+    // signal that partitioning is going to happen
+    triangulation.signals.pre_partition();
+
+    // check for an easy return
+    if (n_partitions == 1)
+      {
+        for (const auto &cell : triangulation.active_cell_iterators())
+          cell->set_subdomain_id(0);
+        return;
+      }
+
+    // partition this connection graph and get
+    // back a vector of indices, one per degree
+    // of freedom (which is associated with a
+    // cell)
+    std::vector<unsigned int> partition_indices(triangulation.n_active_cells());
+    SparsityTools::partition(
+      cell_connection_graph, cell_weights, n_partitions, partition_indices, zz);
+
+    // finally loop over all cells and set the subdomain ids
+    for (const auto &cell : triangulation.active_cell_iterators())
+      cell->set_subdomain_id(partition_indices[cell->active_cell_index()]);
+  }
+#endif
+
+
+
   namespace internal
   {
     /**

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -323,6 +323,34 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const SparsityTools::Partitioner);
 
       template void
+      partition_triangulation(
+        const unsigned int,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        std::unique_ptr<Zoltan> &);
+
+      template void
+      partition_triangulation(
+        const unsigned int,
+        const std::vector<unsigned int> &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        std::unique_ptr<Zoltan> &);
+
+      template void
+      partition_triangulation(
+        const unsigned int,
+        const SparsityPattern &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        std::unique_ptr<Zoltan> &);
+
+      template void
+      partition_triangulation(
+        const unsigned int,
+        const std::vector<unsigned int> &,
+        const SparsityPattern &,
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        std::unique_ptr<Zoltan> &);
+
+      template void
       partition_triangulation_zorder(
         const unsigned int,
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,

--- a/source/lac/sparsity_tools.cc
+++ b/source/lac/sparsity_tools.cc
@@ -289,7 +289,8 @@ namespace SparsityTools
     partition_zoltan(const SparsityPattern           &sparsity_pattern,
                      const std::vector<unsigned int> &cell_weights,
                      const unsigned int               n_partitions,
-                     std::vector<unsigned int>       &partition_indices)
+                     std::vector<unsigned int>       &partition_indices,
+                     std::unique_ptr<Zoltan>         &zz)
     {
       // Make sure that ZOLTAN is actually
       // installed and detected
@@ -306,32 +307,37 @@ namespace SparsityTools
         ExcMessage(
           "The cell weighting functionality for Zoltan has not yet been implemented."));
 
-      // MPI environment must have been initialized by this point.
-      std::unique_ptr<Zoltan> zz = std::make_unique<Zoltan>(MPI_COMM_SELF);
 
       // General parameters
       // DEBUG_LEVEL call must precede the call to LB_METHOD
-      zz->Set_Param("DEBUG_LEVEL", "0"); // set level of debug info
-      zz->Set_Param(
-        "LB_METHOD",
-        "GRAPH"); // graph based partition method (LB-load balancing)
-      zz->Set_Param("NUM_LOCAL_PARTS",
-                    std::to_string(n_partitions)); // set number of partitions
+      if (!zz)
+        {
+          // zz is null:
+          /* MPI environment must have been initialized by this point.*/
+          zz = std::make_unique<Zoltan>(MPI_COMM_SELF);
 
-      // The PHG partitioner is a hypergraph partitioner that Zoltan could use
-      // for graph partitioning.
-      // If number of vertices in hyperedge divided by total vertices in
-      // hypergraph exceeds PHG_EDGE_SIZE_THRESHOLD,
-      // then the hyperedge will be omitted as such (dense) edges will likely
-      // incur high communication costs regardless of the partition.
-      // PHG_EDGE_SIZE_THRESHOLD value is raised to 0.5 from the default
-      // value of 0.25 so that the PHG partitioner doesn't throw warning saying
-      // "PHG_EDGE_SIZE_THRESHOLD is low ..." after removing all dense edges.
-      // For instance, in two dimensions if the triangulation being partitioned
-      // is two quadrilaterals sharing an edge and if PHG_EDGE_SIZE_THRESHOLD
-      // value is set to 0.25, PHG will remove all the edges throwing the
-      // above warning.
-      zz->Set_Param("PHG_EDGE_SIZE_THRESHOLD", "0.5");
+          zz->Set_Param("DEBUG_LEVEL", "0"); // set level of debug info
+          zz->Set_Param(
+            "LB_METHOD",
+            "GRAPH"); // graph based partition method (LB-load balancing)
+          zz->Set_Param("NUM_LOCAL_PARTS",
+                        std::to_string(
+                          n_partitions)); // set number of partitions
+
+          // The PHG partitioner is a hypergraph partitioner that Zoltan could
+          // use for graph partitioning. If number of vertices in hyperedge
+          // divided by total vertices in hypergraph exceeds
+          // PHG_EDGE_SIZE_THRESHOLD, then the hyperedge will be omitted as such
+          // (dense) edges will likely incur high communication costs regardless
+          // of the partition. PHG_EDGE_SIZE_THRESHOLD value is raised to 0.5
+          // from the default value of 0.25 so that the PHG partitioner doesn't
+          // throw warning saying "PHG_EDGE_SIZE_THRESHOLD is low ..." after
+          // removing all dense edges. For instance, in two dimensions if the
+          // triangulation being partitioned is two quadrilaterals sharing an
+          // edge and if PHG_EDGE_SIZE_THRESHOLD value is set to 0.25, PHG will
+          // remove all the edges throwing the above warning.
+          zz->Set_Param("PHG_EDGE_SIZE_THRESHOLD", "0.5");
+        }
 
       // Need a non-const object equal to sparsity_pattern
       SparsityPattern graph;
@@ -407,6 +413,7 @@ namespace SparsityTools
   }
 
 
+
   void
   partition(const SparsityPattern           &sparsity_pattern,
             const std::vector<unsigned int> &cell_weights,
@@ -437,13 +444,62 @@ namespace SparsityTools
                       n_partitions,
                       partition_indices);
     else if (partitioner == Partitioner::zoltan)
-      partition_zoltan(sparsity_pattern,
-                       cell_weights,
-                       n_partitions,
-                       partition_indices);
+      {
+        std::unique_ptr<Zoltan> zz = nullptr;
+        partition_zoltan(
+          sparsity_pattern, cell_weights, n_partitions, partition_indices, zz);
+      }
     else
       AssertThrow(false, ExcInternalError());
   }
+
+
+
+#ifdef DEAL_II_TRILINOS_WITH_ZOLTAN
+  void
+  partition(const SparsityPattern     &sparsity_pattern,
+            const unsigned int         n_partitions,
+            std::vector<unsigned int> &partition_indices,
+            std::unique_ptr<Zoltan>   &zz)
+  {
+    std::vector<unsigned int> cell_weights;
+
+    // Call the other more general function
+    partition(
+      sparsity_pattern, cell_weights, n_partitions, partition_indices, zz);
+  }
+
+
+
+  void
+  partition(const SparsityPattern           &sparsity_pattern,
+            const std::vector<unsigned int> &cell_weights,
+            const unsigned int               n_partitions,
+            std::vector<unsigned int>       &partition_indices,
+            std::unique_ptr<Zoltan>         &zz)
+  {
+    Assert(sparsity_pattern.n_rows() == sparsity_pattern.n_cols(),
+           ExcNotQuadratic());
+    Assert(sparsity_pattern.is_compressed(),
+           SparsityPattern::ExcNotCompressed());
+
+    Assert(n_partitions > 0, ExcInvalidNumberOfPartitions(n_partitions));
+    Assert(partition_indices.size() == sparsity_pattern.n_rows(),
+           ExcInvalidArraySize(partition_indices.size(),
+                               sparsity_pattern.n_rows()));
+
+    // check for an easy return
+    if (n_partitions == 1 || (sparsity_pattern.n_rows() == 1))
+      {
+        std::fill_n(partition_indices.begin(), partition_indices.size(), 0U);
+        return;
+      }
+
+    partition_zoltan(
+      sparsity_pattern, cell_weights, n_partitions, partition_indices, zz);
+  }
+#endif
+
 
 
   unsigned int


### PR DESCRIPTION
I was cleaning up my old deal.II branches, and found this:
Some time ago, I implemented a partition method that takes a (Trilinos-) Zoltan object as an argument, allowing full control over the Zoltan parameters. 

My question is: Is this of any interest?

As I do not know if this fits into deal.II, I just created this PR as it is.

If this does not fit into deal.II, please feel free to just close this PR.