### PR TITLE
Reference the right function.

### DIFF
--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -106,7 +106,7 @@ namespace parallel
     namespace GridRefinement
     {
       /**
-       * Like dealii::GridRefinement::refine_and_coarsen_fixed_number, but
+       * Like ::dealii::GridRefinement::refine_and_coarsen_fixed_number, but
        * designed for parallel computations, where each process has only
        * information about locally owned cells.
        *
@@ -161,7 +161,7 @@ namespace parallel
           std::numeric_limits<types::global_cell_index>::max());
 
       /**
-       * Like dealii::GridRefinement::refine_and_coarsen_fixed_fraction, but
+       * Like ::dealii::GridRefinement::refine_and_coarsen_fixed_fraction, but
        * designed for parallel computations, where each process only has
        * information about locally owned cells.
        *


### PR DESCRIPTION
Our scripts replace `dealii::` by nothing before we give stuff to doxygen. This leads to problems if we have
```
namespace GridRefinement {
  void f();
}

namespace parallel::distributed
{
  namespace GridRefinement {
    /**
     * See dealii::GridRefinement::f().
     */
    void f();
  }
}
```
The link to the function in the documentation is supposed to go to the one in the *other* namespace, but because we strip `dealii::`, it actually just references `GridRefinement::f()`, which is the current function.


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
