### PR TITLE
[9.8] Add missing Number() cast in the ReadWriteVector min branch

### DIFF
--- a/doc/news/changes/minor/20260825ErnestoIsmail_2
+++ b/doc/news/changes/minor/20260825ErnestoIsmail_2
@@ -1,0 +1,7 @@
+Fixed: When importing a Tpetra vector with VectorOperation::min,
+ReadWriteVector assigned the value from the Kokkos view without converting it
+to the vector's number type, unlike the surrounding insert, add and max
+branches. This made deal.II fail to compile whenever the Kokkos scalar type
+differed from the ReadWriteVector number type.
+<br>
+(Ernesto Ismail, 2026/08/25)

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -679,7 +679,7 @@ namespace LinearAlgebra
                 ExcMessage(
                   "VectorOperation::min is not defined if there is an imaginary part!)"));
               if (std::real(Number(new_values(i))) - std::real(values[i]) < 0.0)
-                values[i] = new_values(i);
+                values[i] = Number(new_values(i));
             }
           break;
 


### PR DESCRIPTION
Backport of #20166 to the 9.8 release branch, as requested there, in case a
9.8.1 release is cut.

The `VectorOperation::min` branch of `ReadWriteVector::import_elements()` for
Tpetra vectors assigns straight from the Kokkos view, while `insert`, `add` and
`max` in the same `switch` convert to `Number` first. This matters when the
Kokkos scalar type differs from `Number`.

Cherry-picked unchanged from the merged commit. I have kept the changelog entry
that came with it — happy to drop it if entries are not wanted on release
branches.