### PR TITLE
Fix typo in changelog

### DIFF
--- a/doc/news/changes/minor/20260618Kronbichler
+++ b/doc/news/changes/minor/20260618Kronbichler
@@ -3,4 +3,4 @@ VectorizedArray::scatter() are now able to filter out indices with value
 numbers::invalid_unsigned_int, indicating a mask for the vector access.
 This is useful for indirect index access.
 <br>
-(Marin, 2026/06/18)
+(Martin Kronbichler, 2026/06/18)

--- a/doc/news/changes/minor/20260618Kronbichler-2
+++ b/doc/news/changes/minor/20260618Kronbichler-2
@@ -3,4 +3,4 @@ as index numbers::invalid_unsigned_int, rather than as a separate constraint
 that needs to be resolved from a list. This leads to slightly better machine
 code on most machines, thus speeding up matrix-free codes.
 <br>
-(Marin, 2026/06/18)
+(Martin Kronbichler, 2026/06/18)


### PR DESCRIPTION
Writing the changelog for #19969 I observed a copy-paste error I made at some point in a previous changelog (from #14324), where I mistyped my name. Thanks god it was my own name that I got wrong and not someone else's.