### PR TITLE
Use Docker container for icpx CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -246,6 +246,8 @@ jobs:
 
     name: jammy debug intel oneapi
     runs-on: [ubuntu-22.04]
+    container:
+      image: intel/oneapi:2026.1.0-devel-ubuntu22.04
 
     #
     # The following condition only runs the workflow on 'push' or if the
@@ -257,22 +259,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - uses: rscohn2/setup-oneapi@v0
-      with:
-        components: |
-          icx
-          impi
-          mkl
-          tbb
     - name: info
       run: |
-        source /opt/intel/oneapi/setvars.sh
         export I_MPI_CXX=icpx
         mpiicpc -v
         cmake --version
     - name: configure deal.II
       run: |
-        source /opt/intel/oneapi/setvars.sh
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
@@ -291,12 +284,10 @@ jobs:
       run: cat build/detailed.log
     - name: build
       run: |
-        source /opt/intel/oneapi/setvars.sh
         cd build
         make VERBOSE=1
     - name: test
       run: |
-        source /opt/intel/oneapi/setvars.sh
         cd build
         make \
           setup_tests_a-framework \

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -235,6 +235,7 @@ namespace
 #  else
     (void)data;
     (void)compression_level;
+    (void)output;
     Assert(false,
            ExcMessage("This function can only be called if cmake found "
                       "a working libz installation."));


### PR DESCRIPTION
It seems easier to just use an oneAPI container than trying to install oneAPI on Ubuntu 22.04 within the workflow.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
