### PR TITLE
CMake: work around a `ctest --launch` bug that eats our stdin

### DIFF
--- a/cmake/macros/macro_expand_instantiations.cmake
+++ b/cmake/macros/macro_expand_instantiations.cmake
@@ -35,7 +35,7 @@ macro(expand_instantiations _target _inst_in_files)
     string(REGEX REPLACE "\\.in$" "" _inst_file "${_inst_in_file}" )
 
     if(NOT CMAKE_CROSSCOMPILING)
-      set(_command expand_instantiations_exe)
+      set(_command "$<TARGET_FILE:expand_instantiations_exe>")
       set(_dependency expand_instantiations_exe)
     else()
       set(_command expand_instantiations)
@@ -45,19 +45,29 @@ macro(expand_instantiations _target _inst_in_files)
     # create a .inst.tmp file first and only move to the correct name if the
     # first call succeeds. Otherwise we might be generating an incomplete
     # .inst file
+    #
+    # With CTEST_USE_LAUNCHERS enabled, "ctest --launch" sometimes fails to
+    # forward its own stdin to the launched process, see
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/27610 In this case
+    # expand_instantiations reads in an empty file and aborts with
+    #     "Invalid instantiation list: missing 'for'".
+    # Redirect via a small run_expand_instantiations.cmake wrapper instead.
     add_custom_command(
       OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}
       DEPENDS ${_dependency}
               ${CMAKE_BINARY_DIR}/${DEAL_II_SHARE_RELDIR}/template-arguments
               ${CMAKE_CURRENT_SOURCE_DIR}/${_inst_in_file}
-      COMMAND ${_command}
-      ARGS ${CMAKE_BINARY_DIR}/${DEAL_II_SHARE_RELDIR}/template-arguments
-           < ${CMAKE_CURRENT_SOURCE_DIR}/${_inst_in_file}
-           > ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}.tmp
+      COMMAND ${CMAKE_COMMAND}
+      ARGS "-DEXE=${_command}"
+           "-DCLASS_LIST_FILE=${CMAKE_BINARY_DIR}/${DEAL_II_SHARE_RELDIR}/template-arguments"
+           "-DIN=${CMAKE_CURRENT_SOURCE_DIR}/${_inst_in_file}"
+           "-DOUT=${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}.tmp"
+           -P "${CMAKE_SOURCE_DIR}/cmake/scripts/run_expand_instantiations.cmake"
       COMMAND ${CMAKE_COMMAND}
       ARGS -E rename
            ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}.tmp
            ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file}
+      VERBATIM
       )
 
     list(APPEND _inst_targets ${CMAKE_CURRENT_BINARY_DIR}/${_inst_file})

--- a/cmake/scripts/run_expand_instantiations.cmake
+++ b/cmake/scripts/run_expand_instantiations.cmake
@@ -1,0 +1,43 @@
+## -----------------------------------------------------------------------------
+##
+## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+## Copyright (C) 2026 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## Detailed license information governing the source code and contributions
+## can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+##
+## -----------------------------------------------------------------------------
+
+#
+# A small wrapper around an executable to do stdin/stdout redirection. This
+# works around an issue with the ctest launcher that gets enabled with
+# CTEST_USE_LAUNCHER: "ctest --launch" fails to forward its own stdin to
+# the launched process on many CMake/CTest releases (3.28 through 4.1+,
+# backported inconsistently, so we cannot detect it).
+#
+# https://gitlab.kitware.com/cmake/cmake/-/issues/27610
+#
+# The following variables must be set:
+#
+#   EXE             - the expand_instantiations executable to run
+#   CLASS_LIST_FILE - the template-arguments file (passed as a command
+#                      line argument to EXE)
+#   IN              - the .inst.in file to feed to EXE via stdin
+#   OUT             - the file to capture EXE's stdout in
+#
+
+execute_process(
+  COMMAND ${EXE} ${CLASS_LIST_FILE}
+  INPUT_FILE ${IN}
+  OUTPUT_FILE ${OUT}
+  RESULT_VARIABLE _result
+  ERROR_VARIABLE _error
+  )
+
+if(NOT _result EQUAL 0)
+  message(FATAL_ERROR
+    "expand_instantiations failed (exit code ${_result}) while processing "
+    "'${IN}':\n${_error}")
+endif()


### PR DESCRIPTION
ctest --launch (with CTEST_USE_LAUNCHERS) fails to forward its own stdin to the launched process on many CMake/CTest releases (3.28 through 4.1+, backported inconsistently). expand_instantiations then reads an empty file and aborts with
```
Invalid instantiation list: missing 'for'
```
Instead, let's redirect via `execute_process()`'s `INPUT_FILE`/`OUTPUT_FILE` and a small cmake wrapper file instead.

Fixes a regression introduced in #20093

Bug: https://gitlab.kitware.com/cmake/cmake/-/issues/27610

On a side note: I am not that impressed with Sonnet 5. It make basic mistakes, such as summarizing the effect of the problem incorrectly. I also dislike the writing style with constant hyperbole. Fable 5 is clearly much stronger.
