### PR TITLE
Disabled inplace optimizations for device vectors inside MGTwoLevelTranferCore

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_matrix_free.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.templates.h
@@ -3567,7 +3567,9 @@ namespace internal
         this->partitioner_coarse = external_partitioner_coarse;
         success_flags.first      = true;
       }
-    else if (internal::is_partitioner_contained(this->partitioner_coarse,
+    else if (std::is_same_v<typename VectorType::memory_space,
+                            dealii::MemorySpace::Host> &&
+             internal::is_partitioner_contained(this->partitioner_coarse,
                                                 external_partitioner_coarse))
       {
         this->vec_coarse.reinit(0);
@@ -3599,7 +3601,9 @@ namespace internal
         this->partitioner_fine = external_partitioner_fine;
         success_flags.second   = true;
       }
-    else if (internal::is_partitioner_contained(this->partitioner_fine,
+    else if (std::is_same_v<typename VectorType::memory_space,
+                            dealii::MemorySpace::Host> &&
+             internal::is_partitioner_contained(this->partitioner_fine,
                                                 external_partitioner_fine))
       {
         this->vec_fine.reinit(0);


### PR DESCRIPTION
As mentioned in #20011 right now if inplace_operations are enabled on device inside of an MGTwoLevelTransfer object, there will be a segfault when operating on >1 MPI rank. This PR simply disables the possibility of inplace_operations being enabled on device by adding a check to see if we are on host or device.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
