### PR TITLE
Do not compute tangents to faces in 1d.

### DIFF
--- a/include/deal.II/fe/mapping_fe.h
+++ b/include/deal.II/fe/mapping_fe.h
@@ -320,10 +320,16 @@ public:
      * Unit tangential vectors. Used for the computation of boundary forms and
      * normal vectors.
      *
+     * In 1d, faces are just points and while cells in 1d (=lines) have *normal*
+     * vectors at their faces (namely, vectors with a single component that is
+     * +1 or -1), they do not have tangent vectors. As a consequence, the
+     * current member variable is an array of size zero in 1d to ensure that
+     * it cannot accidentally be used.
+     *
      * Filled once.
      */
     std::array<std::vector<Tensor<1, dim>>,
-               ReferenceCells::max_n_faces<dim>() * 2>
+               (dim > 1 ? ReferenceCells::max_n_faces<dim>() * 2 : 0)>
       unit_tangentials;
 
     /**

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -146,22 +146,26 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
       aux.resize(dim - 1,
                  std::vector<Tensor<1, spacedim>>(n_original_q_points));
 
-      // Compute tangentials to the unit cell.
-      const auto reference_cell = this->fe.reference_cell();
-      const auto n_faces        = reference_cell.n_faces();
-
-      for (unsigned int i = 0; i < n_faces; ++i)
+      // Compute tangentials to the faces of the unit cell. In 1d, a
+      // face is a point, so there is no tangent space.
+      if constexpr (dim > 1)
         {
-          unit_tangentials[i].resize(n_original_q_points);
-          std::fill(unit_tangentials[i].begin(),
-                    unit_tangentials[i].end(),
-                    reference_cell.face_tangent_vector(i, 0));
-          if (dim > 2)
+          const auto reference_cell = this->fe.reference_cell();
+          const auto n_faces        = reference_cell.n_faces();
+
+          for (unsigned int i = 0; i < n_faces; ++i)
             {
-              unit_tangentials[n_faces + i].resize(n_original_q_points);
-              std::fill(unit_tangentials[n_faces + i].begin(),
-                        unit_tangentials[n_faces + i].end(),
-                        reference_cell.face_tangent_vector(i, 1));
+              unit_tangentials[i].resize(n_original_q_points);
+              std::fill(unit_tangentials[i].begin(),
+                        unit_tangentials[i].end(),
+                        reference_cell.face_tangent_vector(i, 0));
+              if constexpr (dim > 2)
+                {
+                  unit_tangentials[n_faces + i].resize(n_original_q_points);
+                  std::fill(unit_tangentials[n_faces + i].begin(),
+                            unit_tangentials[n_faces + i].end(),
+                            reference_cell.face_tangent_vector(i, 1));
+                }
             }
         }
     }


### PR DESCRIPTION
In working on `ReferenceCell` (see #20116 and #20179), I came by a place where we are calling `ReferenceCell<1>::face_tangent_vector()`. The function returns the vector $(1)^T$ in that case, with a comment that that's "convenient". I think that's undesirable, because we are in 1d and so all vectors have only one component, faces of cells are just points, and there *is* no tangent vector. (There is a *normal* vector, however, which is either $(+1)^T$ or $(-1)^T$, depending on whether you look at the right or left face of a line.)

Anyway, I would like to change that function to error out in 1d, but that trips up a piece of code in `MappingFE::InternalData::initialize_face`. This patch addresses this: If we're in 1d, just don't ask for these tangent vectors. I *think* that we don't ever use them either, but just to make sure I'm making sure that the array we put them into has size zero in 1d so that we definitely get tripped up if anyone ever asks for this data.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
