### PR TITLE
read_partitioned_msh: fix material ids.

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3402,8 +3402,6 @@ GridIn<dim, spacedim>::read_partitioned_msh(const std::string &file_prefix,
               for (unsigned int j = 0; j < element_ids[i].size(); ++j)
                 {
                   CellData<dim> cell(n_vertices);
-
-                  cell.material_id = numbers::invalid_material_id;
                   if (auto it = entity_to_material.find({dim, entity_tag});
                       it != entity_to_material.end())
                     cell.material_id = it->second;
@@ -3434,7 +3432,7 @@ GridIn<dim, spacedim>::read_partitioned_msh(const std::string &file_prefix,
                     cell_info.subdomain_id = rank;
 
                   cell_info.level_subdomain_id = cell_info.subdomain_id;
-
+                  cell_info.material_id        = cell.material_id;
 
                   // --- Universal boundary ID assignment for faces ---
                   if constexpr (dim > 0)

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13575,6 +13575,16 @@ void Triangulation<dim, spacedim>::create_triangulation(
             while (cell_info->id != cell->id().template to_binary<dim>())
               ++cell;
 
+            if (level == 0)
+              {
+                Assert(cell->material_id() == cell_info->material_id,
+                       ExcMessage(
+                         "The coarsest level material_ids must match."));
+                Assert(cell->manifold_id() == cell_info->manifold_id,
+                       ExcMessage(
+                         "The coarsest level manifold_ids must match."));
+              }
+
             cell->set_material_id(cell_info->material_id);
             if (dim == 2)
               for (const auto face : cell->face_indices())


### PR DESCRIPTION
Fixes #20143.

@tamiko I'm a bit puzzled that this bug made it into the release because it was caught by the GMSH API tests. Were those not enabled on the CI? We might want to cherry-pick this to 9.8.1.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
