### PR TITLE
Fix typo in documentation main page

### DIFF
--- a/doc/doxygen/headers/main.h
+++ b/doc/doxygen/headers/main.h
@@ -167,7 +167,7 @@
  *   abstract properties of the finite dimensional space $V_h$ in which we
  *   seek the discrete solution, the %DoFHandler classes enumerate a concrete
  *   basis of this space so that we can represent the discrete solution as
- *   $u_h(\mathbf x)= \sum_j U_j \varphi_i(\mathbf x)$ by an ordered set of
+ *   $u_h(\mathbf x)= \sum_j U_j \varphi_j(\mathbf x)$ by an ordered set of
  *   coefficients $U_j$.
  *
  *   Just as with triangulation objects, most operations on


### PR DESCRIPTION
This PR is to fix the equation that  can be found in the main page of deal.II documentation $u_h(\mathbf x)= \sum_j U_j \varphi_j(\mathbf x)$. Index of shape function has been changed (from i to j) to match the summation index.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [ ] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
