### PR TITLE
Make TpetraWrappers::Vector::max() return the maximal element

### DIFF
--- a/doc/news/changes/incompatibilities/20260826ErnestoIsmail
+++ b/doc/news/changes/incompatibilities/20260826ErnestoIsmail
@@ -1,0 +1,8 @@
+Changed: LinearAlgebra::TpetraWrappers::Vector::max() returned the infinity
+norm of the vector rather than the maximal value of its elements, so for a
+vector whose largest-magnitude entry is negative it returned a positive
+number. It now returns the maximal element, as documented and as
+TrilinosWrappers::MPI::Vector::max() has always done. Code relying on the
+previous behaviour should call linfty_norm() instead.
+<br>
+(Ernesto Ismail, 2026/08/26)

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1171,15 +1171,42 @@ namespace LinearAlgebra
     Number
     Vector<Number, MemorySpace>::max() const
     {
-      Assert(numbers::NumberTraits<Number>::is_complex == false,
-             ExcMessage(
-               "Not implemented for complex number types at the moment."));
+      // The body below cannot be compiled for complex numbers: it compares
+      // entries with operator> and initialises the running maximum with
+      // std::numeric_limits<Number>::lowest(), neither of which is defined
+      // for complex types. Guarding with `if constexpr` keeps that code out
+      // of instantiations for complex Number.
+      if constexpr (numbers::NumberTraits<Number>::is_complex == false)
+        {
+          // Make sure we have a view available to access the vector entries.
+          if (!vector_1d_view)
+            {
+              auto vector_2d_view =
+                vector->template getLocalView<Kokkos::HostSpace>(
+                  Tpetra::Access::ReadWriteStruct{});
 
-      // Reset our cached vector view so that trilinos operations on device do
-      // not detect an existing host view.
-      vector_1d_view.reset();
+              vector_1d_view =
+                Kokkos::subview(vector_2d_view, Kokkos::ALL(), 0);
+            }
 
-      return vector->normInf();
+          Number max_value = std::numeric_limits<Number>::lowest();
+
+          const size_t this_local_length = vector->getLocalLength();
+
+          for (size_type i = 0; i < this_local_length; ++i)
+            if ((*vector_1d_view)(i) > max_value)
+              max_value = (*vector_1d_view)(i);
+
+          return Utilities::MPI::max(max_value, get_mpi_communicator());
+        }
+      else
+        {
+          Assert(false,
+                 ExcMessage(
+                   "The 'max' operation is not defined for complex numbers, "
+                   "and so cannot be used on vectors over complex values."));
+          return Number();
+        }
     }
 
 

--- a/tests/trilinos_tpetra/71.cc
+++ b/tests/trilinos_tpetra/71.cc
@@ -65,9 +65,27 @@ test()
   const double eps =
     typeid(typename VectorType::value_type) == typeid(double) ? 1e-14 : 1e-5;
 
-  Assert(std::fabs(vector_ghosted.min()) < eps, ExcInternalError());
-  Assert(std::fabs(vector_ghosted.max() - (vector_ghosted.size() - 1)) < eps,
-         ExcInternalError());
+  AssertThrow(std::fabs(vector_ghosted.min()) < eps, ExcInternalError());
+  AssertThrow(std::fabs(vector_ghosted.max() - (vector_ghosted.size() - 1)) <
+                eps,
+              ExcInternalError());
+
+  // Check again with a vector all of whose entries are negative. This is the
+  // case that distinguishes the maximal element from the infinity norm: for
+  // the vector above the two happen to coincide, so a max() implemented as
+  // the infinity norm passes unnoticed.
+  for (unsigned int i = 0; i < vector_distributed.size(); ++i)
+    {
+      vector_distributed(i) = -1.0 * (i + 1);
+    }
+  vector_distributed.compress(VectorOperation::insert);
+
+  vector_ghosted = vector_distributed;
+
+  AssertThrow(std::fabs(vector_ghosted.min() + 1.0 * vector_ghosted.size()) <
+                eps,
+              ExcInternalError());
+  AssertThrow(std::fabs(vector_ghosted.max() + 1.0) < eps, ExcInternalError());
 }
 
 


### PR DESCRIPTION
Fixes #20173.

`LinearAlgebra::TpetraWrappers::Vector::max()` is documented as "Compute the maximal value of the elements of this vector", but returned `vector->normInf()`, the infinity norm. The two agree only when the largest-magnitude element is non-negative, and differ in sign otherwise.

The sibling class settles what the behaviour should be. `TrilinosWrappers::MPI::Vector` carries identical documentation for `min()` and `max()` and implements them with Epetra's `MinValue` and `MaxValue`, keeping `NormInf` for `linfty_norm()`. The Tpetra class appears to have inherited the interface and the documentation but not the semantics. This patch makes it match: an element-wise reduction mirroring `min()` directly above it, with the same `if constexpr` guard so complex scalars are excluded rather than compiled.

Two details worth flagging for review:

`std::numeric_limits<Number>::lowest()` is the initial value, not `::min()`, which for floating point is the smallest positive normal and would never see a negative maximum.

The `vector_1d_view.reset()` and its comment are gone, because the new body creates the view lazily exactly as `min()` does. That is deliberate mirroring rather than an accidental deletion.

### Verification

Against a deal.II 9.8.0 build, using the same test binary and the same library path, changing only the body of `max()`:

    entries:   -3, -1
    min():     -3   (expected -3)
    max():      3   (before)
    max():     -1   (after)

### Note on compatibility

This changes observable behaviour, so the changelog entry is under `incompatibilities/` rather than `minor/`. Code that relied on the previous return value should call `linfty_norm()`.

This touches the body immediately following `min()`, which #20172 also rewrites, so a rebase may be needed depending on merge order.