### PR TITLE
Triangulation: optimize set_neighbor().

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -8081,6 +8081,26 @@ CellAccessor<dim, spacedim>::is_artificial_on_level() const
 
 
 template <int dim, int spacedim>
+inline void
+CellAccessor<dim, spacedim>::set_neighbor(
+  const unsigned int                               face_no,
+  const TriaIterator<CellAccessor<dim, spacedim>> &neighbor) const
+{
+  AssertIndexRange(face_no, this->n_faces());
+
+  Assert(neighbor.state() != IteratorState::invalid,
+         ExcMessage("The provided neighbor must be either a valid iterator or "
+                    "an end iterator (to indicate a boundary face)"));
+  auto &level = this->tria->levels[this->level()];
+  level->set_neighbor(this->present_index,
+                      face_no,
+                      neighbor->level(),
+                      neighbor->index());
+}
+
+
+
+template <int dim, int spacedim>
 inline types::material_id
 CellAccessor<dim, spacedim>::material_id() const
 {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -3604,9 +3604,8 @@ namespace internal
         // anisotropic refinement and more than one cell neighboring at a
         // given side of the face we will automatically get the active one on
         // the highest level as we loop over cells from lower levels first.
-        const typename Triangulation<dim, spacedim>::cell_iterator dummy;
         std::vector<typename Triangulation<dim, spacedim>::cell_iterator>
-          adjacent_cells(2 * triangulation.n_raw_faces(), dummy);
+          adjacent_cells(2 * triangulation.n_raw_faces(), triangulation.end());
 
         for (const auto &cell : triangulation.cell_iterators())
           for (auto f : cell->face_indices())
@@ -12784,7 +12783,7 @@ namespace internal
                                                              test.first,
                                                              test.second);
           else
-            return typename Triangulation<dim, spacedim>::cell_iterator();
+            return triangulation.end();
         };
 
         for (const auto &cell : triangulation.cell_iterators())

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2314,26 +2314,6 @@ CellAccessor<dim, spacedim>::recursively_set_subdomain_id(
 }
 
 
-
-template <int dim, int spacedim>
-void
-CellAccessor<dim, spacedim>::set_neighbor(
-  const unsigned int                               face_no,
-  const TriaIterator<CellAccessor<dim, spacedim>> &neighbor) const
-{
-  AssertIndexRange(face_no, this->n_faces());
-
-  auto &level = this->tria->levels[this->level()];
-  if (neighbor.state() == IteratorState::valid)
-    level->set_neighbor(this->present_index,
-                        face_no,
-                        neighbor->level(),
-                        neighbor->index());
-  else
-    level->set_neighbor(this->present_index, face_no, -1, -1);
-}
-
-
 template <int dim, int spacedim>
 std::set<TriaActiveIterator<CellAccessor<dim, spacedim>>>
 CellAccessor<dim, spacedim>::get_cells_adjacent_to_line(


### PR DESCRIPTION
This makes setting up neighbors about 28% faster, which makes refinement about 3% faster (as measured by callgrind and isotropic refinement of a tetrahedral Triangulation).

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
