### PR TITLE
 Fix concurrent builds of shared test executable targets with variable mpirun=N

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -455,10 +455,29 @@ function(deal_ii_add_test _category _test_name _comparison_file)
       # fixture", see
       # https://cmake.org/cmake/help/latest/prop_test/FIXTURES_REQUIRED.html#prop_test:FIXTURES_REQUIRED
       #
+      # Note that whether the executable target is shared is a property of
+      # the target and not of the individual comparison file we are
+      # currently processing: all comparison files of a test map to the same
+      # executable target. It is therefore not sufficient to only check the
+      # annotation of the current comparison file. A test that has both a
+      # "foo.output" and a "foo.mpirun=N.output" comparison file does share
+      # its executable target, and the unannotated variant has to require
+      # the setup fixture as well. Otherwise it is run concurrently with the
+      # test building the shared target, and the two builds clobber the same
+      # object file.
+      #
       set(_shared_target FALSE)
       if(NOT "${_n_cpu}${_n_threads}" STREQUAL "00" OR "${_source_file}" MATCHES "(prm|json)$")
         set(_shared_target TRUE)
+      else()
+        file(GLOB _annotated_variants "${CMAKE_CURRENT_SOURCE_DIR}/${_test_name}.*")
+        list(FILTER _annotated_variants INCLUDE REGEX "\\.(mpirun|threads)=")
+        if(NOT "${_annotated_variants}" STREQUAL "")
+          set(_shared_target TRUE)
+        endif()
+      endif()
 
+      if(_shared_target)
         #
         # Build system-internal target name and final test name for the
         # "executable" test. We have to make sure that the target and test

--- a/doc/news/changes/minor/20260812Blais
+++ b/doc/news/changes/minor/20260812Blais
@@ -1,0 +1,11 @@
+Fixed: A test that provides both an unannotated comparison file
+(`foo.output`) and one carrying an `.mpirun=N.` annotation
+(`foo.mpirun=N.output`) shares a single executable target between all of its
+variants. Only the annotated variants required the setup fixture that builds
+this shared target, so the unannotated variant could be scheduled
+concurrently with it by `ctest -j`. Both then invoked a build of the same
+target, and the two concurrent builds could clobber the same object file,
+letting the test fail with a linker error. All variants of such a test now
+require the setup fixture. This regularly crashed the CI in Lethe.
+<br>
+(Bruno Blais, 2026/08/12)


### PR DESCRIPTION
A test with output files that mix an unannotated variant with an .mpirun=N.  one — e.g. tests/base/mpi_gather_01, which has mpi_gather_01.output, mpi_gather_01.mpirun=2.output and mpi_gather_01.mpirun=6.output — can fail spuriously under ctest -j with a linker error such as:

[1/3] Building CXX object .../mpi_gather_01.cc.o
[2/3] Linking CXX executable .../mpi_gather_01.debug
mold: fatal: .../mpi_gather_01.cc.o: unknown file type

The cause (I think):
All comparison files of a test map to a single executable target, and deal_ii_add_test() already guards against concurrent builds of a shared target by declaring a test_dependency/<target>.executable test and attaching it to the run tests as a setup fixture. But _shared_target is derived from _n_cpu of the comparison file currently being processed, while deal_ii_pickup_tests() calls deal_ii_add_test() once per comparison file. The unannotated variant therefore has _n_cpu == 0 and never gets FIXTURES_REQUIRED, even though its target is shared. ctest is then free to start it at the same time as the fixture test, both invoke a build of the same target, and the two builds race on the same object file. 

We had this random race condition on the Lethe CI which would always crash 20% of the time. The temporary solution I found was to manually name the test `.mpirun=1.output` instead of .output, but i find this is more a Hack than anything else.

Eight tests currently have this pattern and are fixed by this change without needing renames:
base/mpi_all_gather_01     base/mpi_gather_01      base/mpi_scatter_01
base/mpi_some_to_some_01   lac/linear_operator_09.with_petsc=on
petsc/petsc_snes_03        petsc/petsc_snes_04
sacado/helper_scalar_coupled_3_components_01_3


@tamiko I think you are the one that wrote this feature, so I would really appreciate your input on this. I might have made a mistake, but I definitely think something is off. This is super hard to reproduce on a local machine though. 

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
