### PR TITLE
Deprecate a function introduced in #16644.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4154,7 +4154,13 @@ public:
    * once on the underlying triangulation.
    *
    * This is only implemented for the case where dim==3.
+   *
+   * @deprecated This function was introduced in deal.II 9.8 to fix a bug
+   *   in handling edges in FE_NedelecSZ, but it will be removed again
+   *   after 9.8 in favor of a better approach. You will not want to use this
+   *   function in user code.
    */
+  DEAL_II_DEPRECATED
   std::set<TriaActiveIterator<CellAccessor<dim, spacedim>>>
   get_cells_adjacent_to_line(const unsigned int i) const;
 


### PR DESCRIPTION
This patch immediately deprecates the function in `TriaAccessor` introduced in #16644 again, see https://github.com/dealii/dealii/pull/16644#issuecomment-4846523435. It will become obsolete when we implement #19905 -- in fact, with the data then no longer existing in the triangulation, the function can no longer work to begin with. So make sure that people don't use the newly introduced function because it will only exist in this one release.

This is not the optimal solution, but seems reasonable to me in view of the timeline to the release.