### PR TITLE
Require Epetra for step-33

### DIFF
--- a/examples/step-33/CMakeLists.txt
+++ b/examples/step-33/CMakeLists.txt
@@ -40,13 +40,15 @@ endif()
 #
 # Are all dependencies fulfilled?
 #
-if(NOT DEAL_II_TRILINOS_WITH_SACADO OR NOT DEAL_II_WITH_MUPARSER)
+if(NOT DEAL_II_TRILINOS_WITH_EPETRA OR NOT DEAL_II_TRILINOS_WITH_SACADO OR NOT DEAL_II_WITH_MUPARSER)
   message(FATAL_ERROR "
 Error! This tutorial requires a deal.II library that was configured with the following options:
     DEAL_II_WITH_MUPARSER = ON
+    DEAL_II_TRILINOS_WITH_EPETRA = ON
     DEAL_II_TRILINOS_WITH_SACADO = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options:
     DEAL_II_WITH_MUPARSER = ${DEAL_II_WITH_MUPARSER}
+    DEAL_II_TRILINOS_WITH_EPETRA = ${DEAL_II_TRILINOS_WITH_EPETRA}
     DEAL_II_TRILINOS_WITH_SACADO = ${DEAL_II_TRILINOS_WITH_SACADO}
 This conflicts with the requirements."
     )


### PR DESCRIPTION
Related to https://github.com/dealii/dealii/issues/19932. step-33 is the only step explicitly using `Epetra` native types so we should guard accordingly.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
