### PR TITLE
Change sign for pressure term in step 104

### DIFF
--- a/examples/step-104/step-104.cc
+++ b/examples/step-104/step-104.cc
@@ -609,7 +609,7 @@ namespace Step104
           velocity_term[d][d] -= pressure_value;
         fe_u.submit_gradient(velocity_term, q_point);
 
-        const Number pressure_term = trace(gradient_u);
+        const Number pressure_term = -trace(gradient_u);
         fe_p.submit_value(pressure_term, q_point);
       });
 

--- a/tests/examples/step-104.with_mpi=true.with_p4est=true.output
+++ b/tests/examples/step-104.with_mpi=true.with_p4est=true.output
@@ -7,12 +7,12 @@ refinement: 0, n_dofs: 2312 = 2187 + 125
 GMG velocity block smoothers:
     level: 1 n_dofs: 375, eigenvalue spectrum: [ 0.3748094237, 1.432009386 ]
     level: 2 n_dofs: 2187, eigenvalue spectrum: [ 0.09606982461, 1.534153946 ]
-Solver converged in 11 iterations in 0 seconds
+Solver converged in 10 iterations in 0 seconds
 velocity error: 0.04512777779 pressure error: 0.1489693597
 
 refinement: 1, n_dofs: 15468 = 14739 + 729
 GMG velocity block smoothers:
     level: 2 n_dofs: 2187, eigenvalue spectrum: [ 0.09606982458, 1.538632983 ]
     level: 3 n_dofs: 14739, eigenvalue spectrum: [ 0.02701368613, 1.586314951 ]
-Solver converged in 28 iterations in 0 seconds
+Solver converged in 20 iterations in 0 seconds
 velocity error: 0.006038671786 pressure error: 0.01232929908


### PR DESCRIPTION
This term corresponds to the weak form -(q, div **u**). From preliminary testing iteration counts seem to improve dramatically (36 -> 24) for 50M DoFs.  @tjhei 

Work in progress until test results are updated.