### PR TITLE
LA::BlockVector: support update_ghost_values_start/finish

### DIFF
--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -413,6 +413,35 @@ namespace LinearAlgebra
       update_ghost_values() const;
 
       /**
+       * Initiates communication for the @p update_ghost_values() function
+       * with non-blocking communication. This function does not wait for the
+       * transfer to finish, in order to allow for other computations during
+       * the time it takes until all data arrives.
+       *
+       * Before the data is actually exchanged, the function must be followed
+       * by a call to @p update_ghost_values_finish().
+       *
+       * In case this function is called for more than one vector before
+       * @p update_ghost_values_finish() is invoked, it is mandatory to specify
+       * a unique communication channel to each such call. Otherwise, data
+       * corruption can occur. Consecutive channels starting from the given
+       * value are used.
+       */
+      void
+      update_ghost_values_start(
+        const unsigned int communication_channel_start = 100) const;
+
+      /**
+       * For all requests that have been started in update_ghost_values_start,
+       * wait for the communication to finish.
+       *
+       * Must follow a call to the @p update_ghost_values_start function
+       * before reading data from ghost indices.
+       */
+      void
+      update_ghost_values_finish() const;
+
+      /**
        * This method zeros the entries on ghost dofs, but does not touch
        * locally owned DoFs.
        *

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -458,24 +458,55 @@ namespace LinearAlgebra
     void
     BlockVector<Number, MemorySpace>::update_ghost_values() const
     {
+      update_ghost_values_start();
+      update_ghost_values_finish();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::update_ghost_values_start(
+      const unsigned int communication_channel_start) const
+    {
+      // Have at most communication_block_size ghost exchanges in parallel and
+      // wait for others to finish by tackling them chunk by chunk. The last
+      // chunk is potentially smaller, so we iterate backwards and leave the
+      // full chunk 0 for update_ghost_values_finish() to finish.
       const unsigned int n_chunks =
         (this->n_blocks() + communication_block_size - 1) /
         communication_block_size;
-      for (unsigned int c = 0; c < n_chunks; ++c)
+      for (unsigned int c = n_chunks; c > 0; --c)
         {
-          const unsigned int start = c * communication_block_size;
+          const unsigned int chunk_index = c - 1;
+          const unsigned int start = chunk_index * communication_block_size;
           const unsigned int end =
             std::min(start + communication_block_size, this->n_blocks());
 
-          // In order to avoid conflict with possible other ongoing
-          // communication requests (from LA::distributed::Vector that supports
-          // unfinished requests), add 100 to the communication tag (the first
-          // 100 can be used by normal vectors)
           for (unsigned int block = start; block < end; ++block)
-            this->block(block).update_ghost_values_start(block - start + 100);
-          for (unsigned int block = start; block < end; ++block)
-            this->block(block).update_ghost_values_finish();
+            this->block(block).update_ghost_values_start(
+              block - start + communication_channel_start);
+
+          if (chunk_index > 0)
+            {
+              // finish the current chunk:
+              for (unsigned int block = start; block < end; ++block)
+                this->block(block).update_ghost_values_finish();
+            }
         }
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    void
+    BlockVector<Number, MemorySpace>::update_ghost_values_finish() const
+    {
+      const unsigned int start = 0;
+      const unsigned int end =
+        std::min(start + communication_block_size, this->n_blocks());
+      for (unsigned int block = start; block < end; ++block)
+        this->block(block).update_ghost_values_finish();
     }
 
 


### PR DESCRIPTION
Like ::Vector, support doing update_ghost_values in the background.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
