### PR TITLE
Only module-export PETSC_TRUE/FALSE if they are not macros.

### DIFF
--- a/module/interface_module_partitions/petsc.ccm
+++ b/module/interface_module_partitions/petsc.ccm
@@ -194,9 +194,7 @@ export
   using ::PCSORSetSymmetric;
   using ::PETSC_COMM_WORLD;
   using ::PETSC_COPY_VALUES;
-  using ::PETSC_FALSE;
   using ::PETSC_OWN_POINTER;
-  using ::PETSC_TRUE;
   using ::PETSC_VIEWER_STDOUT_;
   using ::PetscBool;
   using ::PetscCopyMode;
@@ -245,6 +243,17 @@ export
   using ::PetscSFSetUp;
   using ::PetscTrMalloc;
   using ::PetscViewerPushFormat;
+
+  // For some versions of PETSc, PETSC_FALSE and PETSC_TRUE are compiler
+  // values, whereas for others they are preprocessor variables. Export
+  // them if they fall in the former category.
+#  ifndef PETSC_FALSE
+  using ::PETSC_FALSE;
+#  endif
+
+#  ifndef PETSC_TRUE
+  using ::PETSC_TRUE;
+#  endif
 
 #  if defined(PETSC_HAVE_SAWS)
   using ::PetscStackSAWsGrantAccess;

--- a/module/interface_module_partitions/petsc.ccm
+++ b/module/interface_module_partitions/petsc.ccm
@@ -760,4 +760,21 @@ CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(VECNEST)
 #  undef VECNEST
 EXPORT_PREPROCESSOR_SYMBOL(VECNEST)
 
+
+// For some versions of PETSc, PETSC_FALSE and PETSC_TRUE are
+// compiler values, whereas for others they are preprocessor
+// variables. In the latter case, we have to create export-able
+// symbols:
+#  ifdef PETSC_FALSE
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_FALSE)
+#    undef PETSC_FALSE
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_FALSE)
+#  endif
+
+#  ifdef PETSC_TRUE
+CREATE_EXPORTABLE_PREPROCESSOR_SYMBOL(PETSC_TRUE)
+#    undef PETSC_TRUE
+EXPORT_PREPROCESSOR_SYMBOL(PETSC_TRUE)
+#  endif
+
 #endif


### PR DESCRIPTION
Fixes some of the module problems in https://cdash.dealii.org/builds/2855. Apparently for the version of PETSc used there, `PETSC_FALSE/TRUE` are macros, see also https://petsc.org/release/include/petscsystypes.h.html#PETSC_FALSE . We clearly can't export those.

Related to #18071.