### PR TITLE
parallel::shared::Triangulation: synchronize flags in prepare_coarsening_and_refinement()

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -283,6 +283,22 @@ namespace parallel
       execute_coarsening_and_refinement() override;
 
       /**
+       * Prepare the triangulation for coarsening and refinement.
+       *
+       * @note In addition to what the function of the base
+       * dealii::Triangulation class does, this function first synchronizes
+       * the refinement and coarsening flags over all processes. Each MPI
+       * process only needs to set these flags on its own locally owned
+       * cells; synchronizing them first guarantees that decisions made
+       * during flag smoothing (such as removing the coarsening flags of a
+       * group of sibling cells if not all children are flagged) are made
+       * with knowledge of the flags set by all processes, and consequently
+       * do not depend on how the triangulation is partitioned.
+       */
+      virtual bool
+      prepare_coarsening_and_refinement() override;
+
+      /**
        * Create a triangulation.
        *
        * This function also partitions triangulation based on the MPI
@@ -406,6 +422,16 @@ namespace parallel
        */
       void
       partition();
+
+      /**
+       * Synchronize the refinement and coarsening flags over all MPI
+       * processes: Each process only needs to set the flags on its own
+       * locally owned cells; this function combines the flags of all
+       * processes so that afterwards every process holds the complete set
+       * of flags for the entire (replicated) triangulation.
+       */
+      void
+      communicate_refinement_and_coarsening_flags();
 
       /**
        * A vector containing subdomain IDs of cells obtained by partitioning

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -353,7 +353,8 @@ namespace parallel
 
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    void Triangulation<dim,
+                       spacedim>::communicate_refinement_and_coarsening_flags()
     {
       // make sure that all refinement/coarsening flags are the same on all
       // processes
@@ -414,6 +415,27 @@ namespace parallel
               cell->set_coarsen_flag();
           }
       }
+    }
+
+
+
+    template <int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
+    {
+      communicate_refinement_and_coarsening_flags();
+
+      return dealii::Triangulation<dim, spacedim>::
+        prepare_coarsening_and_refinement();
+    }
+
+
+
+    template <int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    {
+      communicate_refinement_and_coarsening_flags();
 
       dealii::Triangulation<dim, spacedim>::execute_coarsening_and_refinement();
       partition();

--- a/tests/sharedtria/refine_and_coarsen_03.cc
+++ b/tests/sharedtria/refine_and_coarsen_03.cc
@@ -1,0 +1,127 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+// Check that calling prepare_coarsening_and_refinement() directly on a
+// parallel::shared::Triangulation, as is customary before attaching data
+// for a solution transfer, synchronizes refinement and coarsening flags
+// over all processes *before* flag smoothing runs.
+//
+// Refinement and coarsening flags only need to be set on locally owned
+// cells. If prepare_coarsening_and_refinement() does not synchronize the
+// flags first, smoothing (in particular the rule that a family of sibling
+// cells is only coarsened if all children are flagged) only sees the
+// flags this process has set itself. Flags on cells owned by other
+// processes, which are artificial here, default to false. For a family
+// that straddles a partition boundary this drops the coarsen flag on
+// every process, and the resulting mesh ends up depending on the
+// partitioning.
+//
+// We check this by counting, immediately after
+// prepare_coarsening_and_refinement(), how many active cells (including
+// artificial ones) have a refine/coarsen flag set: with synchronized
+// flags this count has to be identical on every process. The cell counts
+// logged by this test therefore have to agree between the mpirun=1 and
+// mpirun=3 output files.
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  parallel::shared::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    /*allow_artificial_cells*/ true,
+    parallel::shared::Triangulation<dim>::partition_zorder);
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(2);
+  deallog << "cells before: " << tria.n_global_active_cells() << std::endl;
+
+  // Set refinement and coarsening flags on locally owned cells only:
+
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        const auto center = cell->center();
+
+        bool refine = true;
+        for (unsigned int d = 0; d < dim; ++d)
+          refine = refine && (center[d] < 0.25);
+
+        if (refine)
+          cell->set_refine_flag();
+        else if (center[0] > 0.5)
+          cell->set_coarsen_flag();
+      }
+
+  tria.prepare_coarsening_and_refinement();
+
+  // Immediately after prepare_coarsening_and_refinement() every process
+  // must see the complete, partition-independent set of flags. We count
+  // over *all* active cells (including artificial ones), since a flag on
+  // an artificial cell can only ever become visible through
+  // synchronization:
+
+  unsigned int n_refine_flags  = 0;
+  unsigned int n_coarsen_flags = 0;
+  for (const auto &cell : tria.active_cell_iterators())
+    {
+      if (cell->refine_flag_set())
+        ++n_refine_flags;
+      if (cell->coarsen_flag_set())
+        ++n_coarsen_flags;
+    }
+  deallog << "flags after prepare: refine=" << n_refine_flags
+          << " coarsen=" << n_coarsen_flags << std::endl;
+
+  AssertThrow(Utilities::MPI::max(n_refine_flags, MPI_COMM_WORLD) ==
+                Utilities::MPI::min(n_refine_flags, MPI_COMM_WORLD),
+              ExcInternalError());
+  AssertThrow(Utilities::MPI::max(n_coarsen_flags, MPI_COMM_WORLD) ==
+                Utilities::MPI::min(n_coarsen_flags, MPI_COMM_WORLD),
+              ExcInternalError());
+
+  tria.execute_coarsening_and_refinement();
+  deallog << "cells after: " << tria.n_global_active_cells() << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  mpi_initlog();
+
+  deallog.push("1d");
+  test<1>();
+  deallog.pop();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/refine_and_coarsen_03.mpirun=1.output
+++ b/tests/sharedtria/refine_and_coarsen_03.mpirun=1.output
@@ -1,0 +1,13 @@
+
+DEAL:1d::cells before: 8
+DEAL:1d::flags after prepare: refine=2 coarsen=4
+DEAL:1d::cells after: 8
+DEAL:1d::OK
+DEAL:2d::cells before: 64
+DEAL:2d::flags after prepare: refine=4 coarsen=32
+DEAL:2d::cells after: 52
+DEAL:2d::OK
+DEAL:3d::cells before: 512
+DEAL:3d::flags after prepare: refine=8 coarsen=256
+DEAL:3d::cells after: 344
+DEAL:3d::OK

--- a/tests/sharedtria/refine_and_coarsen_03.mpirun=3.output
+++ b/tests/sharedtria/refine_and_coarsen_03.mpirun=3.output
@@ -1,0 +1,13 @@
+
+DEAL:1d::cells before: 8
+DEAL:1d::flags after prepare: refine=2 coarsen=4
+DEAL:1d::cells after: 8
+DEAL:1d::OK
+DEAL:2d::cells before: 64
+DEAL:2d::flags after prepare: refine=4 coarsen=32
+DEAL:2d::cells after: 52
+DEAL:2d::OK
+DEAL:3d::cells before: 512
+DEAL:3d::flags after prepare: refine=8 coarsen=256
+DEAL:3d::cells after: 344
+DEAL:3d::OK


### PR DESCRIPTION
The first commit from #20095 that makes sense:

Each MPI process only needs to set refinement and coarsening flags on its own locally owned cells; so far the flags were only synchronized over all processes in `execute_coarsening_and_refinement()`. If a user calls `prepare_coarsening_and_refinement()` directly (as is customary before attaching data for a solution transfer), flag smoothing thus ran with only the locally owned flags visible. In particular the rule that a group of sibling cells is only coarsened if all children are flagged then deletes coarsening flags of families straddling a partition boundary - and the resulting mesh depends on the partitioning.

Factor the flag synchronization out of `execute_coarsening_and_refinement()` into a helper function `communicate_refinement_and_coarsening_flags()` and call it from a new `prepare_coarsening_and_refinement()` override as well.

This hopefully closes #5359
