### PR TITLE
Use an inplace_vector of the correct size.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -16688,18 +16688,21 @@ template <int dim, int spacedim>
 DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
 void Triangulation<dim, spacedim>::reset_cell_vertex_indices_cache()
 {
-  std::array<unsigned int, ReferenceCells::max_n_vertices<dim>()>
-    cell_vertices{};
   for (unsigned int l = 0; l < levels.size(); ++l)
     for (const auto &cell : cell_iterators_on_level(l))
       {
-        if constexpr (running_in_debug_mode())
-          cell_vertices.fill(numbers::invalid_unsigned_int);
+        const unsigned int n_vertices = cell->n_vertices();
 
-        const auto n_vertices = cell->n_vertices();
-        Assert(n_vertices <= cell_vertices.size(), ExcInternalError());
+        std_cxx26::inplace_vector<unsigned int,
+                                  ReferenceCells::max_n_vertices<dim>()>
+          cell_vertices(n_vertices);
+        if constexpr (running_in_debug_mode())
+          std::fill(cell_vertices.begin(),
+                    cell_vertices.end(),
+                    numbers::invalid_unsigned_int);
+
         GridTools::internal::extract_vertices_without_cache<dim, spacedim>(
-          cell, ArrayView<unsigned int>(cell_vertices.data(), n_vertices));
+          cell, cell_vertices);
         for (unsigned int vertex_no = 0; vertex_no < n_vertices; ++vertex_no)
           levels[l]->set_cached_vertex_index(cell->index(),
                                              vertex_no,


### PR DESCRIPTION
We used `std::array` with the max necessary size before, but that is no longer necessary.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
