### PR TITLE
CMake: autodetect CUDA-aware MPI support

### DIFF
--- a/cmake/configure/configure_10_mpi.cmake
+++ b/cmake/configure/configure_10_mpi.cmake
@@ -40,6 +40,7 @@ macro(feature_mpi_find_external var)
 endmacro()
 
 macro(feature_mpi_configure_external)
+  set_if_empty(DEAL_II_MPI_WITH_DEVICE_SUPPORT ${MPI_WITH_DEVICE_SUPPORT})
 
   #
   # We must convert the MPIEXEC_(PRE|POST)FLAGS strings to lists in order
@@ -47,13 +48,6 @@ macro(feature_mpi_configure_external)
   #
   separate_arguments(MPIEXEC_PREFLAGS)
   separate_arguments(MPIEXEC_POSTFLAGS)
-
-  #
-  # TODO: We might consider refactoring this option into an automatic check
-  # (in Modules/FindMPI.cmake) at some point. For the time being this is an
-  # advanced configuration option.
-  option(DEAL_II_MPI_WITH_DEVICE_SUPPORT "Enable MPI Device support" OFF)
-  mark_as_advanced(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
 endmacro()
 
 macro(feature_mpi_error_message)
@@ -73,12 +67,3 @@ endmacro()
 
 
 configure_feature(MPI)
-
-
-if(NOT DEAL_II_WITH_MPI)
-  #
-  # Disable and hide the DEAL_II_MPI_WITH_DEVICE_SUPPORT option
-  #
-  set(DEAL_II_MPI_WITH_DEVICE_SUPPORT)
-  unset(DEAL_II_MPI_WITH_DEVICE_SUPPORT CACHE)
-endif()

--- a/cmake/modules/FindDEAL_II_MPI.cmake
+++ b/cmake/modules/FindDEAL_II_MPI.cmake
@@ -14,13 +14,14 @@
 # Find MPI
 #
 # This module exports:
-#   MPI_LIBRARIES
-#   MPI_INCLUDE_DIRS
 #   MPI_CXX_FLAGS
+#   MPI_INCLUDE_DIRS
+#   MPI_LIBRARIES
 #   MPI_LINKER_FLAGS
 #   MPI_VERSION
 #   MPI_VERSION_MAJOR
 #   MPI_VERSION_MINOR
+#   MPI_WITH_DEVICE_SUPPORT
 #   OMPI_VERSION
 #
 
@@ -105,6 +106,48 @@ if(NOT DEFINED MPI_VERSION OR MPI_VERSION STREQUAL ".")
 endif()
 
 #
+# Check whether the MPI implementation is able to work with buffers that
+# reside in device memory directly, instead of requiring an explicit copy to
+# host memory first (known as "device-aware" or "CUDA-aware" MPI).
+#
+# There is no portable way of querying this at configure time. But the two
+# major MPI implementations both advertise the capability with preprocessor
+# symbols exported by the (non standard) mpi-ext.h header.
+#
+# Should the heuristic fail for a given MPI implementation the check can
+# always be overridden on the command line by configuring with
+# -DDEAL_II_MPI_WITH_DEVICE_SUPPORT=ON.
+#
+
+clear_cmake_required()
+set(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS_SAVED} ${MPI_CXX_COMPILE_FLAGS}")
+set(CMAKE_REQUIRED_INCLUDES ${MPI_CXX_INCLUDE_PATH} ${MPI_C_INCLUDE_PATH})
+
+unset_if_changed(CHECK_MPI_DEVICE_SUPPORT_SAVED
+  "${MPI_CXX_COMPILER}${CMAKE_REQUIRED_INCLUDES}"
+  MPI_WITH_DEVICE_SUPPORT
+  )
+
+CHECK_CXX_SOURCE_COMPILES(
+  "
+  #include <mpi.h>
+  #include <mpi-ext.h>
+
+  #if !defined(MPIX_CUDA_AWARE_SUPPORT) || MPIX_CUDA_AWARE_SUPPORT == 0
+  #  if !defined(MPIX_ROCM_AWARE_SUPPORT) || MPIX_ROCM_AWARE_SUPPORT == 0
+  #    error \"This MPI library does not advertise device support.\"
+  #  endif
+  #endif
+
+  int main()
+  {
+  }
+  "
+  MPI_WITH_DEVICE_SUPPORT)
+
+reset_cmake_required()
+
+#
 # Make sure that we do not run into underlinking on Debian/Ubuntu systems with
 # lld / ld.gold and missing libopen-pal.so on the link line:
 #
@@ -155,6 +198,8 @@ process_feature(MPI
   CXX_FLAGS OPTIONAL MPI_CXX_COMPILE_FLAGS
   LINKER_FLAGS OPTIONAL MPI_CXX_LINK_FLAGS
   CLEAR
+    CHECK_MPI_DEVICE_SUPPORT_SAVED
+    MPI_WITH_DEVICE_SUPPORT
     MPI_C_COMPILER
     MPI_CXX_COMPILER
     MPIEXEC

--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -25,16 +25,23 @@
       Several MPI implementations are able to perform MPI operations with data
       located in device memory directly without the need to copy to CPU memory
       explicitly first. This feature is commonly known as "CUDA-aware MPI".
-      In case deal.II is compiled with MPI support and the MPI implementation
-      supports this feature, you can tell deal.II to use it by configuring with
+      If deal.II is configured with <code>-DDEAL_II_WITH_MPI=ON</code> then
+      the configuration system queries the MPI library for this capability and
+      sets <code>DEAL_II_MPI_WITH_DEVICE_SUPPORT</code> accordingly.
+      </p>
+
+      <p>
+      The check is a heuristic based on preprocessor symbols exported by the
+      <code>mpi-ext.h</code> header, which not every MPI implementation
+      provides. If the detection fails for your MPI library you can override
+      the result by configuring with
       <pre>
 
         -DDEAL_II_WITH_MPI=ON
         -DDEAL_II_MPI_WITH_DEVICE_SUPPORT=ON
       </pre>
-      Note, that there is no check that detects if the MPI implementation
-      really is CUDA-aware. Activating this flag for incompatible MPI libraries
-      will lead to segmentation faults in MPI calls.
+      Note, that this bypasses the check. Setting the flag for an MPI library
+      that is not CUDA-aware will lead to segmentation faults in MPI calls.
     </p>
 
     <p>


### PR DESCRIPTION
A small CMake configuration change to automatically detect CUDA-aware MPI support.


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
