### PR TITLE
Preprocessor macros for Tpetra vector element access

### DIFF
--- a/include/deal.II/lac/vector_element_access.h
+++ b/include/deal.II/lac/vector_element_access.h
@@ -121,10 +121,11 @@ namespace internal
 
     return vector[0][trilinos_i];
   }
+#endif
 
 
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template <typename NumberType, typename MemorySpace>
   struct ElementAccess<
     LinearAlgebra::TpetraWrappers::Vector<NumberType, MemorySpace>>
@@ -148,7 +149,7 @@ namespace internal
 
 
 
-#    ifndef DOXYGEN
+#  ifndef DOXYGEN
   template <typename NumberType, typename MemorySpace>
   inline void
   ElementAccess<
@@ -212,7 +213,6 @@ namespace internal
         static_cast<TrilinosWrappers::types::int_type>(i));
     return vector_1d(trilinos_i);
   }
-#    endif
 #  endif
 #endif
 } // namespace internal


### PR DESCRIPTION
These preprocessor macros were subtly wrong. We want to implement the Epetra vector specializations if `DEAL_II_TRILINOS_WITH_EPETRA` (correct). And we want the Tpetra vector specialization if `DEAL_II_TRILINOS_WITH_TPETRA` (instead of both Epetra and Tpetra).