### PR TITLE
Move the triangulation 'Policy' class into the 'Triangulation' class.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -96,9 +96,6 @@ namespace internal
 
     class TriaObjects;
 
-    template <int, int>
-    class Policy;
-
     /**
      * Forward declaration of a class into which we put much of the
      * implementation of the Triangulation class. See the .cc file for more
@@ -4196,12 +4193,20 @@ protected:
 
 private:
   /**
+   * A class that implements Triangulation-specific tasks related to creation,
+   * refinement, and coarsening. The class is only forward-declared here,
+   * and is used as a type-erase mechanism so that we don't have to
+   * declare the concrete implementation class members in the header file.
+   */
+  class Policy;
+  template <typename PolicyClass>
+  class PolicyWrapper;
+
+  /**
    * Policy with the Triangulation-specific tasks related to creation,
    * refinement, and coarsening.
    */
-  std::unique_ptr<
-    dealii::internal::TriangulationImplementation::Policy<dim, spacedim>>
-    policy;
+  std::unique_ptr<Policy> policy;
 
   /**
    * If add_periodicity() is called, this variable stores the given periodic

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4124,6 +4124,24 @@ public:
                  << " is not defined in this Triangulation!");
   /** @} */
 
+  /**
+   * A class that implements Triangulation-specific tasks related to creation,
+   * refinement, and coarsening. The class is only forward-declared here,
+   * and is used as a type-erasure mechanism so that we don't have to
+   * declare the concrete implementation class members in the header file.
+   *
+   * @note This class should really be `private`, but that would require
+   *   concrete implementations of this class to also be member classes so
+   *   that they can derive from this base class. It turns out that this leads
+   *   to compiler errors with MS Visual Studio 2022 and 2025, so we make
+   *   these derived classes non-members and then need to have this class
+   *   be a `public` class. Since it's only actually declared in the .cc file,
+   *   there is no harm -- no other entity outside the tria.cc file sees
+   *   what this class actually is, and so can't use it even though it's
+   *   declared as `public`.
+   */
+  class Policy;
+
 protected:
   /**
    * Do some smoothing in the process of refining the triangulation. See the
@@ -4190,18 +4208,7 @@ protected:
   void
   update_periodic_face_map();
 
-
 private:
-  /**
-   * A class that implements Triangulation-specific tasks related to creation,
-   * refinement, and coarsening. The class is only forward-declared here,
-   * and is used as a type-erase mechanism so that we don't have to
-   * declare the concrete implementation class members in the header file.
-   */
-  class Policy;
-  template <typename PolicyClass>
-  class PolicyWrapper;
-
   /**
    * Policy with the Triangulation-specific tasks related to creation,
    * refinement, and coarsening.

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2191,73 +2191,72 @@ public:
 };
 
 
-/**
- * A simple implementation of the interface Policy. It simply delegates the
- * task to the functions with the same name provided by class specified by
- * the template argument T.
- */
-template <int dim, int spacedim>
-DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
-template <typename T>
-class Triangulation<dim, spacedim>::PolicyWrapper
-  : public Triangulation<dim, spacedim>::Policy
-{
-public:
-  void
-  update_neighbors(Triangulation<dim, spacedim> &tria) override
-  {
-    T::update_neighbors(tria);
-  }
-
-  void
-  delete_children(Triangulation<dim, spacedim>                         &tria,
-                  typename Triangulation<dim, spacedim>::cell_iterator &cell,
-                  std::vector<unsigned int> &line_cell_count,
-                  std::vector<unsigned int> &quad_cell_count) override
-  {
-    T::delete_children(tria, cell, line_cell_count, quad_cell_count);
-  }
-
-  typename Triangulation<dim, spacedim>::DistortedCellList
-  execute_refinement(Triangulation<dim, spacedim> &triangulation,
-                     const bool check_for_distorted_cells) override
-  {
-    return T::execute_refinement(triangulation, check_for_distorted_cells);
-  }
-
-  void
-  prevent_distorted_boundary_cells(
-    Triangulation<dim, spacedim> &triangulation) override
-  {
-    T::prevent_distorted_boundary_cells(triangulation);
-  }
-
-  void
-  prepare_refinement_dim_dependent(
-    Triangulation<dim, spacedim> &triangulation) override
-  {
-    T::prepare_refinement_dim_dependent(triangulation);
-  }
-
-  bool
-  coarsening_allowed(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell) override
-  {
-    return T::template coarsening_allowed<dim, spacedim>(cell);
-  }
-
-  std::unique_ptr<typename Triangulation<dim, spacedim>::Policy>
-  clone() override
-  {
-    return std::make_unique<PolicyWrapper<T>>();
-  }
-};
-
-
 namespace internal
 {
   namespace TriangulationImplementation
   {
+
+    /**
+     * A simple implementation of the interface Policy. It simply delegates the
+     * task to the functions with the same name provided by class specified by
+     * the template argument T.
+     */
+    template <int dim, int spacedim, typename T>
+    class PolicyWrapper : public Triangulation<dim, spacedim>::Policy
+    {
+    public:
+      void
+      update_neighbors(Triangulation<dim, spacedim> &tria) override
+      {
+        T::update_neighbors(tria);
+      }
+
+      void
+      delete_children(
+        Triangulation<dim, spacedim>                         &tria,
+        typename Triangulation<dim, spacedim>::cell_iterator &cell,
+        std::vector<unsigned int>                            &line_cell_count,
+        std::vector<unsigned int> &quad_cell_count) override
+      {
+        T::delete_children(tria, cell, line_cell_count, quad_cell_count);
+      }
+
+      typename Triangulation<dim, spacedim>::DistortedCellList
+      execute_refinement(Triangulation<dim, spacedim> &triangulation,
+                         const bool check_for_distorted_cells) override
+      {
+        return T::execute_refinement(triangulation, check_for_distorted_cells);
+      }
+
+      void
+      prevent_distorted_boundary_cells(
+        Triangulation<dim, spacedim> &triangulation) override
+      {
+        T::prevent_distorted_boundary_cells(triangulation);
+      }
+
+      void
+      prepare_refinement_dim_dependent(
+        Triangulation<dim, spacedim> &triangulation) override
+      {
+        T::prepare_refinement_dim_dependent(triangulation);
+      }
+
+      bool
+      coarsening_allowed(
+        const typename Triangulation<dim, spacedim>::cell_iterator &cell)
+        override
+      {
+        return T::template coarsening_allowed<dim, spacedim>(cell);
+      }
+
+      std::unique_ptr<typename Triangulation<dim, spacedim>::Policy>
+      clone() override
+      {
+        return std::make_unique<PolicyWrapper<dim, spacedim, T>>();
+      }
+    };
+
 
     /**
      * A class that represents a (compressed) array of arrays. It is used to
@@ -13348,13 +13347,19 @@ void Triangulation<dim, spacedim>::reset_policy()
 {
   if (this->all_reference_cells_are_hyper_cube())
     {
-      this->policy = std::make_unique<
-        PolicyWrapper<internal::TriangulationImplementation::Implementation>>();
+      this->policy =
+        std::make_unique<internal::TriangulationImplementation::PolicyWrapper<
+          dim,
+          spacedim,
+          internal::TriangulationImplementation::Implementation>>();
     }
   else
     {
-      this->policy = std::make_unique<PolicyWrapper<
-        internal::TriangulationImplementation::ImplementationMixedMesh>>();
+      this->policy =
+        std::make_unique<internal::TriangulationImplementation::PolicyWrapper<
+          dim,
+          spacedim,
+          internal::TriangulationImplementation::ImplementationMixedMesh>>();
     }
 }
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2119,139 +2119,145 @@ namespace internal
                                   tria_object.children.size()));
         }
     }
+  } // namespace TriangulationImplementation
+} // namespace internal
 
 
+/**
+ * An interface for algorithms that implement Triangulation-specific tasks
+ * related to creation, refinement, and coarsening.
+ */
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+class Triangulation<dim, spacedim>::Policy
+{
+public:
+  /**
+   * Destructor.
+   */
+  virtual ~Policy() = default;
 
-    /**
-     * An interface for algorithms that implement Triangulation-specific tasks
-     * related to creation, refinement, and coarsening.
-     */
-    template <int dim, int spacedim>
-    class Policy
-    {
-    public:
-      /**
-       * Destructor.
-       */
-      virtual ~Policy() = default;
+  /**
+   * Update neighbors.
+   */
+  virtual void
+  update_neighbors(Triangulation<dim, spacedim> &tria) = 0;
 
-      /**
-       * Update neighbors.
-       */
-      virtual void
-      update_neighbors(Triangulation<dim, spacedim> &tria) = 0;
+  /**
+   * Delete children of given cell.
+   */
+  virtual void
+  delete_children(Triangulation<dim, spacedim> &triangulation,
+                  typename Triangulation<dim, spacedim>::cell_iterator &cell,
+                  std::vector<unsigned int> &line_cell_count,
+                  std::vector<unsigned int> &quad_cell_count) = 0;
 
-      /**
-       * Delete children of given cell.
-       */
-      virtual void
-      delete_children(
-        Triangulation<dim, spacedim>                         &triangulation,
-        typename Triangulation<dim, spacedim>::cell_iterator &cell,
-        std::vector<unsigned int>                            &line_cell_count,
-        std::vector<unsigned int> &quad_cell_count) = 0;
+  /**
+   * Execute refinement.
+   */
+  virtual typename Triangulation<dim, spacedim>::DistortedCellList
+  execute_refinement(Triangulation<dim, spacedim> &triangulation,
+                     const bool check_for_distorted_cells) = 0;
 
-      /**
-       * Execute refinement.
-       */
-      virtual typename Triangulation<dim, spacedim>::DistortedCellList
-      execute_refinement(Triangulation<dim, spacedim> &triangulation,
-                         const bool check_for_distorted_cells) = 0;
+  /**
+   * Prevent distorted boundary cells.
+   */
+  virtual void
+  prevent_distorted_boundary_cells(
+    Triangulation<dim, spacedim> &triangulation) = 0;
 
-      /**
-       * Prevent distorted boundary cells.
-       */
-      virtual void
-      prevent_distorted_boundary_cells(
-        Triangulation<dim, spacedim> &triangulation) = 0;
+  /**
+   * Prepare refinement.
+   */
+  virtual void
+  prepare_refinement_dim_dependent(
+    Triangulation<dim, spacedim> &triangulation) = 0;
 
-      /**
-       * Prepare refinement.
-       */
-      virtual void
-      prepare_refinement_dim_dependent(
-        Triangulation<dim, spacedim> &triangulation) = 0;
+  /**
+   * Check if coarsening is allowed for the given cell.
+   */
+  virtual bool
+  coarsening_allowed(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell) = 0;
 
-      /**
-       * Check if coarsening is allowed for the given cell.
-       */
-      virtual bool
-      coarsening_allowed(
-        const typename Triangulation<dim, spacedim>::cell_iterator &cell) = 0;
-
-      /**
-       * A sort of virtual copy constructor, this function returns a copy of
-       * the policy object. Derived classes need to override the function here
-       * in this base class and return an object of the same type as the derived
-       * class.
-       */
-      virtual std::unique_ptr<Policy<dim, spacedim>>
-      clone() = 0;
-    };
-
+  /**
+   * A sort of virtual copy constructor, this function returns a copy of
+   * the policy object. Derived classes need to override the function here
+   * in this base class and return an object of the same type as the derived
+   * class.
+   */
+  virtual std::unique_ptr<Policy>
+  clone() = 0;
+};
 
 
-    /**
-     * A simple implementation of the interface Policy. It simply delegates the
-     * task to the functions with the same name provided by class specified by
-     * the template argument T.
-     */
-    template <int dim, int spacedim, typename T>
-    class PolicyWrapper : public Policy<dim, spacedim>
-    {
-    public:
-      void
-      update_neighbors(Triangulation<dim, spacedim> &tria) override
-      {
-        T::update_neighbors(tria);
-      }
+/**
+ * A simple implementation of the interface Policy. It simply delegates the
+ * task to the functions with the same name provided by class specified by
+ * the template argument T.
+ */
+template <int dim, int spacedim>
+DEAL_II_CXX20_REQUIRES((concepts::is_valid_dim_spacedim<dim, spacedim>))
+template <typename T>
+class Triangulation<dim, spacedim>::PolicyWrapper
+  : public Triangulation<dim, spacedim>::Policy
+{
+public:
+  void
+  update_neighbors(Triangulation<dim, spacedim> &tria) override
+  {
+    T::update_neighbors(tria);
+  }
 
-      void
-      delete_children(
-        Triangulation<dim, spacedim>                         &tria,
-        typename Triangulation<dim, spacedim>::cell_iterator &cell,
-        std::vector<unsigned int>                            &line_cell_count,
-        std::vector<unsigned int> &quad_cell_count) override
-      {
-        T::delete_children(tria, cell, line_cell_count, quad_cell_count);
-      }
+  void
+  delete_children(Triangulation<dim, spacedim>                         &tria,
+                  typename Triangulation<dim, spacedim>::cell_iterator &cell,
+                  std::vector<unsigned int> &line_cell_count,
+                  std::vector<unsigned int> &quad_cell_count) override
+  {
+    T::delete_children(tria, cell, line_cell_count, quad_cell_count);
+  }
 
-      typename Triangulation<dim, spacedim>::DistortedCellList
-      execute_refinement(Triangulation<dim, spacedim> &triangulation,
-                         const bool check_for_distorted_cells) override
-      {
-        return T::execute_refinement(triangulation, check_for_distorted_cells);
-      }
+  typename Triangulation<dim, spacedim>::DistortedCellList
+  execute_refinement(Triangulation<dim, spacedim> &triangulation,
+                     const bool check_for_distorted_cells) override
+  {
+    return T::execute_refinement(triangulation, check_for_distorted_cells);
+  }
 
-      void
-      prevent_distorted_boundary_cells(
-        Triangulation<dim, spacedim> &triangulation) override
-      {
-        T::prevent_distorted_boundary_cells(triangulation);
-      }
+  void
+  prevent_distorted_boundary_cells(
+    Triangulation<dim, spacedim> &triangulation) override
+  {
+    T::prevent_distorted_boundary_cells(triangulation);
+  }
 
-      void
-      prepare_refinement_dim_dependent(
-        Triangulation<dim, spacedim> &triangulation) override
-      {
-        T::prepare_refinement_dim_dependent(triangulation);
-      }
+  void
+  prepare_refinement_dim_dependent(
+    Triangulation<dim, spacedim> &triangulation) override
+  {
+    T::prepare_refinement_dim_dependent(triangulation);
+  }
 
-      bool
-      coarsening_allowed(
-        const typename Triangulation<dim, spacedim>::cell_iterator &cell)
-        override
-      {
-        return T::template coarsening_allowed<dim, spacedim>(cell);
-      }
+  bool
+  coarsening_allowed(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell) override
+  {
+    return T::template coarsening_allowed<dim, spacedim>(cell);
+  }
 
-      std::unique_ptr<Policy<dim, spacedim>>
-      clone() override
-      {
-        return std::make_unique<PolicyWrapper<dim, spacedim, T>>();
-      }
-    };
+  std::unique_ptr<typename Triangulation<dim, spacedim>::Policy>
+  clone() override
+  {
+    return std::make_unique<PolicyWrapper<T>>();
+  }
+};
 
+
+namespace internal
+{
+  namespace TriangulationImplementation
+  {
 
     /**
      * A class that represents a (compressed) array of arrays. It is used to
@@ -13342,19 +13348,13 @@ void Triangulation<dim, spacedim>::reset_policy()
 {
   if (this->all_reference_cells_are_hyper_cube())
     {
-      this->policy =
-        std::make_unique<internal::TriangulationImplementation::PolicyWrapper<
-          dim,
-          spacedim,
-          internal::TriangulationImplementation::Implementation>>();
+      this->policy = std::make_unique<
+        PolicyWrapper<internal::TriangulationImplementation::Implementation>>();
     }
   else
     {
-      this->policy =
-        std::make_unique<internal::TriangulationImplementation::PolicyWrapper<
-          dim,
-          spacedim,
-          internal::TriangulationImplementation::ImplementationMixedMesh>>();
+      this->policy = std::make_unique<PolicyWrapper<
+        internal::TriangulationImplementation::ImplementationMixedMesh>>();
     }
 }
 


### PR DESCRIPTION
There is really no good reason to have this class be out in the public. It's a part of the `Triangulation` class's implementation, so let's put it in there. Fixes #20123.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
