### PR TITLE
FEValuesBase: replace std::visit with a switch statement.

### DIFF
--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -145,14 +145,22 @@ operator typename Triangulation<dim, spacedim>::cell_iterator() const
 {
   Assert(is_initialized(), ExcNotReinited());
 
-  // We can always convert to a tria iterator, regardless of which of
-  // the three types of cell we store.
-  return std::visit(
-    [](auto &cell_iterator) ->
-    typename Triangulation<dim, spacedim>::cell_iterator {
-      return cell_iterator;
-    },
-    cell.value());
+  auto convert = [](const auto &cell) {
+    return typename Triangulation<dim, spacedim>::cell_iterator(cell);
+  };
+
+  switch (cell.value().index())
+    {
+      case 0:
+        return convert(std::get<0>(cell.value()));
+      case 1:
+        return convert(std::get<1>(cell.value()));
+      case 2:
+        return convert(std::get<2>(cell.value()));
+      default:
+        DEAL_II_ASSERT_UNREACHABLE();
+        return {};
+    }
 }
 
 


### PR DESCRIPTION
std::visit() with GCC uses something like a vtable (see __gen_vtable_impl) which is much slower than doing it ourselves (which we already do for every other function which accesses the variant anyway).

This change makes a loop in which we call FEValues::reinit() and do nothing about 15% faster. I'd also like to get this in 9.8 since it is very small.

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
