### PR TITLE
[9.9] Do not declare a function not needed.

### DIFF
--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -32,16 +32,6 @@ namespace internal
 {
   namespace
   {
-    template <std::size_t dim>
-    void
-    compute_tensor_index(const unsigned int,
-                         const unsigned int,
-                         const unsigned int,
-                         std::array<unsigned int, dim> &)
-    {
-      DEAL_II_NOT_IMPLEMENTED();
-    }
-
     void
     compute_tensor_index(const unsigned int n,
                          const unsigned int,


### PR DESCRIPTION
The current development version of Clang warns about functions that are defined as either `static` or in anonymous namespaces within `.cc` files and that are not used. This here is a case where we have overloads for `dim==1,2,3` and *also* declare a general template. But the latter is not necessary -- for functions, it is not necessary to have a general template because functions are *overloaded*, not *specialized*. So remove it.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
