### PR TITLE
CMake cleanup: deprecate DEAL_II_FALLTHROUGH

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -24,7 +24,6 @@
 #   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
 #   DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
 #   DEAL_II_HAVE_CXX17_LEGENDRE_FUNCTIONS
-#   DEAL_II_FALLTHROUGH
 #   DEAL_II_CONSTEXPR
 #
 
@@ -494,13 +493,6 @@ CHECK_CXX_SOURCE_COMPILES(
   }
   "
   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS)
-
-#
-# The [[fallthrough]] attribute is a language feature in C++17, which we
-# require. Simply set the macro unconditionally.
-#
-set(DEAL_II_FALLTHROUGH "[[fallthrough]]")
-
 
 #
 # Check for c++17 Bessel function support. Unfortunately libc++ version 10

--- a/doc/news/changes/minor/20260804MatthiasMaier_2
+++ b/doc/news/changes/minor/20260804MatthiasMaier_2
@@ -1,0 +1,4 @@
+Deprecated: The macro DEAL_II_FALLTHROUGH is deprecated. Use the C++17
+attribute [[fallthrough]] directly instead.
+<br>
+(Matthias Maier, 2026/08/04)

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -270,7 +270,14 @@ DEAL_II_NAMESPACE_CLOSE
 #  endif
 #endif
 
-#cmakedefine DEAL_II_FALLTHROUGH @DEAL_II_FALLTHROUGH@
+/**
+ * An alias for the C++17 attribute <code>[[fallthrough]]</code>.
+ *
+ * @deprecated This macro is deprecated. Use the C++17 attribute
+ * <code>[[fallthrough]]</code> directly instead.
+ */
+#define DEAL_II_FALLTHROUGH [[fallthrough]]
+
 #cmakedefine DEAL_II_CONSTEXPR @DEAL_II_CONSTEXPR@
 
 

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1038,32 +1038,32 @@ namespace Utilities
                   if (!comp(*first, val))
                     return first;
                   ++first;
-                  DEAL_II_FALLTHROUGH;
+                  [[fallthrough]];
                 case 6:
                   if (!comp(*first, val))
                     return first;
                   ++first;
-                  DEAL_II_FALLTHROUGH;
+                  [[fallthrough]];
                 case 5:
                   if (!comp(*first, val))
                     return first;
                   ++first;
-                  DEAL_II_FALLTHROUGH;
+                  [[fallthrough]];
                 case 4:
                   if (!comp(*first, val))
                     return first;
                   ++first;
-                  DEAL_II_FALLTHROUGH;
+                  [[fallthrough]];
                 case 3:
                   if (!comp(*first, val))
                     return first;
                   ++first;
-                  DEAL_II_FALLTHROUGH;
+                  [[fallthrough]];
                 case 2:
                   if (!comp(*first, val))
                     return first;
                   ++first;
-                  DEAL_II_FALLTHROUGH;
+                  [[fallthrough]];
                 case 1:
                   if (!comp(*first, val))
                     return first;

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -148,7 +148,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
                                               face_no)][i];
                   }
               }
-              DEAL_II_FALLTHROUGH;
+              [[fallthrough]];
 
             case 2:
               {
@@ -175,7 +175,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
                       }
                   }
               }
-              DEAL_II_FALLTHROUGH;
+              [[fallthrough]];
 
             case 1:
               {

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1156,18 +1156,18 @@ namespace internal
                 r2 = op(index++);
                 for (size_type j = 1; j < 8; ++j)
                   r2 += op(index++);
-                DEAL_II_FALLTHROUGH;
+                [[fallthrough]];
               case 2:
                 r1 = op(index++);
                 for (size_type j = 1; j < 8; ++j)
                   r1 += op(index++);
                 r1 += r2;
-                DEAL_II_FALLTHROUGH;
+                [[fallthrough]];
               case 1:
                 r2 = op(index++);
                 for (size_type j = 1; j < 8; ++j)
                   r2 += op(index++);
-                DEAL_II_FALLTHROUGH;
+                [[fallthrough]];
               default:
                 for (size_type j = 0; j < remainder_inner; ++j)
                   r0 += op(index++);

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -513,7 +513,7 @@ namespace VectorTools
             update_flags |= UpdateFlags(update_gradients);
             if (spacedim == dim + 1)
               update_flags |= UpdateFlags(update_normal_vectors);
-            DEAL_II_FALLTHROUGH;
+            [[fallthrough]];
 
           default:
             update_flags |= UpdateFlags(update_values);

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -152,7 +152,7 @@ namespace VectorTools
             break;
 
           case FiniteElementData<dim>::H1:
-            DEAL_II_FALLTHROUGH;
+            [[fallthrough]];
           case FiniteElementData<dim>::L2:
             // See Monk, Finite Element Methods for Maxwell's Equations,
             // p. 77ff, formula (3.74).

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -854,15 +854,15 @@ namespace
             case 3:
               AssertIndexRange(zstep, n_subdivisions + 1);
               point_no += (n_subdivisions + 1) * (n_subdivisions + 1) * zstep;
-              DEAL_II_FALLTHROUGH;
+              [[fallthrough]];
             case 2:
               AssertIndexRange(ystep, n_subdivisions + 1);
               point_no += (n_subdivisions + 1) * ystep;
-              DEAL_II_FALLTHROUGH;
+              [[fallthrough]];
             case 1:
               AssertIndexRange(xstep, n_subdivisions + 1);
               point_no += xstep;
-              DEAL_II_FALLTHROUGH;
+              [[fallthrough]];
             case 0:
               // break here for dim<=3
               break;

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3558,10 +3558,10 @@ GridIn<dim, spacedim>::parse_tecplot_header(
     {
       case 3:
         IJK[2] = 0;
-        DEAL_II_FALLTHROUGH;
+        [[fallthrough]];
       case 2:
         IJK[1] = 0;
-        DEAL_II_FALLTHROUGH;
+        [[fallthrough]];
       case 1:
         IJK[0] = 0;
     }

--- a/tests/performance/instrumentation_step_22.cc
+++ b/tests/performance/instrumentation_step_22.cc
@@ -611,7 +611,7 @@ StokesProblem<dim>::run()
         triangulation.refine_global(4 - dim);
         break;
       case TestingEnvironment::medium:
-        DEAL_II_FALLTHROUGH;
+        [[fallthrough]];
       case TestingEnvironment::heavy:
         triangulation.refine_global(5 - dim);
         break;

--- a/tests/performance/instrumentation_step_3.cc
+++ b/tests/performance/instrumentation_step_3.cc
@@ -100,7 +100,7 @@ Step3::make_grid()
         triangulation.refine_global(6);
         break;
       case TestingEnvironment::medium:
-        DEAL_II_FALLTHROUGH;
+        [[fallthrough]];
       case TestingEnvironment::heavy:
         triangulation.refine_global(7);
         break;

--- a/tests/performance/timing_step_22.cc
+++ b/tests/performance/timing_step_22.cc
@@ -609,7 +609,7 @@ StokesProblem<dim>::run()
         triangulation.refine_global(5 - dim);
         break;
       case TestingEnvironment::medium:
-        DEAL_II_FALLTHROUGH;
+        [[fallthrough]];
       case TestingEnvironment::heavy:
         triangulation.refine_global(6 - dim);
         break;

--- a/tests/performance/timing_step_3.cc
+++ b/tests/performance/timing_step_3.cc
@@ -101,7 +101,7 @@ Step3::make_grid()
         triangulation.refine_global(9);
         break;
       case TestingEnvironment::medium:
-        DEAL_II_FALLTHROUGH;
+        [[fallthrough]];
       case TestingEnvironment::heavy:
         triangulation.refine_global(10);
         break;


### PR DESCRIPTION
Use `[[fallthrough]]` in our codebase directly and deprecate the macro.

The topmost commit is from #20102 and the branch has to be rebased prior to merging.
