### PR TITLE
Clean up a test with 2d curl type

### DIFF
--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -206,9 +206,8 @@ test(const FiniteElement<dim> &fe,
                                         QGauss<dim>(fe.degree + 2),
                                         VectorTools::L2_norm);
 
-      typename FEValuesViews::Vector<dim>::curl_type total_curl;
+      typename FEValuesViews::Vector<dim>::curl_type total_curl{};
       double                                         total_div = 0;
-      total_curl *= 0.;
 
       FEValues<dim> fe_values(mapping,
                               fe,


### PR DESCRIPTION
I observed a spurious test failure (that is not appearing regularly), and found that we use `total_curl *= 0` for a variable of type `double` that was otherwise left uninitialized (as this is what we changed the 2d curl into recently). But if the memory content used to be `nan` before, this won't give us a zero. Let us properly initialize the variable. I wanted to write `= 0` but realized that in case we want to ever use this code in 3d as well, we should have it work for a tensor, too.