### PR TITLE
Fix FEValuesViews::Vector for non-primitive elements on codim-1 meshes

### DIFF
--- a/doc/news/changes/minor/20260624Nielsen
+++ b/doc/news/changes/minor/20260624Nielsen
@@ -1,0 +1,7 @@
+Fixed: FEValuesViews::Vector now correctly returns all spacedim components of
+the value, gradient, divergence, Hessian, third derivative and symmetric
+gradient for non-primitive vector elements on codimension-one meshes (dim &lt;
+spacedim). The non-primitive branch previously only looped over the first dim
+components and dropped the remaining ones.
+<br>
+(Jakob Tore Kammeyer Nielsen, 2026/06/24)

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -2190,7 +2190,7 @@ namespace FEValuesViews
     else
       {
         value_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] = fe_values->finite_element_output.shape_values(
@@ -2228,7 +2228,7 @@ namespace FEValuesViews
     else
       {
         gradient_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =
@@ -2264,7 +2264,7 @@ namespace FEValuesViews
     else
       {
         divergence_type return_value = 0;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value +=
@@ -2472,7 +2472,7 @@ namespace FEValuesViews
     else
       {
         hessian_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =
@@ -2512,7 +2512,7 @@ namespace FEValuesViews
     else
       {
         third_derivative_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =
@@ -2615,7 +2615,7 @@ namespace FEValuesViews
     else
       {
         gradient_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =


### PR DESCRIPTION
Related to adding support for Raviart-Thomas elements on codim-1 meshes. See [https://groups.google.com/g/dealii/c/6Z8jBTShIq8](https://groups.google.com/g/dealii/c/6Z8jBTShIq8).

This is preparing FEValuesViews to work for non-primitive elements on codim-1 meshes.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [x ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [ ] No generative AI tools were used in preparing this contribution.

I have used Claude Opus to generate a draft of the change and the commit message.