### PR TITLE
Fix some issues with the Abaqus-to-UCD conversion, part 1.

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -5698,8 +5698,8 @@ namespace
 
     // Write out title - Note: No other commented text can be inserted below
     // the title in a UCD file
-    output << "# Abaqus to UCD mesh conversion" << std::endl;
-    output << "# Mesh type: AVS UCD" << std::endl;
+    output << "# Abaqus to UCD mesh conversion" << '\n';
+    output << "# Mesh type: AVS UCD" << '\n';
 
     // ========================================================
     // ASCII UCD File Format
@@ -5729,22 +5729,24 @@ namespace
 
     // Write out header
     output << node_list.size() << "\t" << (cell_list.size() + face_list.size())
-           << "\t0\t0\t0" << std::endl;
-
-    output.width(16);
-    output.precision(8);
+           << "\t0\t0\t0" << '\n';
 
     // Write out node numbers
     // Loop over all nodes
+    output.setf(std::ios::scientific, std::ios::floatfield);
     for (const auto &node : node_list)
       {
-        // Node number
-        output << node[0] << "\t";
+        // Node number. It is stored as a double, but it's an integer, so we can
+        // just output it as that:
+        output << static_cast<int>(node[0]) << "\t";
 
-        // Node coordinates
-        output.setf(std::ios::scientific, std::ios::floatfield);
+        // Node coordinates. For these, we need to set the precision and width
+        // so that we catch as much precision as possible:
         for (unsigned int jj = 1; jj < spacedim + 1; ++jj)
           {
+            output.width(20);
+            output.precision(16);
+
             // invoke tolerance -> set points close to zero equal to zero
             if (std::abs(node[jj]) > tolerance)
               output << static_cast<double>(node[jj]) << "\t";
@@ -5754,9 +5756,9 @@ namespace
         if (spacedim == 2)
           output << 0.0 << "\t";
 
-        output << std::endl;
-        output.unsetf(std::ios::floatfield);
+        output << '\n';
       }
+    output.unsetf(std::ios::floatfield);
 
     // Write out cell node numbers
     for (unsigned int ii = 0; ii < cell_list.size(); ++ii)
@@ -5767,7 +5769,7 @@ namespace
              ++jj)
           output << cell_list[ii][jj] << "\t";
 
-        output << std::endl;
+        output << '\n';
       }
 
     // Write out quad node numbers
@@ -5779,8 +5781,10 @@ namespace
              ++jj)
           output << face_list[ii][jj] << "\t";
 
-        output << std::endl;
+        output << '\n';
       }
+
+    output << std::flush;
   }
 } // namespace
 


### PR DESCRIPTION
Not urgent, but harmless nonetheless: When we read Abaqus files, we first internally convert them to UCD files for which we have a reader. In the function that writes UCD, we use `std::endl` in a lot of places, which (i) is an endline character, but also (ii) calls `std::flush`. The latter is unnecessary. We can save a good bit of time by replacing it by `\n`. 

Separately, we set field width and precision at the top of a loop, but that only affects the next floating point number we output. So the converted UCD file looks like this:
```
# Abaqus to UCD mesh conversion
# Mesh type: AVS UCD
11193	9785	0	0	0
               1	5.00000000e+03	0.00000000e+00	-6.86000000e+03	
2	0.00000000e+00	-5.71000000e+03	-6.86000000e+03	
3	4.39713000e+03	-2.71816400e+03	-6.86000000e+03	
4	2.62795800e+03	-4.85770800e+03	-6.86000000e+03	
...
```
What we want is this:
```
# Abaqus to UCD mesh conversion
# Mesh type: AVS UCD
11193   9785    0       0       0
1       5.0000000000000000e+03  0.0000000000000000e+00  -6.8600000000000000e+03 
2       0.0000000000000000e+00  -5.7100000000000000e+03 -6.8600000000000000e+03 
3       4.3971300000000001e+03  -2.7181640000000002e+03 -6.8600000000000000e+03 
4       2.6279580000000001e+03  -4.8577079999999996e+03 -6.8600000000000000e+03 
5       5.0000000000000000e+03  0.0000000000000000e+00  0.0000000000000000e+00  
6       5.0000000000000000e+03  0.0000000000000000e+00  -3.4300000000000000e+03 
7       0.0000000000000000e+00  -5.7100000000000000e+03 0.0000000000000000e+00  
8       2.6279580000000001e+03  -4.8577079999999996e+03 0.0000000000000000e+00  
9       4.3971300000000001e+03  -2.7181640000000002e+03 0.0000000000000000e+00  
10      0.0000000000000000e+00  -5.7100000000000000e+03 -3.4300000000000000e+03 
11      2.6486570000000002e+03  -4.8430240000000003e+03 -3.4300000000000000e+03 
...
```
We get this by setting field width and precision right before the output.


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.
