### PR TITLE
Make the private constructor of ReferenceCell 'explicit'.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1192,7 +1192,7 @@ private:
    * be called by a function in an internal namespace that is a `friend`
    * of this class.
    */
-  constexpr ReferenceCell(const std::uint8_t kind);
+  explicit constexpr ReferenceCell(const std::uint8_t kind);
 
   /**
    * Table containing all 'vertex' permutations for a vertex. Defined
@@ -1354,7 +1354,7 @@ namespace internal
 
     // Call the private constructor, which we can from here because this
     // function is a 'friend'.
-    return {kind};
+    return ReferenceCell<dim>(kind);
   }
 } // namespace internal
 
@@ -1954,7 +1954,8 @@ ReferenceCell<dim>::new_isotropic_child_cell_faces(
             {
               // Considerations that went into creating this table
               // - Keep aspect ratio of 1.0 if parent had 1.0 (this is why the
-              //   centre wedge is rotated by 180° compared to the parent)
+              //   centre wedge is rotated by 180 degrees compared to the
+              //   parent)
               // - Order of children is similar to the order of a reference
               //   triangle in the x-y-plane (i.e. like the top triangle of the
               //   parent)


### PR DESCRIPTION
I was investigating something I don't understand and thought it might have to do with the fact that `ReferenceCell` has a converting constructor from an integer that is not `explicit`. That turned out not to be the case, but it's probably good practice to make the constructor `explicit` anyway.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
