### PR TITLE
Add changelog entry for removing deprecated code for 9.6 and 9.8

### DIFF
--- a/doc/news/changes/incompatibilities/20260821Arndt
+++ b/doc/news/changes/incompatibilities/20260821Arndt
@@ -1,0 +1,5 @@
+Removed: Deprecations from the 9.6 and 9.8 release have been removed.
+See https://github.com/dealii/dealii/pull/20082 and
+https://github.com/dealii/dealii/pull/20090 for details.
+<br>
+(Daniel Arndt, 2028/08/21)


### PR DESCRIPTION


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
