### PR TITLE
DoFHandler: mark some more functions as inline.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1839,7 +1839,8 @@ inline types::global_dof_index
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-types::global_dof_index DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
+inline types::global_dof_index
+  DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 {
   return number_cache.n_locally_owned_dofs;
 }
@@ -1848,7 +1849,7 @@ types::global_dof_index DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const IndexSet &DoFHandler<dim, spacedim>::locally_owned_dofs() const
+inline const IndexSet &DoFHandler<dim, spacedim>::locally_owned_dofs() const
 {
   return number_cache.locally_owned_dofs;
 }
@@ -1857,7 +1858,7 @@ const IndexSet &DoFHandler<dim, spacedim>::locally_owned_dofs() const
 
 template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-const IndexSet &DoFHandler<dim, spacedim>::locally_owned_mg_dofs(
+inline const IndexSet &DoFHandler<dim, spacedim>::locally_owned_mg_dofs(
   const unsigned int level) const
 {
   Assert(level < this->get_triangulation().n_global_levels(),


### PR DESCRIPTION
Oddly enough, according to callgrind DoFHandler::locally_owned_dofs() was not inlined.

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
