### PR TITLE
Move a function into the 'protected' section.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -4133,23 +4133,6 @@ public:
   point_inside(const Point<spacedim> &p) const;
 
   /**
-   * Set the neighboring cell behind the given @p face_no of this cell
-   * to the cell described by @p neighbor. If the current cell does
-   * not have a neighbor behind this face (in other words: if that face
-   * is at the boundary of the domain), then provide an end iterator as
-   * argument.
-   *
-   * This function shouldn't really be public (but needs to for various
-   * reasons in order not to make a long list of functions friends): it
-   * modifies internal data structures and may leave things. Do not use it
-   * from application codes.
-   */
-  void
-  set_neighbor(const unsigned int                               face_no,
-               const TriaIterator<CellAccessor<dim, spacedim>> &neighbor) const;
-
-
-  /**
    * Return all cells adjacent to line @p i of this cell.
    *
    * @note This information is not computed by default, as the computation
@@ -4211,6 +4194,17 @@ public:
   DeclException0(ExcCellFlaggedForCoarsening);
 
 protected:
+  /**
+   * Set the neighboring cell behind the given @p face_no of this cell
+   * to the cell described by @p neighbor. If the current cell does
+   * not have a neighbor behind this face (in other words: if that face
+   * is at the boundary of the domain), then provide an end iterator as
+   * argument.
+   */
+  void
+  set_neighbor(const unsigned int                               face_no,
+               const TriaIterator<CellAccessor<dim, spacedim>> &neighbor) const;
+
   /**
    * This function assumes that the neighbor is not coarser than the current
    * cell. In this case it returns the neighbor_of_neighbor() value. If,


### PR DESCRIPTION
Implements @drwells suggestion from here: https://github.com/dealii/dealii/pull/20122#pullrequestreview-4902099883 Strictly speaking, this is an incompatible change. In practice, it strikes me as such a bad idea to call this function from user space that I'm willing to just move the function without saying much about it.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
