### PR TITLE
[9.8] Take over cherry-pick candidates.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,6 +53,8 @@ jobs:
             os: ubuntu-22.04
           - ubuntu_version: noble
             os: ubuntu-24.04
+          - ubuntu_version: resolute
+            os: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v7
@@ -104,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble]
+        ubuntu_version: [jammy, noble, resolute]
         os: [ubuntu-24.04, ubuntu-24.04-arm]
         include:
           - os: ubuntu-24.04
@@ -158,6 +160,10 @@ jobs:
         # messaging module was unable to find any relevant network
         # interfaces."
         export OMPI_MCA_btl_base_warn_component_unused='0'
+        # Disable UCX OSC to prevent errors of the kind:
+        # "../ompi/mca/osc/ucx/osc_ucx_component.c:375  Error: OSC UCX
+        # component priority set inside component query failed"
+        export OMPI_MCA_osc='^ucx'
 
         cd build
         make \
@@ -187,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble]
+        ubuntu_version: [jammy, noble, resolute]
 
     container:
       image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.7.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,15 @@ if(POLICY CMP0167)
 endif()
 
 if(POLICY CMP0177)
-  # Introduced in CMAKE 3:31: Normalize DESTINATION paths so that they do
+  # Introduced in CMake 3:31: Normalize DESTINATION paths so that they do
   # not contain "." or "..".
   cmake_policy(SET CMP0177 NEW)
+endif()
+
+if(POLICY CMP0219)
+  # Introduced in CMake 4.4: macro() invocations preserve backslashes in
+  # arguments.
+  cmake_policy(SET CMP0219 OLD)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)

--- a/doc/news/9.7.1-vs-9.8.0.h
+++ b/doc/news/9.7.1-vs-9.8.0.h
@@ -114,14 +114,14 @@ inconvenience this causes.
   Changed: In three space dimensions, the curl of a vector field is unambiguously
   a three-dimensional vector. In two space dimensions, it is typically defined
   as a scalar, interpreted as the magnitude of a vector aligned with the $z$-axis
-  that results from taking the curl of a vector field that lives in the $x-y$ plane.
+  that results from taking the curl of a vector field that lives in the $x$-$y$ plane.
   For historical reasons, deal.II used to represent this scalar as a Tensor<1,1>
   (i.e., a tensor of rank one -- a tensor with one index -- for which the only
   possible value of the index is zero). This is, of course, entirely equivalent
   to it being a scalar, but it is semantically wrong: The data type should have
-  been a scalar, not an array of which one can take the zeroth element. This is
+  been a scalar, not a vector with one element. This is
   now fixed: The data type defined by FEValuesViews::Vector::curl_type used for
-  curls is not simply a scalar value for `dim==2`. For `dim==3`, it is
+  curls is now simply a scalar value for `dim==2`. For `dim==3`, it is
   unchanged from what it was before.
   <br>
   (Wolfgang Bangerth, 2026/03/31)
@@ -138,7 +138,7 @@ inconvenience this causes.
  </li>
 
  <li>
-  Deprecated: Overloads for TrilinosWrappers classes allowing a default number of
+  Deprecated: Overloads for TrilinosWrappers sparse matrix classes allowing a default number of
   entries per row have been deprecated. The respective overloads for TpetraWrappers
   classes have been removed.
   <br>
@@ -166,7 +166,7 @@ inconvenience this causes.
   elements need to be treated as unchangeable. This is because whenever
   you change a locally-owned element of such a vector, this change is
   not propagated to those processes that store this element among their
-  ghost elements. As a consequence, these processes view of the vector
+  ghost elements; these processes' view of the vector
   is now no longer in sync with the view on that process that owns the
   element, and that is a common source of very hard to find bugs.
   <br>

--- a/doc/news/9.7.1-vs-9.8.0.h
+++ b/doc/news/9.7.1-vs-9.8.0.h
@@ -114,7 +114,7 @@ inconvenience this causes.
   Changed: In three space dimensions, the curl of a vector field is unambiguously
   a three-dimensional vector. In two space dimensions, it is typically defined
   as a scalar, interpreted as the magnitude of a vector aligned with the $z$-axis
-  the results from taking the curl of a vector field that lives in the $x-y$ plane.
+  that results from taking the curl of a vector field that lives in the $x-y$ plane.
   For historical reasons, deal.II used to represent this scalar as a Tensor<1,1>
   (i.e., a tensor of rank one -- a tensor with one index -- for which the only
   possible value of the index is zero). This is, of course, entirely equivalent

--- a/doc/news/9.7.1-vs-9.8.0.h
+++ b/doc/news/9.7.1-vs-9.8.0.h
@@ -431,6 +431,20 @@ inconvenience this causes.
 <ol>
 
  <li>
+  New: We introduced a new function
+  parallel::shared::Triangulation::communicate_coarsening_and_refinement_flags()
+  that communicates coarsen and refine flags among all MPI processes prior
+  to mesh refinement. Previously, this functionality was an inherent part of
+  parallel::shared::Triangulation::execute_coarsening_and_refinement()
+  and has now been moved into a separate helper function. Now, both functions
+  parallel::shared::Triangulation::prepare_coarsening_and_refinement() and
+  parallel::shared::Triangulation::execute_coarsening_and_refinement()
+  begin with communicating flags through the new helper function.
+  <br>
+  (Matthias Maier, 2026/08/01)
+ </li>
+
+ <li>
   Fixed: TriangulationDescription::Description now correctly sets material_ids
   of cells on finer levels.
   <br>

--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -106,7 +106,7 @@ namespace parallel
     namespace GridRefinement
     {
       /**
-       * Like dealii::GridRefinement::refine_and_coarsen_fixed_number, but
+       * Like ::dealii::GridRefinement::refine_and_coarsen_fixed_number, but
        * designed for parallel computations, where each process has only
        * information about locally owned cells.
        *
@@ -161,7 +161,7 @@ namespace parallel
           std::numeric_limits<types::global_cell_index>::max());
 
       /**
-       * Like dealii::GridRefinement::refine_and_coarsen_fixed_fraction, but
+       * Like ::dealii::GridRefinement::refine_and_coarsen_fixed_fraction, but
        * designed for parallel computations, where each process only has
        * information about locally owned cells.
        *

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -431,7 +431,7 @@ namespace parallel
        * of flags for the entire (replicated) triangulation.
        */
       void
-      communicate_refinement_and_coarsening_flags();
+      communicate_coarsening_and_refinement_flags();
 
       /**
        * A vector containing subdomain IDs of cells obtained by partitioning

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -283,6 +283,22 @@ namespace parallel
       execute_coarsening_and_refinement() override;
 
       /**
+       * Prepare the triangulation for coarsening and refinement.
+       *
+       * @note In addition to what the function of the base
+       * dealii::Triangulation class does, this function first synchronizes
+       * the refinement and coarsening flags over all processes. Each MPI
+       * process only needs to set these flags on its own locally owned
+       * cells; synchronizing them first guarantees that decisions made
+       * during flag smoothing (such as removing the coarsening flags of a
+       * group of sibling cells if not all children are flagged) are made
+       * with knowledge of the flags set by all processes, and consequently
+       * do not depend on how the triangulation is partitioned.
+       */
+      virtual bool
+      prepare_coarsening_and_refinement() override;
+
+      /**
        * Create a triangulation.
        *
        * This function also partitions triangulation based on the MPI
@@ -406,6 +422,16 @@ namespace parallel
        */
       void
       partition();
+
+      /**
+       * Synchronize the refinement and coarsening flags over all MPI
+       * processes: Each process only needs to set the flags on its own
+       * locally owned cells; this function combines the flags of all
+       * processes so that afterwards every process holds the complete set
+       * of flags for the entire (replicated) triangulation.
+       */
+      void
+      communicate_refinement_and_coarsening_flags();
 
       /**
        * A vector containing subdomain IDs of cells obtained by partitioning

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -353,7 +353,8 @@ namespace parallel
 
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    void Triangulation<dim,
+                       spacedim>::communicate_refinement_and_coarsening_flags()
     {
       // make sure that all refinement/coarsening flags are the same on all
       // processes
@@ -414,6 +415,27 @@ namespace parallel
               cell->set_coarsen_flag();
           }
       }
+    }
+
+
+
+    template <int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
+    {
+      communicate_refinement_and_coarsening_flags();
+
+      return dealii::Triangulation<dim, spacedim>::
+        prepare_coarsening_and_refinement();
+    }
+
+
+
+    template <int dim, int spacedim>
+    DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+    void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
+    {
+      communicate_refinement_and_coarsening_flags();
 
       dealii::Triangulation<dim, spacedim>::execute_coarsening_and_refinement();
       partition();

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -354,7 +354,7 @@ namespace parallel
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     void Triangulation<dim,
-                       spacedim>::communicate_refinement_and_coarsening_flags()
+                       spacedim>::communicate_coarsening_and_refinement_flags()
     {
       // make sure that all refinement/coarsening flags are the same on all
       // processes
@@ -423,7 +423,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
     {
-      communicate_refinement_and_coarsening_flags();
+      communicate_coarsening_and_refinement_flags();
 
       return dealii::Triangulation<dim, spacedim>::
         prepare_coarsening_and_refinement();
@@ -435,7 +435,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
     {
-      communicate_refinement_and_coarsening_flags();
+      communicate_coarsening_and_refinement_flags();
 
       dealii::Triangulation<dim, spacedim>::execute_coarsening_and_refinement();
       partition();

--- a/tests/sharedtria/refine_and_coarsen_03.cc
+++ b/tests/sharedtria/refine_and_coarsen_03.cc
@@ -1,0 +1,127 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+
+// Check that calling prepare_coarsening_and_refinement() directly on a
+// parallel::shared::Triangulation, as is customary before attaching data
+// for a solution transfer, synchronizes refinement and coarsening flags
+// over all processes *before* flag smoothing runs.
+//
+// Refinement and coarsening flags only need to be set on locally owned
+// cells. If prepare_coarsening_and_refinement() does not synchronize the
+// flags first, smoothing (in particular the rule that a family of sibling
+// cells is only coarsened if all children are flagged) only sees the
+// flags this process has set itself. Flags on cells owned by other
+// processes, which are artificial here, default to false. For a family
+// that straddles a partition boundary this drops the coarsen flag on
+// every process, and the resulting mesh ends up depending on the
+// partitioning.
+//
+// We check this by counting, immediately after
+// prepare_coarsening_and_refinement(), how many active cells (including
+// artificial ones) have a refine/coarsen flag set: with synchronized
+// flags this count has to be identical on every process. The cell counts
+// logged by this test therefore have to agree between the mpirun=1 and
+// mpirun=3 output files.
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  parallel::shared::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    /*allow_artificial_cells*/ true,
+    parallel::shared::Triangulation<dim>::partition_zorder);
+
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  tria.refine_global(2);
+  deallog << "cells before: " << tria.n_global_active_cells() << std::endl;
+
+  // Set refinement and coarsening flags on locally owned cells only:
+
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        const auto center = cell->center();
+
+        bool refine = true;
+        for (unsigned int d = 0; d < dim; ++d)
+          refine = refine && (center[d] < 0.25);
+
+        if (refine)
+          cell->set_refine_flag();
+        else if (center[0] > 0.5)
+          cell->set_coarsen_flag();
+      }
+
+  tria.prepare_coarsening_and_refinement();
+
+  // Immediately after prepare_coarsening_and_refinement() every process
+  // must see the complete, partition-independent set of flags. We count
+  // over *all* active cells (including artificial ones), since a flag on
+  // an artificial cell can only ever become visible through
+  // synchronization:
+
+  unsigned int n_refine_flags  = 0;
+  unsigned int n_coarsen_flags = 0;
+  for (const auto &cell : tria.active_cell_iterators())
+    {
+      if (cell->refine_flag_set())
+        ++n_refine_flags;
+      if (cell->coarsen_flag_set())
+        ++n_coarsen_flags;
+    }
+  deallog << "flags after prepare: refine=" << n_refine_flags
+          << " coarsen=" << n_coarsen_flags << std::endl;
+
+  AssertThrow(Utilities::MPI::max(n_refine_flags, MPI_COMM_WORLD) ==
+                Utilities::MPI::min(n_refine_flags, MPI_COMM_WORLD),
+              ExcInternalError());
+  AssertThrow(Utilities::MPI::max(n_coarsen_flags, MPI_COMM_WORLD) ==
+                Utilities::MPI::min(n_coarsen_flags, MPI_COMM_WORLD),
+              ExcInternalError());
+
+  tria.execute_coarsening_and_refinement();
+  deallog << "cells after: " << tria.n_global_active_cells() << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  mpi_initlog();
+
+  deallog.push("1d");
+  test<1>();
+  deallog.pop();
+
+  deallog.push("2d");
+  test<2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3>();
+  deallog.pop();
+}

--- a/tests/sharedtria/refine_and_coarsen_03.mpirun=1.output
+++ b/tests/sharedtria/refine_and_coarsen_03.mpirun=1.output
@@ -1,0 +1,13 @@
+
+DEAL:1d::cells before: 8
+DEAL:1d::flags after prepare: refine=2 coarsen=4
+DEAL:1d::cells after: 8
+DEAL:1d::OK
+DEAL:2d::cells before: 64
+DEAL:2d::flags after prepare: refine=4 coarsen=32
+DEAL:2d::cells after: 52
+DEAL:2d::OK
+DEAL:3d::cells before: 512
+DEAL:3d::flags after prepare: refine=8 coarsen=256
+DEAL:3d::cells after: 344
+DEAL:3d::OK

--- a/tests/sharedtria/refine_and_coarsen_03.mpirun=3.output
+++ b/tests/sharedtria/refine_and_coarsen_03.mpirun=3.output
@@ -1,0 +1,13 @@
+
+DEAL:1d::cells before: 8
+DEAL:1d::flags after prepare: refine=2 coarsen=4
+DEAL:1d::cells after: 8
+DEAL:1d::OK
+DEAL:2d::cells before: 64
+DEAL:2d::flags after prepare: refine=4 coarsen=32
+DEAL:2d::cells after: 52
+DEAL:2d::OK
+DEAL:3d::cells before: 512
+DEAL:3d::flags after prepare: refine=8 coarsen=256
+DEAL:3d::cells after: 344
+DEAL:3d::OK


### PR DESCRIPTION
Take over #20081 #20085 #20086 #20088 #20099 #20113.

The PRs touch documentation, a CMake policy, and let the github-CI run on resolute/26.04. Nothing major, so we would not need a new dedicated release candidate. (EDIT: This patch now also changes behavior of p::s::T::prepare_for_coarsening_and_refinement.)

Part of #19728.