### PR TITLE
ReferenceCell::new_isotropic_*: use references.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -927,7 +927,7 @@ public:
    * ReferenceCell<dim>::get_isotropic_refinement_choice) is provided by
    * @p refinement_choice .
    */
-  constexpr dealii::ndarray<unsigned int, 13, 4>
+  const ndarray<unsigned int, 13, 4> &
   new_isotropic_child_face_lines(const unsigned int refinement_choice) const;
 
   /**
@@ -943,7 +943,7 @@ public:
    * ReferenceCell<dim>::get_isotropic_refinement_choice) is provided by
    * @p refinement_choice .
    */
-  constexpr dealii::ndarray<unsigned int, 13, 4, 2>
+  const ndarray<unsigned int, 13, 4, 2> &
   new_isotropic_child_face_line_vertices(
     const unsigned int refinement_choice) const;
 
@@ -958,7 +958,7 @@ public:
    * ReferenceCell<dim>::get_isotropic_refinement_choice) is provided by
    * @p refinement_choice .
    */
-  constexpr dealii::ndarray<unsigned int, 10, 6>
+  const ndarray<unsigned int, 10, 6> &
   new_isotropic_child_cell_faces(const unsigned int refinement_choice) const;
 
   /**
@@ -972,7 +972,7 @@ public:
    * ReferenceCell<dim>::get_isotropic_refinement_choice) is provided by
    * @p refinement_choice .
    */
-  constexpr dealii::ndarray<unsigned int, 10, 8>
+  const ndarray<unsigned int, 10, 8> &
   new_isotropic_child_cell_vertices(const unsigned int refinement_choice) const;
 
   /**
@@ -1550,553 +1550,577 @@ ReferenceCell<dim>::faces_for_given_vertex(const unsigned int vertex) const
 
 
 template <int dim>
-constexpr dealii::ndarray<unsigned int, 13, 4>
+const ndarray<unsigned int, 13, 4> &
 ReferenceCell<dim>::new_isotropic_child_face_lines(
   const unsigned int refinement_choice) const
 {
   AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
 
+  const unsigned int X = numbers::invalid_unsigned_int;
   if constexpr (dim == 3)
-    {
-      const unsigned int X = numbers::invalid_unsigned_int;
-
-      switch (this->kind)
-        {
-          case ReferenceCells::Tetrahedron:
+    switch (this->kind)
+      {
+        case ReferenceCells::Tetrahedron:
+          switch (refinement_choice)
             {
-              switch (refinement_choice)
+              case 0:
                 {
-                  case 0:
-                    // new line is (6,8)
-                    return {{{{2, 3, 8, X}},
-                             {{0, 9, 5, X}},
-                             {{1, 6, 11, X}},
-                             {{4, 10, 7, X}},
-                             {{2, 12, 5, X}},
-                             {{1, 9, 12, X}},
-                             {{4, 8, 12, X}},
-                             {{6, 12, 10, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}}}};
-                  case 1:
-                    // new line is (5,7)
-                    return {{{{2, 3, 8, X}},
-                             {{0, 9, 5, X}},
-                             {{1, 6, 11, X}},
-                             {{4, 10, 7, X}},
-                             {{0, 3, 12, X}},
-                             {{1, 12, 8, X}},
-                             {{4, 12, 9, X}},
-                             {{7, 11, 12, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}}}};
-                  case 2:
-                    // new line is (4,9)
-                    return {{{{2, 3, 8, X}},
-                             {{0, 9, 5, X}},
-                             {{1, 6, 11, X}},
-                             {{4, 10, 7, X}},
-                             {{0, 12, 11, X}},
-                             {{2, 6, 12, X}},
-                             {{3, 12, 7, X}},
-                             {{5, 10, 12, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}},
-                             {{X, X, X, X}}}};
-                  default:
-                    DEAL_II_ASSERT_UNREACHABLE();
+                  // new line is (6,8)
+                  static constexpr ndarray<unsigned int, 13, 4> table_68 = {
+                    {{{2, 3, 8, X}},
+                     {{0, 9, 5, X}},
+                     {{1, 6, 11, X}},
+                     {{4, 10, 7, X}},
+                     {{2, 12, 5, X}},
+                     {{1, 9, 12, X}},
+                     {{4, 8, 12, X}},
+                     {{6, 12, 10, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}}}};
+                  return table_68;
                 }
+              case 1:
+                {
+                  // new line is (5,7)
+                  static constexpr ndarray<unsigned int, 13, 4> table_57 = {
+                    {{{2, 3, 8, X}},
+                     {{0, 9, 5, X}},
+                     {{1, 6, 11, X}},
+                     {{4, 10, 7, X}},
+                     {{0, 3, 12, X}},
+                     {{1, 12, 8, X}},
+                     {{4, 12, 9, X}},
+                     {{7, 11, 12, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}}}};
+                  return table_57;
+                }
+              case 2:
+                {
+                  // new line is (4,9)
+                  static constexpr ndarray<unsigned int, 13, 4> table_49 = {
+                    {{{2, 3, 8, X}},
+                     {{0, 9, 5, X}},
+                     {{1, 6, 11, X}},
+                     {{4, 10, 7, X}},
+                     {{0, 12, 11, X}},
+                     {{2, 6, 12, X}},
+                     {{3, 12, 7, X}},
+                     {{5, 10, 12, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}},
+                     {{X, X, X, X}}}};
+                  return table_49;
+                }
+              default:
+                DEAL_II_ASSERT_UNREACHABLE();
             }
 
-          case ReferenceCells::Pyramid:
-            {
-              constexpr dealii::ndarray<unsigned int, 13, 4>
-                new_quad_lines_pyramid = {
-                  {{{0, 10, 16, X}}, // child 0
-                   {{2, 16, 6, X}},
-                   {{0, 17, 12, X}}, // child 1
-                   {{3, 7, 17, X}},
-                   {{1, 18, 15, X}}, // child 2
-                   {{2, 4, 18, X}},
-                   {{1, 13, 19, X}}, // child 3
-                   {{3, 19, 9, X}},
-                   {{5, 8, 11, 14}},  // child 9 (top)
-                   {{11, 17, 16, X}}, // child 8 (upside down)
-                   {{14, 18, 19, X}},
-                   {{5, 16, 18, X}},
-                   {{8, 19, 17, X}}}};
-              return new_quad_lines_pyramid;
-            }
+        case ReferenceCells::Pyramid:
+          {
+            static constexpr ndarray<unsigned int, 13, 4>
+              new_quad_lines_pyramid = {
+                {{{0, 10, 16, X}}, // child 0
+                 {{2, 16, 6, X}},
+                 {{0, 17, 12, X}}, // child 1
+                 {{3, 7, 17, X}},
+                 {{1, 18, 15, X}}, // child 2
+                 {{2, 4, 18, X}},
+                 {{1, 13, 19, X}}, // child 3
+                 {{3, 19, 9, X}},
+                 {{5, 8, 11, 14}},  // child 9 (top)
+                 {{11, 17, 16, X}}, // child 8 (upside down)
+                 {{14, 18, 19, X}},
+                 {{5, 16, 18, X}},
+                 {{8, 19, 17, X}}}};
+            return new_quad_lines_pyramid;
+          }
 
-          case ReferenceCells::Wedge:
-            {
-              constexpr dealii::ndarray<unsigned int, 13, 4>
-                new_quad_lines_wedge = {{{{2, 20, 11, X}}, // mid tri
-                                         {{3, 6, 18, X}},
-                                         {{19, 7, 10, X}},
-                                         {{18, 19, 20, X}},
-                                         {{4, 0, 14, 18}}, // lower
-                                         {{0, 8, 12, 20}},
-                                         {{8, 4, 13, 19}},
-                                         {{5, 1, 18, 15}}, // upper
-                                         {{1, 9, 20, 17}},
-                                         {{9, 5, 19, 16}},
-                                         {{X, X, X, X}},
-                                         {{X, X, X, X}},
-                                         {{X, X, X, X}}}};
-              return new_quad_lines_wedge;
-            }
+        case ReferenceCells::Wedge:
+          {
+            static constexpr ndarray<unsigned int, 13, 4> new_quad_lines_wedge =
+              {{{{2, 20, 11, X}}, // mid tri
+                {{3, 6, 18, X}},
+                {{19, 7, 10, X}},
+                {{18, 19, 20, X}},
+                {{4, 0, 14, 18}}, // lower
+                {{0, 8, 12, 20}},
+                {{8, 4, 13, 19}},
+                {{5, 1, 18, 15}}, // upper
+                {{1, 9, 20, 17}},
+                {{9, 5, 19, 16}},
+                {{X, X, X, X}},
+                {{X, X, X, X}},
+                {{X, X, X, X}}}};
+            return new_quad_lines_wedge;
+          }
 
-          case ReferenceCells::Hexahedron:
-            {
-              constexpr dealii::ndarray<unsigned int, 13, 4>
-                new_quad_lines_hex = {{{{10, 28, 16, 24}},
-                                       {{28, 14, 17, 25}},
-                                       {{11, 29, 24, 20}},
-                                       {{29, 15, 25, 21}},
-                                       {{18, 26, 0, 28}},
-                                       {{26, 22, 1, 29}},
-                                       {{19, 27, 28, 4}},
-                                       {{27, 23, 29, 5}},
-                                       {{2, 24, 8, 26}},
-                                       {{24, 6, 9, 27}},
-                                       {{3, 25, 26, 12}},
-                                       {{25, 7, 27, 13}},
-                                       {{X, X, X, X}}}};
-              return new_quad_lines_hex;
-            }
+        case ReferenceCells::Hexahedron:
+          {
+            static constexpr ndarray<unsigned int, 13, 4> new_quad_lines_hex = {
+              {{{10, 28, 16, 24}},
+               {{28, 14, 17, 25}},
+               {{11, 29, 24, 20}},
+               {{29, 15, 25, 21}},
+               {{18, 26, 0, 28}},
+               {{26, 22, 1, 29}},
+               {{19, 27, 28, 4}},
+               {{27, 23, 29, 5}},
+               {{2, 24, 8, 26}},
+               {{24, 6, 9, 27}},
+               {{3, 25, 26, 12}},
+               {{25, 7, 27, 13}},
+               {{X, X, X, X}}}};
+            return new_quad_lines_hex;
+          }
 
-          default:
-            DEAL_II_ASSERT_UNREACHABLE();
-        }
-    }
+        default:
+          DEAL_II_ASSERT_UNREACHABLE();
+      }
   else
     // We should never get here except in the 3d case.
     DEAL_II_ASSERT_UNREACHABLE();
 
-  return {};
+  static constexpr ndarray<unsigned int, 13, 4> empty{};
+  return empty;
 }
 
 
 
 template <int dim>
-constexpr dealii::ndarray<unsigned int, 13, 4, 2>
+const ndarray<unsigned int, 13, 4, 2> &
 ReferenceCell<dim>::new_isotropic_child_face_line_vertices(
   const unsigned int refinement_choice) const
 {
   AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
 
+  const unsigned int X = numbers::invalid_unsigned_int;
   if constexpr (dim == 3)
-    {
-      const unsigned int X = numbers::invalid_unsigned_int;
-
-      switch (this->kind)
-        {
-          case ReferenceCells::Tetrahedron:
+    switch (this->kind)
+      {
+        case ReferenceCells::Tetrahedron:
+          switch (refinement_choice)
             {
-              switch (refinement_choice)
+              case 0:
                 {
-                  case 0:
-                    // new line is (6, 8)
-                    return {{{{{{6, 4}}, {{4, 7}}, {{7, 6}}, {{X, X}}}},
-                             {{{{4, 5}}, {{5, 8}}, {{8, 4}}, {{X, X}}}},
-                             {{{{5, 6}}, {{6, 9}}, {{9, 5}}, {{X, X}}}},
-                             {{{{7, 8}}, {{8, 9}}, {{9, 7}}, {{X, X}}}},
-                             {{{{4, 6}}, {{6, 8}}, {{8, 4}}, {{X, X}}}},
-                             {{{{6, 5}}, {{5, 8}}, {{8, 6}}, {{X, X}}}},
-                             {{{{8, 7}}, {{7, 6}}, {{6, 8}}, {{X, X}}}},
-                             {{{{9, 6}}, {{6, 8}}, {{8, 9}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
-                  case 1:
-                    // new line is (5, 7)
-                    return {{{{{{6, 4}}, {{4, 7}}, {{7, 6}}, {{X, X}}}},
-                             {{{{4, 5}}, {{5, 8}}, {{8, 4}}, {{X, X}}}},
-                             {{{{5, 6}}, {{6, 9}}, {{9, 5}}, {{X, X}}}},
-                             {{{{7, 8}}, {{8, 9}}, {{9, 7}}, {{X, X}}}},
-                             {{{{5, 4}}, {{4, 7}}, {{7, 5}}, {{X, X}}}},
-                             {{{{6, 5}}, {{5, 7}}, {{7, 6}}, {{X, X}}}},
-                             {{{{8, 7}}, {{7, 5}}, {{5, 8}}, {{X, X}}}},
-                             {{{{7, 9}}, {{9, 5}}, {{5, 7}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
-                  case 2:
-                    // new line is (4, 9)
-                    return {{{{{{6, 4}}, {{4, 7}}, {{7, 6}}, {{X, X}}}},
-                             {{{{4, 5}}, {{5, 8}}, {{8, 4}}, {{X, X}}}},
-                             {{{{5, 6}}, {{6, 9}}, {{9, 5}}, {{X, X}}}},
-                             {{{{7, 8}}, {{8, 9}}, {{9, 7}}, {{X, X}}}},
-                             {{{{5, 4}}, {{4, 9}}, {{9, 5}}, {{X, X}}}},
-                             {{{{4, 6}}, {{6, 9}}, {{9, 4}}, {{X, X}}}},
-                             {{{{7, 4}}, {{4, 9}}, {{9, 7}}, {{X, X}}}},
-                             {{{{4, 8}}, {{8, 9}}, {{9, 4}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                             {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
-                  default:
-                    DEAL_II_ASSERT_UNREACHABLE();
+                  // new line is (6, 8)
+                  static constexpr ndarray<unsigned int, 13, 4, 2> table_68 = {
+                    {{{{{6, 4}}, {{4, 7}}, {{7, 6}}, {{X, X}}}},
+                     {{{{4, 5}}, {{5, 8}}, {{8, 4}}, {{X, X}}}},
+                     {{{{5, 6}}, {{6, 9}}, {{9, 5}}, {{X, X}}}},
+                     {{{{7, 8}}, {{8, 9}}, {{9, 7}}, {{X, X}}}},
+                     {{{{4, 6}}, {{6, 8}}, {{8, 4}}, {{X, X}}}},
+                     {{{{6, 5}}, {{5, 8}}, {{8, 6}}, {{X, X}}}},
+                     {{{{8, 7}}, {{7, 6}}, {{6, 8}}, {{X, X}}}},
+                     {{{{9, 6}}, {{6, 8}}, {{8, 9}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
+                  return table_68;
                 }
+              case 1:
+                {
+                  // new line is (5, 7)
+                  static constexpr ndarray<unsigned int, 13, 4, 2> table_57 = {
+                    {{{{{6, 4}}, {{4, 7}}, {{7, 6}}, {{X, X}}}},
+                     {{{{4, 5}}, {{5, 8}}, {{8, 4}}, {{X, X}}}},
+                     {{{{5, 6}}, {{6, 9}}, {{9, 5}}, {{X, X}}}},
+                     {{{{7, 8}}, {{8, 9}}, {{9, 7}}, {{X, X}}}},
+                     {{{{5, 4}}, {{4, 7}}, {{7, 5}}, {{X, X}}}},
+                     {{{{6, 5}}, {{5, 7}}, {{7, 6}}, {{X, X}}}},
+                     {{{{8, 7}}, {{7, 5}}, {{5, 8}}, {{X, X}}}},
+                     {{{{7, 9}}, {{9, 5}}, {{5, 7}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
+                  return table_57;
+                }
+              case 2:
+                {
+                  // new line is (4, 9)
+                  static constexpr ndarray<unsigned int, 13, 4, 2> table_49 = {
+                    {{{{{6, 4}}, {{4, 7}}, {{7, 6}}, {{X, X}}}},
+                     {{{{4, 5}}, {{5, 8}}, {{8, 4}}, {{X, X}}}},
+                     {{{{5, 6}}, {{6, 9}}, {{9, 5}}, {{X, X}}}},
+                     {{{{7, 8}}, {{8, 9}}, {{9, 7}}, {{X, X}}}},
+                     {{{{5, 4}}, {{4, 9}}, {{9, 5}}, {{X, X}}}},
+                     {{{{4, 6}}, {{6, 9}}, {{9, 4}}, {{X, X}}}},
+                     {{{{7, 4}}, {{4, 9}}, {{9, 7}}, {{X, X}}}},
+                     {{{{4, 8}}, {{8, 9}}, {{9, 4}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                     {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
+                  return table_49;
+                }
+              default:
+                DEAL_II_ASSERT_UNREACHABLE();
             }
 
-          case ReferenceCells::Pyramid:
-            {
-              constexpr dealii::ndarray<unsigned int, 13, 4, 2>
-                quad_lines_vertices_pyramid = {
-                  {// child 0
-                   {{{{13, 7}}, {{7, 9}}, {{9, 13}}, {{X, X}}}},
-                   {{{{5, 13}}, {{13, 9}}, {{9, 5}}, {{X, X}}}},
-                   // child 1
-                   {{{{7, 13}}, {{13, 10}}, {{10, 7}}, {{X, X}}}},
-                   {{{{13, 6}}, {{6, 10}}, {{10, 13}}, {{X, X}}}},
-                   // child 2
-                   {{{{8, 13}}, {{13, 11}}, {{11, 8}}, {{X, X}}}},
-                   {{{{13, 5}}, {{5, 11}}, {{11, 13}}, {{X, X}}}},
-                   // child 3
-                   {{{{13, 8}}, {{8, 12}}, {{12, 13}}, {{X, X}}}},
-                   {{{{6, 13}}, {{13, 12}}, {{12, 6}}, {{X, X}}}},
-                   // child 9 (top)
-                   {{{{9, 11}}, {{10, 12}}, {{9, 10}}, {{11, 12}}}},
-                   // child 8 (upside down)
-                   {{{{9, 10}}, {{10, 13}}, {{13, 9}}, {{X, X}}}},
-                   {{{{12, 11}}, {{11, 13}}, {{13, 12}}, {{X, X}}}},
-                   {{{{11, 9}}, {{9, 13}}, {{13, 11}}, {{X, X}}}},
-                   {{{{10, 12}}, {{12, 13}}, {{13, 10}}, {{X, X}}}}}};
-              return quad_lines_vertices_pyramid;
-            }
+        case ReferenceCells::Pyramid:
+          {
+            static constexpr ndarray<unsigned int, 13, 4, 2>
+              quad_lines_vertices_pyramid = {
+                {// child 0
+                 {{{{13, 7}}, {{7, 9}}, {{9, 13}}, {{X, X}}}},
+                 {{{{5, 13}}, {{13, 9}}, {{9, 5}}, {{X, X}}}},
+                 // child 1
+                 {{{{7, 13}}, {{13, 10}}, {{10, 7}}, {{X, X}}}},
+                 {{{{13, 6}}, {{6, 10}}, {{10, 13}}, {{X, X}}}},
+                 // child 2
+                 {{{{8, 13}}, {{13, 11}}, {{11, 8}}, {{X, X}}}},
+                 {{{{13, 5}}, {{5, 11}}, {{11, 13}}, {{X, X}}}},
+                 // child 3
+                 {{{{13, 8}}, {{8, 12}}, {{12, 13}}, {{X, X}}}},
+                 {{{{6, 13}}, {{13, 12}}, {{12, 6}}, {{X, X}}}},
+                 // child 9 (top)
+                 {{{{9, 11}}, {{10, 12}}, {{9, 10}}, {{11, 12}}}},
+                 // child 8 (upside down)
+                 {{{{9, 10}}, {{10, 13}}, {{13, 9}}, {{X, X}}}},
+                 {{{{12, 11}}, {{11, 13}}, {{13, 12}}, {{X, X}}}},
+                 {{{{11, 9}}, {{9, 13}}, {{13, 11}}, {{X, X}}}},
+                 {{{{10, 12}}, {{12, 13}}, {{13, 10}}, {{X, X}}}}}};
+            return quad_lines_vertices_pyramid;
+          }
 
-          case ReferenceCells::Wedge:
-            {
-              constexpr dealii::ndarray<unsigned int, 13, 4, 2>
-                quad_lines_vertices_wedge = {
-                  {// mid tri
-                   {{{{12, 15}}, {{15, 17}}, {{17, 12}}, {{X, X}}}},
-                   {{{{15, 13}}, {{13, 16}}, {{16, 15}}, {{X, X}}}},
-                   {{{{17, 16}}, {{16, 14}}, {{14, 17}}, {{X, X}}}},
-                   {{{{15, 16}}, {{16, 17}}, {{17, 15}}, {{X, X}}}},
-                   // lower
-                   {{{{7, 16}}, {{6, 15}}, {{7, 6}}, {{16, 15}}}},
-                   {{{{6, 15}}, {{8, 17}}, {{6, 8}}, {{15, 17}}}},
-                   {{{{8, 17}}, {{7, 16}}, {{8, 7}}, {{17, 16}}}},
-                   // upper
-                   {{{{16, 10}}, {{15, 9}}, {{16, 15}}, {{10, 9}}}},
-                   {{{{15, 9}}, {{17, 11}}, {{15, 17}}, {{9, 11}}}},
-                   {{{{17, 11}}, {{16, 10}}, {{17, 16}}, {{11, 10}}}},
-                   {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                   {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
-                   {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
-              return quad_lines_vertices_wedge;
-            }
+        case ReferenceCells::Wedge:
+          {
+            static constexpr ndarray<unsigned int, 13, 4, 2>
+              quad_lines_vertices_wedge = {
+                {// mid tri
+                 {{{{12, 15}}, {{15, 17}}, {{17, 12}}, {{X, X}}}},
+                 {{{{15, 13}}, {{13, 16}}, {{16, 15}}, {{X, X}}}},
+                 {{{{17, 16}}, {{16, 14}}, {{14, 17}}, {{X, X}}}},
+                 {{{{15, 16}}, {{16, 17}}, {{17, 15}}, {{X, X}}}},
+                 // lower
+                 {{{{7, 16}}, {{6, 15}}, {{7, 6}}, {{16, 15}}}},
+                 {{{{6, 15}}, {{8, 17}}, {{6, 8}}, {{15, 17}}}},
+                 {{{{8, 17}}, {{7, 16}}, {{8, 7}}, {{17, 16}}}},
+                 // upper
+                 {{{{16, 10}}, {{15, 9}}, {{16, 15}}, {{10, 9}}}},
+                 {{{{15, 9}}, {{17, 11}}, {{15, 17}}, {{9, 11}}}},
+                 {{{{17, 11}}, {{16, 10}}, {{17, 16}}, {{11, 10}}}},
+                 {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                 {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}},
+                 {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
+            return quad_lines_vertices_wedge;
+          }
 
-          case ReferenceCells::Hexahedron:
-            {
-              constexpr dealii::ndarray<unsigned int, 13, 4, 2>
-                quad_lines_vertices_hex = {
-                  {{{{{10, 22}}, {{24, 26}}, {{10, 24}}, {{22, 26}}}},
-                   {{{{24, 26}}, {{11, 23}}, {{24, 11}}, {{26, 23}}}},
-                   {{{{22, 14}}, {{26, 25}}, {{22, 26}}, {{14, 25}}}},
-                   {{{{26, 25}}, {{23, 15}}, {{26, 23}}, {{25, 15}}}},
-                   {{{{8, 24}}, {{20, 26}}, {{8, 20}}, {{24, 26}}}},
-                   {{{{20, 26}}, {{12, 25}}, {{20, 12}}, {{26, 25}}}},
-                   {{{{24, 9}}, {{26, 21}}, {{24, 26}}, {{9, 21}}}},
-                   {{{{26, 21}}, {{25, 13}}, {{26, 25}}, {{21, 13}}}},
-                   {{{{16, 20}}, {{22, 26}}, {{16, 22}}, {{20, 26}}}},
-                   {{{{22, 26}}, {{17, 21}}, {{22, 17}}, {{26, 21}}}},
-                   {{{{20, 18}}, {{26, 23}}, {{20, 26}}, {{18, 23}}}},
-                   {{{{26, 23}}, {{21, 19}}, {{26, 21}}, {{23, 19}}}},
-                   {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
-              return quad_lines_vertices_hex;
-            }
-          default:
-            DEAL_II_ASSERT_UNREACHABLE();
-        }
-    }
+        case ReferenceCells::Hexahedron:
+          {
+            static constexpr ndarray<unsigned int, 13, 4, 2>
+              quad_lines_vertices_hex = {
+                {{{{{10, 22}}, {{24, 26}}, {{10, 24}}, {{22, 26}}}},
+                 {{{{24, 26}}, {{11, 23}}, {{24, 11}}, {{26, 23}}}},
+                 {{{{22, 14}}, {{26, 25}}, {{22, 26}}, {{14, 25}}}},
+                 {{{{26, 25}}, {{23, 15}}, {{26, 23}}, {{25, 15}}}},
+                 {{{{8, 24}}, {{20, 26}}, {{8, 20}}, {{24, 26}}}},
+                 {{{{20, 26}}, {{12, 25}}, {{20, 12}}, {{26, 25}}}},
+                 {{{{24, 9}}, {{26, 21}}, {{24, 26}}, {{9, 21}}}},
+                 {{{{26, 21}}, {{25, 13}}, {{26, 25}}, {{21, 13}}}},
+                 {{{{16, 20}}, {{22, 26}}, {{16, 22}}, {{20, 26}}}},
+                 {{{{22, 26}}, {{17, 21}}, {{22, 17}}, {{26, 21}}}},
+                 {{{{20, 18}}, {{26, 23}}, {{20, 26}}, {{18, 23}}}},
+                 {{{{26, 23}}, {{21, 19}}, {{26, 21}}, {{23, 19}}}},
+                 {{{{X, X}}, {{X, X}}, {{X, X}}, {{X, X}}}}}};
+            return quad_lines_vertices_hex;
+          }
+        default:
+          DEAL_II_ASSERT_UNREACHABLE();
+      }
   else
     // We should never get here except in the 3d case.
     DEAL_II_ASSERT_UNREACHABLE();
 
-  return {};
+  static constexpr ndarray<unsigned int, 13, 4, 2> empty{};
+  return empty;
 }
 
 
 
 template <int dim>
-constexpr dealii::ndarray<unsigned int, 10, 6>
+const ndarray<unsigned int, 10, 6> &
 ReferenceCell<dim>::new_isotropic_child_cell_faces(
   const unsigned int refinement_choice) const
 {
   AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
 
+  const unsigned int X = numbers::invalid_unsigned_int;
   if constexpr (dim == 3)
-    {
-      const unsigned int X = numbers::invalid_unsigned_int;
-
-      switch (this->kind)
-        {
-          case ReferenceCells::Tetrahedron:
+    switch (this->kind)
+      {
+        case ReferenceCells::Tetrahedron:
+          switch (refinement_choice)
             {
-              switch (refinement_choice)
+              case 0:
                 {
-                  case 0:
-                    // new line is (6, 8)
-                    return {{
-                      {{8, 13, 16, 0, X, X}},
-                      {{9, 12, 1, 21, X, X}},
-                      {{10, 2, 17, 20, X, X}},
-                      {{3, 14, 18, 22, X, X}},
-                      {{11, 1, 4, 5, X, X}},
-                      {{15, 0, 4, 6, X, X}},
-                      {{19, 7, 6, 3, X, X}},
-                      {{23, 5, 2, 7, X, X}},
-                      {{X, X, X, X, X, X}},
-                      {{X, X, X, X, X, X}},
-                    }};
-                  case 1:
-                    // new line is (5, 7)
-                    return {{
-                      {{8, 13, 16, 0, X, X}},
-                      {{9, 12, 1, 21, X, X}},
-                      {{10, 2, 17, 20, X, X}},
-                      {{3, 14, 18, 22, X, X}},
-                      {{11, 4, 0, 5, X, X}},
-                      {{15, 4, 1, 6, X, X}},
-                      {{19, 2, 5, 7, X, X}},
-                      {{23, 6, 7, 3, X, X}},
-                      {{X, X, X, X, X, X}},
-                      {{X, X, X, X, X, X}},
-                    }};
-                  case 2:
-                    // new line is (4, 9)
-                    return {{
-                      {{8, 13, 16, 0, X, X}},
-                      {{9, 12, 1, 21, X, X}},
-                      {{10, 2, 17, 20, X, X}},
-                      {{3, 14, 18, 22, X, X}},
-                      {{11, 4, 5, 2, X, X}},
-                      {{15, 6, 7, 3, X, X}},
-                      {{19, 5, 0, 6, X, X}},
-                      {{23, 1, 4, 7, X, X}},
-                      {{X, X, X, X, X, X}},
-                      {{X, X, X, X, X, X}},
-                    }};
-                  default:
-                    DEAL_II_ASSERT_UNREACHABLE();
+                  // new line is (6, 8)
+                  static constexpr ndarray<unsigned int, 10, 6> table_68 = {{
+                    {{8, 13, 16, 0, X, X}},
+                    {{9, 12, 1, 21, X, X}},
+                    {{10, 2, 17, 20, X, X}},
+                    {{3, 14, 18, 22, X, X}},
+                    {{11, 1, 4, 5, X, X}},
+                    {{15, 0, 4, 6, X, X}},
+                    {{19, 7, 6, 3, X, X}},
+                    {{23, 5, 2, 7, X, X}},
+                    {{X, X, X, X, X, X}},
+                    {{X, X, X, X, X, X}},
+                  }};
+                  return table_68;
                 }
+              case 1:
+                {
+                  // new line is (5, 7)
+                  static constexpr ndarray<unsigned int, 10, 6> table_57 = {{
+                    {{8, 13, 16, 0, X, X}},
+                    {{9, 12, 1, 21, X, X}},
+                    {{10, 2, 17, 20, X, X}},
+                    {{3, 14, 18, 22, X, X}},
+                    {{11, 4, 0, 5, X, X}},
+                    {{15, 4, 1, 6, X, X}},
+                    {{19, 2, 5, 7, X, X}},
+                    {{23, 6, 7, 3, X, X}},
+                    {{X, X, X, X, X, X}},
+                    {{X, X, X, X, X, X}},
+                  }};
+                  return table_57;
+                }
+              case 2:
+                {
+                  // new line is (4, 9)
+                  static constexpr ndarray<unsigned int, 10, 6> table_49 = {{
+                    {{8, 13, 16, 0, X, X}},
+                    {{9, 12, 1, 21, X, X}},
+                    {{10, 2, 17, 20, X, X}},
+                    {{3, 14, 18, 22, X, X}},
+                    {{11, 4, 5, 2, X, X}},
+                    {{15, 6, 7, 3, X, X}},
+                    {{19, 5, 0, 6, X, X}},
+                    {{23, 1, 4, 7, X, X}},
+                    {{X, X, X, X, X, X}},
+                    {{X, X, X, X, X, X}},
+                  }};
+                  return table_49;
+                }
+              default:
+                DEAL_II_ASSERT_UNREACHABLE();
             }
-          case ReferenceCells::Pyramid:
-            {
-              constexpr dealii::ndarray<unsigned int, 10, 6>
-                cell_quads_pyramid = {{
-                  {{13, 17, 0, 26, 1, X}}, // bottom pyramids
-                  {{14, 2, 22, 25, 3, X}}, //
-                  {{15, 18, 4, 5, 29, X}}, //
-                  {{16, 6, 21, 7, 30, X}}, //
-                  {{5, 1, 20, 11, X, X}},  // bottom wedges
-                  {{7, 3, 12, 24, X, X}},  //
-                  {{0, 2, 28, 9, X, X}},   //
-                  {{4, 6, 10, 32, X, X}},  //
-                  {{8, 9, 10, 11, 12, X}}, // upside down pyramid
-                  {{8, 19, 23, 27, 31, X}} // top pyramid
-                }};
-              return cell_quads_pyramid;
-            }
-
-          case ReferenceCells::Wedge:
-            {
-              // Considerations that went into creating this table
-              // - Keep aspect ratio of 1.0 if parent had 1.0 (this is why the
-              //   centre wedge is rotated by 180 degrees compared to the
-              //   parent)
-              // - Order of children is similar to the order of a reference
-              //   triangle in the x-y-plane (i.e. like the top triangle of the
-              //   parent)
-              constexpr dealii::ndarray<unsigned int, 10, 6> cell_quads_wedge =
-                {{
-                  {{23, 0, 10, 5, 19, X}}, // bottom children
-                  {{22, 1, 11, 14, 4, X}}, //
-                  {{24, 2, 6, 15, 18, X}}, //
-                  {{25, 3, 6, 5, 4, X}},   //
-                  {{0, 26, 12, 8, 21, X}}, // top children
-                  {{1, 27, 13, 16, 7, X}}, //
-                  {{2, 28, 9, 17, 20, X}}, //
-                  {{3, 29, 9, 8, 7, X}},   //
-                  {{X, X, X, X, X, X}},
-                  {{X, X, X, X, X, X}},
-                }};
-              return cell_quads_wedge;
-            }
-
-          case ReferenceCells::Hexahedron:
-            {
-              constexpr dealii::ndarray<unsigned int, 10, 6> cell_quads_hex = {{
-                {{12, 0, 20, 4, 28, 8}},  // bottom children
-                {{0, 16, 22, 6, 29, 9}},  //
-                {{13, 1, 4, 24, 30, 10}}, //
-                {{1, 17, 6, 26, 31, 11}}, //
-                {{14, 2, 21, 5, 8, 32}},  // top children
-                {{2, 18, 23, 7, 9, 33}},  //
-                {{15, 3, 5, 25, 10, 34}}, //
-                {{3, 19, 7, 27, 11, 35}}, //
-                {{X, X, X, X, X, X}},
-                {{X, X, X, X, X, X}},
+        case ReferenceCells::Pyramid:
+          {
+            static constexpr ndarray<unsigned int, 10, 6> cell_quads_pyramid = {
+              {
+                {{13, 17, 0, 26, 1, X}}, // bottom pyramids
+                {{14, 2, 22, 25, 3, X}}, //
+                {{15, 18, 4, 5, 29, X}}, //
+                {{16, 6, 21, 7, 30, X}}, //
+                {{5, 1, 20, 11, X, X}},  // bottom wedges
+                {{7, 3, 12, 24, X, X}},  //
+                {{0, 2, 28, 9, X, X}},   //
+                {{4, 6, 10, 32, X, X}},  //
+                {{8, 9, 10, 11, 12, X}}, // upside down pyramid
+                {{8, 19, 23, 27, 31, X}} // top pyramid
               }};
-              return cell_quads_hex;
-            }
-          default:
-            DEAL_II_ASSERT_UNREACHABLE();
-        }
-    }
+            return cell_quads_pyramid;
+          }
+
+        case ReferenceCells::Wedge:
+          {
+            // Considerations that went into creating this table
+            // - Keep aspect ratio of 1.0 if parent had 1.0 (this is why the
+            //   centre wedge is rotated by 180 degrees compared to the
+            //   parent)
+            // - Order of children is similar to the order of a reference
+            //   triangle in the x-y-plane (i.e. like the top triangle of the
+            //   parent)
+            static constexpr ndarray<unsigned int, 10, 6> cell_quads_wedge = {{
+              {{23, 0, 10, 5, 19, X}}, // bottom children
+              {{22, 1, 11, 14, 4, X}}, //
+              {{24, 2, 6, 15, 18, X}}, //
+              {{25, 3, 6, 5, 4, X}},   //
+              {{0, 26, 12, 8, 21, X}}, // top children
+              {{1, 27, 13, 16, 7, X}}, //
+              {{2, 28, 9, 17, 20, X}}, //
+              {{3, 29, 9, 8, 7, X}},   //
+              {{X, X, X, X, X, X}},
+              {{X, X, X, X, X, X}},
+            }};
+            return cell_quads_wedge;
+          }
+
+        case ReferenceCells::Hexahedron:
+          {
+            static constexpr ndarray<unsigned int, 10, 6> cell_quads_hex = {{
+              {{12, 0, 20, 4, 28, 8}},  // bottom children
+              {{0, 16, 22, 6, 29, 9}},  //
+              {{13, 1, 4, 24, 30, 10}}, //
+              {{1, 17, 6, 26, 31, 11}}, //
+              {{14, 2, 21, 5, 8, 32}},  // top children
+              {{2, 18, 23, 7, 9, 33}},  //
+              {{15, 3, 5, 25, 10, 34}}, //
+              {{3, 19, 7, 27, 11, 35}}, //
+              {{X, X, X, X, X, X}},
+              {{X, X, X, X, X, X}},
+            }};
+            return cell_quads_hex;
+          }
+        default:
+          DEAL_II_ASSERT_UNREACHABLE();
+      }
   else
     // We should never get here except in the 3d case.
     DEAL_II_ASSERT_UNREACHABLE();
 
-  return {};
+  static constexpr ndarray<unsigned int, 10, 6> empty{};
+  return empty;
 }
 
 
 
 template <int dim>
-constexpr dealii::ndarray<unsigned int, 10, 8>
+const ndarray<unsigned int, 10, 8> &
 ReferenceCell<dim>::new_isotropic_child_cell_vertices(
   const unsigned int refinement_choice) const
 {
   AssertIndexRange(refinement_choice, n_isotropic_refinement_choices());
 
+  constexpr unsigned int X = numbers::invalid_unsigned_int;
   if constexpr (dim == 3)
-    {
-      constexpr unsigned int X = numbers::invalid_unsigned_int;
-
-      switch (this->kind)
-        {
-          case ReferenceCells::Tetrahedron:
+    switch (this->kind)
+      {
+        case ReferenceCells::Tetrahedron:
+          switch (refinement_choice)
             {
-              switch (refinement_choice)
+              case 0:
                 {
-                  case 0:
-                    // new line is (6,8)
-                    return {{
-                      {{0, 4, 6, 7, X, X, X, X}},
-                      {{4, 1, 5, 8, X, X, X, X}},
-                      {{6, 5, 2, 9, X, X, X, X}},
-                      {{7, 8, 9, 3, X, X, X, X}},
-                      {{4, 5, 6, 8, X, X, X, X}},
-                      {{4, 7, 8, 6, X, X, X, X}},
-                      {{6, 9, 7, 8, X, X, X, X}},
-                      {{5, 8, 9, 6, X, X, X, X}},
-                      {{X, X, X, X, X, X, X, X}},
-                      {{X, X, X, X, X, X, X, X}},
-                    }};
-                  case 1:
-                    // new line is (5,7)
-                    return {{
-                      {{0, 4, 6, 7, X, X, X, X}},
-                      {{4, 1, 5, 8, X, X, X, X}},
-                      {{6, 5, 2, 9, X, X, X, X}},
-                      {{7, 8, 9, 3, X, X, X, X}},
-                      {{4, 5, 6, 7, X, X, X, X}},
-                      {{4, 7, 8, 5, X, X, X, X}},
-                      {{6, 9, 7, 5, X, X, X, X}},
-                      {{5, 8, 9, 7, X, X, X, X}},
-                      {{X, X, X, X, X, X, X, X}},
-                      {{X, X, X, X, X, X, X, X}},
-                    }};
-                  case 2:
-                    // new line is (4,9)
-                    return {{
-                      {{0, 4, 6, 7, X, X, X, X}},
-                      {{4, 1, 5, 8, X, X, X, X}},
-                      {{6, 5, 2, 9, X, X, X, X}},
-                      {{7, 8, 9, 3, X, X, X, X}},
-                      {{4, 5, 6, 9, X, X, X, X}},
-                      {{4, 7, 8, 9, X, X, X, X}},
-                      {{6, 9, 7, 4, X, X, X, X}},
-                      {{5, 8, 9, 4, X, X, X, X}},
-                      {{X, X, X, X, X, X, X, X}},
-                      {{X, X, X, X, X, X, X, X}},
-                    }};
-
-                  default:
-                    DEAL_II_ASSERT_UNREACHABLE();
+                  // new line is (6,8)
+                  static constexpr ndarray<unsigned int, 10, 8> table_68 = {{
+                    {{0, 4, 6, 7, X, X, X, X}},
+                    {{4, 1, 5, 8, X, X, X, X}},
+                    {{6, 5, 2, 9, X, X, X, X}},
+                    {{7, 8, 9, 3, X, X, X, X}},
+                    {{4, 5, 6, 8, X, X, X, X}},
+                    {{4, 7, 8, 6, X, X, X, X}},
+                    {{6, 9, 7, 8, X, X, X, X}},
+                    {{5, 8, 9, 6, X, X, X, X}},
+                    {{X, X, X, X, X, X, X, X}},
+                    {{X, X, X, X, X, X, X, X}},
+                  }};
+                  return table_68;
                 }
-            }
-          case ReferenceCells::Pyramid:
-            {
-              constexpr dealii::ndarray<unsigned int, 10, 8>
-                cell_vertices_pyramid = {{
-                  {{0, 7, 5, 13, 9, X, X, X}},    // bottom pyramid
-                  {{7, 1, 13, 6, 10, X, X, X}},   //
-                  {{5, 13, 2, 8, 11, X, X, X}},   //
-                  {{13, 6, 8, 3, 12, X, X, X}},   //
-                  {{5, 13, 11, 9, X, X, X, X}},   // bottom wedges
-                  {{13, 6, 12, 10, X, X, X, X}},  //
-                  {{7, 13, 9, 10, X, X, X, X}},   //
-                  {{13, 8, 11, 12, X, X, X, X}},  //
-                  {{9, 11, 10, 12, 13, X, X, X}}, // upside down pyramid
-                  {{9, 10, 11, 12, 4, X, X, X}},  // top pyramid
-                }};
-              return cell_vertices_pyramid;
-            }
+              case 1:
+                {
+                  // new line is (5,7)
+                  static constexpr ndarray<unsigned int, 10, 8> table_57 = {{
+                    {{0, 4, 6, 7, X, X, X, X}},
+                    {{4, 1, 5, 8, X, X, X, X}},
+                    {{6, 5, 2, 9, X, X, X, X}},
+                    {{7, 8, 9, 3, X, X, X, X}},
+                    {{4, 5, 6, 7, X, X, X, X}},
+                    {{4, 7, 8, 5, X, X, X, X}},
+                    {{6, 9, 7, 5, X, X, X, X}},
+                    {{5, 8, 9, 7, X, X, X, X}},
+                    {{X, X, X, X, X, X, X, X}},
+                    {{X, X, X, X, X, X, X, X}},
+                  }};
+                  return table_57;
+                }
+              case 2:
+                {
+                  // new line is (4,9)
+                  static constexpr ndarray<unsigned int, 10, 8> table_49 = {{
+                    {{0, 4, 6, 7, X, X, X, X}},
+                    {{4, 1, 5, 8, X, X, X, X}},
+                    {{6, 5, 2, 9, X, X, X, X}},
+                    {{7, 8, 9, 3, X, X, X, X}},
+                    {{4, 5, 6, 9, X, X, X, X}},
+                    {{4, 7, 8, 9, X, X, X, X}},
+                    {{6, 9, 7, 4, X, X, X, X}},
+                    {{5, 8, 9, 4, X, X, X, X}},
+                    {{X, X, X, X, X, X, X, X}},
+                    {{X, X, X, X, X, X, X, X}},
+                  }};
+                  return table_49;
+                }
 
-          case ReferenceCells::Wedge:
-            {
-              constexpr dealii::ndarray<unsigned int, 10, 8>
-                cell_vertices_wedge = {{
-                  {{0, 6, 8, 12, 15, 17, X, X}},   // bottom children
-                  {{6, 1, 7, 15, 13, 16, X, X}},   //
-                  {{8, 7, 2, 17, 16, 14, X, X}},   //
-                  {{7, 8, 6, 16, 17, 15, X, X}},   //
-                  {{12, 15, 17, 3, 9, 11, X, X}},  // top children
-                  {{15, 13, 16, 9, 4, 10, X, X}},  //
-                  {{17, 16, 14, 11, 10, 5, X, X}}, //
-                  {{16, 17, 15, 10, 11, 9, X, X}}, //
-                  {{X, X, X, X, X, X, X, X}},
-                  {{X, X, X, X, X, X, X, X}},
-                }};
-              return cell_vertices_wedge;
+              default:
+                DEAL_II_ASSERT_UNREACHABLE();
             }
+        case ReferenceCells::Pyramid:
+          {
+            static constexpr ndarray<unsigned int, 10, 8>
+              cell_vertices_pyramid = {{
+                {{0, 7, 5, 13, 9, X, X, X}},    // bottom pyramid
+                {{7, 1, 13, 6, 10, X, X, X}},   //
+                {{5, 13, 2, 8, 11, X, X, X}},   //
+                {{13, 6, 8, 3, 12, X, X, X}},   //
+                {{5, 13, 11, 9, X, X, X, X}},   // bottom wedges
+                {{13, 6, 12, 10, X, X, X, X}},  //
+                {{7, 13, 9, 10, X, X, X, X}},   //
+                {{13, 8, 11, 12, X, X, X, X}},  //
+                {{9, 11, 10, 12, 13, X, X, X}}, // upside down pyramid
+                {{9, 10, 11, 12, 4, X, X, X}},  // top pyramid
+              }};
+            return cell_vertices_pyramid;
+          }
 
-          case ReferenceCells::Hexahedron:
-            {
-              constexpr dealii::ndarray<unsigned int, 10, 8> cell_vertices_hex =
-                {{
-                  {{0, 10, 8, 24, 16, 22, 20, 26}},  // bottom children
-                  {{10, 1, 24, 9, 22, 17, 26, 21}},  //
-                  {{8, 24, 2, 11, 20, 26, 18, 23}},  //
-                  {{24, 9, 11, 3, 26, 21, 23, 19}},  //
-                  {{16, 22, 20, 26, 4, 14, 12, 25}}, // top children
-                  {{22, 17, 26, 21, 14, 5, 25, 13}}, //
-                  {{20, 26, 18, 23, 12, 25, 6, 15}}, //
-                  {{26, 21, 23, 19, 25, 13, 15, 7}}, //
-                  {{X, X, X, X, X, X, X, X}},
-                  {{X, X, X, X, X, X, X, X}},
-                }};
-              return cell_vertices_hex;
-            }
+        case ReferenceCells::Wedge:
+          {
+            static constexpr ndarray<unsigned int, 10, 8> cell_vertices_wedge =
+              {{
+                {{0, 6, 8, 12, 15, 17, X, X}},   // bottom children
+                {{6, 1, 7, 15, 13, 16, X, X}},   //
+                {{8, 7, 2, 17, 16, 14, X, X}},   //
+                {{7, 8, 6, 16, 17, 15, X, X}},   //
+                {{12, 15, 17, 3, 9, 11, X, X}},  // top children
+                {{15, 13, 16, 9, 4, 10, X, X}},  //
+                {{17, 16, 14, 11, 10, 5, X, X}}, //
+                {{16, 17, 15, 10, 11, 9, X, X}}, //
+                {{X, X, X, X, X, X, X, X}},
+                {{X, X, X, X, X, X, X, X}},
+              }};
+            return cell_vertices_wedge;
+          }
 
-          default:
-            DEAL_II_ASSERT_UNREACHABLE();
-        }
-    }
+        case ReferenceCells::Hexahedron:
+          {
+            static constexpr ndarray<unsigned int, 10, 8> cell_vertices_hex = {{
+              {{0, 10, 8, 24, 16, 22, 20, 26}},  // bottom children
+              {{10, 1, 24, 9, 22, 17, 26, 21}},  //
+              {{8, 24, 2, 11, 20, 26, 18, 23}},  //
+              {{24, 9, 11, 3, 26, 21, 23, 19}},  //
+              {{16, 22, 20, 26, 4, 14, 12, 25}}, // top children
+              {{22, 17, 26, 21, 14, 5, 25, 13}}, //
+              {{20, 26, 18, 23, 12, 25, 6, 15}}, //
+              {{26, 21, 23, 19, 25, 13, 15, 7}}, //
+              {{X, X, X, X, X, X, X, X}},
+              {{X, X, X, X, X, X, X, X}},
+            }};
+            return cell_vertices_hex;
+          }
+
+        default:
+          DEAL_II_ASSERT_UNREACHABLE();
+      }
   else
     // We should never get here except in the 3d case.
     DEAL_II_ASSERT_UNREACHABLE();
 
-  return {};
+  static constexpr ndarray<unsigned int, 10, 8> empty{};
+  return empty;
 }
 
 


### PR DESCRIPTION
Previously we copied these tables every time we needed them. That took up a small but measurable amount of runtime (about 2.5% of execute_refinement_isotropic(), as measured by callgrind). It is much more efficient to set up the tables once and return references.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
