### PR TITLE
Set CTEST_USE_LAUNCHERS for CDash submission

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ add_subdirectory(examples)
 add_subdirectory(contrib/utilities)
 
 if(DEAL_II_HAVE_TESTS_DIRECTORY)
+  include(CTestUseLaunchers)
   add_subdirectory(tests)
 endif()
 

--- a/tests/run_testsuite.cmake
+++ b/tests/run_testsuite.cmake
@@ -472,6 +472,8 @@ endif()
 set(_status "neutral")
 set(_summary "")
 
+set(CTEST_USE_LAUNCHERS true)
+
 ctest_start(Experimental TRACK ${TRACK})
 
 message("-- Running ctest_update() to query git information")


### PR DESCRIPTION
This should improve the parsing of warnings and errors in CDash.