### PR TITLE
Fix conflicting dark mode rules and add a light/dark toggle to the documentation

### DIFF
--- a/doc/doxygen/custom.css
+++ b/doc/doxygen/custom.css
@@ -1,12 +1,26 @@
 /*
- * Set primary color equal to the main webpage.
+ * Set primary color equal to the main webpage. --primary-color is defined
+ * by doxygen-awesome.css; the --dealii-* variables below are our own.
+ *
+ * Colors that differ between light and dark mode are declared here as
+ * variables and overridden in the html.dark-mode block at the end of this
+ * file. doxygen-awesome-darkmode-toggle.js always sets either the light-mode
+ * or the dark-mode class on <html>, so the class selector is sufficient and no
+ * prefers-color-scheme query is needed.
  */
 html {
     --primary-color: #546d78;
+
+    --dealii-link-color: #1779c4;
+    --dealii-box-foreground: black;
+    --dealii-box-background: #f9f9f9;
+    --dealii-box-border-color: #aaa;
+    --dealii-table-header-background: #D6E2FA;
+    --dealii-table-header-foreground: #000000;
 }
 
 a:link, a:visited, a:hover, a:focus, a:active {
-    color: #1779c4 !important;
+    color: var(--dealii-link-color) !important;
 }
 
 /*
@@ -35,26 +49,24 @@ a:link, a:visited, a:hover, a:focus, a:active {
     border-bottom: none;
 }
 
-@media (prefers-color-scheme: light) {
-  table.tutorial {
-    color: black;
-    border: 1px solid #aaa;
-    background-color: #f9f9f9;
+table.tutorial {
+    color: var(--dealii-box-foreground);
+    border: 1px solid var(--dealii-box-border-color);
+    background-color: var(--dealii-box-background);
     padding: 5px;
     font-size: 95%;
-  }
 }
 div.tutorial {
-    color: black;
-    border: 1px solid #aaa;
-    background-color: #f9f9f9;
+    color: var(--dealii-box-foreground);
+    border: 1px solid var(--dealii-box-border-color);
+    background-color: var(--dealii-box-background);
     padding: 50px;
     font-size: 95%;
 }
 div.doxygen-generated-exception-message {
-    color: black;
-    border: 1px solid #aaa;
-    background-color: #f9f9f9;
+    color: var(--dealii-box-foreground);
+    border: 1px solid var(--dealii-box-border-color);
+    background-color: var(--dealii-box-background);
     padding: 5px;
     font-size: 95%;
 }
@@ -66,8 +78,8 @@ div.doxygen-generated-exception-message {
  * would no longer be visible).
  */
 table.doxtable th {
-    background-color: #D6E2FA;
-    color: #000000;
+    background-color: var(--dealii-table-header-background);
+    color: var(--dealii-table-header-foreground);
 }
 
 div.image img[src="fe_enriched_1d.png"] {
@@ -136,4 +148,27 @@ div.image img[src="fe_enriched_h-refinement.png"] {
  */
 .CodeFragmentInTutorialComment {
     /* background-color: #FF33F0; */
+}
+
+/*
+ * Dark mode overrides.
+ */
+html.dark-mode {
+    --primary-color: #8ba3ae;
+
+    --dealii-link-color: #5ca8e2;
+    --dealii-box-foreground: var(--page-foreground-color);
+    --dealii-box-background: #232529;
+    --dealii-box-border-color: #4a4d52;
+    --dealii-table-header-background: #2b3b55;
+    --dealii-table-header-foreground: var(--page-foreground-color);
+}
+
+/*
+ * Formula images generated with USE_MATHJAX = NO have black glyphs on a
+ * transparent background and are not covered by the image inversion rules in
+ * doxygen-awesome.css, so they are inverted here as well.
+ */
+html.dark-mode img.formulaDsp, html.dark-mode img.formulaInl {
+    filter: invert();
 }

--- a/doc/doxygen/doxygen-awesome-darkmode-toggle.js
+++ b/doc/doxygen/doxygen-awesome-darkmode-toggle.js
@@ -1,0 +1,157 @@
+/**
+
+Doxygen Awesome
+https://github.com/jothepro/doxygen-awesome-css
+
+MIT License
+
+Copyright (c) 2021 - 2023 jothepro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+class DoxygenAwesomeDarkModeToggle extends HTMLElement {
+    // SVG icons from https://fonts.google.com/icons
+    // Licensed under the Apache 2.0 license:
+    // https://www.apache.org/licenses/LICENSE-2.0.html
+    static lightModeIcon = `<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#FCBF00"><rect fill="none" height="24" width="24"/><circle cx="12" cy="12" opacity=".3" r="3"/><path d="M12,9c1.65,0,3,1.35,3,3s-1.35,3-3,3s-3-1.35-3-3S10.35,9,12,9 M12,7c-2.76,0-5,2.24-5,5s2.24,5,5,5s5-2.24,5-5 S14.76,7,12,7L12,7z M2,13l2,0c0.55,0,1-0.45,1-1s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S1.45,13,2,13z M20,13l2,0c0.55,0,1-0.45,1-1 s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S19.45,13,20,13z M11,2v2c0,0.55,0.45,1,1,1s1-0.45,1-1V2c0-0.55-0.45-1-1-1S11,1.45,11,2z M11,20v2c0,0.55,0.45,1,1,1s1-0.45,1-1v-2c0-0.55-0.45-1-1-1C11.45,19,11,19.45,11,20z M5.99,4.58c-0.39-0.39-1.03-0.39-1.41,0 c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0s0.39-1.03,0-1.41L5.99,4.58z M18.36,16.95 c-0.39-0.39-1.03-0.39-1.41,0c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0c0.39-0.39,0.39-1.03,0-1.41 L18.36,16.95z M19.42,5.99c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06c-0.39,0.39-0.39,1.03,0,1.41 s1.03,0.39,1.41,0L19.42,5.99z M7.05,18.36c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06 c-0.39,0.39-0.39,1.03,0,1.41s1.03,0.39,1.41,0L7.05,18.36z"/></svg>`
+    static darkModeIcon = `<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#FE9700"><rect fill="none" height="24" width="24"/><path d="M9.37,5.51C9.19,6.15,9.1,6.82,9.1,7.5c0,4.08,3.32,7.4,7.4,7.4c0.68,0,1.35-0.09,1.99-0.27 C17.45,17.19,14.93,19,12,19c-3.86,0-7-3.14-7-7C5,9.07,6.81,6.55,9.37,5.51z" opacity=".3"/><path d="M9.37,5.51C9.19,6.15,9.1,6.82,9.1,7.5c0,4.08,3.32,7.4,7.4,7.4c0.68,0,1.35-0.09,1.99-0.27C17.45,17.19,14.93,19,12,19 c-3.86,0-7-3.14-7-7C5,9.07,6.81,6.55,9.37,5.51z M12,3c-4.97,0-9,4.03-9,9s4.03,9,9,9s9-4.03,9-9c0-0.46-0.04-0.92-0.1-1.36 c-0.98,1.37-2.58,2.26-4.4,2.26c-2.98,0-5.4-2.42-5.4-5.4c0-1.81,0.89-3.42,2.26-4.4C12.92,3.04,12.46,3,12,3L12,3z"/></svg>`
+    static title = "Toggle Light/Dark Mode"
+
+    static prefersLightModeInDarkModeKey = "prefers-light-mode-in-dark-mode"
+    static prefersDarkModeInLightModeKey = "prefers-dark-mode-in-light-mode"
+
+    static _staticConstructor = function() {
+        DoxygenAwesomeDarkModeToggle.enableDarkMode(DoxygenAwesomeDarkModeToggle.userPreference)
+        // Update the color scheme when the browsers preference changes
+        // without user interaction on the website.
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            DoxygenAwesomeDarkModeToggle.onSystemPreferenceChanged()
+        })
+        // Update the color scheme when the tab is made visible again.
+        // It is possible that the appearance was changed in another tab 
+        // while this tab was in the background.
+        document.addEventListener("visibilitychange", visibilityState => {
+            if (document.visibilityState === 'visible') {
+                DoxygenAwesomeDarkModeToggle.onSystemPreferenceChanged()
+            }
+        });
+    }()
+
+    static init() {
+        $(function() {
+            $(document).ready(function() {
+                const toggleButton = document.createElement('doxygen-awesome-dark-mode-toggle')
+                toggleButton.title = DoxygenAwesomeDarkModeToggle.title
+                toggleButton.updateIcon()
+
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                    toggleButton.updateIcon()
+                })
+                document.addEventListener("visibilitychange", visibilityState => {
+                    if (document.visibilityState === 'visible') {
+                        toggleButton.updateIcon()
+                    }
+                });
+
+                $(document).ready(function(){
+                    document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
+                })
+                $(window).resize(function(){
+                    document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
+                })
+            })
+        })
+    }
+
+    constructor() {
+        super();
+        this.onclick=this.toggleDarkMode
+    }
+
+    /**
+     * @returns `true` for dark-mode, `false` for light-mode system preference
+     */
+    static get systemPreference() {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+
+    /**
+     * @returns `true` for dark-mode, `false` for light-mode user preference
+     */
+    static get userPreference() {
+        return (!DoxygenAwesomeDarkModeToggle.systemPreference && localStorage.getItem(DoxygenAwesomeDarkModeToggle.prefersDarkModeInLightModeKey)) || 
+        (DoxygenAwesomeDarkModeToggle.systemPreference && !localStorage.getItem(DoxygenAwesomeDarkModeToggle.prefersLightModeInDarkModeKey))
+    }
+
+    static set userPreference(userPreference) {
+        DoxygenAwesomeDarkModeToggle.darkModeEnabled = userPreference
+        if(!userPreference) {
+            if(DoxygenAwesomeDarkModeToggle.systemPreference) {
+                localStorage.setItem(DoxygenAwesomeDarkModeToggle.prefersLightModeInDarkModeKey, true)
+            } else {
+                localStorage.removeItem(DoxygenAwesomeDarkModeToggle.prefersDarkModeInLightModeKey)
+            }
+        } else {
+            if(!DoxygenAwesomeDarkModeToggle.systemPreference) {
+                localStorage.setItem(DoxygenAwesomeDarkModeToggle.prefersDarkModeInLightModeKey, true)
+            } else {
+                localStorage.removeItem(DoxygenAwesomeDarkModeToggle.prefersLightModeInDarkModeKey)
+            }
+        }
+        DoxygenAwesomeDarkModeToggle.onUserPreferenceChanged()
+    }
+
+    static enableDarkMode(enable) {
+        if(enable) {
+            DoxygenAwesomeDarkModeToggle.darkModeEnabled = true
+            document.documentElement.classList.add("dark-mode")
+            document.documentElement.classList.remove("light-mode")
+        } else {
+            DoxygenAwesomeDarkModeToggle.darkModeEnabled = false
+            document.documentElement.classList.remove("dark-mode")
+            document.documentElement.classList.add("light-mode")
+        }
+    }
+
+    static onSystemPreferenceChanged() {
+        DoxygenAwesomeDarkModeToggle.darkModeEnabled = DoxygenAwesomeDarkModeToggle.userPreference
+        DoxygenAwesomeDarkModeToggle.enableDarkMode(DoxygenAwesomeDarkModeToggle.darkModeEnabled)
+    }
+
+    static onUserPreferenceChanged() {
+        DoxygenAwesomeDarkModeToggle.enableDarkMode(DoxygenAwesomeDarkModeToggle.darkModeEnabled)
+    }
+
+    toggleDarkMode() {
+        DoxygenAwesomeDarkModeToggle.userPreference = !DoxygenAwesomeDarkModeToggle.userPreference
+        this.updateIcon()
+    }
+
+    updateIcon() {
+        if(DoxygenAwesomeDarkModeToggle.darkModeEnabled) {
+            this.innerHTML = DoxygenAwesomeDarkModeToggle.darkModeIcon
+        } else {
+            this.innerHTML = DoxygenAwesomeDarkModeToggle.lightModeIcon
+        }
+    }
+}
+
+customElements.define("doxygen-awesome-dark-mode-toggle", DoxygenAwesomeDarkModeToggle);

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -132,6 +132,10 @@ MATHJAX_RELPATH        = @_mathjax_relpath@
 MATHJAX_EXTENSIONS     = TeX/AMSmath TeX/AMSsymbols
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 200
+# Required by doxygen-awesome.css for Doxygen >= 1.9.5: without it Doxygen
+# emits its own dark-mode rules guarded by html:not(.dark-mode), which
+# conflict with the html:not(.light-mode) rules in the theme.
+HTML_COLORSTYLE        = LIGHT
 HTML_EXTRA_STYLESHEET  = @CMAKE_CURRENT_SOURCE_DIR@/doxygen-awesome.css \
                          @CMAKE_CURRENT_SOURCE_DIR@/custom.css
 

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -138,6 +138,7 @@ HTML_COLORSTYLE_SAT    = 200
 HTML_COLORSTYLE        = LIGHT
 HTML_EXTRA_STYLESHEET  = @CMAKE_CURRENT_SOURCE_DIR@/doxygen-awesome.css \
                          @CMAKE_CURRENT_SOURCE_DIR@/custom.css
+HTML_EXTRA_FILES       = @CMAKE_CURRENT_SOURCE_DIR@/doxygen-awesome-darkmode-toggle.js
 
 # disable the navigation column
 DISABLE_INDEX          = NO

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -20,6 +20,8 @@ if (m'</head>')
 {
     print '<link rel="SHORTCUT ICON" href="deal.ico"></link>', "\n";
     print '<script type="text/javascript" src="$relpath^custom.js"></script>', "\n";
+    print '<script type="text/javascript" src="$relpath^doxygen-awesome-darkmode-toggle.js"></script>', "\n";
+    print '<script type="text/javascript">DoxygenAwesomeDarkModeToggle.init()</script>', "\n";
     print '<meta name="author" content="The deal.II Authors <authors@dealii.org>"></meta>', "\n";
     print '<meta name="copyright" content="Copyright (C) 1998 - @DEAL_II_PACKAGE_YEAR@ by the deal.II authors"></meta>', "\n";
     print '<meta name="deal.II-version" content="@DEAL_II_PACKAGE_VERSION@"></meta>', "\n";


### PR DESCRIPTION
# Fix conflicting dark mode rules and add a light/dark toggle to the documentation

## The problem

Parts of the documentation are illegible when the generated pages render in
dark mode, and there is currently no way for a reader to switch back to light
mode.

- Formulas built with `USE_MATHJAX = NO` are images with black glyphs, and are
  unreadable against a dark background.
- Tutorial figures are a mixture: line art on a transparent background
  disappears into the dark page entirely, while figures with an opaque light
  background show up as bright slabs.
- The boxed tutorial environments and `doxtable` header rows in `custom.css`
  hardcode black text on a light background.

The operating system's colour scheme is currently the only input, so a reader
who hits any of this has no recourse.

## Why a toggle rather than more CSS

The two image failure modes need opposite treatments — the transparent figures
want inverting, the opaque ones want leaving alone (or the reverse, depending
on the figure). Distinguishing them means classifying several hundred
checked-in tutorial images by hand, and inverting colour solution plots would
mangle their colour maps regardless. There is no blanket rule that fixes both
cases.

This PR therefore does not try to make dark mode good. It makes dark mode
*escapable*: when a reader hits something they cannot read, they can switch to
light mode and carry on. The rest of the changes are what that requires.

### Problematic current dark mode
<img width="508" height="834" alt="dark-illegible-before" src="https://github.com/user-attachments/assets/b8ba6eab-ccd1-4b6a-bbb6-4c850ac389fe" />

### Lightmode works in all cases and is what a user should fall back to
<img width="482" height="852" alt="light-legible" src="https://github.com/user-attachments/assets/41e4d12c-d6dc-4a96-a368-f720f449f364" />

## Why no toggle currently works

Two stylesheets both implement dark mode, using guard classes that are the
inverse of one another:

| file | guard |
| --- | --- |
| `doxygen.css` (generated by doxygen) | `@media (prefers-color-scheme: dark) { html:not(.dark-mode) { ... } }` |
| `doxygen-awesome.css` (bundled theme) | `@media (prefers-color-scheme: dark) { html:not(.light-mode) { ... } }` |

Because the guards are opposites, no single class on `<html>` switches both
off: adding `light-mode` disables the theme's dark rules but leaves doxygen's
active, and adding `dark-mode` does the reverse. The page stays dark whatever
a toggle does.

doxygen-awesome requires `HTML_COLORSTYLE = LIGHT` for doxygen 1.9.5 and
newer, precisely so that doxygen does not emit its own colour-scheme rules.
`options.dox.in` never set it, so doxygen fell back to its `AUTO_LIGHT`
default and emitted them.

## The changes

**1. `Set HTML_COLORSTYLE=LIGHT as required by doxygen-awesome.css`**

One line in `options.dox.in`. Doxygen stops emitting its own dark-mode block
and the bundled theme is left in sole control. Verified with
`grep -c 'prefers-color-scheme' doc/doxygen/deal.II/doxygen.css`, which drops
from 1 to 0.

This commit is self-contained and fixes the conflict on its own, if the
remainder is not wanted.

**2. `Add doxygen-awesome dark mode toggle`**

Adds `doxygen-awesome-darkmode-toggle.js` from upstream, registers it via
`HTML_EXTRA_FILES`, and loads it from `scripts/mod_header.pl.in` (two lines).
This puts a sun/moon button next to the search box.

The script stores only a *disagreement* with the system preference
(`prefers-light-mode-in-dark-mode` / `prefers-dark-mode-in-light-mode` in
`localStorage`), so default behaviour is unchanged: readers on a light system
still get light, readers on a dark system still get dark. They simply gain a
way to change it, and the choice persists across pages and sessions.

Also converts the deal.II-specific colours in `custom.css` into variables with
an `html.dark-mode` override block, so the tutorial boxes and `doxtable`
headers are readable in dark mode, and inverts `img.formulaDsp` /
`img.formulaInl` so that image formulas are legible. MathJax-rendered formulas
already inherit the page foreground colour and need no rule of their own.
Light mode output is unchanged.

The `table.tutorial` rule was previously wrapped in
`@media (prefers-color-scheme: light)`. That guard tests the *system* setting,
so with a toggle present a reader who switches to light on a dark machine
would get no styling at all; it is now handled through the same variables as
the other two boxes.

### Images of after the patch
<img width="342" height="211" alt="toggle-dark" src="https://github.com/user-attachments/assets/e664e201-db38-4c36-a28a-159120d11520" />
<img width="361" height="235" alt="toggle-light" src="https://github.com/user-attachments/assets/10193e7c-bf70-42f1-852c-6c298a6e1833" />
<img width="480" height="873" alt="dark-after-w-mathjax" src="https://github.com/user-attachments/assets/abe2267b-a886-4778-ba9c-c481166b232c" />
<img width="503" height="860" alt="dark-after-no-mathjax" src="https://github.com/user-attachments/assets/e936fff0-481b-4e78-a29d-8b9aed74cf43" />

## A question for reviewers

This vendors a second file from doxygen-awesome into the tree. Since
`doxygen-awesome.css` already carries local modifications (`2ef16bb3ee`,
`905b55ae7f`), keeping two upstream files in sync by hand may not be what you
want — happy to restructure this as a submodule instead if you wou



ld prefer.

## Testing

Built locally and checked in light and dark mode, with
`DEAL_II_DOXYGEN_USE_MATHJAX` both `ON` and `OFF`.

The tutorial figures themselves are not addressed here, for the reasons above.