### PR TITLE
gh-actions: Update tidy checks to ubuntu-26.04.

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   tidy:
     name: tidy
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     #
     # The following condition only runs the workflow on 'push' or if the

--- a/include/deal.II/base/enable_observer_pointer.h
+++ b/include/deal.II/base/enable_observer_pointer.h
@@ -345,7 +345,7 @@ template <typename StreamType>
 inline void
 EnableObserverPointer::list_subscribers(StreamType &stream) const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   for (const auto &it : counter_map)
     stream << it.second << '/' << counter << " subscriptions from \""

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -93,7 +93,7 @@ public:
    * <code>throw</code>, or by simply reaching the closing brace. In all of
    * these cases, it is not necessary to remember to pop the prefix manually
    * using LogStream::pop(). In this, it works just like the better known
-   * std::unique_ptr and std::lock_guard classes.
+   * std::unique_ptr and std::scoped_lock classes.
    */
   class Prefix
   {

--- a/include/deal.II/base/task_result.h
+++ b/include/deal.II/base/task_result.h
@@ -429,7 +429,7 @@ namespace Threads
     // First lock the other object, then move the members of the other
     // object and reset it. Note that we do not have to wait for
     // the other object's task to finish (nor should we).
-    std::lock_guard<std::mutex> lock(other.mutex);
+    std::scoped_lock lock(other.mutex);
 
     result_is_available       = other.result_is_available.load();
     other.result_is_available = false;
@@ -466,7 +466,7 @@ namespace Threads
     // Having established that there is no previous task still running,
     // set the current task as the one we're waiting for:
     {
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
       task = t;
     }
   }
@@ -485,7 +485,7 @@ namespace Threads
     // object, and finally reset it. Note that we do not have to wait for
     // the other object's task to finish (nor should we): We may simply
     // inherit the other object's task.
-    std::lock_guard<std::mutex> lock(other.mutex);
+    std::scoped_lock lock(other.mutex);
 
     result_is_available       = other.result_is_available.load();
     other.result_is_available = false;
@@ -515,7 +515,7 @@ namespace Threads
     // to check that perhaps it has appeared in the meantime. We again use
     // the double-checking pattern:
     {
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
       if (result_is_available)
         return;
       else
@@ -559,7 +559,7 @@ namespace Threads
   inline void
   TaskResult<T>::clear()
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     if (result_is_available)
       {
@@ -596,7 +596,7 @@ namespace Threads
       // that this happens under the lock, so only one thread gets to be in
       // this code block at the same time:
       {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         if (result_is_available)
           return;
         else
@@ -637,7 +637,7 @@ namespace Threads
       // result_is_available==true and task.has_value()==false. We can
       // check that, but only under a lock.
       {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         if (result_is_available)
           return false;
         else

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -962,7 +962,7 @@ namespace Threads
         // Else, we need to go under a lock and try again. A different thread
         // may have waited and finished the task since then, so we have to try
         // a second time. (This is Schmidt's double-checking pattern.)
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         if (task_has_finished)
           return;
         else

--- a/include/deal.II/fe/mapping_fe_field.templates.h
+++ b/include/deal.II/fe/mapping_fe_field.templates.h
@@ -512,7 +512,7 @@ MappingFEField<dim, spacedim, VectorType>::get_vertices(
   else
     AssertDimension(euler_vector[0]->size(), euler_dof_handler->n_dofs());
 
-  std::lock_guard<std::mutex> lock(fe_values_mutex);
+  std::scoped_lock lock(fe_values_mutex);
   fe_values.reinit(dof_cell);
   if (uses_level_dofs)
     dof_cell->get_mg_dof_indices(dof_indices);

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1729,7 +1729,7 @@ BlockMatrixBase<MatrixType>::set(const size_type  row,
 
   // lock access to the temporary data structure to
   // allow multiple threads to call this function concurrently
-  std::lock_guard<std::mutex> lock(temporary_data.mutex);
+  std::scoped_lock lock(temporary_data.mutex);
 
   // Resize scratch arrays
   if (temporary_data.column_indices.size() < this->n_block_cols())
@@ -1991,7 +1991,7 @@ BlockMatrixBase<MatrixType>::add(const size_type  row,
     }
 
   // Lock scratch arrays, then resize them
-  std::lock_guard<std::mutex> lock(temporary_data.mutex);
+  std::scoped_lock lock(temporary_data.mutex);
 
   if (temporary_data.column_indices.size() < this->n_block_cols())
     {

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1036,7 +1036,7 @@ namespace LinearAlgebra
 
 #ifdef DEAL_II_WITH_MPI
       // make this function thread safe
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
 
       // allocate import_data in case it is not set up yet
       if (partitioner->n_import_indices() > 0)
@@ -1132,7 +1132,7 @@ namespace LinearAlgebra
       // compress_requests.empty()
 
       // make this function thread safe
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
       if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
         {
@@ -1198,7 +1198,7 @@ namespace LinearAlgebra
         return;
 
       // make this function thread safe
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
 
       // allocate import_data in case it is not set up yet
       if (partitioner->n_import_indices() > 0)
@@ -1296,7 +1296,7 @@ namespace LinearAlgebra
       if (update_ghost_values_requests.size() > 0)
         {
           // make this function thread safe
-          std::lock_guard<std::mutex> lock(mutex);
+          std::scoped_lock lock(mutex);
 
 #  if !defined(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
           if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -4030,7 +4030,7 @@ PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
                  const VectorType &rhs,
                  VectorType       &solution) const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
   if (eigenvalues_are_initialized == false)
     estimate_eigenvalues(rhs);
 

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -938,7 +938,7 @@ TensorProductMatrixSymmetricSum<dim, Number, n_rows_1d>::vmult(
   const ArrayView<Number>       &dst_view,
   const ArrayView<const Number> &src_view) const
 {
-  std::lock_guard<std::mutex> lock(this->mutex);
+  std::scoped_lock lock(this->mutex);
   this->vmult(dst_view, src_view, this->tmp_array);
 }
 

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -1282,7 +1282,7 @@ namespace LinearAlgebra
       {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
         // Make this part of the function thread safe
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
 #  endif
 
         vector_map = vector->getMap().ptr();
@@ -1331,7 +1331,7 @@ namespace LinearAlgebra
             {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
-              std::lock_guard<std::mutex> lock(mutex);
+              std::scoped_lock lock(mutex);
 #  endif
 
               // The element is not in the locally owned part, and
@@ -1346,7 +1346,7 @@ namespace LinearAlgebra
             {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
-              std::lock_guard<std::mutex> lock(mutex);
+              std::scoped_lock lock(mutex);
 #  endif
 
               // If the element was not in the locally owned part,
@@ -1420,7 +1420,7 @@ namespace LinearAlgebra
       {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
         // Make this part of the function thread safe
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
 #  endif
 
         vector_map = vector->getMap().ptr();
@@ -1469,7 +1469,7 @@ namespace LinearAlgebra
             {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
-              std::lock_guard<std::mutex> lock(mutex);
+              std::scoped_lock lock(mutex);
 #  endif
 
               // The element is not in the locally owned part, and
@@ -1484,7 +1484,7 @@ namespace LinearAlgebra
             {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
               // Make this part of the function thread safe
-              std::lock_guard<std::mutex> lock(mutex);
+              std::scoped_lock lock(mutex);
 #  endif
 
               // If the element was not in the locally owned part,

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -405,7 +405,7 @@ namespace LinearAlgebra
       {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
         // Make this part of the function thread safe
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
 #  endif
 
         vector_map = vector->getMap().ptr();
@@ -840,7 +840,7 @@ namespace LinearAlgebra
     {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
       // Make this part of the function thread safe
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
 #  endif
 
       // Get the local index
@@ -1313,7 +1313,7 @@ namespace LinearAlgebra
     {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
       // Make this part of the function thread safe
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
 #  endif
 
       return vector->getGlobalLength();
@@ -1337,7 +1337,7 @@ namespace LinearAlgebra
     {
 #  ifndef HAVE_TEUCHOS_THREAD_SAFE
       // Make this part of the function thread safe
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
 #  endif
 
       const size_type begin = vector->getMap()->getMinGlobalIndex();

--- a/include/deal.II/lac/vector_memory.templates.h
+++ b/include/deal.II/lac/vector_memory.templates.h
@@ -112,7 +112,7 @@ inline GrowingVectorMemory<VectorType>::GrowingVectorMemory(
   // the member variable being accessed is 'static', which is the case
   // for the things get_pool() returns, and in that case the mutex itself
   // must also be 'static' as it is here.
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
   get_pool().initialize(initial_size);
 }
 
@@ -137,7 +137,7 @@ template <typename VectorType>
 inline VectorType *
 GrowingVectorMemory<VectorType>::alloc()
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   ++total_alloc;
   ++current_alloc;
@@ -166,7 +166,7 @@ template <typename VectorType>
 inline void
 GrowingVectorMemory<VectorType>::free(const VectorType *const v)
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   // Find the vector to be de-allocated and mark it as now unused:
   for (entry_type &i : *get_pool().data)
@@ -190,7 +190,7 @@ template <typename VectorType>
 inline void
 GrowingVectorMemory<VectorType>::release_unused_memory()
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   if (get_pool().data != nullptr)
     get_pool().data->clear();
@@ -202,7 +202,7 @@ template <typename VectorType>
 inline std::size_t
 GrowingVectorMemory<VectorType>::memory_consumption() const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   std::size_t result = sizeof(*this);
   for (const auto &[_, ptr] : *get_pool().data)

--- a/source/base/enable_observer_pointer.cc
+++ b/source/base/enable_observer_pointer.cc
@@ -136,7 +136,7 @@ void
 EnableObserverPointer::subscribe(std::atomic<bool> *const validity,
                                  const std::string       &id) const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   if (object_info == nullptr)
     object_info = &typeid(*this);
@@ -161,7 +161,7 @@ EnableObserverPointer::unsubscribe(std::atomic<bool> *const validity,
       return;
     }
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   auto it = counter_map.find(id);
   if (it == counter_map.end())

--- a/source/base/flow_function.cc
+++ b/source/base/flow_function.cc
@@ -70,7 +70,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);
@@ -100,7 +100,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);
@@ -123,7 +123,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);
@@ -145,7 +145,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_gradients[d].resize(n_points);
@@ -173,7 +173,7 @@ namespace Functions
 
     // guard access to the aux_*
     // variables in multithread mode
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     for (unsigned int d = 0; d < dim + 1; ++d)
       aux_values[d].resize(n_points);

--- a/source/base/function_cspline.cc
+++ b/source/base/function_cspline.cc
@@ -69,7 +69,7 @@ namespace Functions
     // GSL functions may modify gsl_interp_accel *acc object (last argument).
     // This can only work in multithreaded applications if we lock the data
     // structures via a mutex.
-    std::lock_guard<std::mutex> lock(acc_mutex);
+    std::scoped_lock lock(acc_mutex);
 
     const double x = p[0];
     Assert(x >= interpolation_points.front() &&
@@ -90,7 +90,7 @@ namespace Functions
     // GSL functions may modify gsl_interp_accel *acc object (last argument).
     // This can only work in multithreaded applications if we lock the data
     // structures via a mutex.
-    std::lock_guard<std::mutex> lock(acc_mutex);
+    std::scoped_lock lock(acc_mutex);
 
     const double x = p[0];
     Assert(x >= interpolation_points.front() &&
@@ -114,7 +114,7 @@ namespace Functions
     // GSL functions may modify gsl_interp_accel *acc object (last argument).
     // This can only work in multithreaded applications if we lock the data
     // structures via a mutex.
-    std::lock_guard<std::mutex> lock(acc_mutex);
+    std::scoped_lock lock(acc_mutex);
 
     const double x = p[0];
     Assert(x >= interpolation_points.front() &&

--- a/source/base/incremental_function.cc
+++ b/source/base/incremental_function.cc
@@ -52,7 +52,7 @@ namespace Functions
   {
     // since we modify a mutable member variable, lock the
     // the data via a mutex
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     // Cache the time state of the base class in case it has been changed
     // within the user code. We reset the wrapped function to the original
@@ -81,7 +81,7 @@ namespace Functions
   {
     // since we modify a mutable member variable, lock the
     // the data via a mutex
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     // Cache the time state of the base class in case it has been changed
     // within the user code. We reset the wrapped function to the original

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -150,7 +150,7 @@ IndexSet::do_compress() const
     // via a mutex, so that users can call 'const' functions from threads
     // in parallel (and these 'const' functions can then call compress()
     // which itself calls the current function)
-    std::lock_guard<std::mutex> lock(compress_mutex);
+    std::scoped_lock lock(compress_mutex);
 
     // see if any of the contiguous ranges can be merged. do not use
     // std::vector::erase in-place as it is quadratic in the number of

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -192,7 +192,7 @@ LogStream::operator<<(std::ostream &(*p)(std::ostream &))
 
   if (query_streambuf.flushed())
     {
-      std::lock_guard<std::mutex> lock(write_lock);
+      std::scoped_lock lock(write_lock);
 
       // Print the line head in case of a previous newline:
       if (at_newline)
@@ -219,7 +219,7 @@ LogStream::attach(std::ostream                 &o,
                   const bool                    print_job_id,
                   const std::ios_base::fmtflags flags)
 {
-  std::lock_guard<std::mutex> lock(log_lock);
+  std::scoped_lock lock(log_lock);
   file = &o;
   o.setf(flags);
   if (print_job_id)
@@ -230,7 +230,7 @@ LogStream::attach(std::ostream                 &o,
 void
 LogStream::detach()
 {
-  std::lock_guard<std::mutex> lock(log_lock);
+  std::scoped_lock lock(log_lock);
   file = nullptr;
 }
 
@@ -348,9 +348,9 @@ LogStream::width(const std::streamsize wide)
 unsigned int
 LogStream::depth_console(const unsigned int n)
 {
-  std::lock_guard<std::mutex> lock(log_lock);
-  const unsigned int          h = std_depth;
-  std_depth                     = n;
+  std::scoped_lock   lock(log_lock);
+  const unsigned int h = std_depth;
+  std_depth            = n;
   return h;
 }
 
@@ -359,9 +359,9 @@ LogStream::depth_console(const unsigned int n)
 unsigned int
 LogStream::depth_file(const unsigned int n)
 {
-  std::lock_guard<std::mutex> lock(log_lock);
-  const unsigned int          h = file_depth;
-  file_depth                    = n;
+  std::scoped_lock   lock(log_lock);
+  const unsigned int h = file_depth;
+  file_depth           = n;
   return h;
 }
 
@@ -370,9 +370,9 @@ LogStream::depth_file(const unsigned int n)
 bool
 LogStream::log_thread_id(const bool flag)
 {
-  std::lock_guard<std::mutex> lock(log_lock);
-  const bool                  h = print_thread_id;
-  print_thread_id               = flag;
+  std::scoped_lock lock(log_lock);
+  const bool       h = print_thread_id;
+  print_thread_id    = flag;
   return h;
 }
 

--- a/source/base/mu_parser_internal.cc
+++ b/source/base/mu_parser_internal.cc
@@ -157,8 +157,8 @@ namespace internal
     double
     mu_rand_seed(const double seed)
     {
-      static std::mutex           rand_mutex;
-      std::lock_guard<std::mutex> lock(rand_mutex);
+      static std::mutex rand_mutex;
+      std::scoped_lock  lock(rand_mutex);
 
       std::uniform_real_distribution<> uniform_distribution(0., 1.);
 
@@ -177,7 +177,7 @@ namespace internal
     mu_rand()
     {
       static std::mutex                rand_mutex;
-      std::lock_guard<std::mutex>      lock(rand_mutex);
+      std::scoped_lock                 lock(rand_mutex);
       std::uniform_real_distribution<> uniform_distribution(0., 1.);
       const unsigned int  seed = static_cast<unsigned long>(std::time(nullptr));
       static std::mt19937 rng(seed);

--- a/source/base/parallel.cc
+++ b/source/base/parallel.cc
@@ -88,7 +88,7 @@ namespace parallel
     std::shared_ptr<tbb::affinity_partitioner>
     TBBPartitioner::acquire_one_partitioner()
     {
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
       if (in_use)
         return std::make_shared<tbb::affinity_partitioner>();
 
@@ -104,7 +104,7 @@ namespace parallel
     {
       if (p.get() == my_partitioner.get())
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          std::scoped_lock lock(mutex);
           in_use = false;
         }
     }

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -62,7 +62,7 @@ ParameterAcceptor::ParameterAcceptor(const std::string &name)
   : acceptor_id(ParameterAcceptor::get_next_free_id())
   , section_name(name)
 {
-  std::lock_guard<std::mutex> l(class_list_mutex);
+  std::scoped_lock l(class_list_mutex);
   class_list.insert(this);
 }
 
@@ -70,7 +70,7 @@ ParameterAcceptor::ParameterAcceptor(const std::string &name)
 
 ParameterAcceptor::~ParameterAcceptor()
 {
-  std::lock_guard<std::mutex> l(class_list_mutex);
+  std::scoped_lock l(class_list_mutex);
   // Notice that it is possible that the class is no longer in the static list.
   // This happens when the clear() method has been called. erase() does the
   // righy thing anyway by only removing this class if it's still in the list.
@@ -137,7 +137,7 @@ ParameterAcceptor::initialize(std::istream &input_stream, ParameterHandler &prm)
 void
 ParameterAcceptor::clear()
 {
-  std::lock_guard<std::mutex> l(class_list_mutex);
+  std::scoped_lock l(class_list_mutex);
   class_list.clear();
   prm.clear();
 }
@@ -294,9 +294,9 @@ ParameterAcceptor::get_acceptor_id() const
 unsigned int
 ParameterAcceptor::get_next_free_id()
 {
-  static std::mutex           id_mutex;
-  std::lock_guard<std::mutex> lock(id_mutex);
-  static int                  current_id = 0;
+  static std::mutex id_mutex;
+  std::scoped_lock  lock(id_mutex);
+  static int        current_id = 0;
   return current_id++;
 }
 

--- a/source/base/polynomials_abf.cc
+++ b/source/base/polynomials_abf.cc
@@ -83,7 +83,7 @@ PolynomialsABF<dim>::evaluate(
   // using a mutex to make sure they
   // are not used by multiple threads
   // at once
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   p_values.resize((values.empty()) ? 0 : n_sub);
   p_grads.resize((grads.empty()) ? 0 : n_sub);

--- a/source/base/polynomials_bdm.cc
+++ b/source/base/polynomials_bdm.cc
@@ -80,7 +80,7 @@ PolynomialsBDM<dim>::evaluate(
   // guard access to the scratch arrays in the following block using a
   // mutex to make sure they are not used by multiple threads at once
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
 
     p_values.resize((values.empty()) ? 0 : n_sub);
     p_grads.resize((grads.empty()) ? 0 : n_sub);

--- a/source/base/thread_management.cc
+++ b/source/base/thread_management.cc
@@ -41,7 +41,7 @@ namespace Threads
       // std::abort, though
       static Mutex mutex;
       {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
 
         std::cerr
           << std::endl
@@ -81,7 +81,7 @@ namespace Threads
       // std::abort, though
       static Mutex mutex;
       {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
 
         std::cerr
           << std::endl

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -187,7 +187,7 @@ Timer::start()
   // synchronize_and_update(), but before the number of laps is increased
   // is critical, since the same mutex is locked inside
   // synchronize_and_update().
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   if (is_running() == false)
     {
@@ -212,7 +212,7 @@ void
 Timer::stop()
 {
   // Make sure only one thread at a time stops the timer
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   AssertThrow(is_running() == true,
               ExcMessage(
@@ -313,7 +313,7 @@ Timer::synchronize_and_update() const
 
   // Make sure only one thread synchronizes the shared state
   // and all other threads wait until synchronization is done.
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   if (is_synchronized == false)
     {
@@ -488,7 +488,7 @@ TimerOutput::~TimerOutput()
 void
 TimerOutput::enter_subsection(const std::string &section_name)
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   Assert(section_name.empty() == false, ExcMessage("Section string is empty."));
 
@@ -528,7 +528,7 @@ TimerOutput::leave_subsection(const std::string &section_name)
   Assert(!active_sections.empty(),
          ExcMessage("Cannot exit any section because none has been entered!"));
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   if (!section_name.empty())
     {
@@ -1179,7 +1179,7 @@ TimerOutput::enable_output()
 void
 TimerOutput::reset()
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
   sections.clear();
   active_sections.clear();
   timer_all.restart();

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -439,7 +439,7 @@ FE_DGQ<dim, spacedim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -516,7 +516,7 @@ FE_DGQ<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
+      std::scoped_lock lock(restriction_matrix_mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -3356,7 +3356,7 @@ FE_Nedelec<dim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -3413,7 +3413,7 @@ FE_Nedelec<dim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
+      std::scoped_lock lock(restriction_matrix_mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -3280,7 +3280,7 @@ FE_NedelecSZ<dim, spacedim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -402,7 +402,7 @@ FE_PolyTensor<dim, spacedim>::shape_value_component(
   AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, dim);
 
-  std::lock_guard<std::mutex> lock(cache_mutex);
+  std::scoped_lock lock(cache_mutex);
 
   if (cached_point != p || cached_values.empty())
     {
@@ -447,7 +447,7 @@ FE_PolyTensor<dim, spacedim>::shape_grad_component(
   AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, dim);
 
-  std::lock_guard<std::mutex> lock(cache_mutex);
+  std::scoped_lock lock(cache_mutex);
 
   if (cached_point != p || cached_grads.empty())
     {
@@ -493,7 +493,7 @@ FE_PolyTensor<dim, spacedim>::shape_grad_grad_component(
   AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, dim);
 
-  std::lock_guard<std::mutex> lock(cache_mutex);
+  std::scoped_lock lock(cache_mutex);
 
   if (cached_point != p || cached_grad_grads.empty())
     {

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -581,8 +581,8 @@ FE_PyramidP<dim, spacedim>::hp_line_dof_identities(
   // check if the support points are the same location on the line
   // the pyramid base is defined by the vertices [-1,-1,0], [1,-1,0],
   // [-1,1,0], [1,1,0], to avoid rescaling use the support points on the faces
-  const auto face_support_points = this->get_unit_face_support_points(0);
-  const auto face_support_points_other =
+  const auto  face_support_points = this->get_unit_face_support_points(0);
+  const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(0);
 
   // now just compare the DoFs on the line going from [0,0] to [1,0]
@@ -650,8 +650,8 @@ FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
     }
 
   // compare the face support points
-  const auto face_support_points = this->get_unit_face_support_points(face_no);
-  const auto face_support_points_other =
+  const auto  face_support_points = this->get_unit_face_support_points(face_no);
+  const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(face_no_neighbor);
 
   // get the offsets to only compare the DoFs within the face as the vertices

--- a/source/fe/fe_pyramid_p.cc
+++ b/source/fe/fe_pyramid_p.cc
@@ -581,7 +581,7 @@ FE_PyramidP<dim, spacedim>::hp_line_dof_identities(
   // check if the support points are the same location on the line
   // the pyramid base is defined by the vertices [-1,-1,0], [1,-1,0],
   // [-1,1,0], [1,1,0], to avoid rescaling use the support points on the faces
-  const auto  face_support_points = this->get_unit_face_support_points(0);
+  const auto &face_support_points = this->get_unit_face_support_points(0);
   const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(0);
 
@@ -650,7 +650,7 @@ FE_PyramidP<dim, spacedim>::hp_quad_dof_identities(
     }
 
   // compare the face support points
-  const auto  face_support_points = this->get_unit_face_support_points(face_no);
+  const auto &face_support_points = this->get_unit_face_support_points(face_no);
   const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(face_no_neighbor);
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1207,7 +1207,7 @@ FE_Q_Base<dim, spacedim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -1410,7 +1410,7 @@ FE_Q_Base<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
+      std::scoped_lock lock(restriction_matrix_mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -832,8 +832,8 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
       // check if the support points are the same location on the line
       // to avoid rescaling for pyramids use the support points on the faces
-      const auto face_support_points = this->get_unit_face_support_points(0);
-      const auto face_support_points_other =
+      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(0);
 
       // now just compare the DoFs on the line going from [0,0] to [1,0]
@@ -941,8 +941,8 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       // compare the face support points
-      const auto face_support_points = this->get_unit_face_support_points(0);
-      const auto face_support_points_other =
+      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(face_no_neighbor);
 
       // get the offsets to skip vertices and lines

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -832,7 +832,7 @@ FE_Q_Base<dim, spacedim>::hp_line_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
       // check if the support points are the same location on the line
       // to avoid rescaling for pyramids use the support points on the faces
-      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points = this->get_unit_face_support_points(0);
       const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(0);
 
@@ -941,7 +941,7 @@ FE_Q_Base<dim, spacedim>::hp_quad_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
       // compare the face support points
-      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points = this->get_unit_face_support_points(0);
       const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(face_no_neighbor);
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -692,7 +692,7 @@ FE_RaviartThomasNodal<dim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -751,7 +751,7 @@ FE_RaviartThomasNodal<dim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
+      std::scoped_lock lock(restriction_matrix_mutex);
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -941,7 +941,7 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
       // check if the support points are the same location on the line
       // to avoid rescaling for pyramids use the support points on the faces
-      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points = this->get_unit_face_support_points(0);
       const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(0);
 
@@ -1013,7 +1013,7 @@ FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
         (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ? 1 : 0;
 
       // compare the face support points
-      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points = this->get_unit_face_support_points(0);
       const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(face_no_neighbor);
 

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -389,7 +389,7 @@ FE_SimplexPoly<dim, spacedim>::get_prolongation_matrix(
   // initialization upon first request
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
@@ -483,7 +483,7 @@ FE_SimplexPoly<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
+      std::scoped_lock lock(restriction_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->restriction[refinement_case - 1][child].n() ==
@@ -1213,7 +1213,7 @@ FE_SimplexDGP<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(this->restriction_matrix_mutex);
+      std::scoped_lock lock(this->restriction_matrix_mutex);
 
       // if matrix got updated while waiting for the lock
       if (this->restriction[refinement_case - 1][child].n() ==

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -941,8 +941,8 @@ FE_SimplexP<dim, spacedim>::hp_line_dof_identities(
       std::vector<std::pair<unsigned int, unsigned int>> identities;
       // check if the support points are the same location on the line
       // to avoid rescaling for pyramids use the support points on the faces
-      const auto face_support_points = this->get_unit_face_support_points(0);
-      const auto face_support_points_other =
+      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(0);
 
       // now just compare the DoFs on the line going from [0,0] to [1,0]
@@ -1013,8 +1013,8 @@ FE_SimplexP<dim, spacedim>::hp_quad_dof_identities(
         (dynamic_cast<const FE_PyramidP<dim> *>(&fe_other) != nullptr) ? 1 : 0;
 
       // compare the face support points
-      const auto face_support_points = this->get_unit_face_support_points(0);
-      const auto face_support_points_other =
+      const auto  face_support_points = this->get_unit_face_support_points(0);
+      const auto &face_support_points_other =
         fe_other.get_unit_face_support_points(face_no_neighbor);
 
       // get the offsets to only compare the DoFs within the face as the

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -862,7 +862,7 @@ FESystem<dim, spacedim>::get_restriction_matrix(
   // initialization upon first request
   if (this->restriction[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(restriction_matrix_mutex);
+      std::scoped_lock lock(restriction_matrix_mutex);
 
       // check if updated while waiting for lock
       if (this->restriction[refinement_case - 1][child].n() ==
@@ -945,7 +945,7 @@ FESystem<dim, spacedim>::get_prolongation_matrix(
   // restriction matrix
   if (this->prolongation[refinement_case - 1][child].n() == 0)
     {
-      std::lock_guard<std::mutex> lock(prolongation_matrix_mutex);
+      std::scoped_lock lock(prolongation_matrix_mutex);
 
       if (this->prolongation[refinement_case - 1][child].n() ==
           this->n_dofs_per_cell())

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -304,7 +304,7 @@ FE_WedgeP<dim, spacedim>::hp_line_dof_identities(
   std::vector<std::pair<unsigned int, unsigned int>> identities;
   // check if the support points are the same location on the line
   // to avoid rescaling for pyramids use the support points on the faces
-  const auto  face_support_points = this->get_unit_face_support_points(0);
+  const auto &face_support_points = this->get_unit_face_support_points(0);
   const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(0);
 
@@ -371,7 +371,7 @@ FE_WedgeP<dim, spacedim>::hp_quad_dof_identities(
     }
 
   // compare the face support points
-  const auto  face_support_points = this->get_unit_face_support_points(face_no);
+  const auto &face_support_points = this->get_unit_face_support_points(face_no);
   const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(face_no_neighbor);
 

--- a/source/fe/fe_wedge_p.cc
+++ b/source/fe/fe_wedge_p.cc
@@ -304,8 +304,8 @@ FE_WedgeP<dim, spacedim>::hp_line_dof_identities(
   std::vector<std::pair<unsigned int, unsigned int>> identities;
   // check if the support points are the same location on the line
   // to avoid rescaling for pyramids use the support points on the faces
-  const auto face_support_points = this->get_unit_face_support_points(0);
-  const auto face_support_points_other =
+  const auto  face_support_points = this->get_unit_face_support_points(0);
+  const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(0);
 
   // now just compare the DoFs on the line going from [0,0] to [1,0]
@@ -371,8 +371,8 @@ FE_WedgeP<dim, spacedim>::hp_quad_dof_identities(
     }
 
   // compare the face support points
-  const auto face_support_points = this->get_unit_face_support_points(face_no);
-  const auto face_support_points_other =
+  const auto  face_support_points = this->get_unit_face_support_points(face_no);
+  const auto &face_support_points_other =
     fe_other.get_unit_face_support_points(face_no_neighbor);
 
   // get the offsets to skip vertices and lines

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -166,7 +166,7 @@ MappingQEulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
   // fill shift vector for each support point using an fe_values object. make
   // sure that the fe_values variable isn't used simultaneously from different
   // threads
-  std::lock_guard<std::mutex> lock(fe_values_mutex);
+  std::scoped_lock lock(fe_values_mutex);
   fe_values.reinit(dof_cell);
   if (mg_vector)
     {

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -92,7 +92,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(vertex_to_cells_mutex);
+    std::scoped_lock lock(vertex_to_cells_mutex);
 
     if (update_flags & update_vertex_to_cell_map)
       {
@@ -116,7 +116,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(vertex_to_cell_centers_mutex);
+    std::scoped_lock lock(vertex_to_cell_centers_mutex);
 
     if (update_flags & update_vertex_to_cell_centers_directions)
       {
@@ -141,7 +141,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(used_vertices_mutex);
+    std::scoped_lock lock(used_vertices_mutex);
 
     if (update_flags & update_used_vertices)
       {
@@ -165,7 +165,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(used_vertices_rtree_mutex);
+    std::scoped_lock lock(used_vertices_rtree_mutex);
 
     if (update_flags & update_used_vertices_rtree)
       {
@@ -197,7 +197,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(cell_bounding_boxes_rtree_mutex);
+    std::scoped_lock lock(cell_bounding_boxes_rtree_mutex);
 
     if (update_flags & update_cell_bounding_boxes_rtree)
       {
@@ -231,8 +231,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(
-      locally_owned_cell_bounding_boxes_rtree_mutex);
+    std::scoped_lock lock(locally_owned_cell_bounding_boxes_rtree_mutex);
 
     if (update_flags & update_locally_owned_cell_bounding_boxes_rtree)
       {
@@ -270,7 +269,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(covering_rtree_mutex);
+    std::scoped_lock lock(covering_rtree_mutex);
 
     if (update_flags & update_covering_rtree ||
         covering_rtree.find(level) == covering_rtree.end())
@@ -311,7 +310,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(vertex_to_neighbor_subdomain_mutex);
+    std::scoped_lock lock(vertex_to_neighbor_subdomain_mutex);
 
     if (update_flags & update_vertex_to_neighbor_subdomain)
       {
@@ -342,7 +341,7 @@ namespace GridTools
     // reset the flag that indices that this needs to happen to zero), and
     // then return it. Make this thread-safe by using a mutex to guard
     // all of this:
-    std::lock_guard<std::mutex> lock(vertices_with_ghost_neighbors_mutex);
+    std::scoped_lock lock(vertices_with_ghost_neighbors_mutex);
 
     if (update_flags & update_vertex_with_ghost_neighbors)
       {

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -713,7 +713,7 @@ LAPACKFullMatrix<number>::vmult(Vector<number>       &w,
         }
       case svd:
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          std::scoped_lock lock(mutex);
           AssertDimension(v.size(), this->n());
           AssertDimension(w.size(), this->m());
           // Compute V^T v
@@ -748,7 +748,7 @@ LAPACKFullMatrix<number>::vmult(Vector<number>       &w,
         }
       case inverse_svd:
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          std::scoped_lock lock(mutex);
           AssertDimension(w.size(), this->n());
           AssertDimension(v.size(), this->m());
           // Compute U^T v
@@ -850,7 +850,7 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number>       &w,
         }
       case svd:
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          std::scoped_lock lock(mutex);
           AssertDimension(w.size(), this->n());
           AssertDimension(v.size(), this->m());
 
@@ -886,7 +886,7 @@ LAPACKFullMatrix<number>::Tvmult(Vector<number>       &w,
         }
       case inverse_svd:
         {
-          std::lock_guard<std::mutex> lock(mutex);
+          std::scoped_lock lock(mutex);
           AssertDimension(v.size(), this->n());
           AssertDimension(w.size(), this->m());
 
@@ -1045,7 +1045,7 @@ LAPACKFullMatrix<number>::Tmmult(LAPACKFullMatrix<number>       &C,
   // https://stackoverflow.com/questions/3548069/multiplying-three-matrices-in-blas-with-the-middle-one-being-diagonal
   // http://mathforum.org/kb/message.jspa?messageID=3546564
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
   // First, get V*B into "work" array
   work.resize(kk * nn);
   // following http://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=2&t=768#p2577
@@ -1444,7 +1444,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::norm(const char type) const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   Assert(state == LAPACKSupport::matrix ||
            state == LAPACKSupport::inverse_matrix,
@@ -1521,7 +1521,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::reciprocal_condition_number(const number a_norm) const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
   Assert(state == cholesky, ExcState(state));
   number rcond = 0.;
 
@@ -1554,7 +1554,7 @@ template <typename number>
 number
 LAPACKFullMatrix<number>::reciprocal_condition_number() const
 {
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
   Assert(property == upper_triangular || property == lower_triangular,
          ExcProperty(property));
   number rcond = 0.;

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -1464,7 +1464,7 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric(
   Assert(property == LAPACKSupport::symmetric,
          ExcMessage("Matrix has to be symmetric for this operation."));
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   const bool use_values = (std::isnan(eigenvalue_limits.first) ||
                            std::isnan(eigenvalue_limits.second)) ?
@@ -1805,7 +1805,7 @@ ScaLAPACKMatrix<NumberType>::eigenpairs_symmetric_MRRR(
   Assert(property == LAPACKSupport::symmetric,
          ExcMessage("Matrix has to be symmetric for this operation."));
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   const bool use_values = (std::isnan(eigenvalue_limits.first) ||
                            std::isnan(eigenvalue_limits.second)) ?
@@ -2042,7 +2042,7 @@ ScaLAPACKMatrix<NumberType>::compute_SVD(ScaLAPACKMatrix<NumberType> *U,
              ExcDimensionMismatch(grid->blacs_context,
                                   VT->grid->blacs_context));
     }
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   std::vector<NumberType> sv(std::min(n_rows, n_columns));
 
@@ -2157,7 +2157,7 @@ ScaLAPACKMatrix<NumberType>::least_squares(ScaLAPACKMatrix<NumberType> &B,
          ExcMessage(
            "Use identical block-cyclic distribution for matrices A and B"));
 
-  std::lock_guard<std::mutex> lock(mutex);
+  std::scoped_lock lock(mutex);
 
   if (grid->mpi_process_is_active)
     {
@@ -2309,8 +2309,8 @@ ScaLAPACKMatrix<NumberType>::reciprocal_condition_number(
   Assert(state == LAPACKSupport::cholesky,
          ExcMessage(
            "Matrix has to be in Cholesky state before calling this function."));
-  std::lock_guard<std::mutex> lock(mutex);
-  NumberType                  rcond = 0.;
+  std::scoped_lock lock(mutex);
+  NumberType       rcond = 0.;
 
   if (grid->mpi_process_is_active)
     {
@@ -2412,8 +2412,8 @@ ScaLAPACKMatrix<NumberType>::norm_general(const char type) const
   Assert(state == LAPACKSupport::matrix ||
            state == LAPACKSupport::inverse_matrix,
          ExcMessage("norms can be called in matrix state only."));
-  std::lock_guard<std::mutex> lock(mutex);
-  NumberType                  res = 0.;
+  std::scoped_lock lock(mutex);
+  NumberType       res = 0.;
 
   if (grid->mpi_process_is_active)
     {
@@ -2473,8 +2473,8 @@ ScaLAPACKMatrix<NumberType>::norm_symmetric(const char type) const
          ExcMessage("norms can be called in matrix state only."));
   Assert(property == LAPACKSupport::symmetric,
          ExcMessage("Matrix has to be symmetric for this operation."));
-  std::lock_guard<std::mutex> lock(mutex);
-  NumberType                  res = 0.;
+  std::scoped_lock lock(mutex);
+  NumberType       res = 0.;
 
   if (grid->mpi_process_is_active)
     {

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -1246,8 +1246,7 @@ namespace internal
                 const unsigned int next_bucket =
                   (*it / bucket_size_threading + 1) * bucket_size_threading;
 
-                std::lock_guard<std::mutex> lock(
-                  mutexes[*it / bucket_size_threading]);
+                std::scoped_lock lock(mutexes[*it / bucket_size_threading]);
                 for (; it != end_unique && *it < next_bucket; ++it)
                   {
                     AssertIndexRange(*it, row_lengths.size());
@@ -1285,8 +1284,7 @@ namespace internal
                 const unsigned int next_bucket =
                   (*it / bucket_size_threading + 1) * bucket_size_threading;
 
-                std::lock_guard<std::mutex> lock(
-                  mutexes[*it / bucket_size_threading]);
+                std::scoped_lock lock(mutexes[*it / bucket_size_threading]);
                 for (; it != end_unique && *it < next_bucket; ++it)
                   if (row_lengths[*it] > 0)
                     connectivity_dof.add(*it, block);

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -421,7 +421,7 @@ namespace LaplaceSolver
 
         cell->get_dof_indices(local_dof_indices);
 
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -500,7 +500,7 @@ namespace LaplaceSolver
 
 
         cell->get_dof_indices(local_dof_indices);
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/bits/unit_support_points_02.cc
+++ b/tests/bits/unit_support_points_02.cc
@@ -37,7 +37,7 @@ void
 check2(const FiniteElement<dim> &fe)
 {
   deallog << fe.get_name() << std::endl;
-  const std::vector<Point<dim - 1>> unit_f_s_p =
+  const std::vector<Point<dim - 1>> &unit_f_s_p =
     fe.get_unit_face_support_points();
   for (unsigned int i = 0; i < unit_f_s_p.size(); ++i)
     deallog << i << ' ' << unit_f_s_p[i] << std::endl;

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -424,7 +424,7 @@ namespace LaplaceSolver
 
         cell->get_dof_indices(local_dof_indices);
 
-        std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < dofs_per_cell; ++j)
             linear_system.matrix.add(local_dof_indices[i],

--- a/tests/multithreading/thread_local_storage_01.cc
+++ b/tests/multithreading/thread_local_storage_01.cc
@@ -47,7 +47,7 @@ execute(int i)
   // accessed
   static Threads::Mutex m;
   {
-    std::lock_guard<std::mutex> l(m);
+    std::scoped_lock l(m);
     ++counter;
   }
 

--- a/tests/multithreading/thread_local_storage_02.cc
+++ b/tests/multithreading/thread_local_storage_02.cc
@@ -57,7 +57,7 @@ execute(int i)
   // accessed
   static Threads::Mutex m;
   {
-    std::lock_guard<std::mutex> l(m);
+    std::scoped_lock l(m);
     ++counter;
   }
 

--- a/tests/numerics/time_dependent_01.cc
+++ b/tests/numerics/time_dependent_01.cc
@@ -36,8 +36,8 @@ public:
   virtual void
   end_sweep()
   {
-    static Threads::Mutex       mutex;
-    std::lock_guard<std::mutex> lock(mutex);
+    static Threads::Mutex mutex;
+    std::scoped_lock      lock(mutex);
     end_sweep_flags[time_step_number] = true;
   }
 

--- a/tests/simplex/pyramid_support_points.cc
+++ b/tests/simplex/pyramid_support_points.cc
@@ -34,7 +34,7 @@ test(const unsigned int degree)
     for (const auto f : fe.reference_cell().face_indices())
       {
         deallog << "Face " << f << std::endl;
-        const auto unit_face_support_points =
+        const auto &unit_face_support_points =
           fe.get_unit_face_support_points(f);
         for (const auto &p : unit_face_support_points)
           deallog << p << std::endl;


### PR DESCRIPTION
This PR updates the clang-tidy CI check to the new ubuntu-26.04 image which effectively updates the clang-tidy version from 18.0 to 21.1.6. 

Not many new warnings were introduced, which this PR also addresses.

- [modernize-use-scoped-lock](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-scoped-lock.html)
- [performance-unnecessary-copy-initialization](https://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-copy-initialization.html)


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
