### PR TITLE
Renamed shared tria helper function. Added changelog.

### DIFF
--- a/doc/news/9.7.1-vs-9.8.0.h
+++ b/doc/news/9.7.1-vs-9.8.0.h
@@ -431,6 +431,20 @@ inconvenience this causes.
 <ol>
 
  <li>
+  New: We introduced a new function
+  parallel::shared::Triangulation::communicate_coarsening_and_refinement_flags()
+  that communicates coarsen and refine flags among all MPI processes prior
+  to mesh refinement. Previously, this functionality was an inherent part of
+  parallel::shared::Triangulation::execute_coarsening_and_refinement()
+  and has now been moved into a separate helper function. Now, both functions
+  parallel::shared::Triangulation::prepare_coarsening_and_refinement() and
+  parallel::shared::Triangulation::execute_coarsening_and_refinement()
+  begin with communicating flags through the new helper function.
+  <br>
+  (Matthias Maier, 2026/08/01)
+ </li>
+
+ <li>
   Fixed: TriangulationDescription::Description now correctly sets material_ids
   of cells on finer levels.
   <br>

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -431,7 +431,7 @@ namespace parallel
        * of flags for the entire (replicated) triangulation.
        */
       void
-      communicate_refinement_and_coarsening_flags();
+      communicate_coarsening_and_refinement_flags();
 
       /**
        * A vector containing subdomain IDs of cells obtained by partitioning

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -354,7 +354,7 @@ namespace parallel
     template <int dim, int spacedim>
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     void Triangulation<dim,
-                       spacedim>::communicate_refinement_and_coarsening_flags()
+                       spacedim>::communicate_coarsening_and_refinement_flags()
     {
       // make sure that all refinement/coarsening flags are the same on all
       // processes
@@ -423,7 +423,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     bool Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
     {
-      communicate_refinement_and_coarsening_flags();
+      communicate_coarsening_and_refinement_flags();
 
       return dealii::Triangulation<dim, spacedim>::
         prepare_coarsening_and_refinement();
@@ -435,7 +435,7 @@ namespace parallel
     DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
     void Triangulation<dim, spacedim>::execute_coarsening_and_refinement()
     {
-      communicate_refinement_and_coarsening_flags();
+      communicate_coarsening_and_refinement_flags();
 
       dealii::Triangulation<dim, spacedim>::execute_coarsening_and_refinement();
       partition();


### PR DESCRIPTION
Follow up to #20099.

Added a changelog as requested. I have placed it directly in the `9.7.1-vs-9.8.0.h` as to easily cherry-pick this commit for the 9.8 branch.

Also renamed the helper function to be consistent with the naming scheme of refinement functions, i.e., by mentioning coarsening first.