### PR TITLE
gh-actions: Update indent checks to ubuntu-26.04.

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -19,7 +19,7 @@ jobs:
     # run the indent checks
 
     name: indent
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v7
@@ -61,7 +61,7 @@ jobs:
     # build the documentation
 
     name: doxygen
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     env:
       MAKEFLAGS: "--jobs=4"
@@ -103,7 +103,7 @@ jobs:
     # run pre-commit checks
 
     name: pre-commit
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     env:
       SKIP: clang-format, no-commit-to-branch

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -112,6 +112,13 @@ VERBATIM_HEADERS       = NO
 ALPHABETICAL_INDEX     = YES
 
 #---------------------------------------------------------------------------
+# configuration options related to the markdown formatting
+#---------------------------------------------------------------------------
+
+MARKDOWN_SUPPORT       = YES
+MARKDOWN_STRICT        = NO
+
+#---------------------------------------------------------------------------
 # configuration options related to the HTML output
 #---------------------------------------------------------------------------
 


### PR DESCRIPTION
Related to #20014. Follow-up to #20021.

This PR updates the indent CI checks to the new ubuntu-26.04 image which effectively updates the doxygen version from 1.9.8 to 1.15.0.

I have added a 'markdown' section to `options.dox.in`. doxygen 1.15.0 introduces a new option `MARKDOWN_STRICT`[^2] that defaults to `YES`. Older versions of doxygen simply ignore this option and give a warning about it being unknown.

Throughout the library, we use quotation style like LaTeX (\`...' or \`\`...''), which is incompatible with `MARKDOWN_STRICT=YES`. Those quotes would be interpreted by markdown as code spans[^1] and would have a missing closing backtick. doxygen reports these incidents as warnings, but unfortunately we can't just ignore them, as unclosed code spans would have other implications as the warnings in #20014 suggest.

It seems that doxygen is pushing towards the use of markdown with its new default behavior. To comply, we would need to transition to a quotation style compatible to markdown. For now, let's stick to the backwards compatible option and set `MARKDOWN_STRICT=NO`, so the current deal.II documentation can also be build with the latest doxygen versions.

[^1]: https://www.doxygen.nl/manual/markdown.html#mddox_code_spans
[^2]: https://www.doxygen.nl/manual/config.html#cfg_markdown_strict

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->