### PR TITLE
Portable::MatrixFree: add asserts

### DIFF
--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -619,6 +619,8 @@ namespace Portable
     submit_value(const value_type &value, const int q_point)
   {
     AssertIndexRange(q_point, n_q_points);
+    Assert(precomputed_data->JxW.size() > 0,
+           ExcMessage("submit_value() requires precomputed JxW"));
     if constexpr (n_components_ == 1)
       {
         shared_data->values(q_point, 0) =
@@ -671,6 +673,8 @@ namespace Portable
     get_gradient(const int q_point) const
   {
     AssertIndexRange(q_point, n_q_points);
+    Assert(precomputed_data->inv_jacobian.size() > 0,
+           ExcMessage("get_gradient() requires precomputed inv_jacobian"));
     gradient_type grad;
 
     if constexpr (n_components_ == 1)
@@ -714,6 +718,11 @@ namespace Portable
     submit_gradient(const gradient_type &gradient, const int q_point)
   {
     AssertIndexRange(q_point, n_q_points);
+    Assert(precomputed_data->inv_jacobian.size() > 0,
+           ExcMessage("submit_gradient() requires precomputed inv_jacobian"));
+    Assert(precomputed_data->JxW.size() > 0,
+           ExcMessage("submit_gradient() requires precomputed JxW"));
+
     if constexpr (n_components_ == 1)
       {
         for (unsigned int d_1 = 0; d_1 < dim; ++d_1)
@@ -779,6 +788,9 @@ namespace Portable
            ExcMessage("Function get_divergence() only works when the "
                       "number of components and the number of dimensions are "
                       "equal."));
+    Assert(precomputed_data->inv_jacobian.size() > 0,
+           ExcMessage("get_divergence() requires precomputed inv_jacobian"));
+
     Number divergence = 0.;
     for (unsigned int c = 0; c < dim; ++c)
       for (unsigned int d = 0; d < dim; ++d)
@@ -803,6 +815,11 @@ namespace Portable
            ExcMessage("Function submit_divergence() only works when the "
                       "number of components and the number of dimensions are "
                       "equal."));
+    Assert(precomputed_data->inv_jacobian.size() > 0,
+           ExcMessage("submit_divergence() requires precomputed inv_jacobian"));
+    Assert(precomputed_data->JxW.size() > 0,
+           ExcMessage("submit_divergence() requires precomputed JxW"));
+
     for (unsigned int c = 0; c < dim; ++c)
       for (unsigned int d_1 = 0; d_1 < dim; ++d_1)
         shared_data->gradients(q_point, d_1, c) =
@@ -827,6 +844,11 @@ namespace Portable
            ExcMessage("Function submit_symmetric_gradient() only works when "
                       "the number of components and the number of dimensions "
                       "are equal."));
+    Assert(precomputed_data->inv_jacobian.size() > 0,
+           ExcMessage(
+             "submit_symmetric_gradient() requires precomputed inv_jacobian"));
+    Assert(precomputed_data->JxW.size() > 0,
+           ExcMessage("submit_symmetric_gradient() requires precomputed JxW"));
 
     for (unsigned int c = 0; c < dim; ++c)
       for (unsigned int d_1 = 0; d_1 < dim; ++d_1)


### PR DESCRIPTION


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [x] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [ ] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
