### PR TITLE
Optimize update_neighbors() some more.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -12727,30 +12727,25 @@ namespace internal
       {}
 
       template <int dim, int spacedim>
-      void static update_neighbors(Triangulation<dim, spacedim> &triangulation)
+      static void
+      update_neighbors(Triangulation<dim, spacedim> &triangulation)
       {
-        std::vector<std::pair<unsigned int, unsigned int>> adjacent_cells(
-          2 * triangulation.n_raw_faces(),
-          {numbers::invalid_unsigned_int, numbers::invalid_unsigned_int});
+        std::vector<std::pair<int, int>> adjacent_cells(
+          2 * triangulation.n_raw_faces(), {-1, -1});
 
         const auto set_entry = [&](const auto &face_index, const auto &cell) {
-          const std::pair<unsigned int, unsigned int> cell_pair = {
-            cell->level(), cell->index()};
-          unsigned int index;
+          const std::pair<int, int> cell_pair = {cell->level(), cell->index()};
 
-          if (adjacent_cells[2 * face_index].first ==
-                numbers::invalid_unsigned_int &&
-              adjacent_cells[2 * face_index].second ==
-                numbers::invalid_unsigned_int)
+          int index = numbers::invalid_unsigned_int;
+          if (adjacent_cells[2 * face_index].first == -1 &&
+              adjacent_cells[2 * face_index].second == -1)
             {
               index = 2 * face_index + 0;
             }
           else
             {
-              Assert(((adjacent_cells[2 * face_index + 1].first ==
-                       numbers::invalid_unsigned_int) &&
-                      (adjacent_cells[2 * face_index + 1].second ==
-                       numbers::invalid_unsigned_int)),
+              Assert(((adjacent_cells[2 * face_index + 1].first == -1) &&
+                      (adjacent_cells[2 * face_index + 1].second == -1)),
                      ExcNotImplemented());
               index = 2 * face_index + 1;
             }
@@ -12763,17 +12758,12 @@ namespace internal
               const auto &cell) -> TriaIterator<CellAccessor<dim, spacedim>> {
           auto test = adjacent_cells[2 * face_index];
 
-          if (test == std::pair<unsigned int, unsigned int>(cell->level(),
-                                                            cell->index()))
+          if (test == std::make_pair(cell->level(), cell->index()))
             test = adjacent_cells[2 * face_index + 1];
 
-          if ((test.first != numbers::invalid_unsigned_int) &&
-              (test.second != numbers::invalid_unsigned_int))
-            return TriaIterator<CellAccessor<dim, spacedim>>(&triangulation,
-                                                             test.first,
-                                                             test.second);
-          else
-            return triangulation.end();
+          return TriaIterator<CellAccessor<dim, spacedim>>(&triangulation,
+                                                           test.first,
+                                                           test.second);
         };
 
         for (const auto &cell : triangulation.cell_iterators())


### PR DESCRIPTION
This makes the function about 3% faster and also avoids some extra conversions between signed and unsigned integers (i.e., our standard sentinel value for past-the-end level and index is -1).

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
