### PR TITLE
Optimize CellIDTransfer a bit.

### DIFF
--- a/include/deal.II/distributed/repartitioning_policy_tools.h
+++ b/include/deal.II/distributed/repartitioning_policy_tools.h
@@ -13,6 +13,7 @@
 #ifndef dealii_distributed_repartitioning_policy_tools_h
 #define dealii_distributed_repartitioning_policy_tools_h
 
+#include <deal.II/grid/cell_id_translator.h>
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/lac/la_parallel_vector.h>
@@ -103,15 +104,7 @@ namespace RepartitioningPolicyTools
       const Triangulation<dim, spacedim> &tria_coarse_in) const override;
 
   private:
-    /**
-     * Number of coarse cells.
-     */
-    const unsigned int n_coarse_cells;
-
-    /**
-     * Number of global levels.
-     */
-    const unsigned int n_global_levels;
+    internal::CellIDTranslator<dim> cell_id_translator;
 
     /**
      * Index set constructed from the triangulation passed to the constructor.

--- a/include/deal.II/grid/cell_id_translator.h
+++ b/include/deal.II/grid/cell_id_translator.h
@@ -112,8 +112,10 @@ namespace internal
 
     /**
      * Whether or not the Triangulation has Pyramid elements. If so we must
-     * assume the maximum number of children per cell is 10. Otherwise we may
-     * assume it is 2**dim.
+     * assume the maximum number of children per cell is
+     * ReferenceCells::Pyramid.n_isotropic_children() (10). Otherwise we may
+     * assume it is ReferenceCells::get_hypercube<dim>.n_isotropic_children()
+     * (2**dim).
      */
     const bool has_pyramids;
 
@@ -121,8 +123,9 @@ namespace internal
      * Maximum number of children per cell.
      *
      * @note If possible, avoid dividing by this value for performance reasons.
-     * In that circumstance check has_pyramids and, if it is false, use the
-     * 2**dim instead to improve performance.
+     * See the implementation of to_cell_id() for a workaround. In contrast,
+     * multiplication by a known constant isn't much faster than by an arbitrary
+     * integer so that case does not require a workaround.
      */
     const unsigned int max_children_per_cell;
 

--- a/include/deal.II/grid/cell_id_translator.h
+++ b/include/deal.II/grid/cell_id_translator.h
@@ -86,8 +86,8 @@ namespace internal
      * DoFCellAccessor to an index unique on a level.
      */
     template <typename Accessor>
-    static types::global_cell_index
-    translate_level(const TriaIterator<Accessor> &cell);
+    types::global_cell_index
+    translate_level(const TriaIterator<Accessor> &cell) const;
 
     /**
      * Convert the @p i-th child of @p to an index.
@@ -107,8 +107,24 @@ namespace internal
     /**
      * Convert a CellId to a index on that cell's level.
      */
-    static types::global_cell_index
-    to_level_cell_index(const CellId &cell_id);
+    types::global_cell_index
+    to_level_cell_index(const CellId &cell_id) const;
+
+    /**
+     * Whether or not the Triangulation has Pyramid elements. If so we must
+     * assume the maximum number of children per cell is 10. Otherwise we may
+     * assume it is 2**dim.
+     */
+    const bool has_pyramids;
+
+    /**
+     * Maximum number of children per cell.
+     *
+     * @note If possible, avoid dividing by this value for performance reasons.
+     * In that circumstance check has_pyramids and, if it is false, use the
+     * 2**dim instead to improve performance.
+     */
+    const unsigned int max_children_per_cell;
 
     /**
      * Number of global coarse cells.
@@ -133,8 +149,8 @@ namespace internal
   CellIDTranslator<dim>::size() const
   {
     return n_coarse_cells *
-           (Utilities::pow<types::global_cell_index>(
-              ReferenceCells::max_n_children<dim>(), n_global_levels) -
+           (Utilities::pow<types::global_cell_index>(max_children_per_cell,
+                                                     n_global_levels) -
             1);
   }
 
@@ -157,7 +173,8 @@ namespace internal
   template <int dim>
   template <typename Accessor>
   types::global_cell_index
-  CellIDTranslator<dim>::translate_level(const TriaIterator<Accessor> &cell)
+  CellIDTranslator<dim>::translate_level(
+    const TriaIterator<Accessor> &cell) const
   {
     static_assert(dim == Accessor::dimension &&
                     dim == Accessor::structure_dimension,
@@ -180,7 +197,7 @@ namespace internal
                   "The information can only be queried for cells.");
 
     return (translate(cell) - tree_sizes[cell->level()]) *
-             ReferenceCells::max_n_children<dim>() +
+             max_children_per_cell +
            i + tree_sizes[cell->level() + 1];
   }
 } // namespace internal

--- a/include/deal.II/grid/cell_id_translator.h
+++ b/include/deal.II/grid/cell_id_translator.h
@@ -14,13 +14,14 @@
 #define dealii_cell_id_translator_h
 
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/cell_id.h>
 #include <deal.II/grid/tria_accessor.h>
 
 #include <cstdint>
 #include <limits>
+#include <vector>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -122,56 +123,6 @@ namespace internal
 
 
   template <int dim>
-  CellIDTranslator<dim>::CellIDTranslator(
-    const types::global_cell_index n_coarse_cells,
-    const types::global_cell_index n_global_levels)
-    : n_coarse_cells(n_coarse_cells)
-    , n_global_levels(n_global_levels)
-  {
-    // The class stores indices as types::global_cell_index variables,
-    // but when configuring deal.II with default flags, this is a 32-bit
-    // data type and it is possible with highly (locally) refined meshes
-    // that we exceed the maximal 32-bit numbers even with relatively
-    // modest numbers of cells. Check for this by first calculating
-    // the maximal index we will get in 64-bit arithmetic and testing
-    // that it is representable in 32-bit arithmetic:
-    std::uint64_t max_cell_index = 0;
-
-    for (unsigned int i = 0; i < n_global_levels; ++i)
-      max_cell_index +=
-        Utilities::pow<std::uint64_t>(ReferenceCells::max_n_children<dim>(),
-                                      i) *
-        n_coarse_cells;
-
-    max_cell_index -= 1;
-
-    AssertThrow(
-      max_cell_index <= std::numeric_limits<types::global_cell_index>::max(),
-      ExcMessage(
-        "You have exceeded the maximal number of possible indices this function "
-        "can handle. The current setup (n_coarse_cells=" +
-        std::to_string(n_coarse_cells) +
-        ", n_global_levels=" + std::to_string(n_global_levels) + ") requires " +
-        std::to_string(max_cell_index + 1) +
-        " indices but the current deal.II configuration only supports " +
-        std::to_string(std::numeric_limits<types::global_cell_index>::max()) +
-        " indices. You may want to consider to build deal.II with 64bit "
-        "indices (-D DEAL_II_WITH_64BIT_INDICES=\"ON\") to increase the limit "
-        "of indices."));
-
-    // Now do the whole computation again, but for real:
-    tree_sizes.reserve(n_global_levels + 1);
-    tree_sizes.push_back(0);
-    for (unsigned int i = 0; i < n_global_levels; ++i)
-      tree_sizes.push_back(tree_sizes.back() +
-                           Utilities::pow<types::global_cell_index>(
-                             ReferenceCells::max_n_children<dim>(), i) *
-                             n_coarse_cells);
-  }
-
-
-
-  template <int dim>
   types::global_cell_index
   CellIDTranslator<dim>::size() const
   {
@@ -225,52 +176,6 @@ namespace internal
     return (translate(cell) - tree_sizes[cell->level()]) *
              ReferenceCells::max_n_children<dim>() +
            i + tree_sizes[cell->level() + 1];
-  }
-
-
-
-  template <int dim>
-  CellId
-  CellIDTranslator<dim>::to_cell_id(const types::global_cell_index id) const
-  {
-    std::vector<std::uint8_t> child_indices;
-
-    types::global_cell_index id_temp = id;
-
-    types::global_cell_index level = 0;
-
-    for (; level < n_global_levels; ++level)
-      if (id < tree_sizes[level])
-        break;
-    level -= 1;
-
-    id_temp -= tree_sizes[level];
-
-    for (types::global_cell_index l = 0; l < level; ++l)
-      {
-        child_indices.push_back(id_temp %
-                                ReferenceCells::max_n_children<dim>());
-        id_temp /= ReferenceCells::max_n_children<dim>();
-      }
-
-    std::reverse(child_indices.begin(), child_indices.end());
-
-    return {id_temp, child_indices};
-  }
-
-
-
-  template <int dim>
-  types::global_cell_index
-  CellIDTranslator<dim>::to_level_cell_index(const CellId &cell_id)
-  {
-    // compute level id: c_{i+1} = c_{i}*(max_n_children) + q on path to cell
-    auto level_cell_id = cell_id.get_coarse_cell_id();
-    for (const auto &child_index : cell_id.get_child_indices())
-      level_cell_id =
-        level_cell_id * ReferenceCells::max_n_children<dim>() + child_index;
-
-    return level_cell_id;
   }
 } // namespace internal
 

--- a/include/deal.II/grid/cell_id_translator.h
+++ b/include/deal.II/grid/cell_id_translator.h
@@ -14,6 +14,7 @@
 #define dealii_cell_id_translator_h
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/template_constraints.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/cell_id.h>
@@ -24,6 +25,13 @@
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
+
+// Forward declarations
+#ifndef DOXYGEN
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+class Triangulation;
+#endif
 
 namespace internal
 {
@@ -36,8 +44,7 @@ namespace internal
    * cells, using this class:
    * @code
    * // set up translator
-   * CellIDTranslator<dim> translator(tria.n_global_coarse_cells(),
-   *                                  tria.n_global_levels());
+   * CellIDTranslator<dim> translator(tria);
    *
    * // initialize the index set with the correct size
    * IndexSet index_set(translator.size());
@@ -54,11 +61,10 @@ namespace internal
   {
   public:
     /**
-     * Constructor taking the number of global coarse cells and number of
-     * global levels of a triangulation.
+     * Constructor.
      */
-    CellIDTranslator(const types::global_cell_index n_coarse_cells,
-                     const types::global_cell_index n_global_levels);
+    template <int spacedim>
+    CellIDTranslator(const Triangulation<dim, spacedim> &tria);
 
     /**
      * Return maximum number of cells, i.e., in the case the triangulation

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.templates.h
@@ -795,9 +795,7 @@ namespace internal
       , communicator(
           dof_handler_fine
             .get_mpi_communicator() /*TODO: fix for different comms*/)
-      , cell_id_translator(
-          dof_handler_fine.get_triangulation().n_global_coarse_cells(),
-          dof_handler_fine.get_triangulation().n_global_levels())
+      , cell_id_translator(dof_handler_fine.get_triangulation())
     {
       AssertDimension(
         dof_handler_fine.get_triangulation().n_global_coarse_cells(),
@@ -3712,8 +3710,7 @@ MGTwoLevelTransfer<dim, VectorType>::reinit(
   if (do_polynomial_transfer == false)
     {
       const internal::CellIDTranslator<dim> cell_id_translator(
-        dof_handler_fine.get_triangulation().n_global_coarse_cells(),
-        dof_handler_fine.get_triangulation().n_global_levels());
+        dof_handler_fine.get_triangulation());
 
       AssertDimension(
         dof_handler_fine.get_triangulation().n_global_coarse_cells(),

--- a/source/distributed/repartitioning_policy_tools.cc
+++ b/source/distributed/repartitioning_policy_tools.cc
@@ -105,18 +105,14 @@ namespace RepartitioningPolicyTools
   template <int dim, int spacedim>
   FirstChildPolicy<dim, spacedim>::FirstChildPolicy(
     const Triangulation<dim, spacedim> &tria_fine)
-    : n_coarse_cells(tria_fine.n_global_coarse_cells())
-    , n_global_levels(tria_fine.n_global_levels())
+    : cell_id_translator(tria_fine)
   {
     Assert(
       tria_fine.all_reference_cells_are_hyper_cube(),
       ExcMessage(
         "FirstChildPolicy is only working for pure hex meshes at the moment."));
 
-    const internal::CellIDTranslator<dim> cell_id_translator(n_coarse_cells,
-                                                             n_global_levels);
     is_level_partitions.set_size(cell_id_translator.size());
-
     for (const auto &cell : tria_fine.active_cell_iterators())
       if (cell->is_locally_owned())
         add_indices_recursively_for_first_child_policy(cell,
@@ -133,11 +129,7 @@ namespace RepartitioningPolicyTools
   {
     const auto communicator = tria_coarse_in.get_mpi_communicator();
 
-    const internal::CellIDTranslator<dim> cell_id_translator(n_coarse_cells,
-                                                             n_global_levels);
-
     IndexSet is_coarse(cell_id_translator.size());
-
     for (const auto &cell : tria_coarse_in.active_cell_iterators())
       if (cell->is_locally_owned())
         is_coarse.add_index(cell_id_translator.translate(cell));

--- a/source/grid/CMakeLists.txt
+++ b/source/grid/CMakeLists.txt
@@ -29,6 +29,7 @@ endif()
 
 set(_unity_include_src
   cell_id.cc
+  cell_id_translator.cc
   grid_refinement.cc
   intergrid_map.cc
   manifold.cc
@@ -69,6 +70,7 @@ setup_source_list("${_unity_include_src}"
 
 set(_inst
   cell_id.inst.in
+  cell_id_translator.inst.in
   grid_generator_cgal.inst.in
   grid_generator_from_name.inst.in
   grid_generator.inst.in

--- a/source/grid/cell_id_translator.cc
+++ b/source/grid/cell_id_translator.cc
@@ -15,6 +15,7 @@
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/cell_id_translator.h>
+#include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 
 #include <algorithm>
@@ -26,11 +27,11 @@ DEAL_II_NAMESPACE_OPEN
 namespace internal
 {
   template <int dim>
+  template <int spacedim>
   CellIDTranslator<dim>::CellIDTranslator(
-    const types::global_cell_index n_coarse_cells,
-    const types::global_cell_index n_global_levels)
-    : n_coarse_cells(n_coarse_cells)
-    , n_global_levels(n_global_levels)
+    const Triangulation<dim, spacedim> &tria)
+    : n_coarse_cells(tria.n_global_coarse_cells())
+    , n_global_levels(tria.n_global_levels())
   {
     // The class stores indices as types::global_cell_index variables,
     // but when configuring deal.II with default flags, this is a 32-bit

--- a/source/grid/cell_id_translator.cc
+++ b/source/grid/cell_id_translator.cc
@@ -11,6 +11,7 @@
 // -----------------------------------------------------------------------------
 
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/std_cxx26/inplace_vector.h>
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/grid/cell_id_translator.h>
@@ -78,20 +79,18 @@ namespace internal
   CellId
   CellIDTranslator<dim>::to_cell_id(const types::global_cell_index id) const
   {
-    std::vector<std::uint8_t> child_indices;
+    std_cxx26::inplace_vector<std::uint8_t, numbers::max_n_levels - 1>
+      child_indices;
 
-    types::global_cell_index id_temp = id;
-
-    types::global_cell_index level = 0;
-
+    std::uint8_t level = 0;
     for (; level < n_global_levels; ++level)
       if (id < tree_sizes[level])
         break;
+    Assert(level > 0, ExcInternalError());
     level -= 1;
 
-    id_temp -= tree_sizes[level];
-
-    for (types::global_cell_index l = 0; l < level; ++l)
+    types::coarse_cell_id id_temp = id - tree_sizes[level];
+    for (std::uint8_t l = 0; l < level; ++l)
       {
         child_indices.push_back(id_temp %
                                 ReferenceCells::max_n_children<dim>());
@@ -100,7 +99,9 @@ namespace internal
 
     std::reverse(child_indices.begin(), child_indices.end());
 
-    return {id_temp, child_indices};
+    return CellId(id_temp,
+                  static_cast<unsigned int>(child_indices.size()),
+                  child_indices.data());
   }
 
 

--- a/source/grid/cell_id_translator.cc
+++ b/source/grid/cell_id_translator.cc
@@ -100,8 +100,29 @@ namespace internal
     types::coarse_cell_id id_temp = id - tree_sizes[level];
     for (std::uint8_t l = 0; l < level; ++l)
       {
-        child_indices.push_back(id_temp % max_children_per_cell);
-        id_temp /= max_children_per_cell;
+        // Dividing by a known constant is much more efficient than diving by an
+        // arbitrary integer, so special case Pyramids and non-Pyramids:
+        if (has_pyramids)
+          {
+            constexpr unsigned int pyramid_max_children_per_cell =
+              ReferenceCells::Pyramid.n_isotropic_children();
+            Assert(max_children_per_cell <= pyramid_max_children_per_cell,
+                   ExcNotImplemented());
+            child_indices.push_back(id_temp % pyramid_max_children_per_cell);
+            id_temp /= pyramid_max_children_per_cell;
+          }
+        else
+          {
+            constexpr unsigned int hypercube_max_children_per_cell =
+              ReferenceCells::get_hypercube<dim>().n_isotropic_children();
+            // this value is equal for simplices and wedges (i.e., not pyramids)
+            // but we only need it to bound the actual maximum number of
+            // children per cell for this to work
+            Assert(max_children_per_cell <= hypercube_max_children_per_cell,
+                   ExcNotImplemented());
+            child_indices.push_back(id_temp % hypercube_max_children_per_cell);
+            id_temp /= hypercube_max_children_per_cell;
+          }
       }
 
     std::reverse(child_indices.begin(), child_indices.end());

--- a/source/grid/cell_id_translator.cc
+++ b/source/grid/cell_id_translator.cc
@@ -1,0 +1,127 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2021 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/grid/cell_id_translator.h>
+#include <deal.II/grid/tria_accessor.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  template <int dim>
+  CellIDTranslator<dim>::CellIDTranslator(
+    const types::global_cell_index n_coarse_cells,
+    const types::global_cell_index n_global_levels)
+    : n_coarse_cells(n_coarse_cells)
+    , n_global_levels(n_global_levels)
+  {
+    // The class stores indices as types::global_cell_index variables,
+    // but when configuring deal.II with default flags, this is a 32-bit
+    // data type and it is possible with highly (locally) refined meshes
+    // that we exceed the maximal 32-bit numbers even with relatively
+    // modest numbers of cells. Check for this by first calculating
+    // the maximal index we will get in 64-bit arithmetic and testing
+    // that it is representable in 32-bit arithmetic:
+    std::uint64_t max_cell_index = 0;
+
+    for (unsigned int i = 0; i < n_global_levels; ++i)
+      max_cell_index +=
+        Utilities::pow<std::uint64_t>(ReferenceCells::max_n_children<dim>(),
+                                      i) *
+        n_coarse_cells;
+
+    max_cell_index -= 1;
+
+    AssertThrow(
+      max_cell_index <= std::numeric_limits<types::global_cell_index>::max(),
+      ExcMessage(
+        "You have exceeded the maximal number of possible indices this function "
+        "can handle. The current setup (n_coarse_cells=" +
+        std::to_string(n_coarse_cells) +
+        ", n_global_levels=" + std::to_string(n_global_levels) + ") requires " +
+        std::to_string(max_cell_index + 1) +
+        " indices but the current deal.II configuration only supports " +
+        std::to_string(std::numeric_limits<types::global_cell_index>::max()) +
+        " indices. You may want to consider to build deal.II with 64bit "
+        "indices (-D DEAL_II_WITH_64BIT_INDICES=\"ON\") to increase the limit "
+        "of indices."));
+
+    // Now do the whole computation again, but for real:
+    tree_sizes.reserve(n_global_levels + 1);
+    tree_sizes.push_back(0);
+    for (unsigned int i = 0; i < n_global_levels; ++i)
+      tree_sizes.push_back(tree_sizes.back() +
+                           Utilities::pow<types::global_cell_index>(
+                             ReferenceCells::max_n_children<dim>(), i) *
+                             n_coarse_cells);
+  }
+
+
+
+  template <int dim>
+  CellId
+  CellIDTranslator<dim>::to_cell_id(const types::global_cell_index id) const
+  {
+    std::vector<std::uint8_t> child_indices;
+
+    types::global_cell_index id_temp = id;
+
+    types::global_cell_index level = 0;
+
+    for (; level < n_global_levels; ++level)
+      if (id < tree_sizes[level])
+        break;
+    level -= 1;
+
+    id_temp -= tree_sizes[level];
+
+    for (types::global_cell_index l = 0; l < level; ++l)
+      {
+        child_indices.push_back(id_temp %
+                                ReferenceCells::max_n_children<dim>());
+        id_temp /= ReferenceCells::max_n_children<dim>();
+      }
+
+    std::reverse(child_indices.begin(), child_indices.end());
+
+    return {id_temp, child_indices};
+  }
+
+
+
+  template <int dim>
+  types::global_cell_index
+  CellIDTranslator<dim>::to_level_cell_index(const CellId &cell_id)
+  {
+    // compute level id: c_{i+1} = c_{i}*(max_n_children) + q on path to cell
+    auto level_cell_id = cell_id.get_coarse_cell_id();
+    for (const auto &child_index : cell_id.get_child_indices())
+      level_cell_id =
+        level_cell_id * ReferenceCells::max_n_children<dim>() + child_index;
+
+    return level_cell_id;
+  }
+
+} // namespace internal
+
+
+// explicit instantiations
+#include "grid/cell_id_translator.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/grid/cell_id_translator.cc
+++ b/source/grid/cell_id_translator.cc
@@ -30,7 +30,15 @@ namespace internal
   template <int spacedim>
   CellIDTranslator<dim>::CellIDTranslator(
     const Triangulation<dim, spacedim> &tria)
-    : n_coarse_cells(tria.n_global_coarse_cells())
+    : has_pyramids(dim == 3 && std::find(tria.get_reference_cells().begin(),
+                                         tria.get_reference_cells().end(),
+                                         ReferenceCells::Pyramid) !=
+                                 tria.get_reference_cells().end())
+    , max_children_per_cell(
+        has_pyramids ?
+          ReferenceCells::max_n_children<dim>() :
+          ReferenceCells::get_hypercube<dim>().n_isotropic_children())
+    , n_coarse_cells(tria.n_global_coarse_cells())
     , n_global_levels(tria.n_global_levels())
   {
     // The class stores indices as types::global_cell_index variables,
@@ -44,8 +52,7 @@ namespace internal
 
     for (unsigned int i = 0; i < n_global_levels; ++i)
       max_cell_index +=
-        Utilities::pow<std::uint64_t>(ReferenceCells::max_n_children<dim>(),
-                                      i) *
+        Utilities::pow<std::uint64_t>(max_children_per_cell, i) *
         n_coarse_cells;
 
     max_cell_index -= 1;
@@ -68,10 +75,10 @@ namespace internal
     tree_sizes.reserve(n_global_levels + 1);
     tree_sizes.push_back(0);
     for (unsigned int i = 0; i < n_global_levels; ++i)
-      tree_sizes.push_back(tree_sizes.back() +
-                           Utilities::pow<types::global_cell_index>(
-                             ReferenceCells::max_n_children<dim>(), i) *
-                             n_coarse_cells);
+      tree_sizes.push_back(
+        tree_sizes.back() +
+        Utilities::pow<types::global_cell_index>(max_children_per_cell, i) *
+          n_coarse_cells);
   }
 
 
@@ -93,9 +100,8 @@ namespace internal
     types::coarse_cell_id id_temp = id - tree_sizes[level];
     for (std::uint8_t l = 0; l < level; ++l)
       {
-        child_indices.push_back(id_temp %
-                                ReferenceCells::max_n_children<dim>());
-        id_temp /= ReferenceCells::max_n_children<dim>();
+        child_indices.push_back(id_temp % max_children_per_cell);
+        id_temp /= max_children_per_cell;
       }
 
     std::reverse(child_indices.begin(), child_indices.end());
@@ -109,13 +115,12 @@ namespace internal
 
   template <int dim>
   types::global_cell_index
-  CellIDTranslator<dim>::to_level_cell_index(const CellId &cell_id)
+  CellIDTranslator<dim>::to_level_cell_index(const CellId &cell_id) const
   {
     // compute level id: c_{i+1} = c_{i}*(max_n_children) + q on path to cell
     auto level_cell_id = cell_id.get_coarse_cell_id();
     for (const auto &child_index : cell_id.get_child_indices())
-      level_cell_id =
-        level_cell_id * ReferenceCells::max_n_children<dim>() + child_index;
+      level_cell_id = level_cell_id * max_children_per_cell + child_index;
 
     return level_cell_id;
   }

--- a/source/grid/cell_id_translator.inst.in
+++ b/source/grid/cell_id_translator.inst.in
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2021 - 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+for (deal_II_dimension : DIMENSIONS)
+  {
+    namespace internal
+    \{
+      template class CellIDTranslator<deal_II_dimension>;
+    \}
+  }

--- a/source/grid/cell_id_translator.inst.in
+++ b/source/grid/cell_id_translator.inst.in
@@ -11,11 +11,16 @@
 // -----------------------------------------------------------------------------
 
 
-
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
     namespace internal
     \{
+#if deal_II_dimension == deal_II_space_dimension
       template class CellIDTranslator<deal_II_dimension>;
+#endif
+#if deal_II_dimension <= deal_II_space_dimension
+      template CellIDTranslator<deal_II_dimension>::CellIDTranslator(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+#endif
     \}
   }

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1733,11 +1733,8 @@ namespace MGTools
         const auto &tria_coarse = *trias[lvl];
         const auto &tria_fine   = *trias[lvl + 1];
 
-        const unsigned int n_coarse_cells  = tria_fine.n_global_coarse_cells();
-        const unsigned int n_global_levels = tria_fine.n_global_levels();
-
         const dealii::internal::CellIDTranslator<dim> cell_id_translator(
-          n_coarse_cells, n_global_levels);
+          tria_fine);
 
         IndexSet is_fine_owned(cell_id_translator.size());
         IndexSet is_fine_required(cell_id_translator.size());

--- a/tests/multigrid-global-coarsening/global_id_01.cc
+++ b/tests/multigrid-global-coarsening/global_id_01.cc
@@ -13,22 +13,9 @@
 
 // Test CellIDTranslator.
 
-#include <deal.II/base/mpi_consensus_algorithms.h>
-
-#include <deal.II/distributed/fully_distributed_tria.h>
-#include <deal.II/distributed/tria.h>
-
-#include <deal.II/dofs/dof_tools.h>
-
-#include <deal.II/fe/fe_q.h>
-
+#include <deal.II/grid/cell_id_translator.h>
 #include <deal.II/grid/grid_generator.h>
-
-#include <deal.II/lac/la_parallel_vector.h>
-
-#include <deal.II/multigrid/mg_transfer_matrix_free.templates.h>
-
-#include <set>
+#include <deal.II/grid/tria.h>
 
 #include "../tests.h"
 
@@ -40,27 +27,13 @@ test(const MPI_Comm comm)
   GridGenerator::subdivided_hyper_cube(basetria, 4);
   basetria.refine_global(4);
 
-  const auto determine_n_coarse_cells = [&comm](auto &tria) {
-    types::coarse_cell_id n_coarse_cells = 0;
-
-    for (auto cell : tria.active_cell_iterators())
-      if (!cell->is_artificial())
-        n_coarse_cells =
-          std::max(n_coarse_cells, cell->id().get_coarse_cell_id());
-
-    return Utilities::MPI::max(n_coarse_cells, comm) + 1;
-  };
-
   // create translator: CellID <-> unique ID
-  internal::CellIDTranslator<dim> cell_id_translator(
-    determine_n_coarse_cells(basetria), basetria.n_global_levels());
-
-
-  for (auto cell : basetria.cell_iterators())
+  internal::CellIDTranslator<dim> cell_id_translator(basetria);
+  for (const auto &cell : basetria.cell_iterators())
     {
       Assert(cell->id() == cell_id_translator.to_cell_id(
                              cell_id_translator.translate(cell)),
-             ExcNotImplemented());
+             ExcInternalError());
 
       if (cell->has_children())
         {
@@ -69,7 +42,7 @@ test(const MPI_Comm comm)
               Assert(cell->child(c)->id() ==
                        cell_id_translator.to_cell_id(
                          cell_id_translator.translate(cell, c)),
-                     ExcNotImplemented());
+                     ExcInternalError());
             }
         }
     }


### PR DESCRIPTION
Fixes #19918. I didn't rerun the performance benchmarks but I'm reasonably sure this will fix the performance issue @kronbichler tracked down for a few reasons:
1. It returns the index spaces to their original sizes (i.e., it calculates the maximum size for hypercubes via 8 children per cell instead of 10)
2. It avoids dividing by a non-power of 2 by storing a bool indicating whether or not pyramids are present (dividing by a known at compile time power of 2 is about 5x cheaper than dividing by an arbitrary int)
3. I did some benchmarking and multiplying by 8 is not much more performant than multiplying by an arbitrary int

I also tweaked a few minor things:
1. I removed a memory allocation during the conversion back to a `CellId`
2. I moved most of the implementation to a source file
3. Since merging the class we added `tria.n_global_levels()` etc., so I updated the constructor to take a `Triangulation` as an input instead of integers (that way we can check for pyramids).

@kronbichler is there an easy way to locally run the performance tests? I'm not familiar with how that works.