### PR TITLE
Fix out of bounds writes for gmsh files with misleading vertex counts

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2479,6 +2479,12 @@ GridIn<dim, spacedim>::read_msh(std::istream &input_stream)
             else
               in >> vertex_number >> x[0] >> x[1] >> x[2];
 
+            AssertThrow(
+              global_vertex < n_vertices,
+              ExcMessage(
+                "The Gmsh file lists more nodes than were declared in the "
+                "header of the $Nodes section."));
+
             for (unsigned int d = 0; d < spacedim; ++d)
               vertices[global_vertex][d] = x[d];
             // store mapping


### PR DESCRIPTION
Grid_in sizes its array of vertices for gmsh files based on the number of vertices the file reports but for gmsh file versions >= 40 it fills that array looping over each entity block's numNodes independently. A deliberately misconstructed input file could thus write outside the array. This PR prevents that by verifying that we are within the array bounds before writing.

Note: If we think checking every loop iteration is too much, we could promote the AssertDimension check which follows this block to an AssertThrow, but this would only error after the out of bounds write occurs.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [x] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [ ] No generative AI tools were used in preparing this contribution.


This bug was caught as part of a security sweep of deal.II using Claude Opus 4.8. Claude identified the problem and suggested solutions. Assessing the plausibility of the issue and the implementation of the solution were independently conducted by me.
