### PR TITLE
Specify template parameter in Utilities::fixed_power recursion.

### DIFF
--- a/doc/news/changes/minor/20260826Fehling
+++ b/doc/news/changes/minor/20260826Fehling
@@ -1,0 +1,6 @@
+Fixed: The recursion in Utilities::fixed_power now explicitly specifies
+the template parameter for the value type. Previously, template argument
+deduction failed during compilation for data types enabling automatic
+differentiation.
+<br>
+(Marc Fehling, 2026/08/26)

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -951,12 +951,12 @@ namespace Utilities
       return T(1.);
     else if (N < 0)
       // For negative exponents, turn things into a positive exponent
-      return T(1.) / fixed_power<-N>(x);
+      return T(1.) / fixed_power<-N, T>(x);
     else
       // If we get here, we have a positive exponent. Compute the result
       // by repeated squaring:
-      return ((N % 2 == 1) ? x * fixed_power<N / 2>(x * x) :
-                             fixed_power<N / 2>(x * x));
+      return ((N % 2 == 1) ? x * fixed_power<N / 2, T>(x * x) :
+                             fixed_power<N / 2, T>(x * x));
   }
 
 


### PR DESCRIPTION
See changelog entry. This patch prevents compilation errors of the kind
```
/dealii/include/deal.II/base/utilities.h:958:28: error: operands to ‘?:’ have different types ‘Sacado::mpl::enable_if_c<true, Sacado::Fad::Exp::MultiplicationOp<Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, Sacado::Fad::Exp::MultiplicationOp<Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, false, false, Sacado::Fad::Exp::ExprSpecDefault>, false, false, Sacado::Fad::Exp::ExprSpecDefault> >::type’ {aka ‘Sacado::Fad::Exp::MultiplicationOp<Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, Sacado::Fad::Exp::MultiplicationOp<Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, false, false, Sacado::Fad::Exp::ExprSpecDefault>, false, false, Sacado::Fad::Exp::ExprSpecDefault>’} and ‘Sacado::Fad::Exp::MultiplicationOp<Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, Sacado::Fad::Exp::GeneralFad<Sacado::Fad::Exp::DynamicStorage<double, double> >, false, false, Sacado::Fad::Exp::ExprSpecDefault>’
  958 |       return ((N % 2 == 1) ? x * fixed_power<N / 2>(x * x) :
      |              ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  959 |                              fixed_power<N / 2>(x * x));
      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I encountered this problem with gcc 16.2.1.