### PR TITLE
Do not export GCC internal symbols from modules.

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -729,7 +729,13 @@ export
     using std::operator<=>;
   } // namespace std
 
-#if defined(__GLIBCXX__) // For GCC's support library
+
+// When compiling with Clang but using (as is the default) the GCC standard
+// library, we have to export a few symbols from the __gnu_cxx namespace as
+// well. Interestingly, we only need to do this when compiling with Clang but
+// not with GCC; the latter apparently finds these symbols itself and will
+// instead issue errors if we try to export them here.
+#if defined(__GLIBCXX__) && defined(__clang__)
 
   namespace __gnu_cxx
   {


### PR DESCRIPTION
https://cdash.dealii.org/viewBuildError.php?buildid=4 complains that when exporting symbols from `std.ccm`, we are also exporting internal symbols in the GLIBCXX/`__gnu_cxx` namespace.  These symbols don't seem to exist. I must admit that I don't remember where that code block originates -- I believe I had seen it in someone else's `std.ccm` and thought it was necessary, but I have not been able to get modules to build with GCC and so can't tell what the purpose of the code was. In any case, it does not compile, so let's see what happens when we delete it.

I will note that the preprocessor `#ifdef` does *not* check that we are using GCC. This code is also executed when we compile with Clang++ and the GCC standard library. So it is entirely possible that terrible things will now happen and that the right solution is to only disable this code when compiling with GCC but to keep it in when compiling with Clang -- let us see what the testers have to say.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.
