### PR TITLE
Remove an unnecessary #include from step-39.

### DIFF
--- a/examples/step-39/step-39.cc
+++ b/examples/step-39/step-39.cc
@@ -40,9 +40,6 @@
 // The include file for using MeshWorker::mesh_loop()
 #include <deal.II/meshworker/mesh_loop.h>
 
-// The include file for local integrators associated with the Laplacian
-#include <deal.II/integrators/laplace.h>
-
 // Support for multigrid methods
 #include <deal.II/multigrid/mg_tools.h>
 #include <deal.II/multigrid/multigrid.h>


### PR DESCRIPTION
Follow-up to #17016 and #19863.