### PR TITLE
Optimize comparison of ReferenceCell objects.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1156,10 +1156,32 @@ public:
   operator==(const ReferenceCell<dim> &type) const;
 
   /**
+   * Operator for equality comparison against an object with a
+   * dimension other than `dim` (which the compiler would do
+   * with the overload of the operator above). Since the
+   * dimensions do not match, the comparison is necessarily
+   * `false`.
+   */
+  template <int dim2>
+  constexpr bool
+  operator==(const ReferenceCell<dim2> &type) const;
+
+  /**
    * Operator for inequality comparison.
    */
   constexpr bool
   operator!=(const ReferenceCell<dim> &type) const;
+
+  /**
+   * Operator for inequality comparison against an object with a
+   * dimension other than `dim` (which the compiler would do
+   * with the overload of the operator above). Since the
+   * dimensions do not match, the two objects cannot be the same
+   * and this overload consequently always returns `true`.
+   */
+  template <int dim2>
+  constexpr bool
+  operator!=(const ReferenceCell<dim2> &type) const;
 
   /**
    * Write and read the data of this object from a stream for the purpose
@@ -1331,10 +1353,30 @@ ReferenceCell<dim>::operator==(const ReferenceCell<dim> &type) const
 
 
 template <int dim>
+template <int dim2>
+inline constexpr bool
+ReferenceCell<dim>::operator==(const ReferenceCell<dim2> &) const
+{
+  return false;
+}
+
+
+
+template <int dim>
 inline constexpr bool
 ReferenceCell<dim>::operator!=(const ReferenceCell<dim> &type) const
 {
   return kind != type.kind;
+}
+
+
+
+template <int dim>
+template <int dim2>
+inline constexpr bool
+ReferenceCell<dim>::operator!=(const ReferenceCell<dim2> &) const
+{
+  return true;
 }
 
 
@@ -1954,7 +1996,8 @@ ReferenceCell<dim>::new_isotropic_child_cell_faces(
             {
               // Considerations that went into creating this table
               // - Keep aspect ratio of 1.0 if parent had 1.0 (this is why the
-              //   centre wedge is rotated by 180° compared to the parent)
+              //   centre wedge is rotated by 180 degrees compared to the
+              //   parent)
               // - Order of children is similar to the order of a reference
               //   triangle in the x-y-plane (i.e. like the top triangle of the
               //   parent)


### PR DESCRIPTION
I ended up on a deep search of the meaning of `ref_cell == ReferenceCells::Quadrilateral`. The issue is that the object on the left has a template argument `dim`, whereas the right has a template argument of  `2`. So what happens in code where `dim != 2`? It turns out that because we only have `bool ReferenceCell<dim>::operator==(const ReferenceCell<dim> &)`, this operator clearly can't be called. But -- and this is a bit crazy -- every `ReferenceCell` can always be converted to a `std::uint8_t`, and those can then be compared.

But this is of course completely inefficient. We *know* that if `dim != 2`, the comparison `ref_cell == ReferenceCells::Quadrilateral` cannot be `true`. We should just return `false` in that case, which should allow the compiler to eliminate a lot of comparisons outright; see #20129 for an example where that would apply.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
