### PR TITLE
CMake cleanup: remove some obsolete checks assuming an Ubuntu LTS 20.04 baseline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,11 @@
 message(STATUS "This is CMake ${CMAKE_VERSION}")
 message(STATUS "")
 
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.16.0)
 #
-# We support all policy changes up to version 3.13.4.
+# We support all policy changes up to version 3.16.0.
 #
-cmake_policy(VERSION 3.13.4)
+cmake_policy(VERSION 3.16.0)
 
 if(POLICY CMP0144)
   # Introduced in CMake 3.27: find_package(<PackageName>) searches

--- a/cmake/checks/check_01_cpu_features.cmake
+++ b/cmake/checks/check_01_cpu_features.cmake
@@ -286,11 +286,7 @@ if(DEAL_II_ALLOW_PLATFORM_INTROSPECTION)
   # Choosing the right compiler flag is a bit of a mess:
   #
   if(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER "15" )
-      set(_keyword "qopenmp")
-    elseif("${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER "14" )
-      set(_keyword "openmp")
-    endif()
+    set(_keyword "qopenmp")
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(_keyword "openmp")
   else()

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -195,7 +195,6 @@ macro(_test_cxx17_support)
     DEAL_II_HAVE_CXX17_CONSTEXPR_LAMBDA_BUG_OK
     DEAL_II_HAVE_CXX14_FEATURES
     DEAL_II_HAVE_CXX11_FEATURES
-    DEAL_II_HAVE_CXX11_FUNCTIONAL_LLVMBUG20084_OK
     )
 
   CHECK_CXX_SOURCE_COMPILES(
@@ -321,20 +320,10 @@ macro(_test_cxx17_support)
     "
     DEAL_II_HAVE_CXX11_FEATURES)
 
-  # clang libc++ bug, see https://llvm.org/bugs/show_bug.cgi?id=20084
-  CHECK_CXX_SOURCE_COMPILES(
-    "
-    #include <functional>
-    struct A { void foo() const {} };
-    int main() { A a; std::bind(&A::foo,a)(); return 0; }
-    "
-    DEAL_II_HAVE_CXX11_FUNCTIONAL_LLVMBUG20084_OK)
-
   if(DEAL_II_HAVE_CXX17_FEATURES AND
      DEAL_II_HAVE_CXX17_CONSTEXPR_LAMBDA_BUG_OK AND
      DEAL_II_HAVE_CXX14_FEATURES AND
-     DEAL_II_HAVE_CXX11_FEATURES AND
-     DEAL_II_HAVE_CXX11_FUNCTIONAL_LLVMBUG20084_OK)
+     DEAL_II_HAVE_CXX11_FEATURES)
     message(STATUS "C++17 support is enabled.")
     set(DEAL_II_HAVE_CXX17 TRUE)
     set(_cxx_standard 17)

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -194,7 +194,6 @@ macro(_test_cxx17_support)
     DEAL_II_HAVE_CXX17_FEATURES
     DEAL_II_HAVE_CXX17_CONSTEXPR_LAMBDA_BUG_OK
     DEAL_II_HAVE_CXX14_FEATURES
-    DEAL_II_HAVE_CXX14_CLANGAUTODEBUG_BUG_OK
     DEAL_II_HAVE_CXX11_FEATURES
     DEAL_II_HAVE_CXX11_FUNCTIONAL_LLVMBUG20084_OK
     )
@@ -290,28 +289,6 @@ macro(_test_cxx17_support)
     "
     DEAL_II_HAVE_CXX14_FEATURES)
 
-  # Clang-3.5* or older, bail out with a spurious error message in case
-  # of an undeduced auto return type.
-  #
-  # https://llvm.org/bugs/show_bug.cgi?id=16876
-  set(_flags "${DEAL_II_CXX_FLAGS_DEBUG}")
-  strip_flag(_flags "-Wa,--compress-debug-sections")
-  add_flags(CMAKE_REQUIRED_FLAGS "${_flags}")
-  CHECK_CXX_SOURCE_COMPILES(
-    "
-    struct foo
-    {
-      auto func();
-    };
-    int main()
-    {
-      foo bar;
-      (void) bar;
-    }
-    "
-    DEAL_II_HAVE_CXX14_CLANGAUTODEBUG_BUG_OK)
-  _set_up_cmake_required()
-
   # Check some generic C++11 features
   CHECK_CXX_SOURCE_COMPILES(
     "
@@ -356,7 +333,6 @@ macro(_test_cxx17_support)
   if(DEAL_II_HAVE_CXX17_FEATURES AND
      DEAL_II_HAVE_CXX17_CONSTEXPR_LAMBDA_BUG_OK AND
      DEAL_II_HAVE_CXX14_FEATURES AND
-     DEAL_II_HAVE_CXX14_CLANGAUTODEBUG_BUG_OK AND
      DEAL_II_HAVE_CXX11_FEATURES AND
      DEAL_II_HAVE_CXX11_FUNCTIONAL_LLVMBUG20084_OK)
     message(STATUS "C++17 support is enabled.")

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -421,7 +421,6 @@ unset_if_changed(CHECK_CXX_FEATURES_FLAGS_SAVED
   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
   DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
   DEAL_II_HAVE_CXX17_LEGENDRE_FUNCTIONS
-  DEAL_II_CXX14_CONSTEXPR_BUG_OK
   )
 
 
@@ -539,49 +538,16 @@ CHECK_CXX_SOURCE_COMPILES(
 
 
 #
-# Check for correct c++14 constexpr support.
+# C++14 allows to call non-constexpr functions from constexpr functions as
+# long as there exists an argument value such that an invocation of the
+# function or constructor could be an evaluated subexpression of a core
+# constant expression. All supported compilers implement this correctly --
+# with the exception of MSVC, which in some cases crashes with an internal
+# compiler error when we declare the respective functions as 'constexpr',
+# see #9080. Thus, disable "constexpr" unconditionally for MSVC.
 #
-# As long as there exists an argument value such that an invocation of the
-# function or constructor could be an evaluated subexpression of a core constant
-# expression, C++14 allows to call non-constexpr functions from constexpr
-# functions.
-#
-# Unfortunately, not all compilers obey the standard in this regard. In some
-# cases, MSVC 2019 crashes with an internal compiler error when we
-# declare the respective functions as 'constexpr' even though the test below
-# passes, see #9080.
-#
-# We only run this check if we have CXX14 support, otherwise the use of constexpr
-# is limited (non-const constexpr functions for example).
-#
-
-# MSVC has considerable problems with "constexpr", disable unconditionally
-# for now
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   set(DEAL_II_CXX14_CONSTEXPR_BUG true)
-else()
-  check_cxx_compiler_bug(
-    "
-    #define Assert(x,y) if (!(x)) throw y;
-    void bar()
-    {}
-
-    constexpr int
-    foo(const int n)
-    {
-      Assert(n>0, \"hello\");
-      if(!(n >= 0))
-        bar();
-      return n;
-    }
-
-    int main()
-    {
-      constexpr unsigned int n=foo(1);
-      return n;
-    }
-    "
-    DEAL_II_CXX14_CONSTEXPR_BUG)
 endif()
 
 set(DEAL_II_CONSTEXPR "constexpr")

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -419,8 +419,6 @@ unset_if_changed(CHECK_CXX_FEATURES_FLAGS_SAVED
   "${CMAKE_REQUIRED_FLAGS}${CMAKE_CXX_STANDARD}"
   DEAL_II_HAVE_FP_EXCEPTIONS
   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
-  DEAL_II_HAVE_CXX17_ATTRIBUTE_FALLTHROUGH
-  DEAL_II_HAVE_ATTRIBUTE_FALLTHROUGH
   DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
   DEAL_II_HAVE_CXX17_LEGENDRE_FUNCTIONS
   DEAL_II_CXX14_CONSTEXPR_BUG_OK
@@ -499,68 +497,10 @@ CHECK_CXX_SOURCE_COMPILES(
   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS)
 
 #
-# Try to enable a fallthrough attribute. This is a language feature in C++17,
-# but a compiler extension in earlier language versions.
+# The [[fallthrough]] attribute is a language feature in C++17, which we
+# require. Simply set the macro unconditionally.
 #
-CHECK_CXX_SOURCE_COMPILES(
-  "
-  int main()
-  {
-    int i = 42;
-    int j = 10;
-    switch(i)
-      {
-      case 1:
-        ++j;
-        [[fallthrough]];
-      case 2:
-        ++j;
-        [[fallthrough]];
-      default:
-        break;
-      }
-
-    return i + j;
-  }
-  "
-  DEAL_II_HAVE_CXX17_ATTRIBUTE_FALLTHROUGH
-  )
-
-#
-# see if the current compiler configuration supports the GCC extension
-# __attribute__((fallthrough)) syntax instead
-#
-CHECK_CXX_SOURCE_COMPILES(
-  "
-  int main()
-  {
-    int i = 42;
-    int j = 10;
-    switch(i)
-      {
-      case 1:
-        ++j;
-        __attribute__((fallthrough));
-      case 2:
-        ++j;
-        __attribute__((fallthrough));
-      default:
-        break;
-      }
-
-    return i + j;
-  }
-  "
-  DEAL_II_HAVE_ATTRIBUTE_FALLTHROUGH
-  )
-
-if(DEAL_II_HAVE_CXX17_ATTRIBUTE_FALLTHROUGH)
-  set(DEAL_II_FALLTHROUGH "[[fallthrough]]")
-elseif(DEAL_II_HAVE_ATTRIBUTE_FALLTHROUGH)
-  set(DEAL_II_FALLTHROUGH "__attribute__((fallthrough))")
-else()
-  set(DEAL_II_FALLTHROUGH " ")
-endif()
+set(DEAL_II_FALLTHROUGH "[[fallthrough]]")
 
 
 #

--- a/cmake/checks/check_02_compiler_features.cmake
+++ b/cmake/checks/check_02_compiler_features.cmake
@@ -245,11 +245,7 @@ endif()
 # uncompressed by default. Fortunately, we can also enable compressed
 # output for the linker.
 #
-# The flag also doesn't appear to be working on Cygwin, as
-# per email by John Fowkes on the mailing list in Feb 2012,
-# so don't run the test on cygwin.
-#
-# Finally, Intel's icpc compiler complains about the flag
+# Intel's icpc compiler complains about the flag
 # but apparently only if the file to be compiled contains
 # particular content. See bug #46 in the Google Code bug
 # data base (http://code.google.com/p/dealii/issues/detail?id=46).
@@ -258,8 +254,7 @@ endif()
 #
 # - Matthias Maier, rewritten 2012, 2013
 #
-if( (NOT CMAKE_SYSTEM_NAME MATCHES "CYGWIN") AND
-    (NOT CMAKE_SYSTEM_NAME MATCHES "Windows") AND
+if( (NOT CMAKE_SYSTEM_NAME MATCHES "Windows") AND
     (NOT CMAKE_CXX_COMPILER_ID MATCHES "Intel") )
   add_flags(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS_DEBUG}")
   enable_if_supported(DEAL_II_CXX_FLAGS_DEBUG "-Wa,--compress-debug-sections")

--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -38,31 +38,6 @@ CHECK_CXX_SYMBOL_EXISTS("getpid" "unistd.h" DEAL_II_HAVE_GETPID)
 
 ########################################################################
 #                                                                      #
-#                        Mac OSX specific setup:                       #
-#                                                                      #
-########################################################################
-
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  #
-  # On Mac OS X, -rdynamic is accepted by the compiler (i.e.
-  # it doesn't produce an error) but we always get a warning
-  # that it isn't supported.
-  #
-  # TODO: MM: Check whether this is still necessary...
-  #
-  strip_flag(DEAL_II_LINKER_FLAGS "-rdynamic")
-
-  #
-  # At least on Clang 5.0.0 the template depth is set to 128, which is too low
-  # to compile parts of the library. Fix this by setting a large value.
-  #
-  enable_if_supported(DEAL_II_CXX_FLAGS "-ftemplate-depth=1024")
-endif()
-
-
-
-########################################################################
-#                                                                      #
 #                   Windows and CYGWIN specific setup:                 #
 #                                                                      #
 ########################################################################

--- a/cmake/checks/check_02_system_features.cmake
+++ b/cmake/checks/check_02_system_features.cmake
@@ -44,13 +44,6 @@ CHECK_CXX_SYMBOL_EXISTS("getpid" "unistd.h" DEAL_II_HAVE_GETPID)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   #
-  # Use -Wno-long-double on Apple Darwin to avoid some unnecessary
-  # warnings. However, newer gccs on that platform do not have
-  # this flag any more, so check whether we can indeed do this
-  #
-  enable_if_supported(DEAL_II_CXX_FLAGS "-Wno-long-double")
-
-  #
   # On Mac OS X, -rdynamic is accepted by the compiler (i.e.
   # it doesn't produce an error) but we always get a warning
   # that it isn't supported.

--- a/cmake/checks/check_03_compiler_bugs.cmake
+++ b/cmake/checks/check_03_compiler_bugs.cmake
@@ -18,19 +18,6 @@
 
 
 #
-# In intel (at least 13.1 and 14), vectorization causes
-# wrong code. See https://code.google.com/p/dealii/issues/detail?id=156
-# or tests/hp/solution_transfer.cc
-# A work-around is to disable all vectorization.
-#
-# - Timo Heister, 2013, 2015
-#
-if(CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "15.0.3" )
-  enable_if_supported(DEAL_II_CXX_FLAGS_RELEASE "-no-vec")
-endif()
-
-
-#
 # Intel 16.0.1 produces wrong code that creates a race condition in
 # tests/fe/curl_curl_01.debug but 16.0.2 is known to work. Blacklist this
 # version. Also see github.com/dealii/dealii/issues/2203

--- a/cmake/checks/check_03_compiler_bugs.cmake
+++ b/cmake/checks/check_03_compiler_bugs.cmake
@@ -18,16 +18,6 @@
 
 
 #
-# Intel 16.0.1 produces wrong code that creates a race condition in
-# tests/fe/curl_curl_01.debug but 16.0.2 is known to work. Blacklist this
-# version. Also see github.com/dealii/dealii/issues/2203
-#
-if(CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "16.0.1" )
-  message(FATAL_ERROR "Intel compiler version 16.0.1 is not supported, please update to 16.0.2 or newer!")
-endif()
-
-
-#
 # Check for a regression in gcc-11.1.0 where a deleted move constructor
 # prevents templated constructor from being used. For details see
 #

--- a/cmake/macros/check_compiler_setup/CMakeLists.txt
+++ b/cmake/macros/check_compiler_setup/CMakeLists.txt
@@ -1,7 +1,7 @@
 # use a "Custom" build type to avoid auto populated compiler flags
 set(CMAKE_BUILD_TYPE "Custom")
 set(CMAKE_CONFIGURATION_TYPES "DEBUG;RELEASE")
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.16.0)
 project(CheckCompilerSetup)
 add_executable(CheckCompilerSetupExec dummy.cpp)
 

--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -86,14 +86,7 @@ function(pad_string_right output _str _length)
   math(EXPR _strlen "${_length} - ${_strlen}")
 
   if(_strlen GREATER 0)
-    if(${CMAKE_VERSION} VERSION_LESS "3.15")
-      unset(_pad)
-      foreach(_i RANGE 1 ${_strlen}) # inclusive
-        string(APPEND _pad " ")
-      endforeach()
-    else()
-      string(REPEAT " " ${_strlen} _pad)
-    endif()
+    string(REPEAT " " ${_strlen} _pad)
     set(_str "${_str}${_pad}")
   endif()
 
@@ -106,14 +99,7 @@ function(pad_string_left output _str _length)
   math(EXPR _strlen "${_length} - ${_strlen}")
 
   if(_strlen GREATER 0)
-    if(${CMAKE_VERSION} VERSION_LESS "3.15")
-      unset(_pad)
-      foreach(_i RANGE 1 ${_strlen}) # inclusive
-        string(APPEND _pad " ")
-      endforeach()
-    else()
-      string(REPEAT " " ${_strlen} _pad)
-    endif()
+    string(REPEAT " " ${_strlen} _pad)
     set(_str "${_pad}${_str}")
   endif()
 

--- a/cmake/macros/macro_deal_ii_query_git_information.cmake
+++ b/cmake/macros/macro_deal_ii_query_git_information.cmake
@@ -98,14 +98,8 @@ macro(deal_ii_query_git_information)
     #   %cd  - the commit date (for which we use the strict iso date format)
     #
 
-    # --date=iso-strict has been introduced in git 2.2 (released Dec 2014)
-    set(_date_format)
-    if(NOT ${GIT_VERSION_STRING} VERSION_LESS 2.2)
-      set(_date_format "--date=iso-strict")
-    endif()
-
     execute_process(
-       COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"revision=%H, shortrev=%h, date=%cd" ${_date_format}
+       COMMAND ${GIT_EXECUTABLE} log -n 1 --pretty=format:"revision=%H, shortrev=%h, date=%cd" --date=iso-strict
        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
        OUTPUT_VARIABLE _info
        RESULT_VARIABLE _result

--- a/cmake/modules/FindDEAL_II_LAPACK.cmake
+++ b/cmake/modules/FindDEAL_II_LAPACK.cmake
@@ -60,15 +60,6 @@ if(DEFINED LAPACK_LIBRARIES)
 endif()
 
 #
-# Work around a bug in CMake 3.11 by simply filtering out
-# "PkgConf::PKGC_BLAS". See bug
-#   https://gitlab.kitware.com/cmake/cmake/issues/17934
-#
-if(DEFINED BLAS_LIBRARIES)
-  list(REMOVE_ITEM BLAS_LIBRARIES "PkgConfig::PKGC_BLAS")
-endif()
-
-#
 # Well, in case of static archives we have to manually pick up the
 # complete link interface. *sigh*
 #

--- a/cmake/scripts/CMakeLists.txt
+++ b/cmake/scripts/CMakeLists.txt
@@ -12,22 +12,8 @@
 
 add_executable(expand_instantiations_exe expand_instantiations.cc)
 
-#
-# We run into a bug when compiling expand_instantiations with
-# -fuse-ld=gold -pthreads, see https://github.com/dealii/dealii/issues/1798
-# Work around this by stripping -fuse-ld=gold out of the build flags
-# for the script. This does little harm because linking this one file
-# is so exceedingly cheap that there is no speed difference between
-# using gold or the old BFD ld linker.
-#
-# If we are on a system where -fuse-ld=gold simply isn't part of the
-# linker flag, filtering this one command out of the list of flags
-# does not harm either.
-#
-string(REPLACE "-fuse-ld=gold" "" _expand_instantiations_link_flags "${DEAL_II_LINKER_FLAGS}" )
-
 set_target_properties(expand_instantiations_exe PROPERTIES
-  LINK_FLAGS "${_expand_instantiations_link_flags}"
+  LINK_FLAGS "${DEAL_II_LINKER_FLAGS}"
   LINKER_LANGUAGE "CXX"
   COMPILE_DEFINITIONS "${DEAL_II_DEFINITIONS}"
   COMPILE_FLAGS "${DEAL_II_CXX_FLAGS}"

--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -35,14 +35,12 @@ endif()
 
 # Correspondence between AppleClang version and upstream Clang version:
 # https://en.wikipedia.org/wiki/Xcode#Xcode_11.0_-_14.x_(since_SwiftUI_framework)_2
-if(POLICY CMP0025)
-  if( CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
-      CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0" )
-    message(FATAL_ERROR "\n"
-      "deal.II requires support for features of C++17 that are not present in\n"
-      "versions of AppleClang prior to 12.0."
-      )
-  endif()
+if( CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.0" )
+  message(FATAL_ERROR "\n"
+    "deal.II requires support for features of C++17 that are not present in\n"
+    "versions of AppleClang prior to 12.0."
+    )
 endif()
 
 

--- a/doc/news/changes/minor/20260804MatthiasMaier
+++ b/doc/news/changes/minor/20260804MatthiasMaier
@@ -1,0 +1,6 @@
+Changed: The minimum CMake version required to configure and build deal.II
+has been raised to 3.16. In addition, a number of obsolete configure checks
+and workarounds for compiler, linker, and tool versions that can no longer
+build deal.II have been removed from the build system.
+<br>
+(Matthias Maier, 2026/08/04)

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -92,7 +92,7 @@
     </p>
     <ul>
         <li>
-            <a href="https://www.cmake.org/" target="_top">CMake</a> version 3.13.4 or later
+            <a href="https://www.cmake.org/" target="_top">CMake</a> version 3.16 or later
         </li>
 
         <li>

--- a/doc/users/cmake_user.html
+++ b/doc/users/cmake_user.html
@@ -63,7 +63,7 @@
   version):
 
 <pre class="cmake">
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.16.0)
 
 find_package(deal.II 9.8.0 REQUIRED
   HINTS ${DEAL_II_DIR} ../ ../../ $ENV{DEAL_II_DIR}
@@ -271,7 +271,7 @@ mycode/include/*.h
 In this case the top level <code>CMakeLists.txt</code> file may be:
 <pre class="cmake">
 # top level CMakeLists.txt
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.16.0)
 find_package(deal.II 9.8.0 REQUIRED)
 
 deal_ii_initialize_cached_variables()
@@ -660,7 +660,7 @@ set(TARGET_SRC
   # You can specify additional files here!
 )
 
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.16.0)
 deal_ii_initialize_cached_variables()
 project(${TARGET} CXX)
 deal_ii_invoke_autopilot()


### PR DESCRIPTION
This pull request is a quick cleanup run over our 15 year old CMake configuration. I do have some more stuff lined up that I split out in a separate pull request.

- CMake: remove obsolete if(POLICY CMP0025) guard
- CMake: remove workaround for FindBLAS bug in CMake 3.11
- CMake: remove -no-vec workaround for icc < 15.0.3
- CMake: remove blacklist for icc 16.0.1
- CMake: remove Cygwin exclusion for compressed debug sections
- CMake: remove -Wno-long-double flag check on macOS
- CMake: raise minimum required CMake version to 3.16
- CMake: remove string(REPEAT) fallback for CMake < 3.15
- CMake: remove check for clang <= 3.5 auto return type bug
- CMake: remove check for libc++ std::bind bug (LLVM bug 20084)
- CMake: set DEAL_II_FALLTHROUGH unconditionally to [[fallthrough]]
- CMake: simplify OpenMP SIMD flag selection for Intel compilers
- CMake: use git --date=iso-strict unconditionally
- CMake: remove configure test for C++14 relaxed constexpr support
- CMake: remove -fuse-ld=gold workaround for expand_instantiations
- CMake: remove macOS-specific -rdynamic and -ftemplate-depth handling
