### PR TITLE
Optimize `get_line_indices_of_cell()` and `get_line_orientations_of_cell()`.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -3054,10 +3054,20 @@ namespace internal
                          .second;
 
             // 2) LINE dofs
-            if (structdim == 2 || structdim == 3)
-              for (const auto line : accessor.line_indices())
-                index +=
-                  process_object_range(*accessor.line(line), fe_index).second;
+            if constexpr (structdim == 2 || structdim == 3)
+              {
+                const auto line_indices = TriaAccessorImplementation::
+                  Implementation::get_line_indices_of_cell(accessor);
+                for (const auto line_no : accessor.line_indices())
+                  {
+                    const DoFAccessor<1, dim, spacedim, level_dof_access> line(
+                      &accessor.get_triangulation(),
+                      0,
+                      line_indices[line_no],
+                      &accessor.get_dof_handler());
+                    index += process_object_range(line, fe_index).second;
+                  }
+              }
 
             // 3) FACE dofs
             if (structdim == 3)

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4948,9 +4948,10 @@ namespace internal
         // For hexahedra, the classical access via quads -> lines is too
         // inefficient. Unroll this code here to allow the compiler to inline
         // the necessary functions.
-        const auto ref_cell = cell.reference_cell();
-        if (ref_cell == ReferenceCells::Hexahedron)
+        const auto cell_reference_cell = cell.reference_cell();
+        if (cell_reference_cell == ReferenceCells::Hexahedron)
           {
+            constexpr auto reference_cell = ReferenceCells::Hexahedron;
             for (unsigned int f = 4; f < 6; ++f)
               {
                 const auto orientation = cell.combined_face_orientation(f);
@@ -4961,12 +4962,13 @@ namespace internal
                 // the statement of standard_to_real_face_line() when next to
                 // each other, as opposed to be interleaved with a
                 // line_index() call.
-                const std::array<unsigned int, 4> my_indices{
-                  {ref_cell.standard_to_real_face_line(0, f, orientation),
-                   ref_cell.standard_to_real_face_line(1, f, orientation),
-                   ref_cell.standard_to_real_face_line(2, f, orientation),
-                   ref_cell.standard_to_real_face_line(3, f, orientation)}};
-                const auto quad = cell.quad(f);
+                const std::array<unsigned int, 4> my_indices{{
+                  reference_cell.standard_to_real_face_line(0, f, orientation),
+                  reference_cell.standard_to_real_face_line(1, f, orientation),
+                  reference_cell.standard_to_real_face_line(2, f, orientation),
+                  reference_cell.standard_to_real_face_line(3, f, orientation),
+                }};
+                const auto                        quad = cell.quad(f);
                 for (unsigned int l = 0; l < 4; ++l)
                   line_indices[4 * (f - 4) + l] =
                     quad->line_index(my_indices[l]);
@@ -4978,33 +4980,38 @@ namespace internal
                     .levels[cell.level()]
                     ->face_orientations.get_combined_orientation(cell.index(),
                                                                  f);
-                const std::array<unsigned int, 2> my_indices{
-                  {ref_cell.standard_to_real_face_line(0, f, orientation),
-                   ref_cell.standard_to_real_face_line(1, f, orientation)}};
-                const auto quad      = cell.quad(f);
+                const std::array<unsigned int, 2> my_indices{{
+                  reference_cell.standard_to_real_face_line(0, f, orientation),
+                  reference_cell.standard_to_real_face_line(1, f, orientation),
+                }};
+                const auto                        quad = cell.quad(f);
                 line_indices[8 + f]  = quad->line_index(my_indices[0]);
                 line_indices[10 + f] = quad->line_index(my_indices[1]);
               }
           }
-        else if (ref_cell == ReferenceCells::Tetrahedron)
+        else if (cell_reference_cell == ReferenceCells::Tetrahedron)
           {
-            std::array<unsigned int, 3> orientations{
+            constexpr auto reference_cell = ReferenceCells::Tetrahedron;
+            const std::array<unsigned int, 3> orientations{
               {cell.combined_face_orientation(0),
                cell.combined_face_orientation(1),
                cell.combined_face_orientation(2)}};
-            const std::array<unsigned int, 6> my_indices{
-              {ref_cell.standard_to_real_face_line(0, 0, orientations[0]),
-               ref_cell.standard_to_real_face_line(1, 0, orientations[0]),
-               ref_cell.standard_to_real_face_line(2, 0, orientations[0]),
-               ref_cell.standard_to_real_face_line(1, 1, orientations[1]),
-               ref_cell.standard_to_real_face_line(2, 1, orientations[1]),
-               ref_cell.standard_to_real_face_line(1, 2, orientations[2])}};
-            line_indices[0] = cell.quad(0)->line_index(my_indices[0]);
-            line_indices[1] = cell.quad(0)->line_index(my_indices[1]);
-            line_indices[2] = cell.quad(0)->line_index(my_indices[2]);
-            line_indices[3] = cell.quad(1)->line_index(my_indices[3]);
-            line_indices[4] = cell.quad(1)->line_index(my_indices[4]);
-            line_indices[5] = cell.quad(2)->line_index(my_indices[5]);
+            const std::array<unsigned int, 6>           my_indices{{
+              reference_cell.standard_to_real_face_line(0, 0, orientations[0]),
+              reference_cell.standard_to_real_face_line(1, 0, orientations[0]),
+              reference_cell.standard_to_real_face_line(2, 0, orientations[0]),
+              reference_cell.standard_to_real_face_line(1, 1, orientations[1]),
+              reference_cell.standard_to_real_face_line(2, 1, orientations[1]),
+              reference_cell.standard_to_real_face_line(1, 2, orientations[2]),
+            }};
+            const std::array<decltype(cell.quad(0)), 3> quads{
+              {cell.quad(0), cell.quad(1), cell.quad(2)}};
+            line_indices[0] = quads[0]->line_index(my_indices[0]);
+            line_indices[1] = quads[0]->line_index(my_indices[1]);
+            line_indices[2] = quads[0]->line_index(my_indices[2]);
+            line_indices[3] = quads[1]->line_index(my_indices[3]);
+            line_indices[4] = quads[1]->line_index(my_indices[4]);
+            line_indices[5] = quads[2]->line_index(my_indices[5]);
           }
         else
           // For other shapes (wedges, pyramids), we do not currently
@@ -5062,16 +5069,13 @@ namespace internal
         // For hexahedra, the classical access via quads -> lines is too
         // inefficient. Unroll this code here to allow the compiler to inline
         // the necessary functions.
-        const auto ref_cell = cell.reference_cell();
-        if (ref_cell == ReferenceCells::Hexahedron)
+        const auto cell_reference_cell = cell.reference_cell();
+        if (cell_reference_cell == ReferenceCells::Hexahedron)
           {
+            constexpr auto reference_cell = ReferenceCells::Hexahedron;
             for (unsigned int f = 4; f < 6; ++f)
               {
-                const auto orientation =
-                  cell.get_triangulation()
-                    .levels[cell.level()]
-                    ->face_orientations.get_combined_orientation(cell.index(),
-                                                                 f);
+                const auto orientation = cell.combined_face_orientation(f);
 
                 // It might seem superfluous to spell out the four indices and
                 // orientations that get later consumed by a for loop over
@@ -5079,29 +5083,30 @@ namespace internal
                 // to inline the statement of standard_to_real_face_line()
                 // when next to each other, as opposed to be interleaved with
                 // a line_index() call.
-                const std::array<unsigned int, 4> my_indices{
-                  {ref_cell.standard_to_real_face_line(0, f, orientation),
-                   ref_cell.standard_to_real_face_line(1, f, orientation),
-                   ref_cell.standard_to_real_face_line(2, f, orientation),
-                   ref_cell.standard_to_real_face_line(3, f, orientation)}};
-                const auto quad = cell.quad(f);
+                const std::array<unsigned int, 4> my_indices{{
+                  reference_cell.standard_to_real_face_line(0, f, orientation),
+                  reference_cell.standard_to_real_face_line(1, f, orientation),
+                  reference_cell.standard_to_real_face_line(2, f, orientation),
+                  reference_cell.standard_to_real_face_line(3, f, orientation),
+                }};
+                const auto                        quad = cell.quad(f);
                 const std::array<types::geometric_orientation, 4>
-                  my_orientations{{ref_cell.face_to_cell_line_orientation(
+                  my_orientations{{reference_cell.face_to_cell_line_orientation(
                                      0,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[0])),
-                                   ref_cell.face_to_cell_line_orientation(
+                                   reference_cell.face_to_cell_line_orientation(
                                      1,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[1])),
-                                   ref_cell.face_to_cell_line_orientation(
+                                   reference_cell.face_to_cell_line_orientation(
                                      2,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[2])),
-                                   ref_cell.face_to_cell_line_orientation(
+                                   reference_cell.face_to_cell_line_orientation(
                                      3,
                                      f,
                                      orientation,
@@ -5111,22 +5116,20 @@ namespace internal
               }
             for (unsigned int f = 0; f < 2; ++f)
               {
-                const auto orientation =
-                  cell.get_triangulation()
-                    .levels[cell.level()]
-                    ->face_orientations.get_combined_orientation(cell.index(),
-                                                                 f);
+                const auto orientation = cell.combined_face_orientation(f);
                 const std::array<unsigned int, 2> my_indices{
-                  {ref_cell.standard_to_real_face_line(0, f, orientation),
-                   ref_cell.standard_to_real_face_line(1, f, orientation)}};
+                  {reference_cell.standard_to_real_face_line(0, f, orientation),
+                   reference_cell.standard_to_real_face_line(1,
+                                                             f,
+                                                             orientation)}};
                 const auto quad = cell.quad(f);
                 const std::array<types::geometric_orientation, 2>
-                  my_orientations{{ref_cell.face_to_cell_line_orientation(
+                  my_orientations{{reference_cell.face_to_cell_line_orientation(
                                      0,
                                      f,
                                      orientation,
                                      quad->line_orientation(my_indices[0])),
-                                   ref_cell.face_to_cell_line_orientation(
+                                   reference_cell.face_to_cell_line_orientation(
                                      1,
                                      f,
                                      orientation,
@@ -5135,49 +5138,35 @@ namespace internal
                 line_orientations[10 + f] = my_orientations[1];
               }
           }
-        else if (ref_cell == ReferenceCells::Tetrahedron)
+        else if (cell_reference_cell == ReferenceCells::Tetrahedron)
           {
-            std::array<unsigned int, 3> orientations{
+            constexpr auto reference_cell = ReferenceCells::Tetrahedron;
+            const std::array<types::geometric_orientation, 3> orientations{
               {cell.combined_face_orientation(0),
                cell.combined_face_orientation(1),
                cell.combined_face_orientation(2)}};
-            const std::array<unsigned int, 6> my_indices{
-              {ref_cell.standard_to_real_face_line(0, 0, orientations[0]),
-               ref_cell.standard_to_real_face_line(1, 0, orientations[0]),
-               ref_cell.standard_to_real_face_line(2, 0, orientations[0]),
-               ref_cell.standard_to_real_face_line(1, 1, orientations[1]),
-               ref_cell.standard_to_real_face_line(2, 1, orientations[1]),
-               ref_cell.standard_to_real_face_line(1, 2, orientations[2])}};
-            line_orientations[0] = ref_cell.face_to_cell_line_orientation(
-              0,
-              0,
-              orientations[0],
-              cell.quad(0)->line_orientation(my_indices[0]));
-            line_orientations[1] = ref_cell.face_to_cell_line_orientation(
-              1,
-              0,
-              orientations[0],
-              cell.quad(0)->line_orientation(my_indices[1]));
-            line_orientations[2] = ref_cell.face_to_cell_line_orientation(
-              2,
-              0,
-              orientations[0],
-              cell.quad(0)->line_orientation(my_indices[2]));
-            line_orientations[3] = ref_cell.face_to_cell_line_orientation(
-              1,
-              1,
-              orientations[1],
-              cell.quad(1)->line_orientation(my_indices[3]));
-            line_orientations[4] = ref_cell.face_to_cell_line_orientation(
-              2,
-              1,
-              orientations[1],
-              cell.quad(1)->line_orientation(my_indices[4]));
-            line_orientations[5] = ref_cell.face_to_cell_line_orientation(
-              1,
-              2,
-              orientations[2],
-              cell.quad(2)->line_orientation(my_indices[5]));
+            const std::array<unsigned int, 6>           my_indices{{
+              reference_cell.standard_to_real_face_line(0, 0, orientations[0]),
+              reference_cell.standard_to_real_face_line(1, 0, orientations[0]),
+              reference_cell.standard_to_real_face_line(2, 0, orientations[0]),
+              reference_cell.standard_to_real_face_line(1, 1, orientations[1]),
+              reference_cell.standard_to_real_face_line(2, 1, orientations[1]),
+              reference_cell.standard_to_real_face_line(1, 2, orientations[2]),
+            }};
+            const std::array<decltype(cell.quad(0)), 3> quads{
+              {cell.quad(0), cell.quad(1), cell.quad(2)}};
+            line_orientations[0] = reference_cell.face_to_cell_line_orientation(
+              0, 0, orientations[0], quads[0]->line_orientation(my_indices[0]));
+            line_orientations[1] = reference_cell.face_to_cell_line_orientation(
+              1, 0, orientations[0], quads[0]->line_orientation(my_indices[1]));
+            line_orientations[2] = reference_cell.face_to_cell_line_orientation(
+              2, 0, orientations[0], quads[0]->line_orientation(my_indices[2]));
+            line_orientations[3] = reference_cell.face_to_cell_line_orientation(
+              1, 1, orientations[1], quads[1]->line_orientation(my_indices[3]));
+            line_orientations[4] = reference_cell.face_to_cell_line_orientation(
+              2, 1, orientations[1], quads[1]->line_orientation(my_indices[4]));
+            line_orientations[5] = reference_cell.face_to_cell_line_orientation(
+              1, 2, orientations[2], quads[2]->line_orientation(my_indices[5]));
           }
         else
           // For other shapes (wedges, pyramids), we do not currently implement

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -381,15 +381,16 @@ namespace internal
 
         // lines
         if (dim == 2 || dim == 3)
-          reserve_subentities(dof_handler,
-                              1,
-                              dof_handler.tria->n_raw_lines(),
-                              [&](const auto &cell, const auto &process) {
-                                for (const auto line_index :
-                                     cell->line_indices())
-                                  process(fe.n_dofs_per_line(),
-                                          cell->line(line_index)->index());
-                              });
+          reserve_subentities(
+            dof_handler,
+            1,
+            dof_handler.tria->n_raw_lines(),
+            [&](const auto &cell, const auto &process) {
+              const auto line_indices = internal::TriaAccessorImplementation::
+                Implementation::get_line_indices_of_cell(*cell);
+              for (const auto &line_no : cell->line_indices())
+                process(fe.n_dofs_per_line(), line_indices[line_no]);
+            });
 
         // quads
         if (dim == 3)
@@ -1144,9 +1145,14 @@ namespace internal
 
             for (const auto &cell : dof_handler.active_cell_iterators())
               if (!cell->is_artificial())
-                for (const auto l : cell->line_indices())
-                  line_fe_association[cell->active_fe_index()]
-                                     [cell->line_index(l)] = true;
+                {
+                  const auto line_indices =
+                    internal::TriaAccessorImplementation::Implementation::
+                      get_line_indices_of_cell(*cell);
+                  for (const auto line_no : cell->line_indices())
+                    line_fe_association[cell->active_fe_index()]
+                                       [line_indices[line_no]] = true;
+                }
 
             // first check which of the lines is used at all,
             // i.e. is associated with a finite element. we do this


### PR DESCRIPTION
This hint enables the compiler to inline all the subsequent ReferenceCell functions. This makes this function more than twice as fast (as measured by callgrind) for tetrahedra, which makes `get_dof_indices()` about 30% faster.

While we're at it, avoid repeated `quad()` calls by storing them in an array. Similarly, since `get_line_orientations_of_cell()` has essentially the same structure, make the same optimizations there as well. In a future PR I will remove the 'only orientation' function and have 'only indices' and 'indices and orientations' functions instead, since most of the indexing is the same and if we need line orientations then we also need line indices.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
