### PR TITLE
Fix broken explicit instantiations in trilinos_tpetra_precondition_frosch.cc

### DIFF
--- a/doc/news/changes/minor/20260825ErnestoIsmail
+++ b/doc/news/changes/minor/20260825ErnestoIsmail
@@ -1,0 +1,8 @@
+Fixed: The explicit instantiations of
+LinearAlgebra::TpetraWrappers::PreconditionFROSch::initialize() for the float
+scalar type declared a non-const DoFHandler argument and therefore did not
+match the declaration, and one instantiation in the complex-double block was
+malformed. As a consequence deal.II failed to compile against a Trilinos
+configured with Tpetra_INST_FLOAT=ON and ShyLU_DDFROSch.
+<br>
+(Ernesto Ismail, 2026/08/25)

--- a/source/lac/trilinos_tpetra_precondition_frosch.cc
+++ b/source/lac/trilinos_tpetra_precondition_frosch.cc
@@ -29,13 +29,13 @@ namespace LinearAlgebra
     template void
     PreconditionFROSch<float, dealii::MemorySpace::Host>::initialize<2, 2>(
       const SparseMatrix<float, dealii::MemorySpace::Host> &,
-      DoFHandler<2, 2> &,
+      const DoFHandler<2, 2> &,
       const PreconditionFROSch<float, dealii::MemorySpace::Host>::AdditionalData
         &);
     template void
     PreconditionFROSch<float, dealii::MemorySpace::Host>::initialize<3, 3>(
       const SparseMatrix<float, dealii::MemorySpace::Host> &,
-      DoFHandler<3, 3> &,
+      const DoFHandler<3, 3> &,
       const PreconditionFROSch<float, dealii::MemorySpace::Host>::AdditionalData
         &);
 #    endif
@@ -84,7 +84,7 @@ namespace LinearAlgebra
         const DoFHandler<2, 2> &,
         const PreconditionFROSch<std::complex<double>,
                                  dealii::MemorySpace::Host>::AdditionalData &);
-    template void template class PreconditionFROSch<std::complex<double>>;
+    template void
     PreconditionFROSch<std::complex<double>, dealii::MemorySpace::Host>::
       initialize<3, 3>(
         const SparseMatrix<std::complex<double>, dealii::MemorySpace::Host> &,


### PR DESCRIPTION
`source/lac/trilinos_tpetra_precondition_frosch.cc` contains three broken
explicit instantiations. None of them are related to complex scalars; the
first two break any build against a Trilinos with `Tpetra_INST_FLOAT=ON`
and ShyLU_DDFROSch enabled.

1. The `HAVE_TPETRA_INST_FLOAT` block instantiates `initialize<2,2>` and
   `initialize<3,3>` with a non-`const` `DoFHandler`, while the declaration
   in `trilinos_tpetra_precondition.h` takes
   `const DoFHandler<dh_dim, spacedim> &`:

```
   error: template-id 'initialize<2, 2>' for
   'void dealii::LinearAlgebra::TpetraWrappers::PreconditionFROSch<float,
   dealii::MemorySpace::Host>::initialize(const
   dealii::LinearAlgebra::TpetraWrappers::SparseMatrix<float,
   dealii::MemorySpace::Host>&, dealii::DoFHandler<2, 2>&, const
   AdditionalData&)' does not match any template declaration
```

   The `double` and `std::complex<float>` blocks already have the `const`,
   so this looks like an oversight rather than an intentional difference.

2. The `HAVE_TPETRA_INST_COMPLEX_DOUBLE` block contains

```cpp
   template void template class PreconditionFROSch<std::complex<double>>;
   PreconditionFROSch<std::complex<double>, dealii::MemorySpace::Host>::
     initialize<3, 3>(
```

   where a class instantiation has been pasted into the middle of the
   `initialize<3,3>` instantiation. The class is already instantiated a few
   lines above, so the duplicate is dropped and the line becomes
   `template void`.

Both are still present on `master`. Found while building 9.8.0 against
Trilinos 16.2.0 with GCC 11.5.0; see #20164 for the wider context.