### PR TITLE
Make a PETSc iterative solver test more robust

### DIFF
--- a/tests/petsc/deal_solver_full_02.cc
+++ b/tests/petsc/deal_solver_full_02.cc
@@ -69,7 +69,7 @@ main(int argc, char **argv)
     check_solver_within_range(solver.solve(A, u, f, preconditioner),
                               control.last_step(),
                               48,
-                              51);
+                              54);
   }
   GrowingVectorMemory<PETScWrappers::MPI::Vector>::release_unused_memory();
 }


### PR DESCRIPTION
On some systems we see the solver take 52 iterations, https://cdash.dealii.org/tests/15577664 - thus, set the approved range to be between 48 and 54 instead of 48 and 51.