### PR TITLE
Guard TpetraWrappers::Vector::min() with if constexpr

### DIFF
--- a/doc/news/changes/minor/20260826ErnestoIsmail
+++ b/doc/news/changes/minor/20260826ErnestoIsmail
@@ -1,0 +1,8 @@
+Fixed: LinearAlgebra::TpetraWrappers::Vector::min() guarded complex number
+types with a run-time assertion, but its body still had to compile for every
+instantiated type and used operator< as well as std::numeric_limits::max(),
+neither of which is defined for complex numbers. The body is now guarded with
+if constexpr, so that deal.II can be compiled against a Trilinos providing
+complex Tpetra instantiations.
+<br>
+(Ernesto Ismail, 2026/08/26)

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1140,29 +1140,43 @@ namespace LinearAlgebra
     Number
     Vector<Number, MemorySpace>::min() const
     {
-      Assert(numbers::NumberTraits<Number>::is_complex == false,
-             ExcMessage(
-               "Not implemented for complex number types at the moment."));
-
-      // Make sure we have a view available to access the vector entries.
-      if (!vector_1d_view)
+      // The body below cannot be compiled for complex numbers: it compares
+      // entries with operator< and initialises the running minimum with
+      // std::numeric_limits<Number>::max(), neither of which is defined for
+      // complex types. Guarding with `if constexpr` keeps that code out of
+      // instantiations for complex Number, rather than relying on a run-time
+      // assertion in a body that still has to compile.
+      if constexpr (numbers::NumberTraits<Number>::is_complex == false)
         {
-          auto vector_2d_view =
-            vector->template getLocalView<Kokkos::HostSpace>(
-              Tpetra::Access::ReadWriteStruct{});
+          // Make sure we have a view available to access the vector entries.
+          if (!vector_1d_view)
+            {
+              auto vector_2d_view =
+                vector->template getLocalView<Kokkos::HostSpace>(
+                  Tpetra::Access::ReadWriteStruct{});
 
-          vector_1d_view = Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+              vector_1d_view =
+                Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+            }
+
+          Number min_value = std::numeric_limits<Number>::max();
+
+          const size_t this_local_length = vector->getLocalLength();
+
+          for (size_type i = 0; i < this_local_length; ++i)
+            if ((*vector_1d_view)(i) < min_value)
+              min_value = (*vector_1d_view)(i);
+
+          return Utilities::MPI::min(min_value, get_mpi_communicator());
         }
-
-      Number min_value = std::numeric_limits<Number>::max();
-
-      const size_t this_local_length = vector->getLocalLength();
-
-      for (size_type i = 0; i < this_local_length; ++i)
-        if ((*vector_1d_view)(i) < min_value)
-          min_value = (*vector_1d_view)(i);
-
-      return Utilities::MPI::min(min_value, get_mpi_communicator());
+      else
+        {
+          Assert(false,
+                 ExcMessage(
+                   "The 'min' operation is not defined for complex numbers, "
+                   "and so cannot be used on vectors over complex values."));
+          return Number();
+        }
     }
 
 


### PR DESCRIPTION
Fixes #20164.

`LinearAlgebra::TpetraWrappers::Vector::min()` excludes complex number types with a run-time `Assert`, but the body of the function still has to compile for every instantiated `Number`. It initialises the running minimum with `std::numeric_limits<Number>::max()` and compares entries with `operator<`, neither of which is defined for complex types. Building deal.II against a Trilinos that provides complex Tpetra instantiations therefore fails to compile:

    include/deal.II/lac/trilinos_tpetra_vector.templates.h:1162:36: error:
      no match for 'operator<' (operand types are 'Kokkos::complex<double>'
      and 'std::complex<double>')

This follows the approach suggested in https://github.com/dealii/dealii/issues/20164#issuecomment-5418062232: the body is moved inside `if constexpr (numbers::NumberTraits<Number>::is_complex == false)`, so it is never instantiated for complex scalars, with the `Assert` and a default-constructed return value in the `else` branch. Behaviour for real types is unchanged, and complex types still trigger an assertion if `min()` is called.

### Verification

Checked against a purpose-built minimal stack, deliberately kept separate from any existing installation:

* Trilinos 16.2.0 configured with `Trilinos_ENABLE_COMPLEX=ON` and `Tpetra_INST_COMPLEX_DOUBLE=ON`, with Epetra, ML, MueLu, NOX, Zoltan and ShyLU off. The install was confirmed to define `HAVE_TPETRA_INST_COMPLEX_DOUBLE`.
* deal.II 9.8.0 configured with `DEAL_II_ALLOW_AUTODETECTION=OFF` against that Trilinos, confirmed to define `DEAL_II_TRILINOS_WITH_TPETRA_INST_COMPLEX_DOUBLE`, so the complex instantiations really are present.
* Building the `object_lac_release` target without this change fails at `trilinos_tpetra_vector.templates.h:1162` with the error above.
* With this change applied, `object_lac_release` compiles with no errors.

Reaching that error at all requires #20166 first, otherwise the build stops earlier in `read_write_vector.templates.h` for the same underlying reason.