### PR TITLE
Jenkins.serial: disable unity build

### DIFF
--- a/contrib/ci/Jenkinsfile.serial
+++ b/contrib/ci/Jenkinsfile.serial
@@ -106,7 +106,7 @@ pipeline
                     -D CMAKE_BUILD_TYPE=Debug \
                     -D DEAL_II_WITH_MPI=OFF \
                     -D DEAL_II_WITH_TASKFLOW=ON \
-                    -D DEAL_II_UNITY_BUILD=ON \
+                    -D DEAL_II_UNITY_BUILD=OFF \
                     $WORKSPACE/
                   time ninja -j 10 # 12 gives OOM
                   time ninja test # quicktests


### PR DESCRIPTION
We have some issues with running out of RAM. Let's try reducing memory consumption by disabling unity builds.
