### PR TITLE
FiniteElement: make orientation functions available for inlining.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -3192,9 +3192,9 @@ namespace internal
                       0,
                       line_indices[line],
                       fe_index,
-                      [&fe, line_orientation](const auto d) {
+                      [&fe](const auto d) {
                         return fe.adjust_line_dof_index_for_line_orientation(
-                          d, line_orientation);
+                          d, numbers::reverse_line_orientation);
                       },
                       std::integral_constant<int, 1>(),
                       dof_indices_ptr,

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -3331,6 +3331,65 @@ FiniteElement<dim, spacedim>::face_system_to_component_index(
 
 
 template <int dim, int spacedim>
+inline unsigned int
+FiniteElement<dim, spacedim>::adjust_line_dof_index_for_line_orientation(
+  const unsigned int                 index,
+  const types::geometric_orientation combined_orientation) const
+{
+  Assert(combined_orientation == numbers::default_geometric_orientation ||
+           combined_orientation == numbers::reverse_line_orientation,
+         ExcInternalError());
+
+  AssertIndexRange(index, this->n_dofs_per_line());
+  Assert(adjust_line_dof_index_for_line_orientation_table.size() ==
+           this->n_dofs_per_line(),
+         ExcInternalError());
+  if (combined_orientation == numbers::default_geometric_orientation)
+    return index;
+  else
+    return index + adjust_line_dof_index_for_line_orientation_table[index];
+}
+
+
+
+template <int dim, int spacedim>
+inline unsigned int
+FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
+  const unsigned int                 index,
+  const unsigned int                 face,
+  const types::geometric_orientation combined_orientation) const
+{
+  // general template for 1d and 2d: not
+  // implemented. in fact, the function
+  // shouldn't even be called unless we are
+  // in 3d, so throw an internal error
+  Assert(dim == 3, ExcInternalError());
+  if (dim < 3)
+    return index;
+
+  // adjust dofs on 3d faces if the face is
+  // flipped. note that we query a table that
+  // derived elements need to have set up
+  // front. the exception are discontinuous
+  // elements for which there should be no
+  // face dofs anyway (i.e. dofs_per_quad==0
+  // in 3d), so we don't need the table, but
+  // the function should also not have been
+  // called
+  AssertIndexRange(index, this->n_dofs_per_quad(face));
+  const auto table_n = this->n_unique_2d_subobjects() == 1 ? 0 : face;
+  Assert(
+    adjust_quad_dof_index_for_face_orientation_table[table_n].n_elements() ==
+      (this->reference_cell().n_face_orientations(face)) *
+        this->n_dofs_per_quad(face),
+    ExcInternalError());
+  return index + adjust_quad_dof_index_for_face_orientation_table[table_n](
+                   index, combined_orientation);
+}
+
+
+
+template <int dim, int spacedim>
 inline std::pair<std::pair<unsigned int, unsigned int>, unsigned int>
 FiniteElement<dim, spacedim>::system_to_base_index(
   const unsigned int index) const

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -633,65 +633,6 @@ FiniteElement<dim, spacedim>::face_to_cell_index(
 
 
 template <int dim, int spacedim>
-unsigned int
-FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
-  const unsigned int                 index,
-  const unsigned int                 face,
-  const types::geometric_orientation combined_orientation) const
-{
-  // general template for 1d and 2d: not
-  // implemented. in fact, the function
-  // shouldn't even be called unless we are
-  // in 3d, so throw an internal error
-  Assert(dim == 3, ExcInternalError());
-  if (dim < 3)
-    return index;
-
-  // adjust dofs on 3d faces if the face is
-  // flipped. note that we query a table that
-  // derived elements need to have set up
-  // front. the exception are discontinuous
-  // elements for which there should be no
-  // face dofs anyway (i.e. dofs_per_quad==0
-  // in 3d), so we don't need the table, but
-  // the function should also not have been
-  // called
-  AssertIndexRange(index, this->n_dofs_per_quad(face));
-  const auto table_n = this->n_unique_2d_subobjects() == 1 ? 0 : face;
-  Assert(
-    adjust_quad_dof_index_for_face_orientation_table[table_n].n_elements() ==
-      (this->reference_cell().n_face_orientations(face)) *
-        this->n_dofs_per_quad(face),
-    ExcInternalError());
-  return index + adjust_quad_dof_index_for_face_orientation_table[table_n](
-                   index, combined_orientation);
-}
-
-
-
-template <int dim, int spacedim>
-unsigned int
-FiniteElement<dim, spacedim>::adjust_line_dof_index_for_line_orientation(
-  const unsigned int                 index,
-  const types::geometric_orientation combined_orientation) const
-{
-  Assert(combined_orientation == numbers::default_geometric_orientation ||
-           combined_orientation == numbers::reverse_line_orientation,
-         ExcInternalError());
-
-  AssertIndexRange(index, this->n_dofs_per_line());
-  Assert(adjust_line_dof_index_for_line_orientation_table.size() ==
-           this->n_dofs_per_line(),
-         ExcInternalError());
-  if (combined_orientation == numbers::default_geometric_orientation)
-    return index;
-  else
-    return index + adjust_line_dof_index_for_line_orientation_table[index];
-}
-
-
-
-template <int dim, int spacedim>
 bool
 FiniteElement<dim, spacedim>::prolongation_is_implemented() const
 {


### PR DESCRIPTION
This makes `DoFAccessor::get_dof_indices()` require about 6% fewer instructions since these functions get inlined (i.e., they no longer explicitly show up in callgrind's profiling).

I have a couple more relevant patches which make dof lookup quite a bit faster (about 33% fewer total instructions so far).

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 

### AI Declaration Statement

- **Use of AI tools:** 
  - [ ] Generative AI tools were used. In this case, please consider completing the AI declaration statement.
  - [x] No generative AI tools were used in preparing this contribution.


<!-- Optional: If you have used generative AI tools while writing this pull request, please explain what these generative AI tools were used for and which model was used. Feel free to provide example of prompts that were used while writing this pull request. -->
