### PR TITLE
Portable::MatrixFree BlockVector loop: honor team size setting

### DIFF
--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -1502,9 +1502,12 @@ namespace Portable
         for (unsigned int color = 0; color < n_colors; ++color)
           if (n_cells[color] > 0)
             {
-              Kokkos::TeamPolicy<
-                MemorySpace::Default::kokkos_space::execution_space>
-                team_policy(exec, n_cells[color], Kokkos::AUTO);
+              using TeamPolicy = Kokkos::TeamPolicy<
+                MemorySpace::Default::kokkos_space::execution_space>;
+              auto team_policy =
+                (this->team_size == numbers::invalid_unsigned_int) ?
+                  TeamPolicy(exec, n_cells[color], Kokkos::AUTO) :
+                  TeamPolicy(exec, n_cells[color], this->team_size);
 
               for (unsigned int di = 0; di < dof_handler_data.size(); ++di)
                 colored_data[di] = get_data(color, di);


### PR DESCRIPTION
Honor the ``team_size`` specified in ``AdditionalData`` in ``Portable::MatrixFree::distributed_cell_loop``.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
