### PR TITLE
step-104: Use a simpler vector operation

### DIFF
--- a/examples/step-104/step-104.cc
+++ b/examples/step-104/step-104.cc
@@ -817,8 +817,7 @@ namespace Step104
     // Apply the top right block: tmp.u = -B^T * dst.p + src.u
     {
       BT_operator.vmult(tmp, dst);
-      tmp.block(0) *= -1.0;
-      tmp.block(0) += src.block(0);
+      tmp.block(0).sadd(-1.0, 1.0, src.block(0));
     }
 
     // Finally the velocity block:


### PR DESCRIPTION
Rather than first multiplying a vector by -1 and then adding another vector, we can use `sadd(-1, 1, other_vector)`. This reduces the number of writes to the vector by 1 and on the GPU reduces the number of kernel calls.


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
