### PR TITLE
Revert "Do not export some symbols from GCC's libstdc++ if using GCC."

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -729,13 +729,7 @@ export
     using std::operator<=>;
   } // namespace std
 
-
-// When compiling with Clang but using (as is the default) the GCC standard
-// library, we have to export a few symbols from the __gnu_cxx namespace as
-// well. Interestingly, we only need to do this when compiling with Clang but
-// not with GCC; the latter apparently finds these symbols itself and will
-// instead issue errors if we try to export them here.
-#if defined(__GLIBCXX__) && defined(__clang__)
+#if defined(__GLIBCXX__) // For GCC's support library
 
   namespace __gnu_cxx
   {


### PR DESCRIPTION
This reverts commit d3766246dc3354c97fae690a80fcfe0a4b37d139 (i.e., #20003). Let's see whether that has any effect with regard to #20013.

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.
