### PR TITLE
Add missing Number() cast in the ReadWriteVector min branch

### DIFF
--- a/doc/news/changes/minor/20260825ErnestoIsmail_2
+++ b/doc/news/changes/minor/20260825ErnestoIsmail_2
@@ -1,0 +1,7 @@
+Fixed: When importing a Tpetra vector with VectorOperation::min,
+ReadWriteVector assigned the value from the Kokkos view without converting it
+to the vector's number type, unlike the surrounding insert, add and max
+branches. This made deal.II fail to compile whenever the Kokkos scalar type
+differed from the ReadWriteVector number type.
+<br>
+(Ernesto Ismail, 2026/08/25)

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -679,7 +679,7 @@ namespace LinearAlgebra
                 ExcMessage(
                   "VectorOperation::min is not defined if there is an imaginary part!)"));
               if (std::real(Number(new_values(i))) - std::real(values[i]) < 0.0)
-                values[i] = new_values(i);
+                values[i] = Number(new_values(i));
             }
           break;
 


### PR DESCRIPTION
In `ReadWriteVector::import_elements()` for Tpetra vectors, the
`VectorOperation::min` branch assigns straight from the Kokkos view:

```cpp
if (std::real(Number(new_values(i))) - std::real(values[i]) < 0.0)
  values[i] = new_values(i);
```

while `insert`, `add` and `max` in the same `switch` all convert first, e.g.

```cpp
values[i] = Number(new_values(i));
```

This only matters when the Kokkos scalar type differs from `Number` — for
example a Trilinos instantiated for `std::complex<double>` together with a
deal.II `ReadWriteVector<std::complex<float>>`, where it gives

```
error: no match for 'operator=' (operand types are 'std::complex<float>'
and 'const Kokkos::complex<double>')
```

This patch adds the cast, for consistency with the neighbouring branches.
Found while building 9.8.0 against Trilinos 16.2.0 with GCC 11.5.0; the
issue is still present on `master`. Part of the set described in #20164,
companion to #20165.