### PR TITLE
Use 'dim', not 'structdim' in namespace ReferenceCells.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1408,30 +1408,30 @@ namespace ReferenceCells
   n_vertices_to_reference_cell(const unsigned int n_vertices);
 
   /**
-   * Return the maximum number of vertices an object of dimension `structdim`
+   * Return the maximum number of vertices an object of dimension `dim`
    * can have. This is always the number of vertices of a
-   * `structdim`-dimensional hypercube.
+   * `dim`-dimensional hypercube.
    *
    * @see ReferenceCells::max_n_faces()
    */
-  template <int structdim>
+  template <int dim>
   constexpr unsigned int
   max_n_vertices();
 
   /**
-   * Return the maximum number of lines an object of dimension `structdim` can
-   * have. This is always the number of lines of a `structdim`-dimensional
+   * Return the maximum number of lines an object of dimension `dim` can
+   * have. This is always the number of lines of a `dim`-dimensional
    * hypercube.
    *
    * @see ReferenceCells::max_n_faces()
    */
-  template <int structdim>
+  template <int dim>
   constexpr unsigned int
   max_n_lines();
 
   /**
-   * Return the maximum number of faces an object of dimension `structdim` can
-   * have. This is always the number of faces of a `structdim`-dimensional
+   * Return the maximum number of faces an object of dimension `dim` can
+   * have. This is always the number of faces of a `dim`-dimensional
    * hypercube.
    *
    * @note The primary use case of this and the other maxima functions is to
@@ -1444,12 +1444,12 @@ namespace ReferenceCells
    *
    * is a unique index to the `face_no`th face of the current cell.
    */
-  template <int structdim>
+  template <int dim>
   constexpr unsigned int
   max_n_faces();
 
   /**
-   * Return the maximum number of children an object of dimension `structdim`
+   * Return the maximum number of children an object of dimension `dim`
    * can have.
    *
    * @note If a cell is refined anisotropically, the actual number of children
@@ -1457,7 +1457,7 @@ namespace ReferenceCells
    *
    * @see ReferenceCells::max_n_faces()
    */
-  template <int structdim>
+  template <int dim>
   constexpr unsigned int
   max_n_children();
 } // namespace ReferenceCells
@@ -3568,39 +3568,39 @@ namespace ReferenceCells
 
 
 
-  template <int structdim>
+  template <int dim>
   inline constexpr unsigned int
   max_n_vertices()
   {
-    return GeometryInfo<structdim>::vertices_per_cell;
+    return GeometryInfo<dim>::vertices_per_cell;
   }
 
 
 
-  template <int structdim>
+  template <int dim>
   inline constexpr unsigned int
   max_n_lines()
   {
-    return GeometryInfo<structdim>::lines_per_cell;
+    return GeometryInfo<dim>::lines_per_cell;
   }
 
 
 
-  template <int structdim>
+  template <int dim>
   inline constexpr unsigned int
   max_n_faces()
   {
-    return GeometryInfo<structdim>::faces_per_cell;
+    return GeometryInfo<dim>::faces_per_cell;
   }
 
 
 
-  template <int structdim>
+  template <int dim>
   inline constexpr unsigned int
   max_n_children()
   {
     // Pyramids (3D) have 10 children.
-    return structdim == 3 ? 10 : GeometryInfo<structdim>::max_children_per_cell;
+    return dim == 3 ? 10 : GeometryInfo<dim>::max_children_per_cell;
   }
 } // namespace ReferenceCells
 


### PR DESCRIPTION
I'm not sure about the history, but `ReferenceCell` uses `dim` as template argument whereas some of the member functions of `namespace ReferenceCells` use `structdim`. I don't think this makes sense, so rename the latter to the former.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
