### PR TITLE
CMake Policy CMP0219.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,15 @@ if(POLICY CMP0167)
 endif()
 
 if(POLICY CMP0177)
-  # Introduced in CMAKE 3:31: Normalize DESTINATION paths so that they do
+  # Introduced in CMake 3:31: Normalize DESTINATION paths so that they do
   # not contain "." or "..".
   cmake_policy(SET CMP0177 NEW)
+endif()
+
+if(POLICY CMP0219)
+  # Introduced in CMake 4.4: macro() invocations preserve backslashes in
+  # arguments.
+  cmake_policy(SET CMP0219 OLD)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)


### PR DESCRIPTION
CMake 4.4 introduced a new policy [CMP0219](https://cmake.org/cmake/help/latest/policy/CMP0219.html) that affects how backslashes are interpreted in macros. I have set it to `OLD` to ensure compatibility.

Without setting the policy, the following part generates a build warning:
https://github.com/dealii/dealii/blob/b3a6e1f32076790edb0e502edf031552067e46f9/cmake/checks/check_02_compiler_features.cmake#L316-L325
```
CMake Warning (policy) at cmake/checks/check_02_compiler_features.cmake:316 (CHECK_CXX_SOURCE_COMPILES):
  Policy CMP0219 is not set: Macro invocations preserve backslashes in
  arguments.  Run "cmake --help-policy CMP0219" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Command "CHECK_CXX_SOURCE_COMPILES" called with arguments containing
  backslashes.

  Since the policy is not set, backslashes in the arguments:

   "
    _Pragma("GCC diagnostic push")
    _Pragma("GCC diagnostic ignored \\\"-Wextra\\\"")
    _Pragma("GCC diagnostic ignored \\\"-Wunknown-pragmas\\\"")
    _Pragma("GCC diagnostic ignored \\\"-Wpragmas\\\"")
    int main() { return 0; }
    _Pragma("GCC diagnostic pop")
    "

  will be interpreted as escape sequences for compatibility.

  Set the policy to NEW to instead pass

   "
    _Pragma("GCC diagnostic push")
    _Pragma("GCC diagnostic ignored \\\\\\"-Wextra\\\\\\"")
    _Pragma("GCC diagnostic ignored \\\\\\"-Wunknown-pragmas\\\\\\"")
    _Pragma("GCC diagnostic ignored \\\\\\"-Wpragmas\\\\\\"")
    int main() { return 0; }
    _Pragma("GCC diagnostic pop")
    "

  so that argument parsing will preserve the original values.
Call Stack (most recent call first):
  cmake/macros/macro_verbose_include.cmake:16 (include)
  CMakeLists.txt:122 (verbose_include)
This warning is for project developers.  Use -Wno-author or -Wno-policy to
suppress it.
```

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [X] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
