### PR TITLE
split instantiations of mg_tranfer_matrix_free

### DIFF
--- a/source/multigrid/CMakeLists.txt
+++ b/source/multigrid/CMakeLists.txt
@@ -24,7 +24,9 @@ set(_unity_include_src
 set(_separate_src
   mg_tools.cc
   mg_transfer_global_coarsening.cc
-  mg_transfer_matrix_free.cc
+  mg_transfer_matrix_free_inst1.cc
+  mg_transfer_matrix_free_inst2.cc
+  mg_transfer_matrix_free_inst3.cc
   portable_mg_transfer_global_coarsening.cc
   )
 

--- a/source/multigrid/mg_transfer_matrix_free_inst1.cc
+++ b/source/multigrid/mg_transfer_matrix_free_inst1.cc
@@ -14,6 +14,9 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#define SPLIT_INSTANTIATIONS_COUNT 3
+#define SPLIT_INSTANTIATIONS_INDEX 0
+
 #include "multigrid/mg_transfer_matrix_free.inst"
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/multigrid/mg_transfer_matrix_free_inst2.cc
+++ b/source/multigrid/mg_transfer_matrix_free_inst2.cc
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2016 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/multigrid/mg_transfer_matrix_free.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+#define SPLIT_INSTANTIATIONS_COUNT 3
+#define SPLIT_INSTANTIATIONS_INDEX 1
+
+#include "multigrid/mg_transfer_matrix_free.inst"
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/multigrid/mg_transfer_matrix_free_inst3.cc
+++ b/source/multigrid/mg_transfer_matrix_free_inst3.cc
@@ -1,0 +1,22 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2016 - 2025 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+#include <deal.II/multigrid/mg_transfer_matrix_free.templates.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+#define SPLIT_INSTANTIATIONS_COUNT 3
+#define SPLIT_INSTANTIATIONS_INDEX 2
+
+#include "multigrid/mg_transfer_matrix_free.inst"
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
The object file is getting too big
```
-rw-rw-r-- 1 heister heister 68975616 Jun 25 20:41 mg_transfer_matrix_free.cc.o
```
which causes CI failures. Let's split into 3 pieces.