### PR TITLE
PETSc test: Fix output

### DIFF
--- a/tests/petsc/deal_solver_full_02.output
+++ b/tests/petsc/deal_solver_full_02.output
@@ -1,4 +1,4 @@
 
 DEAL::Size 32 Unknowns 961
 DEAL::Solver type: N6dealii14SolverBicgstabINS_13PETScWrappers3MPI6VectorEEE
-DEAL::Solver stopped within 48 - 51 iterations
+DEAL::Solver stopped within 48 - 54 iterations


### PR DESCRIPTION
In #19964 I changed the solver iteration count but forgot to also adjust the expected output, and since this particular test is not part of our CI, I only discovered it now with the test suite run on my machine. This should fix it.