### PR TITLE
step-104: missing call for hanging nodes

### DIFF
--- a/examples/step-104/step-104.cc
+++ b/examples/step-104/step-104.cc
@@ -1016,6 +1016,7 @@ namespace Step104
         constraint.reinit(dof_handler.locally_owned_dofs(),
                           DoFTools::extract_locally_relevant_dofs(dof_handler));
 
+        DoFTools::make_hanging_node_constraints(dof_handler, constraint);
         DoFTools::make_zero_boundary_constraints(dof_handler, constraint);
         constraint.close();
 


### PR DESCRIPTION
While step-104 doesn't run with adaptivity, there is one missing call to make_hanging_node_constraints() that should be there for consistency.
