### PR TITLE
Fix potential out of bounds array access inside grid_in relating to dimEntity reads

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -2564,15 +2564,21 @@ GridIn<dim, spacedim>::read_msh(std::istream &input_stream)
           }
         else if (gmsh_file_format == 40)
           {
-            int tagEntity, dimEntity;
+            int          tagEntity;
+            unsigned int dimEntity;
             in >> tagEntity >> dimEntity >> cell_type >> numElements;
+            AssertThrow(dimEntity < tag_maps.size(),
+                        ExcInvalidGMSHInput(std::to_string(dimEntity)));
             material_id = tag_maps[dimEntity][tagEntity];
           }
         else
           {
             // for gmsh_file_format 4.1 the order of tag and dim is reversed,
-            int tagEntity, dimEntity;
+            int          tagEntity;
+            unsigned int dimEntity;
             in >> dimEntity >> tagEntity >> cell_type >> numElements;
+            AssertThrow(dimEntity < tag_maps.size(),
+                        ExcInvalidGMSHInput(std::to_string(dimEntity)));
             material_id = tag_maps[dimEntity][tagEntity];
           }
 


### PR DESCRIPTION
Right now inside grid_in for gmsh files with version >=40 we create an array of maps called tag_maps of size 4, but then when we write/read from it we index it using "dimEntity" which we just pull from the file directly. This would lead to out of bounds access if dimEntity fell outside the expected range. 

This PR adds an assert to prevent that. Note that I chose to convert dimEntity into an unsigned int to protect against the negative case because dimEntity should never be negative from what I can see. If we don't like that let me know I can change it back and then add a negative case to the assert.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [x] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [ ] No generative AI tools were used in preparing this contribution.


This bug was caught as part of a security sweep of deal.II using Claude Opus 4.8. Claude identified the problem and suggested solutions. Assessing the plausibility of the issue and the implementation of the solution were independently conducted by me.
