### PR TITLE
Remove remaining symbols deprecated in the 9.6 release

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -582,15 +582,6 @@ public:
   set_active_fe_indices(const std::vector<types::fe_index> &active_fe_indices);
 
   /**
-   * @copydoc set_active_fe_indices()
-   *
-   * @deprecated Use set_active_fe_indices() with the types::fe_index datatype.
-   */
-  DEAL_II_DEPRECATED
-  void
-  set_active_fe_indices(const std::vector<unsigned int> &active_fe_indices);
-
-  /**
    * For each locally relevant cell, extract the active finite element index and
    * return them in the order in which we iterate over active cells.
    *

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2170,26 +2170,6 @@ namespace DoFTools
                             std::vector<unsigned int>());
 
   /**
-   * For each active cell of a DoFHandler, extract the active finite element
-   * index and fill the vector given as second argument. This vector is assumed
-   * to have as many entries as there are active cells.
-   *
-   * For DoFHandler objects without hp-capabilities given as first argument, the
-   * returned vector will consist of only zeros, indicating that all cells use
-   * the same finite element. In hp-mode, the values may be different, though.
-   *
-   * As we do not know the active FE index on artificial cells, we set them to
-   * the invalid value numbers::invalid_fe_index.
-   *
-   * @deprecated Use DoFHandler::get_active_fe_indices() that returns the result
-   * vector.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  get_active_fe_indices(const DoFHandler<dim, spacedim> &dof_handler,
-                        std::vector<unsigned int>       &active_fe_indices);
-
-  /**
    * Count how many degrees of freedom live on a set of cells (i.e., a patch)
    * described by the argument.
    *
@@ -2368,35 +2348,6 @@ namespace DoFTools
     const DoFHandler<dim, spacedim>            &dof_handler,
     const ComponentMask                        &mask = {},
     const bool map_locally_relevant_dofs             = true);
-
-  /**
-   * A version of the function of same name that returns the map via its third
-   * argument. This function is deprecated.
-   * @deprecated Use the function that returns the `std::map` instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  map_dofs_to_support_points(
-    const Mapping<dim, spacedim>                       &mapping,
-    const DoFHandler<dim, spacedim>                    &dof_handler,
-    std::map<types::global_dof_index, Point<spacedim>> &support_points,
-    const ComponentMask                                &mask = {},
-    const bool map_locally_relevant_dofs                     = true);
-
-  /**
-   * A version of the function of same name that returns the map via its third
-   * argument. This function is deprecated.
-   * @deprecated Use the function that returns the `std::map` instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  map_dofs_to_support_points(
-    const hp::MappingCollection<dim, spacedim>         &mapping,
-    const DoFHandler<dim, spacedim>                    &dof_handler,
-    std::map<types::global_dof_index, Point<spacedim>> &support_points,
-    const ComponentMask                                &mask = {},
-    const bool map_locally_relevant_dofs                     = true);
-
 
   /**
    * This is the opposite function to the one above. It generates a map where

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -960,25 +960,6 @@ public:
   get_combined_orientation(const ArrayView<const T> &vertices_0,
                            const ArrayView<const T> &vertices_1) const;
 
-
-  /**
-   * Inverse function of compute_orientation(): Given a set of
-   * vertex-associated objects (such as vertex indices, locations, etc.) and
-   * a desired orientation permutation, return the permuted vertex information.
-   *
-   * The size of the input and output arrays, i.e., the template argument `N`,
-   * must be equal to or larger than the number of vertices of the current
-   * entity. If it is larger, only those elements of the input and output
-   * arrays are read from or written to that correspond to valid vertex
-   * indices.
-   *
-   * @deprecated Use permute_by_combined_orientation() instead.
-   */
-  template <typename T, std::size_t N>
-  DEAL_II_DEPRECATED std::array<T, N>
-  permute_according_orientation(const std::array<T, N> &vertices,
-                                const unsigned int      orientation) const;
-
   /**
    * This is the inverse function to get_combined_orientation(): Given a set of
    * vertex-associated objects (such as vertex indices, locations, etc.) and
@@ -4494,34 +4475,6 @@ ReferenceCell<dim>::get_combined_orientation(
   Assert(false,
          (internal::NoPermutation<dim, T>(*this, vertices_0, vertices_1)));
   return std::numeric_limits<types::geometric_orientation>::max();
-}
-
-
-
-template <int dim>
-template <typename T, std::size_t N>
-inline std::array<T, N>
-ReferenceCell<dim>::permute_according_orientation(
-  const std::array<T, N> &vertices,
-  const unsigned int      orientation) const
-{
-  Assert(N >= n_vertices(),
-         ExcMessage("The number of array elements must be equal to or "
-                    "greater than the number of vertices of the cell "
-                    "referenced by this object."));
-
-  // Call the non-deprecated function, taking care of calling it only with
-  // those array elements that we actually care about (see the note
-  // in the documentation about the arguments potentially being
-  // larger arrays than necessary).
-  const auto permutation = permute_by_combined_orientation(
-    make_array_view(vertices.begin(), vertices.begin() + n_vertices()),
-    orientation);
-
-  std::array<T, N> temp;
-  std::copy(permutation.begin(), permutation.end(), temp.begin());
-
-  return temp;
 }
 
 

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -586,18 +586,6 @@ namespace LinearAlgebra
           &communication_pattern = {});
 
       /**
-       * @deprecated Use import_elements() instead.
-       */
-      DEAL_II_DEPRECATED void
-      import(const LinearAlgebra::ReadWriteVector<Number> &V,
-             VectorOperation::values                       operation,
-             std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
-               communication_pattern = {})
-      {
-        import_elements(V, operation, communication_pattern);
-      }
-
-      /**
        * Return the scalar product of two vectors.
        */
       Number

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2621,17 +2621,6 @@ void DoFHandler<dim, spacedim>::set_active_fe_indices(
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-void DoFHandler<dim, spacedim>::set_active_fe_indices(
-  const std::vector<unsigned int> &active_fe_indices)
-{
-  set_active_fe_indices(std::vector<types::fe_index>(active_fe_indices.begin(),
-                                                     active_fe_indices.end()));
-}
-
-
-
-template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 std::vector<types::fe_index> DoFHandler<dim, spacedim>::get_active_fe_indices()
   const
 {

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -2643,10 +2643,8 @@ namespace DoFRenumbering
              "Lexicographic renumbering is not implemented for distributed "
              "triangulations."));
 
-    std::map<types::global_dof_index, Point<dim>> dof_location_map;
-    DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),
-                                         dof_handler,
-                                         dof_location_map);
+    std::map<types::global_dof_index, Point<dim>> dof_location_map =
+      DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dof_handler);
     std::vector<std::pair<types::global_dof_index, Point<dim>>>
       dof_location_vector;
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1780,19 +1780,6 @@ namespace DoFTools
 
 
   template <int dim, int spacedim>
-  void
-  get_active_fe_indices(const DoFHandler<dim, spacedim> &dof_handler,
-                        std::vector<unsigned int>       &active_fe_indices)
-  {
-    AssertDimension(active_fe_indices.size(),
-                    dof_handler.get_triangulation().n_active_cells());
-
-    std::vector<types::fe_index> indices = dof_handler.get_active_fe_indices();
-
-    active_fe_indices.assign(indices.begin(), indices.end());
-  }
-
-  template <int dim, int spacedim>
   std::vector<IndexSet>
   locally_owned_dofs_per_subdomain(const DoFHandler<dim, spacedim> &dof_handler)
   {
@@ -2767,46 +2754,6 @@ namespace DoFTools
     // Let the internal function do all the work, just make sure that it
     // gets a MappingCollection
     support_points = internal::map_dofs_to_support_points_vector(
-      mapping, dof_handler, mask, map_locally_relevant_dofs);
-  }
-
-
-  // This function is deprecated:
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  map_dofs_to_support_points(
-    const Mapping<dim, spacedim>                       &mapping,
-    const DoFHandler<dim, spacedim>                    &dof_handler,
-    std::map<types::global_dof_index, Point<spacedim>> &support_points,
-    const ComponentMask                                &mask,
-    const bool map_locally_relevant_dofs)
-  {
-    support_points.clear();
-
-    // Let the internal function do all the work, just make sure that it
-    // gets a MappingCollection
-    const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
-
-    support_points = internal::map_dofs_to_support_points(
-      mapping_collection, dof_handler, mask, map_locally_relevant_dofs);
-  }
-
-
-  // This function is deprecated:
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  map_dofs_to_support_points(
-    const hp::MappingCollection<dim, spacedim>         &mapping,
-    const DoFHandler<dim, spacedim>                    &dof_handler,
-    std::map<types::global_dof_index, Point<spacedim>> &support_points,
-    const ComponentMask                                &mask,
-    const bool map_locally_relevant_dofs)
-  {
-    support_points.clear();
-
-    // Let the internal function do all the work, just make sure that it
-    // gets a MappingCollection
-    support_points = internal::map_dofs_to_support_points(
       mapping, dof_handler, mask, map_locally_relevant_dofs);
   }
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -220,10 +220,6 @@ for (deal_II_dimension : DIMENSIONS)
       const DoFHandler<deal_II_dimension> &dof_handler,
       const ComponentMask                 &selected_components);
 
-    template void DoFTools::get_active_fe_indices<deal_II_dimension>(
-      const DoFHandler<deal_II_dimension> &dof_handler,
-      std::vector<unsigned int>           &active_fe_indices);
-
     template void DoFTools::get_subdomain_association<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &dof_handler,
       std::vector<types::subdomain_id>    &subdomain_association);
@@ -429,25 +425,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
           &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
         std::vector<Point<deal_II_space_dimension>> &,
-        const ComponentMask &,
-        const bool);
-
-      // This function is deprecated:
-      template void
-      map_dofs_to_support_points<deal_II_dimension, deal_II_space_dimension>(
-        const Mapping<deal_II_dimension, deal_II_space_dimension> &,
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        std::map<types::global_dof_index, Point<deal_II_space_dimension>> &,
-        const ComponentMask &,
-        const bool);
-
-      // This function is deprecated:
-      template void
-      map_dofs_to_support_points<deal_II_dimension, deal_II_space_dimension>(
-        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
-          &,
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        std::map<types::global_dof_index, Point<deal_II_space_dimension>> &,
         const ComponentMask &,
         const bool);
 

--- a/tests/bits/periodicity_06.cc
+++ b/tests/bits/periodicity_06.cc
@@ -101,10 +101,8 @@ make_constraint_matrix(const DoFHandler<2> &dof_handler, int version)
                                                    constraints);
 
   constraints.close();
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(MappingQ<dim, dim>(1),
-                                       dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(MappingQ<dim, dim>(1), dof_handler);
   for (const auto &line : constraints.get_lines())
     for (const auto &entry : line.entries)
       deallog << "DoF " << line.index << " at " << support_points[line.index]

--- a/tests/bits/periodicity_07.cc
+++ b/tests/bits/periodicity_07.cc
@@ -90,10 +90,8 @@ make_constraint_matrix(const DoFHandler<3> &dof_handler, int version)
                                                    constraints);
 
   constraints.close();
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(MappingQ<dim, dim>(1),
-                                       dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(MappingQ<dim, dim>(1), dof_handler);
   for (const auto &line : constraints.get_lines())
     for (const auto &entry : line.entries)
       deallog << "DoF " << line.index << " at " << support_points[line.index]

--- a/tests/dofs/dof_renumbering_10.cc
+++ b/tests/dofs/dof_renumbering_10.cc
@@ -106,9 +106,9 @@ test(const bool adaptive_ref = true)
   // output in Gnuplot for visual inspection
   if (dim == 2)
     {
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dof);
 
       const std::string href = (adaptive_ref ? "" : "global_");
       const std::string base_filename =

--- a/tests/dofs/dof_renumbering_11.cc
+++ b/tests/dofs/dof_renumbering_11.cc
@@ -57,9 +57,9 @@ test(const unsigned int fe_degree, unsigned int n_components)
 
   std::vector<types::global_dof_index> local_dof_indices(fe.dofs_per_cell);
 
-  std::map<types::global_dof_index, Point<dim>> support_points;
   MappingQ1<dim>                                mapping;
-  DoFTools::map_dofs_to_support_points(mapping, dof_handler, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof_handler);
   deallog << "Support points:" << std::endl;
   for (unsigned int i = 0; i < dof_handler.n_dofs(); ++i)
     {

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_01.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_01.cc
@@ -88,9 +88,9 @@ test(const unsigned int flag)
                 << Utilities::int_to_string(flag) << std::endl;
       cm.print(std::cout);
 
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping, dh, support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dh);
 
       const std::string filename = "grid" + Utilities::int_to_string(dim) +
                                    Utilities::int_to_string(flag) + ".gp";

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_03.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_03.cc
@@ -113,9 +113,9 @@ test(const bool left = true)
                 << std::endl;
       cm.print(std::cout);
 
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping, dh, support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dh);
 
       const std::string filename =
         "grid" + Utilities::int_to_string(dim) + ".gp";

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
@@ -220,9 +220,9 @@ test()
         }
 
       {
-        std::map<types::global_dof_index, Point<dim>> support_points;
         MappingQ1<dim>                                mapping;
-        DoFTools::map_dofs_to_support_points(mapping, dh, support_points);
+        std::map<types::global_dof_index, Point<dim>> support_points =
+          DoFTools::map_dofs_to_support_points(mapping, dh);
 
         const std::string filename =
           "grid" + dealii::Utilities::int_to_string(n_mpi_processes) +

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_06.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_06.cc
@@ -238,9 +238,9 @@ test()
             }
         }
 
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping, dh, support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dh);
 
       const std::string filename_gnuplot = "grid_n_ranks_" +
                                            std::to_string(n_ranks) + "_rank_" +

--- a/tests/dofs/dof_tools_write_gnuplot_dof_support_point_info_01.cc
+++ b/tests/dofs/dof_tools_write_gnuplot_dof_support_point_info_01.cc
@@ -55,10 +55,8 @@ test()
   GridOut().write_gnuplot(triangulation, deallog.get_file_stream());
   out << 'e' << std::endl;
 
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),
-                                       dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dof_handler);
   DoFTools::write_gnuplot_dof_support_point_info(deallog.get_file_stream(),
                                                  support_points);
   out << 'e' << std::endl;

--- a/tests/dofs/dof_tools_write_gnuplot_dof_support_point_info_02.cc
+++ b/tests/dofs/dof_tools_write_gnuplot_dof_support_point_info_02.cc
@@ -51,8 +51,8 @@ test()
 
   MappingManifold<dim> mapping;
 
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(mapping, dof_handler, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof_handler);
 
   out << "set view equal xy" << std::endl
       << "plot '-' using 1:2 with lines, '-' with labels point pt 2 offset 1,1"

--- a/tests/dofs/dof_tools_write_gnuplot_dof_support_point_info_03.cc
+++ b/tests/dofs/dof_tools_write_gnuplot_dof_support_point_info_03.cc
@@ -52,8 +52,8 @@ test()
 
   MappingQ<dim> mapping(3);
 
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(mapping, dof_handler, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof_handler);
 
   out << "set view equal xy" << std::endl
       << "plot '-' using 1:2 with lines, '-' with labels point pt 2 offset 1,1"

--- a/tests/dofs/extract_dofs_per_component_01.cc
+++ b/tests/dofs/extract_dofs_per_component_01.cc
@@ -54,9 +54,8 @@ test()
     DoFTools::locally_owned_dofs_per_component(dof, mask);
 
   MappingQ<dim>                                 mapping(1);
-  std::map<types::global_dof_index, Point<dim>> support_points;
-
-  DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof);
 
   for (unsigned int c = 0; c < dofs_per_components.size(); ++c)
     {

--- a/tests/dofs/extract_dofs_per_component_02.cc
+++ b/tests/dofs/extract_dofs_per_component_02.cc
@@ -54,9 +54,8 @@ test()
     DoFTools::locally_owned_dofs_per_component(dof, mask);
 
   MappingQ<dim>                                 mapping(1);
-  std::map<types::global_dof_index, Point<dim>> support_points;
-
-  DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(mapping, dof);
 
   for (unsigned int c = 0; c < dofs_per_components.size(); ++c)
     {

--- a/tests/dofs/map_dofs_to_support_points_01.cc
+++ b/tests/dofs/map_dofs_to_support_points_01.cc
@@ -52,14 +52,14 @@ test()
   mask.set(1, false);
 
   MappingQ<dim>                                 mapping(1);
-  std::map<types::global_dof_index, Point<dim>> support_points_0;
-  DoFTools::map_dofs_to_support_points(mapping, dof, support_points_0, mask);
+  std::map<types::global_dof_index, Point<dim>> support_points_0 =
+    DoFTools::map_dofs_to_support_points(mapping, dof, mask);
 
   mask.set(0, false);
   mask.set(1, true);
 
-  std::map<types::global_dof_index, Point<dim>> support_points_1;
-  DoFTools::map_dofs_to_support_points(mapping, dof, support_points_1, mask);
+  std::map<types::global_dof_index, Point<dim>> support_points_1 =
+    DoFTools::map_dofs_to_support_points(mapping, dof, mask);
 
   auto it_0 = support_points_0.begin();
   auto it_1 = support_points_1.begin();

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -971,14 +971,12 @@ plot_shape_function(DoFHandler<dim> &dof_handler, unsigned int patches = 5)
     {
       std::cout << "...start printing support points" << std::endl;
 
-      std::map<types::global_dof_index, Point<dim>> support_points;
-      MappingQ1<dim>                                mapping;
-      hp::MappingCollection<dim>                    hp_mapping;
+      MappingQ1<dim>             mapping;
+      hp::MappingCollection<dim> hp_mapping;
       for (unsigned int i = 0; i < dof_handler.get_fe_collection().size(); ++i)
         hp_mapping.push_back(mapping);
-      DoFTools::map_dofs_to_support_points(hp_mapping,
-                                           dof_handler,
-                                           support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(hp_mapping, dof_handler);
 
       const std::string base_filename =
         "DOFs" + dealii::Utilities::int_to_string(dim) + "_p" +

--- a/tests/fe/fe_system_components_base.cc
+++ b/tests/fe/fe_system_components_base.cc
@@ -79,11 +79,9 @@ test(const bool renumber = false)
   // print grid and DoFs for visual inspection
   if (true)
     {
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping,
-                                           dof_handler,
-                                           support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dof_handler);
 
       const std::string filename = "grid" + Utilities::int_to_string(dim) +
                                    Utilities::int_to_string(renumber) + ".gp";

--- a/tests/integrators/assembler_simple_system_inhom_01.cc
+++ b/tests/integrators/assembler_simple_system_inhom_01.cc
@@ -673,10 +673,8 @@ MeshWorkerAffineConstraintsTest<dim>::createInhomConstraints()
                                            BoundaryValues<dim>(),
                                            this->constraintsInhom);
   // constraint of the origin
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(this->mapping,
-                                       this->dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(this->mapping, this->dof_handler);
   for (unsigned int dof_index = 0; dof_index < this->dof_handler.n_dofs();
        ++dof_index)
     {

--- a/tests/matrix_free/dof_info_01.cc
+++ b/tests/matrix_free/dof_info_01.cc
@@ -136,9 +136,9 @@ test(const bool adaptive_ref = true)
   // output in Gnuplot
   if (dim == 2)
     {
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dof);
 
       const std::string prefix =
         std::is_same_v<float, number> ? "float_" : "double_";

--- a/tests/matrix_free/dof_info_02.cc
+++ b/tests/matrix_free/dof_info_02.cc
@@ -138,9 +138,9 @@ test(const bool adaptive_ref = true)
   // output in Gnuplot
   if (dim == 2)
     {
-      std::map<types::global_dof_index, Point<dim>> support_points;
       MappingQ1<dim>                                mapping;
-      DoFTools::map_dofs_to_support_points(mapping, dof, support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dof);
 
       const std::string prefix =
         std::is_same_v<float, number> ? "float_" : "double_";

--- a/tests/mpi/map_dofs_to_support_points.cc
+++ b/tests/mpi/map_dofs_to_support_points.cc
@@ -42,8 +42,8 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  std::map<types::global_dof_index, Point<dim>> points;
-  DoFTools::map_dofs_to_support_points(MappingQ<dim>(1), dofh, points);
+  std::map<types::global_dof_index, Point<dim>> points =
+    DoFTools::map_dofs_to_support_points(MappingQ<dim>(1), dofh);
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     {
       for (typename std::map<types::global_dof_index,

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -218,10 +218,8 @@ check(const unsigned int orientation, bool reverse)
 
   unsigned int n_local_constraints = 0;
 
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(MappingQ<dim>(1),
-                                       dof_handler,
-                                       support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(MappingQ<dim>(1), dof_handler);
   IndexSet constraints_lines = constraints.get_local_lines();
 
   for (unsigned int i = 0; i < constraints_lines.n_elements(); ++i)

--- a/tests/mpi/periodicity_06.cc
+++ b/tests/mpi/periodicity_06.cc
@@ -162,10 +162,8 @@ test(const unsigned numRefinementLevels = 2)
   const IndexSet locally_relevant_dofs =
     DoFTools::extract_locally_relevant_dofs(dof_handler);
 
-  std::map<types::global_dof_index, Point<dim>> supportPoints;
-  DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),
-                                       dof_handler,
-                                       supportPoints);
+  std::map<types::global_dof_index, Point<dim>> supportPoints =
+    DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dof_handler);
 
   /// creating combined hanging node and periodic constraint matrix
   AffineConstraints<double> constraints;

--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -140,10 +140,8 @@ test(const unsigned numRefinementLevels = 2)
     Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                dof_handler.locally_owned_dofs());
 
-  std::map<types::global_dof_index, Point<dim>> supportPoints;
-  DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),
-                                       dof_handler,
-                                       supportPoints);
+  std::map<types::global_dof_index, Point<dim>> supportPoints =
+    DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dof_handler);
 
   /// creating combined hanging node and periodic constraint matrix
   AffineConstraints<double> constraints;

--- a/tests/mpi/periodicity_08.cc
+++ b/tests/mpi/periodicity_08.cc
@@ -134,10 +134,8 @@ test()
     Utilities::MPI::all_gather(MPI_COMM_WORLD,
                                dof_handler.locally_owned_dofs());
 
-  std::map<types::global_dof_index, Point<dim>> supportPoints;
-  DoFTools::map_dofs_to_support_points(MappingQ1<dim>(),
-                                       dof_handler,
-                                       supportPoints);
+  std::map<types::global_dof_index, Point<dim>> supportPoints =
+    DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dof_handler);
 
   /// creating combined hanging node and periodic constraint matrix
   AffineConstraints<double> constraints;

--- a/tests/mpi/renumber_cuthill_mckee_03.cc
+++ b/tests/mpi/renumber_cuthill_mckee_03.cc
@@ -113,8 +113,8 @@ test()
       deallog << std::endl;
     }
 
-  std::map<types::global_dof_index, Point<dim>> support_points;
-  DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dofh, support_points);
+  std::map<types::global_dof_index, Point<dim>> support_points =
+    DoFTools::map_dofs_to_support_points(MappingQ1<dim>(), dofh);
   DoFTools::write_gnuplot_dof_support_point_info(deallog.get_file_stream(),
                                                  support_points);
 }

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -490,11 +490,9 @@ namespace Step37
 
     if (dim == 2 && Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) == 1)
       {
-        std::map<types::global_dof_index, Point<dim>> support_points;
         MappingQ<dim> mapping(degree_finite_element);
-        DoFTools::map_dofs_to_support_points(mapping,
-                                             dof_handler,
-                                             support_points);
+        std::map<types::global_dof_index, Point<dim>> support_points =
+          DoFTools::map_dofs_to_support_points(mapping, dof_handler);
 
         const std::string base_filename =
           "grid" + dealii::Utilities::int_to_string(dim) + "_" +

--- a/tests/petsc/bddc.cc
+++ b/tests/petsc/bddc.cc
@@ -155,10 +155,8 @@ main(int argc, char *argv[])
   PETScWrappers::PreconditionBDDC<2>::AdditionalData data;
 
   // Now we setup the dof coordinates if a sufficiently new PETSc is used
-  std::map<types::global_dof_index, Point<2>> dof_2_point;
-  DoFTools::map_dofs_to_support_points(MappingQ1<2>(),
-                                       dof_handler,
-                                       dof_2_point);
+  std::map<types::global_dof_index, Point<2>> dof_2_point =
+    DoFTools::map_dofs_to_support_points(MappingQ1<2>(), dof_handler);
   std::vector<Point<2>> coords(locally_owned_dofs.n_elements());
   unsigned int          k = 0;
   for (auto it = locally_owned_dofs.begin(); it != locally_owned_dofs.end();

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -137,11 +137,8 @@ public:
       dof_handler.locally_owned_dofs(),
       DoFTools::extract_locally_relevant_dofs(dof_handler));
     {
-      std::map<types::global_dof_index, Point<dim>> support_points;
-
-      DoFTools::map_dofs_to_support_points(mapping,
-                                           dof_handler,
-                                           support_points);
+      std::map<types::global_dof_index, Point<dim>> support_points =
+        DoFTools::map_dofs_to_support_points(mapping, dof_handler);
 
       std::vector<types::global_dof_index> global_ids;
 

--- a/tests/simplex/adjust_quad_dof_index_for_face_orientation_02.cc
+++ b/tests/simplex/adjust_quad_dof_index_for_face_orientation_02.cc
@@ -135,13 +135,14 @@ create_tria(const unsigned int  face_no,
   }
 
   {
-    const auto face = dummy.begin()->face(face_no);
+    const auto                  face = dummy.begin()->face(face_no);
+    std::array<unsigned int, 3> v{
+      {face->vertex_index(0), face->vertex_index(1), face->vertex_index(2)}};
+    ArrayView<const unsigned int> view(v.cbegin(), v.size());
+    ;
     const auto permuted =
-      ReferenceCells::Triangle.permute_according_orientation(
-        std::array<unsigned int, 3>{{face->vertex_index(0),
-                                     face->vertex_index(1),
-                                     face->vertex_index(2)}},
-        orientation);
+      ReferenceCells::Triangle.permute_by_combined_orientation(view,
+                                                               orientation);
 
     auto direction =
       cross_product_3d(vertices[permuted[1]] - vertices[permuted[0]],

--- a/tests/simplex/orientation_01.cc
+++ b/tests/simplex/orientation_01.cc
@@ -30,9 +30,11 @@ test(const ReferenceCell<dim> type, const unsigned int n_orientations)
       for (unsigned int i = 0; i < n_points; ++i)
         origin[i] = i;
 
-      const auto permuted = type.permute_according_orientation(origin, o);
-      const unsigned int origin_back =
-        type.compute_orientation(permuted, origin);
+      ArrayView<const unsigned int> origin_view(origin.cbegin(), n_points);
+      const auto                    permuted =
+        type.permute_by_combined_orientation(origin_view, o);
+      const unsigned int origin_back = type.get_combined_orientation(
+        make_array_view(permuted.cbegin(), permuted.cend()), origin_view);
 
       AssertDimension(o, origin_back);
     }

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -41,11 +41,14 @@ test(const types::geometric_orientation orientation)
   }
 
   {
-    const auto &face                = dummy.begin()->face(face_no);
-    const auto  face_reference_cell = face->reference_cell();
-    const auto  permuted =
-      ReferenceCells::Triangle.permute_according_orientation(
-        std::array<unsigned int, 3>{{0, 1, 2}}, orientation);
+    const auto                   &face = dummy.begin()->face(face_no);
+    const auto                    face_reference_cell = face->reference_cell();
+    std::array<unsigned int, 3>   v{{0, 1, 2}};
+    ArrayView<const unsigned int> view(v.cbegin(), v.size());
+    ;
+    const auto permuted =
+      ReferenceCells::Triangle.permute_by_combined_orientation(view,
+                                                               orientation);
 
     auto direction =
       cross_product_3d(vertices[permuted[1]] - vertices[permuted[0]],


### PR DESCRIPTION
Apparently, we missed some in https://github.com/dealii/dealii/pull/18709.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
