### PR TITLE
Stop printing preconditioner names earlieer in a SolverMPGMRES test

### DIFF
--- a/tests/lac/solver_mpgmres_01.cc
+++ b/tests/lac/solver_mpgmres_01.cc
@@ -39,7 +39,7 @@ public:
   void
   vmult(Vector<double> &dst, const Vector<double> &src) const
   {
-    if (print_counter < 3)
+    if (print_counter < 2)
       deallog.get_file_stream()
         << "Applying preconditioner " << name << std::endl;
     preconditioner.vmult(dst, src);

--- a/tests/lac/solver_mpgmres_01.output
+++ b/tests/lac/solver_mpgmres_01.output
@@ -6,7 +6,6 @@ Applying preconditioner C
 Applying preconditioner A
 Applying preconditioner B
 Applying preconditioner C
-Applying preconditioner A
 DEAL::Solver stopped within 1 - 13 iterations
 
 MPGMRES: (truncated)
@@ -16,15 +15,9 @@ Applying preconditioner C
 Applying preconditioner A
 Applying preconditioner B
 Applying preconditioner C
-Applying preconditioner A
-Applying preconditioner B
-Applying preconditioner C
 DEAL::Solver stopped within 13 - 25 iterations
 
 MPGMRES: (full)
-Applying preconditioner A
-Applying preconditioner B
-Applying preconditioner C
 Applying preconditioner A
 Applying preconditioner B
 Applying preconditioner C


### PR DESCRIPTION
In one of the MG-GMRES solver would take one iteration less than usual. Since these print the 'boring' sequence `preconditioner A, preconditioner B, preconditioner C`, I think truncating this output after 2 iterations is enough.