### PR TITLE
Add codimension-one support to FE_RaviartThomasNodal

### DIFF
--- a/doc/news/changes/minor/20260624Nielsen
+++ b/doc/news/changes/minor/20260624Nielsen
@@ -1,0 +1,7 @@
+Fixed: FEValuesViews::Vector now correctly returns all spacedim components of
+the value, gradient, divergence, Hessian, third derivative and symmetric
+gradient for non-primitive vector elements on codimension-one meshes (dim &lt;
+spacedim). The non-primitive branch previously only looped over the first dim
+components and dropped the remaining ones.
+<br>
+(Jakob Tore Kammeyer Nielsen, 2026/06/24)

--- a/doc/news/changes/minor/20260624NielsenPolyTensor
+++ b/doc/news/changes/minor/20260624NielsenPolyTensor
@@ -1,0 +1,10 @@
+New: FE_PolyTensor now supports the codimension-one case (dim &lt; spacedim).
+The internal computation of mapped shape gradients and Hessians, which is
+stored using DerivativeForm objects, is guarded so that the reference-cell
+polynomial gradients and Hessians are copied row by row when dim != spacedim
+instead of relying on a DerivativeForm/Tensor assignment that is only valid
+for dim == spacedim. An explicit instantiation for dim=2, spacedim=3 is
+provided. This is a prerequisite for tensor-valued elements such as
+Raviart-Thomas elements on embedded surfaces.
+<br>
+(Jakob Tore Kammeyer Nielsen, 2026/06/24)

--- a/doc/news/changes/minor/20260624NielsenRTNodal
+++ b/doc/news/changes/minor/20260624NielsenRTNodal
@@ -1,0 +1,11 @@
+New: FE_RaviartThomasNodal is now templated on both dim and spacedim and can
+be used on codimension-one meshes (dim=2, spacedim=3). In this case the
+element represents a spacedim-valued vector field that is everywhere tangential
+to the surface, transformed from the reference cell with the surface Piola
+transform. The element has n_components == spacedim. Note that on non-smooth
+(non-C&sup1;) manifolds the resulting field is non-conforming, as the normal
+direction is discontinuous across cell edges; hanging-node and hp constraints
+as well as mesh refinement with hanging nodes are not yet supported for the
+codimension-one case.
+<br>
+(Jakob Tore Kammeyer Nielsen, 2026/06/24)

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -402,14 +402,24 @@ protected:
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
-                  data.shape_grads[i][k] = grads[i];
+                  {
+                    if constexpr (dim == spacedim)
+                      data.shape_grads[i][k] = grads[i];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        data.shape_grads[i][k][d] = grads[i][d];
+                  }
               else
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   {
                     Tensor<2, dim> add_grads;
                     for (unsigned int j = 0; j < this->n_dofs_per_cell(); ++j)
                       add_grads += inverse_node_matrix(j, i) * grads[j];
-                    data.shape_grads[i][k] = add_grads;
+                    if constexpr (dim == spacedim)
+                      data.shape_grads[i][k] = add_grads;
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        data.shape_grads[i][k][d] = add_grads[d];
                   }
             }
 
@@ -417,7 +427,15 @@ protected:
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
-                  data.shape_grad_grads[i][k] = grad_grads[i];
+                  {
+                    if constexpr (dim == spacedim)
+                      data.shape_grad_grads[i][k] = grad_grads[i];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        for (unsigned int e = 0; e < dim; ++e)
+                          data.shape_grad_grads[i][k][d][e] =
+                            grad_grads[i][d][e];
+                  }
               else
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   {
@@ -425,7 +443,13 @@ protected:
                     for (unsigned int j = 0; j < this->n_dofs_per_cell(); ++j)
                       add_grad_grads +=
                         inverse_node_matrix(j, i) * grad_grads[j];
-                    data.shape_grad_grads[i][k] = add_grad_grads;
+                    if constexpr (dim == spacedim)
+                      data.shape_grad_grads[i][k] = add_grad_grads;
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        for (unsigned int e = 0; e < dim; ++e)
+                          data.shape_grad_grads[i][k][d][e] =
+                            add_grad_grads[d][e];
                   }
             }
         }

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -335,9 +335,41 @@ private:
  * @note The degree stored in the member variable
  * FiniteElementData<dim>::degree is higher by one than the constructor
  * argument!
+ *
+ * <h3>Use on codimension-one (surface) meshes</h3>
+ *
+ * Unlike FE_RaviartThomas, this class is also instantiated for the
+ * codimension-one case <tt>dim=2, spacedim=3</tt>, i.e. for a two-dimensional
+ * surface mesh embedded in three-dimensional space. In this case the element
+ * represents a @p spacedim -valued vector field that
+ * is everywhere <i>tangential</i> to the surface. The reference-cell,
+ * <tt>dim</tt>-valued Raviart-Thomas shape functions are mapped to the real,
+ * tangential, <tt>spacedim</tt>-valued field by the surface Piola transform
+ * @f[
+ *   \mathbf u(\mathbf x)
+ *   = \frac{J\, \hat{\mathbf u}(\hat{\mathbf x})}{\sqrt{\det(J^T J)}},
+ * @f]
+ * where $J \in \mathbb R^{\text{spacedim}\times\text{dim}}$ is the Jacobian of
+ * the mapping from the reference cell to the surface cell. The number of components of the element therefore equals
+ * @p spacedim, not @p dim, so that the field can be accessed as a
+ * @p spacedim -valued vector through FEValuesExtractors::Vector.
+ *
+ * @note The following features are currently not implemented for the
+ * codimension-one case (<tt>dim != spacedim</tt>) and only available for the
+ * usual <tt>dim == spacedim</tt> case: hanging-node and hp constraints (and
+ * therefore mesh refinement involving hanging nodes); restriction and
+ * prolongation matrices. In addition, the inverse interpolation
+ * (convert_generalized_support_point_values_to_dof_values(), as used by
+ * VectorTools::interpolate(), for example) would need to apply the (inverse)
+ * surface Piola transform, which is not implemented for this case; calling
+ * it for <tt>dim != spacedim</tt> therefore triggers
+ * DEAL_II_NOT_IMPLEMENTED() rather than silently returning an incorrect
+ * result. The forward evaluation of
+ * shape function values and gradients, which does use the correct surface
+ * Piola transform, is exact for arbitrary surface orientations.
  */
-template <int dim>
-class FE_RaviartThomasNodal : public FE_PolyTensor<dim>
+template <int dim, int spacedim = dim>
+class FE_RaviartThomasNodal : public FE_PolyTensor<dim, spacedim>
 {
 public:
   /**
@@ -354,21 +386,27 @@ public:
   get_name() const override;
 
   // documentation inherited from the base class
-  virtual std::unique_ptr<FiniteElement<dim, dim>>
+  virtual std::unique_ptr<FiniteElement<dim, spacedim>>
   clone() const override;
 
   virtual void
-  get_face_interpolation_matrix(const FiniteElement<dim> &source,
-                                FullMatrix<double>       &matrix,
+  get_face_interpolation_matrix(const FiniteElement<dim, spacedim> &source,
+                                FullMatrix<double>                 &matrix,
                                 const unsigned int face_no = 0) const override;
 
   virtual void
   get_subface_interpolation_matrix(
-    const FiniteElement<dim> &source,
-    const unsigned int        subface,
-    FullMatrix<double>       &matrix,
-    const unsigned int        face_no = 0) const override;
+    const FiniteElement<dim, spacedim> &source,
+    const unsigned int                  subface,
+    FullMatrix<double>                 &matrix,
+    const unsigned int                  face_no = 0) const override;
 
+  /**
+   * @copydoc FiniteElement::convert_generalized_support_point_values_to_dof_values()
+   *
+   * @note This function is not implemented for the codimension-one case
+   * (<tt>dim != spacedim</tt>).
+   */
   virtual void
   convert_generalized_support_point_values_to_dof_values(
     const std::vector<Vector<double>> &support_point_values,
@@ -378,20 +416,22 @@ public:
   hp_constraints_are_implemented() const override;
 
   virtual std::vector<std::pair<unsigned int, unsigned int>>
-  hp_vertex_dof_identities(const FiniteElement<dim> &fe_other) const override;
+  hp_vertex_dof_identities(
+    const FiniteElement<dim, spacedim> &fe_other) const override;
 
   virtual std::vector<std::pair<unsigned int, unsigned int>>
-  hp_line_dof_identities(const FiniteElement<dim> &fe_other) const override;
+  hp_line_dof_identities(
+    const FiniteElement<dim, spacedim> &fe_other) const override;
 
   virtual std::vector<std::pair<unsigned int, unsigned int>>
-  hp_quad_dof_identities(const FiniteElement<dim> &fe_other,
-                         const unsigned int        face_no = 0) const override;
+  hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other,
+                         const unsigned int face_no = 0) const override;
 
   /**
    * @copydoc FiniteElement::compare_for_domination()
    */
   virtual FiniteElementDomination::Domination
-  compare_for_domination(const FiniteElement<dim> &fe_other,
+  compare_for_domination(const FiniteElement<dim, spacedim> &fe_other,
                          const unsigned int codim = 0) const override final;
 
   virtual const FullMatrix<double> &

--- a/include/deal.II/fe/fe_raviart_thomas.h
+++ b/include/deal.II/fe/fe_raviart_thomas.h
@@ -350,7 +350,8 @@ private:
  *   = \frac{J\, \hat{\mathbf u}(\hat{\mathbf x})}{\sqrt{\det(J^T J)}},
  * @f]
  * where $J \in \mathbb R^{\text{spacedim}\times\text{dim}}$ is the Jacobian of
- * the mapping from the reference cell to the surface cell. The number of components of the element therefore equals
+ * the mapping from the reference cell to the surface cell. The number of
+ * components of the element therefore equals
  * @p spacedim, not @p dim, so that the field can be accessed as a
  * @p spacedim -valued vector through FEValuesExtractors::Vector.
  *

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1219,6 +1219,11 @@ namespace FETools
           std::make_unique<FETools::FEFactory<FE_Q<dim, spacedim>>>();
         result["FE_Bernstein"] =
           std::make_unique<FETools::FEFactory<FE_Bernstein<dim, spacedim>>>();
+        // FE_RaviartThomasNodal is only explicitly instantiated for the
+        // codimension-one case dim=2, spacedim=3.
+        if constexpr (dim == 2 && spacedim == 3)
+          result["FE_RaviartThomasNodal"] = std::make_unique<
+            FETools::FEFactory<FE_RaviartThomasNodal<dim, spacedim>>>();
         result["FE_SimplexP"] =
           std::make_unique<FETools::FEFactory<FE_SimplexP<dim, spacedim>>>();
         result["FE_SimplexDGP"] =

--- a/include/deal.II/fe/fe_values_views.h
+++ b/include/deal.II/fe/fe_values_views.h
@@ -2190,7 +2190,7 @@ namespace FEValuesViews
     else
       {
         value_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] = fe_values->finite_element_output.shape_values(
@@ -2228,7 +2228,7 @@ namespace FEValuesViews
     else
       {
         gradient_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =
@@ -2264,7 +2264,7 @@ namespace FEValuesViews
     else
       {
         divergence_type return_value = 0;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value +=
@@ -2472,7 +2472,7 @@ namespace FEValuesViews
     else
       {
         hessian_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =
@@ -2512,7 +2512,7 @@ namespace FEValuesViews
     else
       {
         third_derivative_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =
@@ -2615,7 +2615,7 @@ namespace FEValuesViews
     else
       {
         gradient_type return_value;
-        for (unsigned int d = 0; d < dim; ++d)
+        for (unsigned int d = 0; d < spacedim; ++d)
           if (shape_function_data[shape_function]
                 .is_nonzero_shape_function_component[d])
             return_value[d] =

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1381,7 +1381,7 @@ namespace internal
             if (is_translation)
               continue;
 
-            if (dim == spacedim && update_flags & update_volume_elements)
+            if (update_flags & update_volume_elements)
               data.volume_elements[i] = derivative.determinant();
 
             if (update_flags & update_contravariant_transformation)

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -756,7 +756,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                                     transformed_shape_values);
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_values(first + d, k) =
                         transformed_shape_values[k][d];
 
@@ -778,7 +778,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                                     mapping_internal,
                                     transformed_shape_values);
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_values(first + d, k) =
                         dof_sign * transformed_shape_values[k][d];
                   break;
@@ -800,7 +800,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                                     transformed_shape_values);
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_values(first + d, k) =
                         dof_sign * transformed_shape_values[k][d];
 
@@ -830,7 +830,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                                     mapping_internal,
                                     transformed_shape_grads);
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_gradients[first + d][k] =
                         transformed_shape_grads[k][d];
                   break;
@@ -854,7 +854,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                           mapping_data.jacobian_pushed_forward_grads[k][n][d];
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_gradients[first + d][k] =
                         transformed_shape_grads[k][d];
                   break;
@@ -863,8 +863,13 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
               case mapping_contravariant:
                 {
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_grads[k + offset] =
-                      fe_data.shape_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_grads[k + offset] =
+                        fe_data.shape_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        fe_data.untransformed_shape_grads[k + offset][d] =
+                          fe_data.shape_grads[dof_index][k + offset][d];
                   mapping.transform(
                     make_array_view(fe_data.untransformed_shape_grads,
                                     offset,
@@ -881,7 +886,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                           mapping_data.jacobian_pushed_forward_grads[k][d][n];
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_gradients[first + d][k] =
                         transformed_shape_grads[k][d];
 
@@ -892,8 +897,13 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
               case mapping_piola:
                 {
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_grads[k + offset] =
-                      fe_data.shape_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_grads[k + offset] =
+                        fe_data.shape_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        fe_data.untransformed_shape_grads[k + offset][d] =
+                          fe_data.shape_grads[dof_index][k + offset][d];
                   mapping.transform(
                     make_array_view(fe_data.untransformed_shape_grads,
                                     offset,
@@ -913,7 +923,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                            mapping_data.jacobian_pushed_forward_grads[k][n][n]);
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_gradients[first + d][k] =
                         dof_sign * transformed_shape_grads[k][d];
 
@@ -933,8 +943,13 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                   // value we want to have on
                   // the real cell.
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_grads[k + offset] =
-                      fe_data.shape_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_grads[k + offset] =
+                        fe_data.shape_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        fe_data.untransformed_shape_grads[k + offset][d] =
+                          fe_data.shape_grads[dof_index][k + offset][d];
 
                   mapping.transform(
                     make_array_view(fe_data.untransformed_shape_grads,
@@ -952,7 +967,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                           mapping_data.jacobian_pushed_forward_grads[k][n][d];
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_gradients[first + d][k] =
                         dof_sign * transformed_shape_grads[k][d];
 
@@ -991,7 +1006,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                           mapping_data.jacobian_pushed_forward_grads[k][n];
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_hessians[first + d][k] =
                         transformed_shape_hessians[k][d];
 
@@ -1000,8 +1015,17 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
               case mapping_covariant:
                 {
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_hessian_tensors[k + offset] =
-                      fe_data.shape_grad_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_hessian_tensors[k + offset] =
+                        fe_data.shape_grad_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        for (unsigned int e = 0; e < dim; ++e)
+                          fe_data
+                            .untransformed_shape_hessian_tensors[k + offset][d]
+                                                                [e] =
+                            fe_data
+                              .shape_grad_grads[dof_index][k + offset][d][e];
 
                   const ArrayView<Tensor<3, spacedim>>
                     transformed_shape_hessians =
@@ -1039,7 +1063,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                             }
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_hessians[first + d][k] =
                         transformed_shape_hessians[k][d];
 
@@ -1049,8 +1073,17 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
               case mapping_contravariant:
                 {
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_hessian_tensors[k + offset] =
-                      fe_data.shape_grad_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_hessian_tensors[k + offset] =
+                        fe_data.shape_grad_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        for (unsigned int e = 0; e < dim; ++e)
+                          fe_data
+                            .untransformed_shape_hessian_tensors[k + offset][d]
+                                                                [e] =
+                            fe_data
+                              .shape_grad_grads[dof_index][k + offset][d][e];
 
                   const ArrayView<Tensor<3, spacedim>>
                     transformed_shape_hessians =
@@ -1104,7 +1137,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                             }
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_hessians[first + d][k] =
                         transformed_shape_hessians[k][d];
 
@@ -1115,8 +1148,17 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
               case mapping_piola:
                 {
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_hessian_tensors[k + offset] =
-                      fe_data.shape_grad_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_hessian_tensors[k + offset] =
+                        fe_data.shape_grad_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        for (unsigned int e = 0; e < dim; ++e)
+                          fe_data
+                            .untransformed_shape_hessian_tensors[k + offset][d]
+                                                                [e] =
+                            fe_data
+                              .shape_grad_grads[dof_index][k + offset][d][e];
 
                   const ArrayView<Tensor<3, spacedim>>
                     transformed_shape_hessians =
@@ -1201,7 +1243,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                             }
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_hessians[first + d][k] =
                         dof_sign * transformed_shape_hessians[k][d];
 
@@ -1211,8 +1253,17 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
               case mapping_nedelec:
                 {
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    fe_data.untransformed_shape_hessian_tensors[k + offset] =
-                      fe_data.shape_grad_grads[dof_index][k + offset];
+                    if constexpr (dim == spacedim)
+                      fe_data.untransformed_shape_hessian_tensors[k + offset] =
+                        fe_data.shape_grad_grads[dof_index][k + offset];
+                    else
+                      for (unsigned int d = 0; d < dim; ++d)
+                        for (unsigned int e = 0; e < dim; ++e)
+                          fe_data
+                            .untransformed_shape_hessian_tensors[k + offset][d]
+                                                                [e] =
+                            fe_data
+                              .shape_grad_grads[dof_index][k + offset][d][e];
 
                   const ArrayView<Tensor<3, spacedim>>
                     transformed_shape_hessians =
@@ -1250,7 +1301,7 @@ FE_PolyTensor<dim, spacedim>::compute_fill(
                             }
 
                   for (unsigned int k = 0; k < n_q_points; ++k)
-                    for (unsigned int d = 0; d < dim; ++d)
+                    for (unsigned int d = 0; d < spacedim; ++d)
                       output_data.shape_hessians[first + d][k] =
                         dof_sign * transformed_shape_hessians[k][d];
 

--- a/source/fe/fe_poly_tensor.inst.in
+++ b/source/fe/fe_poly_tensor.inst.in
@@ -16,3 +16,10 @@ for (deal_II_dimension : DIMENSIONS)
   {
     template class FE_PolyTensor<deal_II_dimension, deal_II_dimension>;
   }
+
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if deal_II_dimension == 2 && deal_II_space_dimension == 3
+    template class FE_PolyTensor<deal_II_dimension, deal_II_space_dimension>;
+#endif
+  }

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -62,21 +62,22 @@ namespace
 
 // --------------------- actual implementation of element --------------------
 
-template <int dim>
-FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int degree)
-  : FE_PolyTensor<dim>(
+template <int dim, int spacedim>
+FE_RaviartThomasNodal<dim, spacedim>::FE_RaviartThomasNodal(
+  const unsigned int degree)
+  : FE_PolyTensor<dim, spacedim>(
       PolynomialsVectorAnisotropic<dim>(
         degree + 1,
         degree,
         FE_RaviartThomas<dim>::get_lexicographic_numbering(degree)),
       FiniteElementData<dim>(get_rt_dpo_vector(dim, degree),
-                             dim,
+                             spacedim,
                              degree + 1,
                              FiniteElementData<dim>::Hdiv),
       std::vector<bool>(1, false),
       std::vector<ComponentMask>(
         PolynomialsVectorAnisotropic<dim>::n_polynomials(degree + 1, degree),
-        ComponentMask(std::vector<bool>(dim, true))))
+        ComponentMask(std::vector<bool>(spacedim, true))))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
 
@@ -99,25 +100,38 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int degree)
       degree == 0 ? QGauss<dim - 1>(1).get_points() :
                     QGaussLobatto<dim - 1>(degree + 1).get_points();
 
-  FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
-  for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->n_dofs_per_face(face_no),
-                              this->n_dofs_per_face(face_no));
-  FETools::compute_face_embedding_matrices<dim, double>(*this,
-                                                        face_embeddings,
-                                                        0,
-                                                        0);
-  this->interface_constraints.reinit(GeometryInfo<dim>::max_children_per_face *
-                                       this->n_dofs_per_face(face_no),
-                                     this->n_dofs_per_face(face_no));
-  unsigned int target_row = 0;
-  for (unsigned int d = 0; d < GeometryInfo<dim>::max_children_per_face; ++d)
-    for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
-      {
-        for (unsigned int j = 0; j < face_embeddings[d].n(); ++j)
-          this->interface_constraints(target_row, j) = face_embeddings[d](i, j);
-        ++target_row;
-      }
+  // The hanging-node interface constraints are computed via
+  // FETools::compute_face_embedding_matrices(), which is currently only
+  // implemented for the case dim == spacedim. For embedded surfaces
+  // (dim < spacedim) we skip this step for now; the resulting element can be
+  // used on (possibly globally refined) surface meshes without hanging nodes.
+  if constexpr (dim == spacedim)
+    {
+      FullMatrix<double>
+        face_embeddings[GeometryInfo<dim>::max_children_per_face];
+      for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face;
+           ++i)
+        face_embeddings[i].reinit(this->n_dofs_per_face(face_no),
+                                  this->n_dofs_per_face(face_no));
+      FETools::compute_face_embedding_matrices<dim, double>(*this,
+                                                            face_embeddings,
+                                                            0,
+                                                            0);
+      this->interface_constraints.reinit(
+        GeometryInfo<dim>::max_children_per_face *
+          this->n_dofs_per_face(face_no),
+        this->n_dofs_per_face(face_no));
+      unsigned int target_row = 0;
+      for (unsigned int d = 0; d < GeometryInfo<dim>::max_children_per_face;
+           ++d)
+        for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
+          {
+            for (unsigned int j = 0; j < face_embeddings[d].n(); ++j)
+              this->interface_constraints(target_row, j) =
+                face_embeddings[d](i, j);
+            ++target_row;
+          }
+    }
 
   // We need to initialize the dof permutation table and the one for the sign
   // change.
@@ -126,9 +140,9 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int degree)
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 std::string
-FE_RaviartThomasNodal<dim>::get_name() const
+FE_RaviartThomasNodal<dim, spacedim>::get_name() const
 {
   // note that the FETools::get_fe_by_name function depends on the particular
   // format of the string this function returns, so they have to be kept in
@@ -136,16 +150,16 @@ FE_RaviartThomasNodal<dim>::get_name() const
 
   // note that this->degree is the maximal polynomial degree and is thus one
   // higher than the argument given to the constructor
-  return "FE_RaviartThomasNodal<" + std::to_string(dim) + ">(" +
-         std::to_string(this->degree - 1) + ")";
+  return "FE_RaviartThomasNodal<" + Utilities::dim_string(dim, spacedim) +
+         ">(" + std::to_string(this->degree - 1) + ")";
 }
 
 
-template <int dim>
-std::unique_ptr<FiniteElement<dim, dim>>
-FE_RaviartThomasNodal<dim>::clone() const
+template <int dim, int spacedim>
+std::unique_ptr<FiniteElement<dim, spacedim>>
+FE_RaviartThomasNodal<dim, spacedim>::clone() const
 {
-  return std::make_unique<FE_RaviartThomasNodal<dim>>(*this);
+  return std::make_unique<FE_RaviartThomasNodal<dim, spacedim>>(*this);
 }
 
 
@@ -155,10 +169,10 @@ FE_RaviartThomasNodal<dim>::clone() const
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 void
-FE_RaviartThomasNodal<
-  dim>::initialize_quad_dof_index_permutation_and_sign_change()
+FE_RaviartThomasNodal<dim, spacedim>::
+  initialize_quad_dof_index_permutation_and_sign_change()
 {
   // for 1d and 2d, do nothing
   if (dim < 3)
@@ -216,9 +230,9 @@ FE_RaviartThomasNodal<
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 bool
-FE_RaviartThomasNodal<dim>::has_support_on_face(
+FE_RaviartThomasNodal<dim, spacedim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
@@ -240,13 +254,24 @@ FE_RaviartThomasNodal<dim>::has_support_on_face(
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 void
-FE_RaviartThomasNodal<dim>::
+FE_RaviartThomasNodal<dim, spacedim>::
   convert_generalized_support_point_values_to_dof_values(
     const std::vector<Vector<double>> &support_point_values,
     std::vector<double>               &nodal_values) const
 {
+  if constexpr (dim != spacedim)
+    {
+      // The computation below assumes that support_point_values are given
+      // in the dim-dimensional reference tangent space, which would require
+      // applying the inverse surface Piola transform first. This is not
+      // implemented for the codimension-one case.
+      (void)support_point_values;
+      (void)nodal_values;
+      DEAL_II_NOT_IMPLEMENTED();
+    }
+
   Assert(support_point_values.size() == this->generalized_support_points.size(),
          ExcDimensionMismatch(support_point_values.size(),
                               this->generalized_support_points.size()));
@@ -295,25 +320,27 @@ FE_RaviartThomasNodal<dim>::
 // an hp-space and make sure that the convergence order is correct with regard
 // to the lowest used polynomial degree
 
-template <int dim>
+template <int dim, int spacedim>
 bool
-FE_RaviartThomasNodal<dim>::hp_constraints_are_implemented() const
+FE_RaviartThomasNodal<dim, spacedim>::hp_constraints_are_implemented() const
 {
   return true;
 }
 
 
-template <int dim>
+template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
-FE_RaviartThomasNodal<dim>::hp_vertex_dof_identities(
-  const FiniteElement<dim> &fe_other) const
+FE_RaviartThomasNodal<dim, spacedim>::hp_vertex_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other) const
 {
   // we can presently only compute these identities if both FEs are
   // FE_RaviartThomasNodals or the other is FE_Nothing.  In either case, no
   // dofs are assigned on the vertex, so we shouldn't be getting here at all.
-  if (dynamic_cast<const FE_RaviartThomasNodal<dim> *>(&fe_other) != nullptr)
+  if (dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> *>(&fe_other) !=
+      nullptr)
     return std::vector<std::pair<unsigned int, unsigned int>>();
-  else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
+  else if (dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other) !=
+           nullptr)
     return std::vector<std::pair<unsigned int, unsigned int>>();
   else
     {
@@ -324,15 +351,15 @@ FE_RaviartThomasNodal<dim>::hp_vertex_dof_identities(
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
-FE_RaviartThomasNodal<dim>::hp_line_dof_identities(
-  const FiniteElement<dim> &fe_other) const
+FE_RaviartThomasNodal<dim, spacedim>::hp_line_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other) const
 {
   // we can presently only compute these identities if both FEs are
   // FE_RaviartThomasNodals or if the other one is FE_Nothing
-  if (const FE_RaviartThomasNodal<dim> *fe_q_other =
-        dynamic_cast<const FE_RaviartThomasNodal<dim> *>(&fe_other))
+  if (const FE_RaviartThomasNodal<dim, spacedim> *fe_q_other =
+        dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> *>(&fe_other))
     {
       // dofs are located on faces; these are only lines in 2d
       if (dim != 2)
@@ -365,7 +392,8 @@ FE_RaviartThomasNodal<dim>::hp_line_dof_identities(
 
       return identities;
     }
-  else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
+  else if (dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other) !=
+           nullptr)
     {
       // the FE_Nothing has no degrees of freedom, so there are no
       // equivalencies to be recorded
@@ -379,16 +407,16 @@ FE_RaviartThomasNodal<dim>::hp_line_dof_identities(
 }
 
 
-template <int dim>
+template <int dim, int spacedim>
 std::vector<std::pair<unsigned int, unsigned int>>
-FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
-  const FiniteElement<dim> &fe_other,
-  const unsigned int        face_no) const
+FE_RaviartThomasNodal<dim, spacedim>::hp_quad_dof_identities(
+  const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int                  face_no) const
 {
   // we can presently only compute these identities if both FEs are
   // FE_RaviartThomasNodals or if the other one is FE_Nothing
-  if (const FE_RaviartThomasNodal<dim> *fe_q_other =
-        dynamic_cast<const FE_RaviartThomasNodal<dim> *>(&fe_other))
+  if (const FE_RaviartThomasNodal<dim, spacedim> *fe_q_other =
+        dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> *>(&fe_other))
     {
       // dofs are located on faces; these are only quads in 3d
       if (dim != 3)
@@ -411,7 +439,8 @@ FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
 
       return identities;
     }
-  else if (dynamic_cast<const FE_Nothing<dim> *>(&fe_other) != nullptr)
+  else if (dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other) !=
+           nullptr)
     {
       // the FE_Nothing has no degrees of freedom, so there are no
       // equivalencies to be recorded
@@ -425,19 +454,19 @@ FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
 }
 
 
-template <int dim>
+template <int dim, int spacedim>
 FiniteElementDomination::Domination
-FE_RaviartThomasNodal<dim>::compare_for_domination(
-  const FiniteElement<dim> &fe_other,
-  const unsigned int        codim) const
+FE_RaviartThomasNodal<dim, spacedim>::compare_for_domination(
+  const FiniteElement<dim, spacedim> &fe_other,
+  const unsigned int                  codim) const
 {
   Assert(codim <= dim, ExcImpossibleInDim(dim));
   (void)codim;
 
   // vertex/line/face/cell domination
   // --------------------------------
-  if (const FE_RaviartThomasNodal<dim> *fe_rt_nodal_other =
-        dynamic_cast<const FE_RaviartThomasNodal<dim> *>(&fe_other))
+  if (const FE_RaviartThomasNodal<dim, spacedim> *fe_rt_nodal_other =
+        dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> *>(&fe_other))
     {
       if (this->degree < fe_rt_nodal_other->degree)
         return FiniteElementDomination::this_element_dominates;
@@ -446,8 +475,8 @@ FE_RaviartThomasNodal<dim>::compare_for_domination(
       else
         return FiniteElementDomination::other_element_dominates;
     }
-  else if (const FE_Nothing<dim> *fe_nothing =
-             dynamic_cast<const FE_Nothing<dim> *>(&fe_other))
+  else if (const FE_Nothing<dim, spacedim> *fe_nothing =
+             dynamic_cast<const FE_Nothing<dim, spacedim> *>(&fe_other))
     {
       if (fe_nothing->is_dominating())
         return FiniteElementDomination::other_element_dominates;
@@ -466,7 +495,7 @@ FE_RaviartThomasNodal<dim>::compare_for_domination(
 
 template <>
 void
-FE_RaviartThomasNodal<1>::get_face_interpolation_matrix(
+FE_RaviartThomasNodal<1, 1>::get_face_interpolation_matrix(
   const FiniteElement<1, 1> & /*x_source_fe*/,
   FullMatrix<double> & /*interpolation_matrix*/,
   const unsigned int) const
@@ -477,7 +506,7 @@ FE_RaviartThomasNodal<1>::get_face_interpolation_matrix(
 
 template <>
 void
-FE_RaviartThomasNodal<1>::get_subface_interpolation_matrix(
+FE_RaviartThomasNodal<1, 1>::get_subface_interpolation_matrix(
   const FiniteElement<1, 1> & /*x_source_fe*/,
   const unsigned int /*subface*/,
   FullMatrix<double> & /*interpolation_matrix*/,
@@ -488,20 +517,21 @@ FE_RaviartThomasNodal<1>::get_subface_interpolation_matrix(
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 void
-FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
-  const FiniteElement<dim> &x_source_fe,
-  FullMatrix<double>       &interpolation_matrix,
-  const unsigned int        face_no) const
+FE_RaviartThomasNodal<dim, spacedim>::get_face_interpolation_matrix(
+  const FiniteElement<dim, spacedim> &x_source_fe,
+  FullMatrix<double>                 &interpolation_matrix,
+  const unsigned int                  face_no) const
 {
   // this is only implemented, if the
   // source FE is also a
   // RaviartThomasNodal element
-  AssertThrow((x_source_fe.get_name().find("FE_RaviartThomasNodal<") == 0) ||
-                (dynamic_cast<const FE_RaviartThomasNodal<dim> *>(
-                   &x_source_fe) != nullptr),
-              typename FiniteElement<dim>::ExcInterpolationNotImplemented());
+  AssertThrow(
+    (x_source_fe.get_name().find("FE_RaviartThomasNodal<") == 0) ||
+      (dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> *>(
+         &x_source_fe) != nullptr),
+    (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
 
   Assert(interpolation_matrix.n() == this->n_dofs_per_face(face_no),
          ExcDimensionMismatch(interpolation_matrix.n(),
@@ -512,16 +542,17 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
 
   // ok, source is a RaviartThomasNodal element, so we will be able to do the
   // work
-  const FE_RaviartThomasNodal<dim> &source_fe =
-    dynamic_cast<const FE_RaviartThomasNodal<dim> &>(x_source_fe);
+  const FE_RaviartThomasNodal<dim, spacedim> &source_fe =
+    dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> &>(x_source_fe);
 
   // Make sure that the element for which the DoFs should be constrained is
   // the one with the higher polynomial degree.  Actually the procedure will
   // work also if this assertion is not satisfied. But the matrices produced
   // in that case might lead to problems in the hp-procedures, which use this
   // method.
-  Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
-         typename FiniteElement<dim>::ExcInterpolationNotImplemented());
+  Assert(
+    this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
+    (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
 
   // generate a quadrature with the generalized support points.  This is later
   // based as a basis for the QProjector, which returns the support points on
@@ -580,20 +611,21 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
 }
 
 
-template <int dim>
+template <int dim, int spacedim>
 void
-FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
-  const FiniteElement<dim> &x_source_fe,
-  const unsigned int        subface,
-  FullMatrix<double>       &interpolation_matrix,
-  const unsigned int        face_no) const
+FE_RaviartThomasNodal<dim, spacedim>::get_subface_interpolation_matrix(
+  const FiniteElement<dim, spacedim> &x_source_fe,
+  const unsigned int                  subface,
+  FullMatrix<double>                 &interpolation_matrix,
+  const unsigned int                  face_no) const
 {
   // this is only implemented, if the source FE is also a RaviartThomasNodal
   // element
-  AssertThrow((x_source_fe.get_name().find("FE_RaviartThomasNodal<") == 0) ||
-                (dynamic_cast<const FE_RaviartThomasNodal<dim> *>(
-                   &x_source_fe) != nullptr),
-              typename FiniteElement<dim>::ExcInterpolationNotImplemented());
+  AssertThrow(
+    (x_source_fe.get_name().find("FE_RaviartThomasNodal<") == 0) ||
+      (dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> *>(
+         &x_source_fe) != nullptr),
+    (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
 
   Assert(interpolation_matrix.n() == this->n_dofs_per_face(face_no),
          ExcDimensionMismatch(interpolation_matrix.n(),
@@ -604,16 +636,17 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
 
   // ok, source is a RaviartThomasNodal element, so we will be able to do the
   // work
-  const FE_RaviartThomasNodal<dim> &source_fe =
-    dynamic_cast<const FE_RaviartThomasNodal<dim> &>(x_source_fe);
+  const FE_RaviartThomasNodal<dim, spacedim> &source_fe =
+    dynamic_cast<const FE_RaviartThomasNodal<dim, spacedim> &>(x_source_fe);
 
   // Make sure that the element for which the DoFs should be constrained is
   // the one with the higher polynomial degree. Actually the procedure will
   // work also if this assertion is not satisfied. But the matrices produced
   // in that case might lead to problems in the hp-procedures, which use this
   // method.
-  Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
-         typename FiniteElement<dim>::ExcInterpolationNotImplemented());
+  Assert(
+    this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
+    (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
 
   // generate a quadrature with the generalized support points.  This is later
   // based as a basis for the QProjector, which returns the support points on
@@ -676,9 +709,9 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 const FullMatrix<double> &
-FE_RaviartThomasNodal<dim>::get_prolongation_matrix(
+FE_RaviartThomasNodal<dim, spacedim>::get_prolongation_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
@@ -701,8 +734,8 @@ FE_RaviartThomasNodal<dim>::get_prolongation_matrix(
 
       // now do the work. need to get a non-const version of data in order to
       // be able to modify them inside a const function
-      FE_RaviartThomasNodal<dim> &this_nonconst =
-        const_cast<FE_RaviartThomasNodal<dim> &>(*this);
+      FE_RaviartThomasNodal<dim, spacedim> &this_nonconst =
+        const_cast<FE_RaviartThomasNodal<dim, spacedim> &>(*this);
       if (refinement_case == RefinementCase<dim>::isotropic_refinement)
         {
           std::vector<std::vector<FullMatrix<double>>> isotropic_matrices(
@@ -735,9 +768,9 @@ FE_RaviartThomasNodal<dim>::get_prolongation_matrix(
 
 
 
-template <int dim>
+template <int dim, int spacedim>
 const FullMatrix<double> &
-FE_RaviartThomasNodal<dim>::get_restriction_matrix(
+FE_RaviartThomasNodal<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,
   const RefinementCase<dim> &refinement_case) const
 {
@@ -760,8 +793,8 @@ FE_RaviartThomasNodal<dim>::get_restriction_matrix(
 
       // now do the work. need to get a non-const version of data in order to
       // be able to modify them inside a const function
-      FE_RaviartThomasNodal<dim> &this_nonconst =
-        const_cast<FE_RaviartThomasNodal<dim> &>(*this);
+      FE_RaviartThomasNodal<dim, spacedim> &this_nonconst =
+        const_cast<FE_RaviartThomasNodal<dim, spacedim> &>(*this);
       if (refinement_case == RefinementCase<dim>::isotropic_refinement)
         {
           std::vector<std::vector<FullMatrix<double>>> isotropic_matrices(

--- a/source/fe/fe_raviart_thomas_nodal.inst.in
+++ b/source/fe/fe_raviart_thomas_nodal.inst.in
@@ -12,7 +12,13 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
-    template class FE_RaviartThomasNodal<deal_II_dimension>;
+#if deal_II_dimension == deal_II_space_dimension
+    template class FE_RaviartThomasNodal<deal_II_dimension,
+                                         deal_II_space_dimension>;
+#elif deal_II_dimension == 2 && deal_II_space_dimension == 3
+    template class FE_RaviartThomasNodal<deal_II_dimension,
+                                         deal_II_space_dimension>;
+#endif
   }

--- a/tests/fe/fe_rt_nodal_surface_01.cc
+++ b/tests/fe/fe_rt_nodal_surface_01.cc
@@ -1,0 +1,96 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Check FE_RaviartThomasNodal<2, 3> on a (flat, tilted) surface mesh embedded
+// in 3d. The element represents a 3d vector field that must be tangential to
+// the surface, so the shape function values dotted with the surface normal
+// have to vanish. Also check that the element reports spacedim components.
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/fe_values_extractors.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_description.h>
+
+#include "../tests.h"
+
+
+void
+test(const unsigned int degree)
+{
+  const unsigned int dim = 2, spacedim = 3;
+
+  // A single quad lying in a tilted but flat plane in 3d, so that the mapping
+  // is affine and the surface Piola transform is exact.
+  Triangulation<dim, spacedim> tria;
+  {
+    std::vector<Point<spacedim>> vertices = {{0, 0, 0},
+                                             {1, 0, 0},
+                                             {0, 1, 1},
+                                             {1, 1, 1}};
+    std::vector<CellData<dim>>   cells(1);
+    cells[0].vertices = {0, 1, 2, 3};
+    tria.create_triangulation(vertices, cells, SubCellData());
+  }
+
+  FE_RaviartThomasNodal<dim, spacedim> fe(degree);
+  deallog << fe.get_name() << std::endl;
+  deallog << "  n_components  = " << fe.n_components() << std::endl;
+  deallog << "  dofs_per_cell = " << fe.dofs_per_cell << std::endl;
+
+  DoFHandler<dim, spacedim> dh(tria);
+  dh.distribute_dofs(fe);
+
+  MappingQ<dim, spacedim> mapping(1);
+  QGauss<dim>             quad(degree + 2);
+  FEValues<dim, spacedim> fev(mapping,
+                              fe,
+                              quad,
+                              update_values | update_normal_vectors);
+  fev.reinit(tria.begin_active());
+
+  const FEValuesExtractors::Vector field(0);
+
+  double max_normal_component = 0.0;
+  for (unsigned int q = 0; q < quad.size(); ++q)
+    {
+      const Tensor<1, spacedim> n = fev.normal_vector(q);
+      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        {
+          const Tensor<1, spacedim> v = fev[field].value(i, q);
+          max_normal_component =
+            std::max(max_normal_component, std::abs(v * n));
+        }
+    }
+
+  // The exact value is zero; print a tolerance-based verdict so the test is
+  // portable across platforms.
+  deallog << "  tangential (max|shape.n| < 1e-10): "
+          << (max_normal_component < 1e-10 ? "yes" : "no") << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  test(0);
+  test(1);
+}

--- a/tests/fe/fe_rt_nodal_surface_01.output
+++ b/tests/fe/fe_rt_nodal_surface_01.output
@@ -1,0 +1,9 @@
+
+DEAL::FE_RaviartThomasNodal<2,3>(0)
+DEAL::  n_components  = 3
+DEAL::  dofs_per_cell = 4
+DEAL::  tangential (max|shape.n| < 1e-10): yes
+DEAL::FE_RaviartThomasNodal<2,3>(1)
+DEAL::  n_components  = 3
+DEAL::  dofs_per_cell = 12
+DEAL::  tangential (max|shape.n| < 1e-10): yes

--- a/tests/fe/fe_rt_nodal_surface_02.cc
+++ b/tests/fe/fe_rt_nodal_surface_02.cc
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Check that FE_RaviartThomasNodal<2, 3> shape values are correct at
+// quadrature points that are processed by the scalar remainder path of
+// MappingQ (i.e., for quadrature rules whose number of points leaves a
+// remainder with respect to the SIMD vectorization width; a 1-point rule is
+// the simplest such case). The Piola transform divides by the volume element
+// sqrt(det(J^T J)), and the remainder path used to skip filling
+// volume_elements for dim != spacedim, so such quadrature points divided by
+// an uninitialized value, yielding NaN/inf (or garbage) shape values. Guard
+// against this by checking that the values from a 1-point rule are finite
+// and agree with the values at the same point from an 8-point rule, which is
+// processed entirely by the vectorized path for all common SIMD widths.
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_raviart_thomas.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/fe_values_extractors.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_description.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int dim = 2, spacedim = 3;
+
+  // A single quad lying in a tilted but flat plane in 3d.
+  Triangulation<dim, spacedim> tria;
+  {
+    std::vector<Point<spacedim>> vertices = {{0, 0, 0},
+                                             {1, 0, 0},
+                                             {0, 1, 1},
+                                             {1, 1, 1}};
+    std::vector<CellData<dim>>   cells(1);
+    cells[0].vertices = {0, 1, 2, 3};
+    tria.create_triangulation(vertices, cells, SubCellData());
+  }
+
+  FE_RaviartThomasNodal<dim, spacedim> fe(0);
+  deallog << fe.get_name() << std::endl;
+
+  DoFHandler<dim, spacedim> dh(tria);
+  dh.distribute_dofs(fe);
+
+  MappingQ<dim, spacedim> mapping(1);
+
+  const Point<dim> midpoint(0.5, 0.5);
+
+  // Evaluate the shape values at the cell midpoint through a 1-point rule
+  // (processed by the scalar remainder path for any SIMD width > 1) and
+  // through a rule of 8 identical points (processed entirely by the
+  // vectorized path for SIMD widths 2, 4, and 8), and compare.
+  const Quadrature<dim> quad_remainder(midpoint);
+  const Quadrature<dim> quad_vectorized(std::vector<Point<dim>>(8, midpoint),
+                                        std::vector<double>(8, 1. / 8.));
+
+  FEValues<dim, spacedim> fev_remainder(mapping,
+                                        fe,
+                                        quad_remainder,
+                                        update_values);
+  FEValues<dim, spacedim> fev_vectorized(mapping,
+                                         fe,
+                                         quad_vectorized,
+                                         update_values);
+  fev_remainder.reinit(tria.begin_active());
+  fev_vectorized.reinit(tria.begin_active());
+
+  const FEValuesExtractors::Vector field(0);
+
+  bool   all_finite     = true;
+  double max_difference = 0.0;
+  for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    {
+      const Tensor<1, spacedim> v = fev_remainder[field].value(i, 0);
+      for (unsigned int d = 0; d < spacedim; ++d)
+        if (!std::isfinite(v[d]))
+          all_finite = false;
+
+      for (unsigned int q = 0; q < quad_vectorized.size(); ++q)
+        max_difference =
+          std::max(max_difference,
+                   (v - fev_vectorized[field].value(i, q)).norm());
+    }
+
+  deallog << "  all shape values finite: " << (all_finite ? "yes" : "no")
+          << std::endl;
+  deallog << "  remainder and vectorized paths agree (diff < 1e-12): "
+          << (max_difference < 1e-12 ? "yes" : "no") << std::endl;
+}

--- a/tests/fe/fe_rt_nodal_surface_02.output
+++ b/tests/fe/fe_rt_nodal_surface_02.output
@@ -1,3 +1,4 @@
+
 DEAL::FE_RaviartThomasNodal<2,3>(0)
 DEAL::  all shape values finite: yes
 DEAL::  remainder and vectorized paths agree (diff < 1e-12): yes

--- a/tests/fe/fe_rt_nodal_surface_02.output
+++ b/tests/fe/fe_rt_nodal_surface_02.output
@@ -1,0 +1,3 @@
+DEAL::FE_RaviartThomasNodal<2,3>(0)
+DEAL::  all shape values finite: yes
+DEAL::  remainder and vectorized paths agree (diff < 1e-12): yes


### PR DESCRIPTION
Adds support for codimension-one (dim=2, spacedim=3) FE_RaviartThomasNodal.

See [https://groups.google.com/g/dealii/c/6Z8jBTShIq8](https://groups.google.com/g/dealii/c/6Z8jBTShIq8).

The implementation has the following limitations:
- No hanging-node or hp constraints
- `convert_generalized_support_point_values_to_dof_values()` throws DEAL_II_NOT_IMPLEMENTED() 

This is my first pull-request, will appreciate any feedback :)

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [x] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [ ] No generative AI tools were used in preparing this contribution.

I have used Claude Opus to generate a draft of all three commits, which I have then reviewed and made minor alterations to.