### PR TITLE
Fix tests/examples/step-104 in release mode

### DIFF
--- a/tests/examples/step-104.diff
+++ b/tests/examples/step-104.diff
@@ -14,11 +14,17 @@
 <           << std::endl;
 ---
 >           << " iterations in " << 0.0 << " seconds" << std::endl;
-1270c1259
+1270,1275c1259,1260
 <           << " MPI ranks (with " << MultithreadInfo::n_threads()
+<           << " threads each) in ";
+<     if constexpr (running_in_debug_mode())
+<       pcout << "DEBUG mode";
+<     else
+<       pcout << "RELEASE mode";
 ---
 >           << " MPI ranks (with "
-1283c1272
+>           << " threads each)";
+1283c1268
 <     unsigned int n_refinements = 10;
 ---
 >     unsigned int n_refinements = 2;

--- a/tests/examples/step-104.with_mpi=true.with_p4est=true.output
+++ b/tests/examples/step-104.with_mpi=true.with_p4est=true.output
@@ -1,4 +1,4 @@
-Running on 1 MPI ranks (with  threads each) in DEBUG mode
+Running on 1 MPI ranks (with  threads each)
 Kokkos execution space: Serial
 dim: 3
 Element: Q2-Q1


### PR DESCRIPTION
This fixes the test failure for the step-104 test: https://cdash.dealii.org/tests/801183 - we should simply not print `debug` or `release` when in testing mode. While there, I ran the script to update the diffs, which gave me another change.


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
