### PR TITLE
Make sure we actually call the function we always intended to call.

### DIFF
--- a/doc/news/changes/minor/20260812Bangerth
+++ b/doc/news/changes/minor/20260812Bangerth
@@ -1,0 +1,9 @@
+Fixed: The Triangulation class had code that checks that a mesh after
+mesh refinement does not have cells that are distorted (e.g.,
+inside-out). Such distorted cells typically happen when the new point
+in the middle of a boundary edge is placed too far inside its adjacent
+cell, for example because the boundary has a lot of curvature. This
+check, however, was lost in a refactoring step many years ago and was
+no longer run. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2026/08/12)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1645,51 +1645,42 @@ namespace
 
 
   /**
-   * Return whether any of the
-   * children of the given cell is
-   * distorted or not. This is the
-   * function for dim==spacedim.
+   * Return whether any of the children of the given cell is distorted
+   * or not.
    */
-  template <int dim>
+  template <int dim, int spacedim>
   bool
   has_distorted_children(
     const typename Triangulation<dim, dim>::cell_iterator &cell)
   {
     Assert(cell->has_children(), ExcInternalError());
 
-    for (unsigned int c = 0; c < cell->n_children(); ++c)
+    if constexpr (dim == spacedim)
       {
-        Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-          vertices[i] = cell->child(c)->vertex(i);
+        for (unsigned int c = 0; c < cell->n_children(); ++c)
+          {
+            Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
+            for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+              vertices[i] = cell->child(c)->vertex(i);
 
-        Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
-        GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
+            Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
+            GeometryInfo<dim>::alternating_form_at_vertices(vertices,
+                                                            determinants);
 
-        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-          if (determinants[i] <=
-              1e-9 * Utilities::fixed_power<dim>(cell->child(c)->diameter()))
-            return true;
+            for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+              if (determinants[i] <= 1e-9 * Utilities::fixed_power<dim>(
+                                              cell->child(c)->diameter()))
+                return true;
+          }
+
+        return false;
       }
-
-    return false;
+    else
+      // Like for collect_distorted_coarse_cells, there is nothing
+      // that we can do in this case.
+      return false;
   }
 
-
-  /**
-   * Function for dim!=spacedim. As
-   * for
-   * collect_distorted_coarse_cells,
-   * there is nothing that we can do
-   * in this case.
-   */
-  template <int dim, int spacedim>
-  bool
-  has_distorted_children(
-    const typename Triangulation<dim, spacedim>::cell_iterator &)
-  {
-    return false;
-  }
 
 
   template <int dim, int spacedim>

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -18,6 +18,8 @@
 #include <deal.II/base/mpi_large_count.h>
 #include <deal.II/base/mpi_stub.h>
 #include <deal.II/base/ndarray.h>
+#include <deal.II/base/signaling_nan.h>
+#include <deal.II/base/std_cxx26/inplace_vector.h>
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/utilities.h>
 
@@ -1645,51 +1647,77 @@ namespace
 
 
   /**
-   * Return whether any of the
-   * children of the given cell is
-   * distorted or not. This is the
-   * function for dim==spacedim.
-   */
-  template <int dim>
-  bool
-  has_distorted_children(
-    const typename Triangulation<dim, dim>::cell_iterator &cell)
-  {
-    Assert(cell->has_children(), ExcInternalError());
-
-    for (unsigned int c = 0; c < cell->n_children(); ++c)
-      {
-        Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-          vertices[i] = cell->child(c)->vertex(i);
-
-        Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
-        GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
-
-        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-          if (determinants[i] <=
-              1e-9 * Utilities::fixed_power<dim>(cell->child(c)->diameter()))
-            return true;
-      }
-
-    return false;
-  }
-
-
-  /**
-   * Function for dim!=spacedim. As
-   * for
-   * collect_distorted_coarse_cells,
-   * there is nothing that we can do
-   * in this case.
+   * Return whether any of the children of the given cell is distorted
+   * or not.
    */
   template <int dim, int spacedim>
   bool
   has_distorted_children(
-    const typename Triangulation<dim, spacedim>::cell_iterator &)
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell)
   {
-    return false;
+    Assert(cell->has_children(), ExcInternalError());
+    Assert(cell->reference_cell().is_hyper_cube(), ExcNotImplemented());
+
+    if constexpr (dim == spacedim)
+      {
+        for (unsigned int c = 0; c < cell->n_children(); ++c)
+          {
+            // We call this function during mesh refinement, at a time
+            // when the cell vertex cache has not yet been
+            // re-built. As a consequence, we cannot call
+            // cell->vertex(), or cell->diameter() (the latter
+            // implicitly depending on the former). Instead, we have to
+            // use a helper function to extract vertex locations into
+            // an array that bypasses the cache.
+
+            const unsigned int n_vertices = cell->child(c)->n_vertices();
+            std_cxx26::inplace_vector<unsigned int,
+                                      ReferenceCells::max_n_vertices<dim>()>
+              child_vertex_indices(n_vertices);
+            GridTools::internal::extract_vertices_without_cache<dim, spacedim>(
+              cell->child(c), child_vertex_indices);
+
+            Point<dim> child_vertices[GeometryInfo<dim>::vertices_per_cell];
+            for (unsigned int i = 0; i < n_vertices; ++i)
+              child_vertices[i] = cell->get_triangulation()
+                                    .get_vertices()[child_vertex_indices[i]];
+
+            Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
+            GeometryInfo<dim>::alternating_form_at_vertices(child_vertices,
+                                                            determinants);
+
+            double child_diameter = numbers::signaling_nan<double>();
+            if constexpr (dim == 1)
+              child_diameter = (child_vertices[1] - child_vertices[0]).norm();
+            else if constexpr (dim == 2)
+              // Take the longer one of the two diagonals of the quadrilateral
+              child_diameter =
+                std::max({(child_vertices[3] - child_vertices[0]).norm(),
+                          (child_vertices[2] - child_vertices[1]).norm()});
+            else if constexpr (dim == 3)
+              // Take the longest of the four diagonals of the hexahedron
+              child_diameter =
+                std::max({(child_vertices[7] - child_vertices[0]).norm(),
+                          (child_vertices[6] - child_vertices[1]).norm(),
+                          (child_vertices[2] - child_vertices[5]).norm(),
+                          (child_vertices[3] - child_vertices[4]).norm()});
+            else
+              DEAL_II_NOT_IMPLEMENTED();
+
+            for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+              if (determinants[i] <=
+                  1e-9 * Utilities::fixed_power<dim>(child_diameter))
+                return true;
+          }
+
+        return false;
+      }
+    else
+      // Like for collect_distorted_coarse_cells, there is nothing
+      // that we can do in this case.
+      return false;
   }
+
 
 
   template <int dim, int spacedim>


### PR DESCRIPTION
The current development version of Clang warns about functions that are defined as either `static` or in anonymous namespaces within `.cc` files and that are not used. This here is an interesting case: We have
```
  template <int dim>
  void f(X<dim,dim> &x) { ... check something useful ...}

  template <int dim, int spacedim>
  void f(X<dim,spacedim> &x) {... just bail out because we can't check things with codim>=1 ...}
```
But then we always call the function via `f<dim,spacedim>(x)`, which -- because the first of the two functions has only one template argument -- means that we're *always* calling the back-up function even if `dim==spacedim`. This is clearly not what was intended. I suspect it's been wrong since we introduced the `spacedim` template argument -- quite a long time in other words.

This patch addresses this by switching between the codim=0 and codim>0 cases within the general template using `if constexpr`. I'm going to be very curious to see whether that triggers anything we might have missed over the last many years because of the wrong call!


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
