### PR TITLE
Use the matrix and vector scalar type in MatrixScaling

### DIFF
--- a/doc/news/changes/minor/20260825ErnestoIsmail_3
+++ b/doc/news/changes/minor/20260825ErnestoIsmail_3
@@ -1,0 +1,7 @@
+Fixed: MatrixScaling assumed that the scalar type of a distributed matrix or
+vector is double. As a consequence deal.II failed to compile against a PETSc
+configured with complex scalars, because PetscScalar is then
+std::complex<double>. The arrays passed to the matrix and vector set()
+functions now use the scalar type of the matrix and vector respectively.
+<br>
+(Ernesto Ismail, 2026/08/25)

--- a/source/lac/matrix_scaling.cc
+++ b/source/lac/matrix_scaling.cc
@@ -275,11 +275,12 @@ MatrixScaling::find_scaling_and_scale_linear_system(Matrix     &matrix,
       Assert(matrix.locally_owned_range_indices() ==
                rhs.locally_owned_elements(),
              ExcMessage("Matrix and vector must have the same partitioning"));
-      std::vector<double> local_updates(row_scaling.size());
+      using Number = typename VectorType::value_type;
+      std::vector<Number> local_updates(row_scaling.size());
       for (auto i : locally_owned_rows)
         {
           auto local_idx           = partitioner.global_to_local(i);
-          local_updates[local_idx] = rhs[i] * row_scaling[local_idx];
+          local_updates[local_idx] = Number(rhs[i]) * row_scaling[local_idx];
         }
       rhs.set(locally_owned_rows.get_index_vector(), local_updates);
       rhs.compress(VectorOperation::insert);
@@ -320,11 +321,12 @@ MatrixScaling::scale_system_solution(VectorType &sol) const
     {
       Assert(locally_owned_cols == sol.locally_owned_elements(),
              ExcMessage("Matrix and vector must have the same partitioning"));
-      std::vector<double> local_updates(column_scaling.size());
+      using Number = typename VectorType::value_type;
+      std::vector<Number> local_updates(column_scaling.size());
       for (auto i : locally_owned_cols)
         {
           auto local_idx           = partitioner.global_to_local(i);
-          local_updates[local_idx] = sol[i] * column_scaling[local_idx];
+          local_updates[local_idx] = Number(sol[i]) * column_scaling[local_idx];
         }
       sol.set(locally_owned_cols.get_index_vector(), local_updates);
       sol.compress(VectorOperation::insert);
@@ -644,6 +646,8 @@ MatrixScaling::do_l1_scaling(Matrix &matrix, const unsigned int nsteps)
 #endif
     false)
     {
+      using Number = typename Matrix::value_type;
+
       Vector<double> local_row_norms(locally_owned_rows.n_elements());
       Vector<double> local_col_norms(locally_owned_cols.n_elements());
       std::map<types::global_dof_index, double>
@@ -727,7 +731,7 @@ MatrixScaling::do_l1_scaling(Matrix &matrix, const unsigned int nsteps)
             {
               auto local_row_idx = partitioner.global_to_local(row);
               auto row_size      = matrix.row_length(row);
-              std::vector<double>                  values(row_size);
+              std::vector<Number>                  values(row_size);
               std::vector<types::global_dof_index> columns(row_size);
               unsigned int                         idx = 0;
               for (auto it = matrix.begin(row); it != matrix.end(row); ++it)
@@ -828,6 +832,8 @@ MatrixScaling::do_linfty_scaling(Matrix &matrix, const unsigned int nsteps)
 #endif
     false)
     {
+      using Number = typename Matrix::value_type;
+
       Vector<double> local_row_norms(locally_owned_rows.n_elements());
       Vector<double> local_col_norms(locally_owned_cols.n_elements());
       std::map<types::global_dof_index, double>
@@ -915,7 +921,7 @@ MatrixScaling::do_linfty_scaling(Matrix &matrix, const unsigned int nsteps)
             {
               auto local_row_idx = partitioner.global_to_local(row);
               auto row_size      = matrix.row_length(row);
-              std::vector<double>                  values(row_size);
+              std::vector<Number>                  values(row_size);
               std::vector<types::global_dof_index> columns(row_size);
               unsigned int                         idx = 0;
               for (auto it = matrix.begin(row); it != matrix.end(row); ++it)
@@ -1095,6 +1101,8 @@ MatrixScaling::do_sk_scaling(Matrix &matrix, const unsigned int nsteps)
 #endif
     false)
     {
+      using Number = typename Matrix::value_type;
+
       Vector<double> local_row_norms(locally_owned_rows.n_elements());
       Vector<double> local_col_norms(locally_owned_cols.n_elements());
       std::map<types::global_dof_index, double>
@@ -1123,7 +1131,7 @@ MatrixScaling::do_sk_scaling(Matrix &matrix, const unsigned int nsteps)
                     {
                       auto local_row_idx = partitioner.global_to_local(row);
                       auto row_size      = matrix.row_length(row);
-                      std::vector<double>                  values(row_size);
+                      std::vector<Number>                  values(row_size);
                       std::vector<types::global_dof_index> columns(row_size);
                       unsigned int                         idx = 0;
                       for (auto it = matrix.begin(row); it != matrix.end(row);
@@ -1213,7 +1221,7 @@ MatrixScaling::do_sk_scaling(Matrix &matrix, const unsigned int nsteps)
                     {
                       auto local_row_idx = partitioner.global_to_local(row);
                       auto row_size      = matrix.row_length(row);
-                      std::vector<double>                  values(row_size);
+                      std::vector<Number>                  values(row_size);
                       std::vector<types::global_dof_index> columns(row_size);
                       unsigned int                         idx = 0;
                       for (auto it = matrix.begin(row); it != matrix.end(row);
@@ -1290,7 +1298,7 @@ MatrixScaling::do_sk_scaling(Matrix &matrix, const unsigned int nsteps)
                     {
                       auto local_row_idx = partitioner.global_to_local(row);
                       auto row_size      = matrix.row_length(row);
-                      std::vector<double>                  values(row_size);
+                      std::vector<Number>                  values(row_size);
                       std::vector<types::global_dof_index> columns(row_size);
                       unsigned int                         idx = 0;
                       for (auto it = matrix.begin(row); it != matrix.end(row);
@@ -1383,7 +1391,7 @@ MatrixScaling::do_sk_scaling(Matrix &matrix, const unsigned int nsteps)
                     {
                       auto local_row_idx = partitioner.global_to_local(row);
                       auto row_size      = matrix.row_length(row);
-                      std::vector<double>                  values(row_size);
+                      std::vector<Number>                  values(row_size);
                       std::vector<types::global_dof_index> columns(row_size);
                       unsigned int                         idx = 0;
                       for (auto it = matrix.begin(row); it != matrix.end(row);


### PR DESCRIPTION
`MatrixScaling` assumes the scalar type of a distributed matrix or vector is
`double`. The branch of `do_l1_scaling()`, `do_linfty_scaling()` and
`do_sk_scaling()` shared between Trilinos and PETSc matrices declares its value
arrays as `std::vector<double>`, which is correct for
`TrilinosWrappers::SparseMatrix` — `TrilinosScalar` is `double` — but not for
`PETScWrappers::MPI::SparseMatrix`, which the file also instantiates
explicitly. Building against a PETSc configured with
`--with-scalar-type=complex` therefore fails:

```
source/lac/matrix_scaling.cc:1136:41: error: cannot convert
  'std::complex<double>' to '...::value_type' {aka 'double'} in assignment

source/lac/matrix_scaling.cc:1139:33: error: no matching function for call to
  'dealii::PETScWrappers::MPI::SparseMatrix::set(const unsigned int&,
   std::vector<unsigned int>&, std::vector<double>&)'

source/lac/matrix_scaling.cc:282:45: error: no match for 'operator*'
  (operand types are 'dealii::PETScWrappers::internal::VectorReference'
   and 'double')
```

This patch uses `typename Matrix::value_type` and
`typename VectorType::value_type` for those arrays, as the *sequential* branch
of each of the same three functions already does, and converts explicitly where
a real scaling factor meets a PETSc `VectorReference`. Eight sites in total; no
behaviour changes for `double`.

Verified by building deal.II 9.8.0 against PETSc 3.24.3
(`--with-scalar-type=complex`) with GCC 11.5.0, OpenMPI 5.0.3 and Trilinos
16.2.0: the file compiles and the library builds and installs. The file is
identical on 9.8.0 and on master, so the patched code is the same in both.

Note that this is not sufficient on its own to build deal.II against complex
PETSc — `source/lac/sparse_direct.cc` implements `SparseDirectMUMPS` against the
real `dmumps` API and fails next. That is a separate matter and is reported in
#20167.