### PR TITLE
Minor improvements to the script that shows code size over time.

### DIFF
--- a/contrib/utilities/plot_code_size.py
+++ b/contrib/utilities/plot_code_size.py
@@ -104,6 +104,7 @@ def main() -> None:
     dates, source_lines, test_lines = read_data(arguments.input)
 
     figure, axes = plt.subplots()
+    axes.set_title("deal.II code size over time")
     axes.plot(
         dates,
         source_lines,
@@ -133,7 +134,7 @@ def main() -> None:
 
     # Anchor five-year ticks at 1997 rather than at years divisible by five.
     axes.set_xlim(date(1997, 1, 1), date(2026, 12, 31))
-    axes.set_xlabel("Date")
+    axes.set_xlabel("Year")
     axes.set_ylabel("Lines of code")
     axes.set_xticks([date(year, 1, 1) for year in range(1997, 2027, 5)])
     axes.xaxis.set_major_formatter(mdates.DateFormatter("%Y"))


### PR DESCRIPTION
Follow-up to #20141: Give the graph a title, and use "Year" instead of "Date" as the x-axis label (because we show years).


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
