### PR TITLE
Make cell_index global inside Portable::MatrixFree

### DIFF
--- a/doc/news/changes/incompatibilities/20260711Moulday
+++ b/doc/news/changes/incompatibilities/20260711Moulday
@@ -1,0 +1,9 @@
+Changed: The cell index exposed to user code in the portable (Kokkos) matrix-free framework is now a global index. Impacts include:
+Portable::FEEvaluation::get_current_cell_index(),
+the cell_index passed to Portable::MatrixFree::Data,
+the cell argument handed to functors by Portable::MatrixFree::evaluate_coefficients(),
+and the cell argument of Portable::MatrixFree::Data::local_q_point_id() and get_quadrature_point() (and
+their host equivalents).
+User code that previously combined get_current_cell_index() with a color offset, or that indexed per-color arrays by cell_index, should now use the global index directly.
+<br>
+(Ryan Moulday, 2026/07/11)

--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -350,7 +350,8 @@ namespace Portable
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
     get_current_cell_index()
   {
-    return cell_id;
+    return precomputed_data->row_start / precomputed_data->padding_length +
+           cell_id;
   }
 
 

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -416,7 +416,15 @@ namespace Portable
       local_q_point_id(const unsigned int cell,
                        const unsigned int q_point) const
       {
-        AssertIndexRange(cell, precomputed_data[0].n_cells);
+        const unsigned int color_shift =
+          precomputed_data[0].row_start / precomputed_data[0].padding_length;
+        Assert(cell >= color_shift,
+               ExcMessage(
+                 "The cell index is smaller than the first cell of the "
+                 "current color."));
+
+        AssertIndexRange(cell - color_shift, precomputed_data[0].n_cells);
+
         AssertIndexRange(q_point, n_q_points);
 
         Assert(precomputed_data[0].n_cells ==
@@ -425,11 +433,7 @@ namespace Portable
         Assert(n_q_points == precomputed_data[0].q_points.extent(0),
                ExcInternalError("q_points array has wrong size"));
 
-        return (precomputed_data[0].row_start /
-                  precomputed_data[0].padding_length +
-                cell) *
-                 n_q_points +
-               q_point;
+        return cell * n_q_points + q_point;
       }
 
 
@@ -442,14 +446,21 @@ namespace Portable
       get_quadrature_point(const unsigned int cell,
                            const unsigned int q_point) const
       {
+        const unsigned int color_shift =
+          precomputed_data[0].row_start / precomputed_data[0].padding_length;
+        Assert(cell >= color_shift,
+               ExcMessage(
+                 "The cell index is smaller than the first cell of the "
+                 "current color."));
+        const unsigned int local_cell = cell - color_shift;
         Assert(precomputed_data[0].n_cells ==
                  precomputed_data[0].q_points.extent(1),
                ExcInternalError());
-        AssertIndexRange(cell, precomputed_data[0].n_cells);
+        AssertIndexRange(local_cell, precomputed_data[0].n_cells);
         AssertIndexRange(q_point, n_q_points);
         Assert(n_q_points == precomputed_data[0].q_points.extent(0),
                ExcInternalError());
-        return precomputed_data[0].q_points(q_point, cell);
+        return precomputed_data[0].q_points(q_point, local_cell);
       }
 
       /**
@@ -1146,7 +1157,7 @@ namespace Portable
                      const unsigned int n_q_points,
                      const unsigned int q_point) const
     {
-      return (row_start / padding_length + cell) * n_q_points + q_point;
+      return cell * n_q_points + q_point;
     }
 
 
@@ -1158,7 +1169,7 @@ namespace Portable
     get_quadrature_point(const unsigned int cell,
                          const unsigned int q_point) const
     {
-      return q_points(q_point, cell);
+      return q_points(q_point, cell - row_start / padding_length);
     }
   };
 

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -506,7 +506,9 @@ namespace Portable
                                 Functor::n_q_points,
                                 precomputed_data[d]);
 
-        const int cell_index = team_member.league_rank();
+        const int cell_index =
+          precomputed_data[0].row_start / precomputed_data[0].padding_length +
+          team_member.league_rank();
 
         typename MatrixFree<dim, Number>::Data data{team_member,
                                                     Functor::n_q_points,
@@ -909,7 +911,9 @@ namespace Portable
               Kokkos::parallel_for(
                 Kokkos::TeamVectorRange(team_member, n_q_points),
                 [&](const int q_point) {
-                  const int cell_index = team_member.league_rank();
+                  const int cell_index =
+                    colored_data[0].row_start / colored_data[0].padding_length +
+                    team_member.league_rank();
 
                   Kokkos::Array<SharedData<dim, Number>, n_max_dof_handlers>
                     shared_data;

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -1413,7 +1413,8 @@ namespace MatrixFreeTools
             fe_eval(data, m_dof_handler_index);
         const typename Portable::MatrixFree<dim, Number>::PrecomputedData
                  *gpu_data = &data->precomputed_data[m_dof_handler_index];
-        const int cell     = data->cell_index;
+        const int cell =
+          data->cell_index - gpu_data->row_start / gpu_data->padding_length;
 
         constexpr int dofs_per_cell = decltype(fe_eval)::tensor_dofs_per_cell;
         typename decltype(fe_eval)::value_type

--- a/tests/matrix_free_kokkos/coefficient_eval_device.cc
+++ b/tests/matrix_free_kokkos/coefficient_eval_device.cc
@@ -148,11 +148,15 @@ test()
         gpu_data, additional_data.mapping_update_flags);
       for (unsigned int cell_id = 0; cell_id < n_cells; ++cell_id)
         {
+          const unsigned int global_cell_id =
+            gpu_data.row_start / gpu_data.padding_length + cell_id;
           for (unsigned int i = 0; i < n_q_points_per_cell; ++i)
             {
               const unsigned int pos =
-                gpu_data_host.local_q_point_id(cell_id, n_q_points_per_cell, i);
-              auto         p = gpu_data_host.get_quadrature_point(cell_id, i);
+                gpu_data_host.local_q_point_id(global_cell_id,
+                                               n_q_points_per_cell,
+                                               i);
+              auto p = gpu_data_host.get_quadrature_point(global_cell_id, i);
               const double p_val = dim == 2 ? p[0] + p[1] : p[0] + p[1] + p[2];
               AssertThrow(std::abs(coef[pos] - p_val) < 1e-12,
                           ExcInternalError());

--- a/tests/matrix_free_kokkos/matrix_free_device_matrix_vector_06c.cc
+++ b/tests/matrix_free_kokkos/matrix_free_device_matrix_vector_06c.cc
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Same as matrix_free_device_matrix_vector_06b (varying coefficients) but with
+// coloring enabled.
+
+#include <deal.II/base/function.h>
+
+#include "../tests.h"
+
+#include "../matrix_free/create_mesh.h"
+#include "matrix_vector_device_common.h"
+
+template <int dim, int fe_degree, typename Number>
+void
+test()
+{
+  if (fe_degree > 1)
+    return;
+  Triangulation<dim> tria;
+  create_mesh(tria);
+  tria.begin_active()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  typename Triangulation<dim>::active_cell_iterator cell, endc;
+  cell = tria.begin_active();
+  endc = tria.end();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 0.5)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.refine_global(1);
+  cell = tria.begin_active();
+  for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
+    {
+      cell                 = tria.begin_active();
+      endc                 = tria.end();
+      unsigned int counter = 0;
+      for (; cell != endc; ++cell, ++counter)
+        if (counter % (7 - i) == 0)
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<Number> constraints;
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           Functions::ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  do_test<dim,
+          fe_degree,
+          Number,
+          LinearAlgebra::distributed::Vector<Number, MemorySpace::Default>,
+          fe_degree + 1>(dof, constraints, tria.n_active_cells(), false, true);
+}

--- a/tests/matrix_free_kokkos/matrix_free_device_matrix_vector_06c.output
+++ b/tests/matrix_free_kokkos/matrix_free_device_matrix_vector_06c.output
@@ -1,0 +1,13 @@
+
+DEAL:double:2d::Testing FE_Q<2>(1)
+DEAL:double:2d::Norm of difference: 3.02e-15
+DEAL:double:2d::
+DEAL:double:3d::Testing FE_Q<3>(1)
+DEAL:double:3d::Norm of difference: 8.28e-16
+DEAL:double:3d::
+DEAL:float:2d::Testing FE_Q<2>(1)
+DEAL:float:2d::Norm of difference: 3.32e-15
+DEAL:float:2d::
+DEAL:float:3d::Testing FE_Q<3>(1)
+DEAL:float:3d::Norm of difference: 8.54e-16
+DEAL:float:3d::

--- a/tests/matrix_free_kokkos/portable_get_cell_iterator_02.cc
+++ b/tests/matrix_free_kokkos/portable_get_cell_iterator_02.cc
@@ -46,11 +46,7 @@ struct CellCenterKernel
              const Portable::DeviceVector<double> &,
              Portable::DeviceVector<double> &) const
   {
-    const unsigned int cell_id = data->cell_index;
-    const unsigned int global_cell_id =
-      data->precomputed_data[0].row_start /
-        data->precomputed_data[0].padding_length +
-      cell_id;
+    const unsigned int global_cell_id = data->cell_index;
 
     Point<dim, double> cell_center;
     for (unsigned int d = 0; d < dim; ++d)
@@ -60,7 +56,7 @@ struct CellCenterKernel
     for (unsigned int q = 0; q < n_q_points; ++q)
       {
         const Point<dim, double> &q_point =
-          data->get_quadrature_point(cell_id, q);
+          data->get_quadrature_point(global_cell_id, q);
         for (unsigned int d = 0; d < dim; ++d)
           cell_center[d] += q_point[d];
       }


### PR DESCRIPTION
Currently `Portable::FEEvaluation::get_current_cell_index()` returns a color-local index, meaning you have to do some manual transformation on this cell index to get the true global index. This PR moves that logic into `Portable::FEEvaluation::get_current_cell_index()` itself, meaning that the output is now global by default. To correspond with this and align with a "global cell index as default" paradigm, several other supporting elements have been adjusted including:

- `Portable::MatrixFree::Data`, specifically `cell_index` is now stored as a global index rather than a color local one.
- `Portable::MatrixFree::evaluate_coefficients()` which now operates over global rather than color local cell indices.
- `Portable::MatrixFree::Data::local_q_point_id()` and `get_quadrature_point()` which both now take a global cell index rather than a color local one. 

Note that this was a deliberate design decision, we could have continued storing `cell_index` as color-local and compensated internally in these functions, but in my opinion it doesn't make a lot of sense that the cell index inputs taken in by all the helper functions should be global while the internal cell_index was local. We can go the other way if that's preferable. 

A few tests which explicitly iterated over color local indices had to be adjusted to comply with this change. This addresses #20030.

A new test has been added matrix_free_device_matrix_vector_06c which explicitly takes advantage of coloring to ensure issues with indexing surface.

Note that this is inherently a breaking change to any code that was already manually compensating for this.

This change works on the local program I was building with and passes all the tests in the matrix_free_kokkos subset.
### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.