### PR TITLE
Adjust tolerance for testing accuracy of floating point numbers

### DIFF
--- a/tests/base/kokkos_point.cc
+++ b/tests/base/kokkos_point.cc
@@ -82,7 +82,7 @@ test_gpu()
   auto check_host =
     Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, check);
 
-  const double tolerance = 1.e-8;
+  const double tolerance = std::is_same_v<Number, double> ? 1.e-14 : 2e-7;
   AssertThrow(std::abs(check_host[0] - 0.) < tolerance, ExcInternalError());
   AssertThrow(std::abs(check_host[1] - 0.) < tolerance, ExcInternalError());
   AssertThrow(std::abs(check_host[2] - 1.) < tolerance, ExcInternalError());


### PR DESCRIPTION
On one of the tester configurations, a check would fail because a `float` number is not within a tolerance of `1e-8`. As soon as rounding happens (which can happen, but does not always), a float can hardly have errors below `5.9e-8`, which is the machine epsilon. As all computations are simple with at most two rounding steps of non-exact numbers, I believe we should set the tolerance to `2e-7` and we should be safe with a round-to-nearest strategy. While there, also make the `double` tolerance more tight. There is no reason not to expect accuracy close the `double` machine epsilon of `1.1e-16` (but I'm more forgiving here and "just" request `1e-14`, because we can have one more rounding step when introducing the decimal numbers set in the test to floating point values).