### PR TITLE
Tpetra: Fix compiling step-50 tests

### DIFF
--- a/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_sparse_matrix.templates.h
@@ -215,6 +215,7 @@ namespace LinearAlgebra
                                      sparsity_pattern,
                                      communicator,
                                      exchange_data);
+            trilinos_sparsity.compress();
             matrix = Utilities::Trilinos::internal::make_rcp<
               TpetraTypes::MatrixType<Number, MemorySpace>>(
               trilinos_sparsity.trilinos_sparsity_pattern());
@@ -328,6 +329,7 @@ namespace LinearAlgebra
                                      sparsity_pattern,
                                      communicator,
                                      exchange_data);
+            trilinos_sparsity.compress();
             matrix = Utilities::Trilinos::internal::make_rcp<
               TpetraTypes::MatrixType<Number, MemorySpace>>(
               trilinos_sparsity.trilinos_sparsity_pattern());

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -104,7 +104,8 @@ namespace internal
     }
 
 
-#ifdef DEAL_II_TRILINOS_WITH_EPETRA
+#ifdef DEAL_II_WITH_TRILINOS
+#  if !defined(DEAL_II_TRILINOS_WITH_TPETRA)
     /**
      * Adjust vectors on all levels to correct size.  Here, we just count the
      * numbers of degrees of freedom on each level and @p reinit each level
@@ -130,6 +131,35 @@ namespace internal
                           tria->get_mpi_communicator());
         }
     }
+#  else
+    /**
+     * Adjust vectors on all levels to correct size.  Here, we just count the
+     * numbers of degrees of freedom on each level and @p reinit each level
+     * vector to this length.
+     */
+    template <int dim, int spacedim, typename Number, typename MemorySpace>
+    void
+    reinit_vector(
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const std::vector<unsigned int> &,
+      MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace>>
+        &v)
+    {
+      const dealii::parallel::TriangulationBase<dim, spacedim> *tria =
+        (dynamic_cast<const dealii::parallel::TriangulationBase<dim, spacedim>
+                        *>(&dof_handler.get_triangulation()));
+      AssertThrow(
+        tria != nullptr,
+        ExcMessage(
+          "multigrid with Trilinos vectors only works with a parallel Triangulation!"));
+
+      for (unsigned int level = v.min_level(); level <= v.max_level(); ++level)
+        {
+          v[level].reinit(dof_handler.locally_owned_mg_dofs(level),
+                          tria->get_mpi_communicator());
+        }
+    }
+#  endif
 #endif
 
 #ifdef DEAL_II_WITH_PETSC

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -145,6 +145,8 @@ namespace internal
       MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<Number, MemorySpace>>
         &v)
     {
+      // The implementation is the same as for TrilinosWrappers::MPI::Vector
+      // above.
       const dealii::parallel::TriangulationBase<dim, spacedim> *tria =
         (dynamic_cast<const dealii::parallel::TriangulationBase<dim, spacedim>
                         *>(&dof_handler.get_triangulation()));

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -105,7 +105,11 @@ namespace internal
 
 
 #ifdef DEAL_II_WITH_TRILINOS
-#  if !defined(DEAL_II_TRILINOS_WITH_TPETRA)
+// TrilinosWrappers is an alias for LinearAlgebra::TpetraWrappers<double,
+// MemorySpace::Host> if Trilinos was configured with Tpetra but without Epetra.
+// Thus, it's sufficient to instantiate TrilinosWrappers when there is Epetra
+// support.
+#  if defined(DEAL_II_TRILINOS_WITH_EPETRA)
     /**
      * Adjust vectors on all levels to correct size.  Here, we just count the
      * numbers of degrees of freedom on each level and @p reinit each level
@@ -131,7 +135,8 @@ namespace internal
                           tria->get_mpi_communicator());
         }
     }
-#  else
+#  endif
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA)
     /**
      * Adjust vectors on all levels to correct size.  Here, we just count the
      * numbers of degrees of freedom on each level and @p reinit each level

--- a/source/lac/trilinos_tpetra_sparsity_pattern.cc
+++ b/source/lac/trilinos_tpetra_sparsity_pattern.cc
@@ -391,10 +391,15 @@ namespace LinearAlgebra
         const size_type<MemorySpace> first_row = row_map->getMinGlobalIndex(),
                                      last_row =
                                        row_map->getMaxGlobalIndex() + 1;
-        Teuchos::Array<size_t> n_entries_per_row(last_row - first_row);
 
-        for (size_type<MemorySpace> row = first_row; row < last_row; ++row)
-          n_entries_per_row[row - first_row] = sp.row_length(row);
+        Teuchos::Array<size_t> n_entries_per_row(
+          row_map->getLocalNumElements());
+
+        if (row_map->getLocalNumElements() > 0)
+          {
+            for (size_type<MemorySpace> row = first_row; row < last_row; ++row)
+              n_entries_per_row[row - first_row] = sp.row_length(row);
+          }
 
         AssertThrow(
           std::accumulate(n_entries_per_row.begin(),
@@ -426,26 +431,29 @@ namespace LinearAlgebra
 
         std::vector<TrilinosWrappers::types::int_type> row_indices;
 
-        for (size_type<MemorySpace> row = first_row; row < last_row; ++row)
+        if (row_map->getLocalNumElements() > 0)
           {
-            const TrilinosWrappers::types::int_type row_length =
-              sp.row_length(row);
-            if (row_length == 0)
-              continue;
+            for (size_type<MemorySpace> row = first_row; row < last_row; ++row)
+              {
+                const TrilinosWrappers::types::int_type row_length =
+                  sp.row_length(row);
+                if (row_length == 0)
+                  continue;
 
-            row_indices.resize(row_length, -1);
-            {
-              typename SparsityPatternType::iterator p = sp.begin(row);
-              // avoid incrementing p over the end of the current row because
-              // it is slow for DynamicSparsityPattern in parallel
-              for (int col = 0; col < row_length;)
+                row_indices.resize(row_length, -1);
                 {
-                  row_indices[col++] = p->column();
-                  if (col < row_length)
-                    ++p;
+                  typename SparsityPatternType::iterator p = sp.begin(row);
+                  // avoid incrementing p over the end of the current row
+                  // because it is slow for DynamicSparsityPattern in parallel
+                  for (int col = 0; col < row_length;)
+                    {
+                      row_indices[col++] = p->column();
+                      if (col < row_length)
+                        ++p;
+                    }
                 }
-            }
-            graph->insertGlobalIndices(row, row_length, row_indices.data());
+                graph->insertGlobalIndices(row, row_length, row_indices.data());
+              }
           }
 
         graph->globalAssemble();

--- a/source/multigrid/mg_level_global_transfer.inst.in
+++ b/source/multigrid/mg_level_global_transfer.inst.in
@@ -103,8 +103,11 @@ for (deal_II_dimension : DIMENSIONS; S1, S2 : REAL_SCALARS)
 
 for (deal_II_dimension : DIMENSIONS)
   {
-#ifdef DEAL_II_WITH_TRILINOS
-#  if !defined(DEAL_II_TRILINOS_WITH_TPETRA)
+// TrilinosWrappers is an alias for LinearAlgebra::TpetraWrappers<double,
+// MemorySpace::Host> if Trilinos was configured with Tpetra but without Epetra.
+// Thus, it's sufficient to instantiate TrilinosWrappers when there is Epetra
+// support.
+#if defined(DEAL_II_TRILINOS_WITH_EPETRA)
     template void
     MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_to_mg(
       const DoFHandler<deal_II_dimension> &,
@@ -120,7 +123,8 @@ for (deal_II_dimension : DIMENSIONS)
       const DoFHandler<deal_II_dimension> &,
       TrilinosWrappers::MPI::Vector &,
       const MGLevelObject<TrilinosWrappers::MPI::Vector> &) const;
-#  else
+#endif
+#if defined(DEAL_II_TRILINOS_WITH_TPETRA)
     template void
     MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<double>>::
       copy_to_mg(const DoFHandler<deal_II_dimension> &,
@@ -141,7 +145,7 @@ for (deal_II_dimension : DIMENSIONS)
         const MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<double>> &)
         const;
 
-#    ifdef DEAL_II_TRILINOS_WITH_TPETRA_INST_FLOAT
+#  ifdef DEAL_II_TRILINOS_WITH_TPETRA_INST_FLOAT
     template void
     MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<float>>::
       copy_to_mg(const DoFHandler<deal_II_dimension> &,
@@ -161,7 +165,6 @@ for (deal_II_dimension : DIMENSIONS)
         LinearAlgebra::TpetraWrappers::Vector<float> &,
         const MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<float>> &)
         const;
-#    endif
 #  endif
 #endif
 

--- a/source/multigrid/mg_level_global_transfer.inst.in
+++ b/source/multigrid/mg_level_global_transfer.inst.in
@@ -103,8 +103,8 @@ for (deal_II_dimension : DIMENSIONS; S1, S2 : REAL_SCALARS)
 
 for (deal_II_dimension : DIMENSIONS)
   {
-#ifdef DEAL_II_TRILINOS_WITH_EPETRA
-
+#ifdef DEAL_II_WITH_TRILINOS
+#  if !defined(DEAL_II_TRILINOS_WITH_TPETRA)
     template void
     MGLevelGlobalTransfer<TrilinosWrappers::MPI::Vector>::copy_to_mg(
       const DoFHandler<deal_II_dimension> &,
@@ -120,6 +120,49 @@ for (deal_II_dimension : DIMENSIONS)
       const DoFHandler<deal_II_dimension> &,
       TrilinosWrappers::MPI::Vector &,
       const MGLevelObject<TrilinosWrappers::MPI::Vector> &) const;
+#  else
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<double>>::
+      copy_to_mg(const DoFHandler<deal_II_dimension> &,
+                 MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<double>> &,
+                 const LinearAlgebra::TpetraWrappers::Vector<double> &) const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<double>>::
+      copy_from_mg(
+        const DoFHandler<deal_II_dimension> &,
+        LinearAlgebra::TpetraWrappers::Vector<double> &,
+        const MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<double>> &)
+        const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<double>>::
+      copy_from_mg_add(
+        const DoFHandler<deal_II_dimension> &,
+        LinearAlgebra::TpetraWrappers::Vector<double> &,
+        const MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<double>> &)
+        const;
+
+#    ifdef DEAL_II_TRILINOS_WITH_TPETRA_INST_FLOAT
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<float>>::
+      copy_to_mg(const DoFHandler<deal_II_dimension> &,
+                 MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<float>> &,
+                 const LinearAlgebra::TpetraWrappers::Vector<float> &) const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<float>>::
+      copy_from_mg(
+        const DoFHandler<deal_II_dimension> &,
+        LinearAlgebra::TpetraWrappers::Vector<float> &,
+        const MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<float>> &)
+        const;
+    template void
+    MGLevelGlobalTransfer<LinearAlgebra::TpetraWrappers::Vector<float>>::
+      copy_from_mg_add(
+        const DoFHandler<deal_II_dimension> &,
+        LinearAlgebra::TpetraWrappers::Vector<float> &,
+        const MGLevelObject<LinearAlgebra::TpetraWrappers::Vector<float>> &)
+        const;
+#    endif
+#  endif
 #endif
 
 #ifdef DEAL_II_WITH_PETSC


### PR DESCRIPTION
Related to #19932. This pull request adds functionality required for compiling the step-50 tests with Trilinos 17. I'm still seeing
```
	4841 - meshworker/step-50-mesh_loop.mpirun=3.debug (Failed)
	6050 - multigrid/step-50_01.mpirun=5.debug (Failed)
	6051 - multigrid/step-50_01.mpirun=8.debug (Failed)
	6053 - multigrid/step-50_02.mpirun=3.debug (Failed)
```
which is largely because the solver doesn't converge or needs more iterations.

Apart from the extra instantiations, we needed to compress the sparsity pattern before creating a matrix with it, and it also turns out that `Tpetra::Map::getMinGlobalIndex` returns garbage if there are no rows stored locally.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.