### PR TITLE
Two minor adjustments to step-104

### DIFF
--- a/examples/step-104/step-104.cc
+++ b/examples/step-104/step-104.cc
@@ -961,9 +961,10 @@ namespace Step104
     {
       dealii::Timer t(tria.get_mpi_communicator());
       stokes_operator.vmult(solution, rhs);
-      const double time          = t.wall_time();
-      const double dofs_p_second = static_cast<double>(solution.size()) / time;
-      pcout << "Stokes operator: " << time << " s, DoFs/s: " << dofs_p_second
+      const double time = t.wall_time();
+      const double mdofs_p_second =
+        1e-6 * static_cast<double>(solution.size()) / time;
+      pcout << "Stokes operator: " << time << " s, MDoFs/s: " << mdofs_p_second
             << std::endl;
       solution = 0.0;
     }
@@ -1098,8 +1099,7 @@ namespace Step104
           }
       }
 
-    MGSmootherPrecondition<LevelMatrixType, SmootherType, VectorType>
-      mg_smoother;
+    MGSmootherRelaxation<LevelMatrixType, SmootherType, VectorType> mg_smoother;
     mg_smoother.initialize(mg_matrices, smoother_data);
 
     // Estimate and print the eigenvalue spectrum of the velocity block on each

--- a/tests/examples/step-104.diff
+++ b/tests/examples/step-104.diff
@@ -1,9 +1,10 @@
-963,966d962
-<       const double time          = t.wall_time();
-<       const double dofs_p_second = static_cast<double>(solution.size()) / time;
-<       pcout << "Stokes operator: " << time << " s, DoFs/s: " << dofs_p_second
+964,968d963
+<       const double time = t.wall_time();
+<       const double mdofs_p_second =
+<         1e-6 * static_cast<double>(solution.size()) / time;
+<       pcout << "Stokes operator: " << time << " s, MDoFs/s: " << mdofs_p_second
 <             << std::endl;
-1198,1205c1194
+1200,1207c1195
 <           << " iterations in " << t.wall_time() << " seconds" << std::endl;
 < 
 <     pcout << "Velocity block GMG timings:"
@@ -14,7 +15,7 @@
 <           << std::endl;
 ---
 >           << " iterations in " << 0.0 << " seconds" << std::endl;
-1270,1275c1259,1260
+1272,1277c1260,1261
 <           << " MPI ranks (with " << MultithreadInfo::n_threads()
 <           << " threads each) in ";
 <     if constexpr (running_in_debug_mode())
@@ -24,7 +25,7 @@
 ---
 >           << " MPI ranks (with "
 >           << " threads each)";
-1283c1268
+1285c1269
 <     unsigned int n_refinements = 10;
 ---
 >     unsigned int n_refinements = 2;


### PR DESCRIPTION
Inspired by the code we're discussing for the release paper, I have two minor suggestions for the step-104 tutorial program:
- For `PreconditionChebyshev` used as a multigrid smoother, we can use `MGSmootherRelaxation` that calls `PreconditionChebyshev::step()`, avoid some memory allocation. I believe the GPU implementation should benefit a bit more than the CPU, where it is some 0.x% change in run time.
- I find it easier to read MDoFs/s or GDoFs/s (when on GPUs) over the plain DoFs/s, but I do not feel strongly about this one.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
