### PR TITLE
Fix an out-of-bounds access in MatrixFree face mapping initialization

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2228,7 +2228,7 @@ namespace internal
                     0;
 
                 const unsigned int ext_hp_quad_index =
-                  data_faces.descriptor.size() == 1 ? 0 : ext_fe_index;
+                  data_faces.q_collection.size() == 1 ? 0 : ext_fe_index;
                 const unsigned int ext_hp_quad_face_no =
                   data_faces.q_collection[ext_hp_quad_index].size() == 1 ?
                     0 :


### PR DESCRIPTION
The exterior face quadrature index was selected based on `data_faces.descriptor.size()` but used to index `data_faces.q_collection`. This could select `ext_fe_index > 0` even when only one quadrature collection
exists. Use `q_collection.size()` consistently, as already done for the interior face.

@kronbichler this change fixes the failing tests of MeltPoolDG. However, I don't know why the segmentation fault didn't appear already earlier.