### PR TITLE
Try using g++ 16 as the base library for modules.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -534,7 +534,7 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
         sudo apt-get update
         sudo apt-get install -yq --no-install-recommends \
-            ninja-build wget lsb-release gnupg g++-15
+            ninja-build wget lsb-release gnupg g++-16
         sudo wget https://apt.llvm.org/llvm.sh && sudo chmod +x llvm.sh && sudo ./llvm.sh 23
     - uses: actions/checkout@v7
       with:

--- a/module/interface_module_partitions/std.ccm
+++ b/module/interface_module_partitions/std.ccm
@@ -730,21 +730,7 @@ export
   } // namespace std
 
 
-// When compiling with Clang but using (as is the default) the GCC standard
-// library, we have to export a few symbols from the __gnu_cxx namespace as
-// well. Interestingly, we only need to do this when compiling with Clang but
-// not with GCC; the latter apparently finds these symbols itself and will
-// instead issue errors if we try to export them here.
-#if defined(__GLIBCXX__) && defined(__clang__)
-
-  namespace __gnu_cxx
-  {
-    using __gnu_cxx::operator-;
-    using __gnu_cxx::operator==;
-    using __gnu_cxx::operator<=>;
-  } // namespace __gnu_cxx
-
-#elif defined(_LIBCPP_VERSION) // For CLang's support library
+#if defined(_LIBCPP_VERSION) // For CLang's support library
 
   _LIBCPP_BEGIN_NAMESPACE_STD
 


### PR DESCRIPTION
Another attempt at fixing #20013: If the GCC 15 libstdc++ doesn't work, try the one from GCC 16.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
