### PR TITLE
gh-actions: Also build on resolute/26.04.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,6 +53,8 @@ jobs:
             os: ubuntu-22.04
           - ubuntu_version: noble
             os: ubuntu-24.04
+          - ubuntu_version: resolute
+            os: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v7
@@ -104,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble]
+        ubuntu_version: [jammy, noble, resolute]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
         include:
           - os: ubuntu-24.04
@@ -158,6 +160,10 @@ jobs:
         # messaging module was unable to find any relevant network
         # interfaces."
         export OMPI_MCA_btl_base_warn_component_unused='0'
+        # Disable UCX OSC to prevent errors of the kind:
+        # "../ompi/mca/osc/ucx/osc_ucx_component.c:375  Error: OSC UCX
+        # component priority set inside component query failed"
+        export OMPI_MCA_osc='^ucx'
 
         cd build
         make \
@@ -187,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble]
+        ubuntu_version: [jammy, noble, resolute]
 
     container:
       image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.7.1


### PR DESCRIPTION
With this patch the github CI will also cover the most recent ubuntu LTS version. I suggest to cherry-pick this patch also to the release branch.

~Blocked by https://github.com/dealii/docker-files/pull/87 which patches symengine.~ (EDIT: Has been merged)

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
