### PR TITLE
Adjust length h for difference approximation in a test

### DIFF
--- a/tests/base/polynomial_jacobi_derivative.cc
+++ b/tests/base/polynomial_jacobi_derivative.cc
@@ -98,9 +98,12 @@ test(const double tol)
               // second derivative
               const double second_deriv = jacobi_polynomial_kth_derivative(
                 2, degree, alpha, beta, x, rescale);
+
+              // derivative approximation is 2nd order, so choose somewhat
+              // larger h to avoid running into cancellation issues
               const double second_deriv_approx =
                 get_finite_difference_second_derivative(
-                  tol, degree, alpha, beta, x, rescale);
+                  4 * tol, degree, alpha, beta, x, rescale);
 
               if (std::abs(second_deriv - second_deriv_approx) < tol)
                 deallog << "ok ";


### PR DESCRIPTION
The test `base/polynomial_jacobi_derivative` recently introduced by #19958 uses a finite difference approximation for the first and second derivative. But those are sensitive to roundoff when the size `h` is too small, and on some system this fails, https://cdash.dealii.org/tests/16077354 . Adjust the value passed to the approximation, by making it larger. The method is formally second-order accurate, so choosing `h=4e-5` should ensure a relative error less than 1e-8, which is somewhere near the threshold for the chosen (absolute) tolerance 1e-5. Note that I tried to think about relative tolerances, but it felt a bigger change than I was comfortable of doing as a quick fix. @dominiktassilostill what do you think?