### PR TITLE
TriaAccessor: make material_id() inline.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -8081,6 +8081,18 @@ CellAccessor<dim, spacedim>::is_artificial_on_level() const
 
 
 template <int dim, int spacedim>
+inline types::material_id
+CellAccessor<dim, spacedim>::material_id() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  return this->tria->levels[this->level()]
+    ->cells.boundary_or_material_id[this->present_index]
+    .material_id;
+}
+
+
+
+template <int dim, int spacedim>
 inline types::subdomain_id
 CellAccessor<dim, spacedim>::subdomain_id() const
 {

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2147,18 +2147,6 @@ CellAccessor<dim, spacedim>::at_boundary() const
 
 
 template <int dim, int spacedim>
-types::material_id
-CellAccessor<dim, spacedim>::material_id() const
-{
-  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  return this->tria->levels[this->level()]
-    ->cells.boundary_or_material_id[this->present_index]
-    .material_id;
-}
-
-
-
-template <int dim, int spacedim>
 void
 CellAccessor<dim, spacedim>::set_material_id(
   const types::material_id mat_id) const


### PR DESCRIPTION
I was surprised to see this function listed in some benchmarking I did this week: we might as well inline it (which we already do for the manifold id, subdomain id, etc.).

Since this is small I'd like to get it in 9.8.

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
