### PR TITLE
Revert "Move logic from setup() into initialize in all petsc preconditioners."

### DIFF
--- a/doc/news/changes/incompatibilities/20250918Moulday
+++ b/doc/news/changes/incompatibilities/20250918Moulday
@@ -1,3 +1,0 @@
-Removed: The `setup` function for all preconditioners in the `PETScWrappers` namespace has been deprecated. Its action is now automatically performed during `initialize`.
-<br>
-(Ryan Moulday, 2025/09/18)

--- a/include/deal.II/lac/petsc_precondition.h
+++ b/include/deal.II/lac/petsc_precondition.h
@@ -97,10 +97,7 @@ namespace PETScWrappers
     /**
      * Explicitly call setup. This is usually not needed since PETSc will
      * automatically call the setup function when needed.
-     *
-     * @deprecated setup() is now explicitly called during initialize().
      */
-    DEAL_II_DEPRECATED_EARLY
     void
     setup();
 

--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -85,7 +85,12 @@ namespace PETScWrappers
 
   void
   PreconditionBase::setup()
-  {}
+  {
+    AssertThrow(pc != nullptr, StandardExceptions::ExcInvalidState());
+
+    PetscErrorCode ierr = PCSetUp(pc);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+  }
 
   MPI_Comm
   PreconditionBase::get_mpi_communicator() const
@@ -181,9 +186,6 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
-
-    PetscErrorCode ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -240,9 +242,6 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
-
-    PetscErrorCode ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -286,9 +285,6 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -338,9 +334,6 @@ namespace PETScWrappers
 
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -385,9 +378,6 @@ namespace PETScWrappers
 
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
 
@@ -431,9 +421,6 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -686,7 +673,6 @@ namespace PETScWrappers
 
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
-
 #  else
     Assert(false,
            ExcMessage("Your PETSc installation does not include a copy of "
@@ -707,9 +693,6 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
-
-    PetscErrorCode ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
 
 #  else // DEAL_II_PETSC_WITH_HYPRE
     (void)matrix_;
@@ -825,9 +808,6 @@ namespace PETScWrappers
     ierr = PCSetFromOptions(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-
 #  else // DEAL_II_PETSC_WITH_HYPRE
     (void)matrix_;
     Assert(false,
@@ -867,9 +847,6 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -924,9 +901,6 @@ namespace PETScWrappers
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
     ierr = PCSetFromOptions(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
@@ -1075,9 +1049,6 @@ namespace PETScWrappers
 
     create_pc_with_mat(matrix_);
     initialize();
-
-    PetscErrorCode ierr = PCSetUp(pc);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 
   /* ----------------- PreconditionShell -------------------- */
@@ -1123,9 +1094,6 @@ namespace PETScWrappers
     initialize(matrix.get_mpi_communicator());
     PetscErrorCode ierr;
     ierr = PCSetOperators(pc, matrix, matrix);
-    AssertThrow(ierr == 0, ExcPETScError(ierr));
-
-    ierr = PCSetUp(pc);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
   }
 


### PR DESCRIPTION
Reverts dealii/dealii#18883 

As seen in #20008 this patch caused some unexpected and not well understood changes to the preconditioner initialization process on the backend. Since this patch didn't really enable any new functionality but only aimed to achieve consistency between Trilinos and PETSc we don't lose anything by reverting it. The only note of caution (and the original motivator for this patch) on the user end is that if setup() is not deliberately called, it is called lazily on the backend during solve, which can erroneously lead users to include their preconditioner setup time inside their solve time. 