### PR TITLE
FEValues: invalidate the cell iterator whenever the Triangulation changes in any way.

### DIFF
--- a/include/deal.II/fe/fe_values_base.h
+++ b/include/deal.II/fe/fe_values_base.h
@@ -1667,22 +1667,10 @@ protected:
   CellIteratorWrapper present_cell;
 
   /**
-   * A signal connection we use to ensure we get informed whenever the
-   * triangulation changes by refinement. We need to know about that because
-   * it invalidates all cell iterators and, as part of that, the
-   * 'present_cell' iterator we keep around between subsequent calls to
-   * reinit() in order to compute the cell similarity.
+   * If the Triangulation changes in any way then clear all cached data (i.e.,
+   * the iterator in present_cell).
    */
-  boost::signals2::connection tria_listener_refinement;
-
-  /**
-   * A signal connection we use to ensure we get informed whenever the
-   * triangulation changes by mesh transformations. We need to know about that
-   * because it invalidates all cell iterators and, as part of that, the
-   * 'present_cell' iterator we keep around between subsequent calls to
-   * reinit() in order to compute the cell similarity.
-   */
-  boost::signals2::connection tria_listener_mesh_transform;
+  boost::signals2::connection tria_listener_any_change;
 
   /**
    * A function that is connected to the triangulation in order to reset the

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -1368,11 +1368,24 @@ FEValuesBase<dim, spacedim>::maybe_invalidate_previous_present_cell(
 {
   if (present_cell.is_initialized())
     {
-      if (&cell->get_triangulation() !=
-          &present_cell
-             .
-             operator typename Triangulation<dim, spacedim>::cell_iterator()
-             ->get_triangulation())
+      const auto stored_cell =
+        present_cell.
+        operator typename Triangulation<dim, spacedim>::cell_iterator();
+
+      // There's no good way to check that the corresponding Triangulation
+      // objects are still alive. approximate that by checking that the
+      // partitioner isn't expired. If the Triangulation doesn't exist any more
+      // this call may crash or the assertion may correctly fail (since there is
+      // no more partitioner).
+      Assert(!cell->get_triangulation()
+                .global_active_cell_index_partitioner()
+                .expired(),
+             ExcInternalError());
+      Assert(!stored_cell->get_triangulation()
+                .global_active_cell_index_partitioner()
+                .expired(),
+             ExcInternalError());
+      if (&cell->get_triangulation() != &stored_cell->get_triangulation())
         {
           // the triangulations for the previous cell and the current cell
           // do not match. disconnect from the previous triangulation and

--- a/source/fe/fe_values_base.cc
+++ b/source/fe/fe_values_base.cc
@@ -235,8 +235,7 @@ FEValuesBase<dim, spacedim>::FEValuesBase(
 template <int dim, int spacedim>
 FEValuesBase<dim, spacedim>::~FEValuesBase()
 {
-  tria_listener_refinement.disconnect();
-  tria_listener_mesh_transform.disconnect();
+  tria_listener_any_change.disconnect();
 }
 
 
@@ -1353,16 +1352,11 @@ template <int dim, int spacedim>
 void
 FEValuesBase<dim, spacedim>::invalidate_present_cell()
 {
-  // if there is no present cell, then we shouldn't be
-  // connected via a signal to a triangulation
+  // We cannot get here unless there is a cell to invalidate
   Assert(present_cell.is_initialized(), ExcInternalError());
 
-  // so delete the present cell and
-  // disconnect from the signal we have with
-  // it
-  tria_listener_refinement.disconnect();
-  tria_listener_mesh_transform.disconnect();
   present_cell = {};
+  tria_listener_any_change.disconnect();
 }
 
 
@@ -1386,24 +1380,15 @@ FEValuesBase<dim, spacedim>::maybe_invalidate_previous_present_cell(
           // cell because we shouldn't be comparing cells from different
           // triangulations
           invalidate_present_cell();
-          tria_listener_refinement =
+          tria_listener_any_change =
             cell->get_triangulation().signals.any_change.connect(
-              [this]() { this->invalidate_present_cell(); });
-          tria_listener_mesh_transform =
-            cell->get_triangulation().signals.mesh_movement.connect(
               [this]() { this->invalidate_present_cell(); });
         }
     }
   else
     {
-      // if this FEValues has never been set to any cell at all, then
-      // at least subscribe to the triangulation to get notified of
-      // changes
-      tria_listener_refinement =
-        cell->get_triangulation().signals.post_refinement.connect(
-          [this]() { this->invalidate_present_cell(); });
-      tria_listener_mesh_transform =
-        cell->get_triangulation().signals.mesh_movement.connect(
+      tria_listener_any_change =
+        cell->get_triangulation().signals.any_change.connect(
           [this]() { this->invalidate_present_cell(); });
     }
 }


### PR DESCRIPTION
In the current implementation, the first time an `FEValuesBase` gets a cell it sets up signals for `refinement` and `mesh_movement`, whereas for a different Triangulation it (correctly) sets up a signal for `any_change` (as well as `mesh_movement`, which is technically redundant). Simplify the situation by only using `any_change`.

This fixes a bug where a Triangulation could be destroyed but FEValuesBase did not invalidate the current cell (since the clear signal is connected to the `any_change` signal and not to `mesh_movement`).

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
