### PR TITLE
Add a script that shows the number of commits per year.

### DIFF
--- a/contrib/utilities/commits_per_year.py
+++ b/contrib/utilities/commits_per_year.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+## -----------------------------------------------------------------------------
+##
+## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+## Copyright (C) 2026 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## Detailed license information governing the source code and contributions
+## can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+##
+## -----------------------------------------------------------------------------
+
+"""Determine the number of non-merge commits to deal.II in each full year.
+
+Execute this program from any directory within a git tree, including from the
+top-level directory.
+
+Usage:
+        python contrib/utilities/commits_per_year.py
+"""
+
+import datetime
+import subprocess
+
+import matplotlib.pyplot as plt
+
+commits_per_year = []
+
+current_year = datetime.datetime.now().year
+years = range(1997, current_year + 1)
+for year in years:
+    commits = subprocess.run(
+        [
+            "git",
+            "log",
+            "--no-merges",
+            "--since",
+            f"{year}/01/01",
+            "--until",
+            f"{year}/12/31",
+            "--format=%H",
+        ],
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+    ).stdout.splitlines()
+
+    print(year, len(commits))
+    commits_per_year.append(len(commits))
+
+# Show the last bar in gray to indicate that the year isn't over yet:
+bar_colors = ["C0"] * len(years)
+bar_colors[-1] = "gray"
+
+fig, ax = plt.subplots()
+ax.bar(years, commits_per_year, color=bar_colors)
+ax.set_xlabel("Year")
+ax.set_ylabel("Number of non-merge commits")
+ax.set_title("deal.II non-merge commits in a given year")
+ax.set_xticks(years[::5])
+fig.tight_layout()
+plt.show()


### PR DESCRIPTION
There is already a script that shows the number of authors per year. This script shows the number of commits per year. This looks like this:
<img width="640" height="480" alt="commits-per-year py" src="https://github.com/user-attachments/assets/603ac01b-d6ab-4433-991b-f677b2bf1ae5" />
It does not look like the number of authors per year:
<img width="573" height="567" alt="authors_per_year" src="https://github.com/user-attachments/assets/3cc2bce2-934e-4cbd-acd7-81fd1b4ec942" />
I'm not entirely sure why that is, but one definite reason is that with git (which we transitioned to right when the number of authors started to really increase), we always rewrite the history. With svn, we'd often commit intermediate states, that were never combined into larger commits.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
