### PR TITLE
Introduce second face number in `hp_quad_dof_identities`

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1349,7 +1349,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int                  face_no = 0) const;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other            = 0) const;
 
   /**
    * Return whether this element dominates another one given as argument

--- a/include/deal.II/fe/fe_bernstein.h
+++ b/include/deal.II/fe/fe_bernstein.h
@@ -174,7 +174,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -368,7 +368,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -341,7 +341,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
-                         const unsigned int        face_no = 0) const override;
+                         const unsigned int        face_no = 0,
+                         const unsigned int face_no_other  = 0) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -460,7 +460,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -269,7 +269,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -408,7 +408,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -163,7 +163,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * Return whether this element implements its hanging node constraints in
@@ -316,7 +317,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<1, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * Return a list of constant modes of the element. For this element, it

--- a/include/deal.II/fe/fe_hermite.h
+++ b/include/deal.II/fe/fe_hermite.h
@@ -144,7 +144,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -483,7 +483,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
-                         const unsigned int        face_no = 0) const override;
+                         const unsigned int        face_no = 0,
+                         const unsigned int face_no_other  = 0) const override;
 
   /**
    * Return the matrix interpolating from a face of one element to the face of

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -299,7 +299,8 @@ public:
 
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   virtual bool
   hp_constraints_are_implemented() const override;

--- a/include/deal.II/fe/fe_pyramid_p.h
+++ b/include/deal.II/fe/fe_pyramid_p.h
@@ -113,7 +113,8 @@ public:
    */
   std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 };
 
 /**

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -250,7 +250,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /** @} */
 

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -624,7 +624,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
-                         const unsigned int        face_no = 0) const override;
+                         const unsigned int        face_no = 0,
+                         const unsigned int face_no_other  = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -385,7 +385,8 @@ public:
 
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
-                         const unsigned int        face_no = 0) const override;
+                         const unsigned int        face_no = 0,
+                         const unsigned int face_no_other  = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()

--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -185,7 +185,8 @@ public:
    */
   std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 };
 
 

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -998,7 +998,8 @@ public:
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()
@@ -1246,7 +1247,8 @@ private:
   template <int structdim>
   std::vector<std::pair<unsigned int, unsigned int>>
   hp_object_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                           const unsigned int face_no = 0) const;
+                           const unsigned int                  face_no = 0,
+                           const unsigned int face_no_other = 0) const;
 
   /**
    * Usually: Fields of cell-independent data.

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -989,6 +989,19 @@ namespace FETools
                      const types::geometric_orientation  combined_orientation);
 
   /**
+   * Given two finite elements which both have support points on their faces,
+   * compute the DoF identities.
+   *
+   * @see FiniteElement::hp_quad_dof_identities()
+   */
+  template <int dim, int spacedim>
+  std::vector<std::pair<unsigned int, unsigned int>>
+  hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe,
+                         const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int                  face_no,
+                         const unsigned int                  face_no_other);
+
+  /**
    * A namespace that contains functions that help setting up internal
    * data structures when implementing FiniteElement which are build
    * from simpler ("base") elements, for example FESystem. The things

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -3407,6 +3407,43 @@ namespace FETools
         return fe.get_first_quad_index(face_no) + index;
       }
   }
+
+
+
+  template <int dim, int spacedim>
+  std::vector<std::pair<unsigned int, unsigned int>>
+  hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe,
+                         const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int                  face_no,
+                         const unsigned int                  face_no_other)
+  {
+    // check that both faces are of the same kind
+    Assert(fe.reference_cell().face_reference_cell(face_no) ==
+             fe_other.reference_cell().face_reference_cell(face_no_other),
+           ExcInternalError());
+
+    std::vector<std::pair<unsigned int, unsigned int>> result;
+
+    // compare the face support points
+    const auto &face_support_points = fe.get_unit_face_support_points(face_no);
+    const auto &face_support_points_other =
+      fe_other.get_unit_face_support_points(face_no_other);
+
+    // get the offsets to only compare the DoFs within the face as the
+    // vertices and lines were done before
+    const unsigned int offset = fe.get_first_face_quad_index(face_no);
+    const unsigned int offset_other =
+      fe_other.get_first_face_quad_index(face_no_other);
+
+    // do the comparison
+    for (unsigned int i = 0; i < fe.n_dofs_per_quad(face_no); ++i)
+      for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_other); ++j)
+        if (face_support_points[i + offset].distance(
+              face_support_points_other[j + offset_other]) < 1e-14)
+          result.emplace_back(i, j);
+
+    return result;
+  }
 } // namespace FETools
 
 

--- a/include/deal.II/fe/fe_wedge_p.h
+++ b/include/deal.II/fe/fe_wedge_p.h
@@ -113,7 +113,8 @@ public:
    */
   std::vector<std::pair<unsigned int, unsigned int>>
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
-                         const unsigned int face_no = 0) const override;
+                         const unsigned int                  face_no = 0,
+                         const unsigned int face_no_other = 0) const override;
 };
 
 /**

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -998,6 +998,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FiniteElement<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &,
+  const unsigned int,
   const unsigned int) const
 {
   DEAL_II_NOT_IMPLEMENTED();

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -276,6 +276,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Bernstein<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &,
+  const unsigned int,
   const unsigned int) const
 {
   // Since this FE is not interpolatory but on the vertices, we can

--- a/source/fe/fe_dgp.cc
+++ b/source/fe/fe_dgp.cc
@@ -196,6 +196,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_DGP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int,
   const unsigned int) const
 {
   // there are no such constraints for DGP elements at all

--- a/source/fe/fe_dgp_monomial.cc
+++ b/source/fe/fe_dgp_monomial.cc
@@ -376,6 +376,7 @@ FE_DGPMonomial<dim>::hp_line_dof_identities(
 template <int dim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_DGPMonomial<dim>::hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
+                                            const unsigned int,
                                             const unsigned int) const
 {
   // there are no such constraints for DGPMonomial

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -572,6 +572,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_DGPNonparametric<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int,
   const unsigned int) const
 {
   // there are no such constraints for DGPNonparametric

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -618,6 +618,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_DGQ<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> & /*fe_other*/,
+  const unsigned int,
   const unsigned int) const
 {
   // this element is discontinuous, so by definition there can

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -977,13 +977,15 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Enriched<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   if (const FE_Enriched<dim, spacedim> *fe_enr_other =
         dynamic_cast<const FE_Enriched<dim, spacedim> *>(&fe_other))
     {
       return fe_system->hp_quad_dof_identities(fe_enr_other->get_fe_system(),
-                                               face_no);
+                                               face_no,
+                                               face_no_other);
     }
   else
     {

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -366,6 +366,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_FaceQ<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int,
   const unsigned int) const
 {
   Assert(dim >= 3, ExcInternalError());
@@ -645,6 +646,7 @@ template <int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_FaceQ<1, spacedim>::hp_quad_dof_identities(
   const FiniteElement<1, spacedim> &,
+  const unsigned int,
   const unsigned int) const
 {
   // this element is continuous only for the highest dimensional bounding object

--- a/source/fe/fe_hermite.cc
+++ b/source/fe/fe_hermite.cc
@@ -601,10 +601,12 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Hermite<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   (void)fe_other;
   (void)face_no;
+  (void)face_no_other;
   return {};
 }
 

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2743,6 +2743,7 @@ FE_Nedelec<dim>::hp_line_dof_identities(
 template <int dim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Nedelec<dim>::hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
+                                        const unsigned int,
                                         const unsigned int) const
 {
   // we can presently only compute

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -249,6 +249,7 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Nothing<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> & /*fe_other*/,
+  const unsigned int,
   const unsigned int) const
 {
   // the FE_Nothing has no

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -616,70 +616,21 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   AssertIndexRange(face_no, 5);
-  std::vector<std::pair<unsigned int, unsigned int>> identities;
 
-  unsigned int face_no_neighbor;
+  Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
+         ExcNotImplemented());
 
-  if (face_no == 0)
-    {
-      // on a quad, neighbor can be a hex, a pyramid or a wedge
-      Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
-             ExcNotImplemented());
-      // for the wedge the first quad face is face no. 2
-      if (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other))
-        face_no_neighbor = 2;
-      else
-        face_no_neighbor = 0;
-    }
-  else
-    {
-      Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
-             ExcNotImplemented());
-      // on tri, neighbor can be a tet, a pyramid or a wedge
-      if (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other))
-        face_no_neighbor = 1;
-      else
-        face_no_neighbor = 0;
-    }
-
-  // compare the face support points
-  const auto face_support_points = this->get_unit_face_support_points(face_no);
-  const auto face_support_points_other =
-    fe_other.get_unit_face_support_points(face_no_neighbor);
-
-  // get the offsets to only compare the DoFs within the face as the vertices
-  // and lines were done before
-  const auto face_reference_cell =
-    this->reference_cell().face_reference_cell(face_no);
-
-  Assert(face_reference_cell ==
-           fe_other.reference_cell().face_reference_cell(face_no_neighbor),
-         ExcInternalError());
-
-  const unsigned int offset =
-    face_reference_cell.n_vertices() +
-    face_reference_cell.n_lines() * this->n_dofs_per_line();
-
-  const unsigned int offset_other =
-    face_reference_cell.n_vertices() +
-    face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
-
-  // do the comparison
-  for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
-    for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
-         ++j)
-      if (face_support_points[i + offset].distance(
-            face_support_points_other[j + offset_other]) < 1e-14)
-        identities.emplace_back(i, j);
-
-  return identities;
+  return FETools::hp_quad_dof_identities(*this,
+                                         fe_other,
+                                         face_no,
+                                         face_no_other);
 }
 
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -892,7 +892,8 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   // we can presently only compute these identities if both FEs are FE_Qs or
   // if the other one is an FE_Nothing
@@ -935,39 +936,11 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
   else if ((dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ||
            (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr))
     {
-      const unsigned int face_no_neighbor =
-        (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ? 0 : 2;
-
-      std::vector<std::pair<unsigned int, unsigned int>> identities;
-
-      // compare the face support points
-      const auto face_support_points = this->get_unit_face_support_points(0);
-      const auto face_support_points_other =
-        fe_other.get_unit_face_support_points(face_no_neighbor);
-
-      // get the offsets to skip vertices and lines
-      const auto face_reference_cell =
-        this->reference_cell().face_reference_cell(0);
-      Assert(face_reference_cell ==
-               fe_other.reference_cell().face_reference_cell(face_no_neighbor),
-             ExcInternalError());
-
-      const auto offset =
-        face_reference_cell.n_vertices() +
-        face_reference_cell.n_lines() * this->n_dofs_per_line();
-
-      const auto offset_other =
-        face_reference_cell.n_vertices() +
-        face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
-
-      // now compare the points
-      for (unsigned int i = 0; i < this->n_dofs_per_quad(0); ++i)
-        for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
-             ++j)
-          if (face_support_points[i + offset].distance(
-                face_support_points_other[j + offset_other]) < 1e-14)
-            identities.emplace_back(i, j);
-      return identities;
+      AssertIndexRange(face_no, 6);
+      return FETools::hp_quad_dof_identities(*this,
+                                             fe_other,
+                                             face_no,
+                                             face_no_other);
     }
   else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
     {

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -297,6 +297,7 @@ template <int dim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_Q_Hierarchical<dim>::hp_quad_dof_identities(
   const FiniteElement<dim> &fe_other,
+  const unsigned int,
   const unsigned int) const
 {
   // we can presently only compute

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -383,7 +383,8 @@ template <int dim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
   const FiniteElement<dim> &fe_other,
-  const unsigned int        face_no) const
+  const unsigned int        face_no,
+  const unsigned int        face_no_other) const
 {
   // we can presently only compute these identities if both FEs are
   // FE_RaviartThomasNodals or if the other one is FE_Nothing
@@ -398,7 +399,7 @@ FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
       const unsigned int p = this->n_dofs_per_quad(face_no);
 
       AssertDimension(fe_q_other->n_unique_faces(), 1);
-      const unsigned int q = fe_q_other->n_dofs_per_quad(0);
+      const unsigned int q = fe_q_other->n_dofs_per_quad(face_no_other);
 
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -1000,49 +1000,20 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   AssertDimension(dim, 3);
+  AssertIndexRange(face_no, 4);
 
   if ((dynamic_cast<const FE_SimplexP<dim> *>(&fe_other) != nullptr) ||
       (dynamic_cast<const FE_WedgeP<dim> *>(&fe_other) != nullptr) ||
       (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr))
     {
-      std::vector<std::pair<unsigned int, unsigned int>> result;
-      const unsigned int                                 face_no_neighbor =
-        (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ? 1 : 0;
-
-      // compare the face support points
-      const auto face_support_points = this->get_unit_face_support_points(0);
-      const auto face_support_points_other =
-        fe_other.get_unit_face_support_points(face_no_neighbor);
-
-      // get the offsets to only compare the DoFs within the face as the
-      // vertices and lines were done before
-      const auto face_reference_cell =
-        this->reference_cell().face_reference_cell(0);
-
-      Assert(face_reference_cell ==
-               fe_other.reference_cell().face_reference_cell(face_no_neighbor),
-             ExcInternalError());
-
-      const unsigned int offset =
-        face_reference_cell.n_vertices() +
-        face_reference_cell.n_lines() * this->n_dofs_per_line();
-
-      const unsigned int offset_other =
-        face_reference_cell.n_vertices() +
-        face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
-
-      // do the comparison
-      for (unsigned int i = 0; i < this->n_dofs_per_quad(0); ++i)
-        for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
-             ++j)
-          if (face_support_points[i + offset].distance(
-                face_support_points_other[j + offset_other]) < 1e-14)
-            result.emplace_back(i, j);
-
-      return result;
+      return FETools::hp_quad_dof_identities(*this,
+                                             fe_other,
+                                             face_no,
+                                             face_no_other);
     }
   else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
     {

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -2353,7 +2353,8 @@ template <int structdim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FESystem<dim, spacedim>::hp_object_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   // since dofs on each subobject (vertex, line, ...) are ordered such that
   // first come all from the first base element all multiplicities, then
@@ -2403,8 +2404,9 @@ FESystem<dim, spacedim>::hp_object_dof_identities(
                 base_identities = base.hp_line_dof_identities(base_other);
                 break;
               case 2:
-                base_identities =
-                  base.hp_quad_dof_identities(base_other, face_no);
+                base_identities = base.hp_quad_dof_identities(base_other,
+                                                              face_no,
+                                                              face_no_other);
                 break;
               default:
                 DEAL_II_NOT_IMPLEMENTED();
@@ -2484,9 +2486,10 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FESystem<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
-  return hp_object_dof_identities<2>(fe_other, face_no);
+  return hp_object_dof_identities<2>(fe_other, face_no, face_no_other);
 }
 
 

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -179,6 +179,13 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const unsigned int,
         const unsigned int,
         const types::geometric_orientation);
+
+      template std::vector<std::pair<unsigned int, unsigned int>>
+      hp_quad_dof_identities(
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        const FiniteElement<deal_II_dimension, deal_II_space_dimension> &,
+        const unsigned int,
+        const unsigned int);
 #endif
 
 #if deal_II_dimension == deal_II_space_dimension

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -338,65 +338,21 @@ template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
 FE_WedgeP<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &fe_other,
-  const unsigned int                  face_no) const
+  const unsigned int                  face_no,
+  const unsigned int                  face_no_other) const
 {
   AssertIndexRange(face_no, 5);
 
-  std::vector<std::pair<unsigned int, unsigned int>> result;
-  unsigned int                                       face_no_neighbor;
+  Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
+           (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
+         ExcNotImplemented());
 
-  if (face_no < 2)
-    {
-      // triangular face
-      Assert((dynamic_cast<const FE_SimplexP<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
-             ExcNotImplemented());
-      if ((dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)))
-        face_no_neighbor = 1;
-      else
-        face_no_neighbor = 0;
-    }
-  else
-    {
-      // quad face
-      Assert((dynamic_cast<const FE_Q<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_PyramidP<dim, spacedim> *>(&fe_other)) ||
-               (dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)),
-             ExcNotImplemented());
-      if ((dynamic_cast<const FE_WedgeP<dim, spacedim> *>(&fe_other)))
-        face_no_neighbor = 2;
-      else
-        face_no_neighbor = 0;
-    }
-
-  // compare the face support points
-  const auto face_support_points = this->get_unit_face_support_points(face_no);
-  const auto face_support_points_other =
-    fe_other.get_unit_face_support_points(face_no_neighbor);
-
-  // get the offsets to skip vertices and lines
-  const auto face_reference_cell =
-    this->reference_cell().face_reference_cell(face_no);
-  Assert(face_reference_cell ==
-           fe_other.reference_cell().face_reference_cell(face_no_neighbor),
-         ExcInternalError());
-
-  const auto offset = face_reference_cell.n_vertices() +
-                      face_reference_cell.n_lines() * this->n_dofs_per_line();
-
-  const auto offset_other =
-    face_reference_cell.n_vertices() +
-    face_reference_cell.n_lines() * fe_other.n_dofs_per_line();
-
-  // now compare the points
-  for (unsigned int i = 0; i < this->n_dofs_per_quad(face_no); ++i)
-    for (unsigned int j = 0; j < fe_other.n_dofs_per_quad(face_no_neighbor);
-         ++j)
-      if (face_support_points[i + offset].distance(
-            face_support_points_other[j + offset_other]) < 1e-14)
-        result.emplace_back(i, j);
-  return result;
+  return FETools::hp_quad_dof_identities(*this,
+                                         fe_other,
+                                         face_no,
+                                         face_no_other);
 }
 
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -562,34 +562,25 @@ namespace hp
   FECollection<dim, spacedim>::hp_quad_dof_identities(
     const std::set<std::pair<unsigned int, unsigned int>> &fes_and_faces) const
   {
-    // first entry in the pair is the fe_index, the second entry is the face_no
-    std::pair<unsigned int, unsigned int> fe_and_face_1 =
-      *fes_and_faces.begin();
-    std::pair<unsigned int, unsigned int> fe_and_face_2 =
-      *(++fes_and_faces.begin());
+    std::map<unsigned int, unsigned int> face_indices;
+    std::set<unsigned int>               fe_indices;
 
-    auto query_quad_dof_identities =
-      [this, &fe_and_face_1, &fe_and_face_2](const unsigned int fe_index_1,
-                                             const unsigned int fe_index_2) {
-        // check if fe_index_1 is the same fe index as in fe_and_face_1
-        // then use the corresponding face
-        const unsigned int face_no = fe_index_1 == fe_and_face_1.first ?
-                                       fe_and_face_1.second :
-                                       fe_and_face_2.second;
-        return (*this)[fe_index_1].hp_quad_dof_identities((*this)[fe_index_2],
-                                                          face_no);
-      };
-
-    // Extract only the FE indices from the pairs we got as inputs
-    std::set<unsigned int> fe_indices_only;
     for (const auto &[fe_index, face_index] : fes_and_faces)
       {
-        fe_indices_only.insert(fe_index);
-        (void)face_index;
+        fe_indices.insert(fe_index);
+        face_indices.emplace(fe_index, face_index);
       }
 
-    return compute_hp_dof_identities(fe_indices_only,
-                                     query_quad_dof_identities);
+    const auto query_quad_dof_identities =
+      [this, &face_indices](const unsigned int fe_index_1,
+                            const unsigned int fe_index_2) {
+        return (*this)[fe_index_1].hp_quad_dof_identities(
+          (*this)[fe_index_2],
+          face_indices.at(fe_index_1),
+          face_indices.at(fe_index_2));
+      };
+
+    return compute_hp_dof_identities(fe_indices, query_quad_dof_identities);
   }
 
 

--- a/tests/simplex/hp_identities_01.cc
+++ b/tests/simplex/hp_identities_01.cc
@@ -73,7 +73,7 @@ test_hp_quad_dof_identities(const FiniteElement<dim> &fe,
           reference_cell_other.face_reference_cell(f_other))
         {
           const auto additional_results =
-            fe.hp_quad_dof_identities(fe_other, f);
+            fe.hp_quad_dof_identities(fe_other, f, f_other);
           for (const auto &r : additional_results)
             results.emplace_back(r);
         }

--- a/tests/simplex/hp_identities_02.cc
+++ b/tests/simplex/hp_identities_02.cc
@@ -130,9 +130,10 @@ test_hp_quad_dof_identities(const FiniteElement<dim> &fe,
       if (reference_cell.face_reference_cell(f) ==
           reference_cell_other.face_reference_cell(f_other))
         {
-          const auto identities = fe.hp_quad_dof_identities(fe_other, f);
+          const auto identities =
+            fe.hp_quad_dof_identities(fe_other, f, f_other);
           const auto identities_other =
-            fe_other.hp_quad_dof_identities(fe, f_other);
+            fe_other.hp_quad_dof_identities(fe, f_other, f);
 
           for (const auto &r : identities)
             results_fe.emplace_back(r);

--- a/tests/simplex/hp_identities_03.cc
+++ b/tests/simplex/hp_identities_03.cc
@@ -141,7 +141,7 @@ test_hp_quad_dof_identities(const FiniteElement<dim> &fe,
       if (reference_cell.face_reference_cell(f) ==
           reference_cell_other.face_reference_cell(f_other))
         {
-          const auto results = fe.hp_quad_dof_identities(fe_other, f);
+          const auto results = fe.hp_quad_dof_identities(fe_other, f, f_other);
 
           unsigned int n_expected = 0;
           // they could have the same support points if they have the same


### PR DESCRIPTION
Follow up to #19913 and #19291. This PR introduces the face number of the neighbor when calling `hp_quad_dof_identities`. It is needed as pyramids and wedges have quadrilaterals and triangles as faces, such it is not clear which faces have to be compared.
