### PR TITLE
TriaAccessor: calculate line indices with line orientations.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -3173,11 +3173,9 @@ namespace internal
         // reversed line orientations.
         if (structdim > 1 && fe.n_dofs_per_line() > 0)
           {
-            const auto line_indices = internal::TriaAccessorImplementation::
-              Implementation::get_line_indices_of_cell(accessor);
-            const auto line_orientations =
+            const auto [line_indices, line_orientations] =
               internal::TriaAccessorImplementation::Implementation::
-                get_line_orientations_of_cell(accessor);
+                get_line_indices_and_orientations_of_cell(accessor);
 
             for (const auto line : accessor.line_indices())
               {

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -5019,12 +5019,18 @@ namespace internal
 
 
       /**
-       * A helper function to provide faster access to
-       * cell->line_orientation(), 1d specialization
+       * Helper function for extracting all indices and orientations at the same
+       * time. Whenever we need line orientations we also need indices and
+       * consolidating the two functions eliminates identical index
+       * calculations.
+       *
+       * @note This function is not used in 1d.
        */
       template <int dim, int spacedim>
-      static std::array<types::geometric_orientation, 1>
-      get_line_orientations_of_cell(const TriaAccessor<1, dim, spacedim> &)
+      static std::pair<std::array<unsigned int, 1>,
+                       std::array<types::geometric_orientation, 1>>
+      get_line_indices_and_orientations_of_cell(
+        const TriaAccessor<1, dim, spacedim> &)
       {
         DEAL_II_ASSERT_UNREACHABLE();
         return {};
@@ -5033,32 +5039,45 @@ namespace internal
 
 
       /**
-       * A helper function to provide faster access to
-       * cell->line_orientation(), 2d specialization
+       * Helper function for extracting all indices and orientations at the same
+       * time. Whenever we need line orientations we also need indices and
+       * consolidating the two functions eliminates identical index
+       * calculations.
        */
       template <int dim, int spacedim>
-      static std::array<types::geometric_orientation, 4>
-      get_line_orientations_of_cell(const TriaAccessor<2, dim, spacedim> &cell)
+      static std::pair<std::array<unsigned int, 4>,
+                       std::array<types::geometric_orientation, 4>>
+      get_line_indices_and_orientations_of_cell(
+        const TriaAccessor<2, dim, spacedim> &cell)
       {
         // For 2d cells the access cell->line_orientation() is already
         // efficient
         std::array<types::geometric_orientation, 4> line_orientations = {};
+        std::array<unsigned int, 4>                 line_indices      = {};
         for (const unsigned int line : cell.line_indices())
-          line_orientations[line] = cell.line_orientation(line);
-        return line_orientations;
+          {
+            line_orientations[line] = cell.line_orientation(line);
+            line_indices[line]      = cell.line_index(line);
+          }
+        return std::make_pair(line_indices, line_orientations);
       }
 
 
 
       /**
-       * A helper function to provide faster access to
-       * cell->line_orientation(), 3d specialization
+       * Helper function for extracting all indices and orientations at the same
+       * time. Whenever we need line orientations we also need indices and
+       * consolidating the two functions eliminates identical index
+       * calculations.
        */
       template <int dim, int spacedim>
-      static std::array<types::geometric_orientation, 12>
-      get_line_orientations_of_cell(const TriaAccessor<3, dim, spacedim> &cell)
+      static std::pair<std::array<unsigned int, 12>,
+                       std::array<types::geometric_orientation, 12>>
+      get_line_indices_and_orientations_of_cell(
+        const TriaAccessor<3, dim, spacedim> &cell)
       {
         std::array<types::geometric_orientation, 12> line_orientations = {};
+        std::array<unsigned int, 12>                 line_indices      = {};
 
         // For hexahedra, the classical access via quads -> lines is too
         // inefficient. Unroll this code here to allow the compiler to inline
@@ -5084,50 +5103,41 @@ namespace internal
                   reference_cell.standard_to_real_face_line(3, f, orientation),
                 }};
                 const auto                        quad = cell.quad(f);
+                for (unsigned int l = 0; l < 4; ++l)
+                  line_indices[4 * (f - 4) + l] =
+                    quad->line_index(my_indices[l]);
                 const std::array<types::geometric_orientation, 4>
-                  my_orientations{{reference_cell.face_to_cell_line_orientation(
-                                     0,
-                                     f,
-                                     orientation,
-                                     quad->line_orientation(my_indices[0])),
-                                   reference_cell.face_to_cell_line_orientation(
-                                     1,
-                                     f,
-                                     orientation,
-                                     quad->line_orientation(my_indices[1])),
-                                   reference_cell.face_to_cell_line_orientation(
-                                     2,
-                                     f,
-                                     orientation,
-                                     quad->line_orientation(my_indices[2])),
-                                   reference_cell.face_to_cell_line_orientation(
-                                     3,
-                                     f,
-                                     orientation,
-                                     quad->line_orientation(my_indices[3]))}};
+                  my_orientations{{
+                    reference_cell.face_to_cell_line_orientation(
+                      0, f, orientation, quad->line_orientation(my_indices[0])),
+                    reference_cell.face_to_cell_line_orientation(
+                      1, f, orientation, quad->line_orientation(my_indices[1])),
+                    reference_cell.face_to_cell_line_orientation(
+                      2, f, orientation, quad->line_orientation(my_indices[2])),
+                    reference_cell.face_to_cell_line_orientation(
+                      3, f, orientation, quad->line_orientation(my_indices[3])),
+                  }};
                 for (unsigned int l = 0; l < 4; ++l)
                   line_orientations[4 * (f - 4) + l] = my_orientations[l];
               }
             for (unsigned int f = 0; f < 2; ++f)
               {
                 const auto orientation = cell.combined_face_orientation(f);
-                const std::array<unsigned int, 2> my_indices{
-                  {reference_cell.standard_to_real_face_line(0, f, orientation),
-                   reference_cell.standard_to_real_face_line(1,
-                                                             f,
-                                                             orientation)}};
-                const auto quad = cell.quad(f);
+
+                const std::array<unsigned int, 2> my_indices{{
+                  reference_cell.standard_to_real_face_line(0, f, orientation),
+                  reference_cell.standard_to_real_face_line(1, f, orientation),
+                }};
+                const auto                        quad = cell.quad(f);
+                line_indices[8 + f]  = quad->line_index(my_indices[0]);
+                line_indices[10 + f] = quad->line_index(my_indices[1]);
                 const std::array<types::geometric_orientation, 2>
-                  my_orientations{{reference_cell.face_to_cell_line_orientation(
-                                     0,
-                                     f,
-                                     orientation,
-                                     quad->line_orientation(my_indices[0])),
-                                   reference_cell.face_to_cell_line_orientation(
-                                     1,
-                                     f,
-                                     orientation,
-                                     quad->line_orientation(my_indices[1]))}};
+                  my_orientations{{
+                    reference_cell.face_to_cell_line_orientation(
+                      0, f, orientation, quad->line_orientation(my_indices[0])),
+                    reference_cell.face_to_cell_line_orientation(
+                      1, f, orientation, quad->line_orientation(my_indices[1])),
+                  }};
                 line_orientations[8 + f]  = my_orientations[0];
                 line_orientations[10 + f] = my_orientations[1];
               }
@@ -5149,6 +5159,13 @@ namespace internal
             }};
             const std::array<decltype(cell.quad(0)), 3> quads{
               {cell.quad(0), cell.quad(1), cell.quad(2)}};
+            line_indices[0] = quads[0]->line_index(my_indices[0]);
+            line_indices[1] = quads[0]->line_index(my_indices[1]);
+            line_indices[2] = quads[0]->line_index(my_indices[2]);
+            line_indices[3] = quads[1]->line_index(my_indices[3]);
+            line_indices[4] = quads[1]->line_index(my_indices[4]);
+            line_indices[5] = quads[2]->line_index(my_indices[5]);
+
             line_orientations[0] = reference_cell.face_to_cell_line_orientation(
               0, 0, orientations[0], quads[0]->line_orientation(my_indices[0]));
             line_orientations[1] = reference_cell.face_to_cell_line_orientation(
@@ -5166,9 +5183,12 @@ namespace internal
           // For other shapes (wedges, pyramids), we do not currently implement
           // an optimized function
           for (unsigned int l = 0; l < std::min(12U, cell.n_lines()); ++l)
-            line_orientations[l] = cell.line_orientation(l);
+            {
+              line_indices[l]      = cell.line_index(l);
+              line_orientations[l] = cell.line_orientation(l);
+            }
 
-        return line_orientations;
+        return std::make_pair(line_indices, line_orientations);
       }
     };
   } // namespace TriaAccessorImplementation


### PR DESCRIPTION
If we need the orientations then we also need the lines, and most of the index calculations are identical. This makes (measured via callgrind) `DoFAccessor::get_dof_indices()` about 4% faster.

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
