### PR TITLE
Export more operators.

### DIFF
--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -741,6 +741,11 @@ export
   {
     using __gnu_cxx::operator-;
     using __gnu_cxx::operator==;
+    using __gnu_cxx::operator<;
+    using __gnu_cxx::operator<=;
+    using __gnu_cxx::operator>;
+    using __gnu_cxx::operator>=;
+    using __gnu_cxx::operator!=;
     using __gnu_cxx::operator<=>;
   } // namespace __gnu_cxx
 


### PR DESCRIPTION
Trying to figure out what causes #20013, my next hypothesis is that for some older-style classes, libstdc++ still uses `operator<` instead of generating that automatically from `operator <=>`. So we should export the old-style operators as well.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.
