### PR TITLE
Add an alternate output for pattern_tools_06.

### DIFF
--- a/tests/parameter_handler/pattern_tools_06.output.3
+++ b/tests/parameter_handler/pattern_tools_06.output.3
@@ -1,0 +1,13 @@
+
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1:3, 5:1
+DEAL::To value : 1:3, 5:1
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1:3, 5:1
+DEAL::To value : 5:1, 1:3
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 1:3, 5:1, 5:2
+DEAL::To value : 1:3, 5:1, 5:2
+DEAL::Pattern  : [Map of <[Integer range -2147483648...2147483647 (inclusive)]>:<[Double -MAX_DOUBLE...MAX_DOUBLE (inclusive)]> of length 0...4294967295 (inclusive)]
+DEAL::To String: 5:1, 5:2, 1:3
+DEAL::To value : 1:3, 5:1, 5:2


### PR DESCRIPTION
unordered_map etc. don't have stable orders and libc++ doesn't print trailing zeros in this context. See https://cdash.dealii.org/builds/2889/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D

This test passes on the CI integrated with GitHub so I won't mark it as 'ready to test'.