### PR TITLE
Use 'dim' in the implementation of ReferenceCell member functions. Part 4: face_tangent_vector().

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -4165,100 +4165,89 @@ inline Tensor<1, dim>
 ReferenceCell<dim>::face_tangent_vector(const unsigned int face_no,
                                         const unsigned int i) const
 {
+  Assert(*this != ReferenceCells::Invalid<dim>, ExcNotImplemented());
   AssertIndexRange(face_no, n_faces());
-
-  // Simplify the 1d case by setting tangents (which are used for boundary
-  // forms and thus Jacobians) equal to the unit vector
-  if constexpr (dim == 1)
-    {
-      return Tensor<1, dim>{{1.0}};
-    }
-
   AssertIndexRange(i, dim - 1);
 
-  switch (this->kind)
+  if constexpr (dim == 0)
+    // 0d cells (vertices) have no faces
+    DEAL_II_ASSERT_UNREACHABLE();
+  else if constexpr (dim == 1)
+    // 1d cells (lines) have points as faces which have no
+    // tangent space
+    DEAL_II_ASSERT_UNREACHABLE();
+  else if constexpr (dim == 2)
     {
-      case ReferenceCells::Vertex:
-      case ReferenceCells::Line:
-      case ReferenceCells::Quadrilateral:
-      case ReferenceCells::Hexahedron:
-        AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
-        return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
-      case ReferenceCells::Triangle:
-        if constexpr (dim == 2)
-          {
-            AssertIndexRange(face_no, 3);
-            constexpr std::array<Tensor<1, dim>, 3> table = {
-              {Point<dim>(1, 0),
-               Point<dim>(-numbers::SQRT1_2, +numbers::SQRT1_2),
-               Point<dim>(0, -1)}};
+      switch (this->kind)
+        {
+          case ReferenceCells::Quadrilateral:
+            return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
+          case ReferenceCells::Triangle:
+            {
+              constexpr std::array<Tensor<1, dim>, 3> table = {
+                {Point<dim>(1, 0),
+                 Point<dim>(-numbers::SQRT1_2, +numbers::SQRT1_2),
+                 Point<dim>(0, -1)}};
 
-            return table[face_no];
-          }
-        else
-          DEAL_II_ASSERT_UNREACHABLE();
-      case ReferenceCells::Tetrahedron:
-        if constexpr (dim == 3)
-          {
-            AssertIndexRange(face_no, 4);
-            // We need std::pow(1.0/3.0, 0.25) in a constexpr context, but that
-            // function isn't constexpr yet so hard-code the value and assert
-            // that it is close
-            constexpr double third_r4 = 0.7598356856515925473311877;
-            Assert(std::abs((third_r4 * third_r4) * (third_r4 * third_r4) -
-                            1.0 / 3.0) < 1e-14,
-                   ExcInternalError());
-            constexpr ndarray<Tensor<1, dim>, 4, 2> table = {
-              {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-               {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
-               {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
-               {{Point<dim>(-third_r4, +third_r4, 0),
-                 Point<dim>(-third_r4, 0, +third_r4)}}}};
+              return table[face_no];
+            }
+        }
+    }
+  else if constexpr (dim == 3)
+    {
+      switch (this->kind)
+        {
+          case ReferenceCells::Hexahedron:
+            return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
+          case ReferenceCells::Tetrahedron:
+            {
+              // We need std::pow(1.0/3.0, 0.25) in a constexpr context, but
+              // that function isn't constexpr yet so hard-code the value and
+              // assert that it is close
+              constexpr double third_r4 = 0.7598356856515925473311877;
+              Assert(std::abs((third_r4 * third_r4) * (third_r4 * third_r4) -
+                              1.0 / 3.0) < 1e-14,
+                     ExcInternalError());
+              constexpr ndarray<Tensor<1, dim>, 4, 2> table = {
+                {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+                 {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
+                 {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
+                 {{Point<dim>(-third_r4, +third_r4, 0),
+                   Point<dim>(-third_r4, 0, +third_r4)}}}};
 
-            return table[face_no][i];
-          }
-        else
-          DEAL_II_ASSERT_UNREACHABLE();
-      case ReferenceCells::Pyramid:
-        if constexpr (dim == 3)
-          {
-            AssertIndexRange(face_no, 5);
-            constexpr ndarray<Tensor<1, dim>, 5, 2> table = {
-              {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-               {{Point<dim>(+numbers::SQRT1_2, 0, +numbers::SQRT1_2),
-                 Point<dim>(0, 1, 0)}},
-               {{Point<dim>(+numbers::SQRT1_2, 0, -numbers::SQRT1_2),
-                 Point<dim>(0, 1, 0)}},
-               {{Point<dim>(1, 0, 0),
-                 Point<dim>(0, +numbers::SQRT1_2, +numbers::SQRT1_2)}},
-               {{Point<dim>(1, 0, 0),
-                 Point<dim>(0, +numbers::SQRT1_2, -numbers::SQRT1_2)}}}};
+              return table[face_no][i];
+            }
+          case ReferenceCells::Pyramid:
+            {
+              constexpr ndarray<Tensor<1, dim>, 5, 2> table = {
+                {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+                 {{Point<dim>(+numbers::SQRT1_2, 0, +numbers::SQRT1_2),
+                   Point<dim>(0, 1, 0)}},
+                 {{Point<dim>(+numbers::SQRT1_2, 0, -numbers::SQRT1_2),
+                   Point<dim>(0, 1, 0)}},
+                 {{Point<dim>(1, 0, 0),
+                   Point<dim>(0, +numbers::SQRT1_2, +numbers::SQRT1_2)}},
+                 {{Point<dim>(1, 0, 0),
+                   Point<dim>(0, +numbers::SQRT1_2, -numbers::SQRT1_2)}}}};
 
-            return table[face_no][i];
-          }
-        else
-          DEAL_II_ASSERT_UNREACHABLE();
-      case ReferenceCells::Wedge:
-        if constexpr (dim == 3)
-          {
-            AssertIndexRange(face_no, 5);
-            constexpr ndarray<Tensor<1, dim>, 5, 2> table = {
-              {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-               {{Point<dim>(1, 0, 0), Point<dim>(0, 1, 0)}},
-               {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
-               {{Point<dim>(-numbers::SQRT1_2, +numbers::SQRT1_2, 0),
-                 Point<dim>(0, 0, 1)}},
-               {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}}}};
+              return table[face_no][i];
+            }
+          case ReferenceCells::Wedge:
+            {
+              constexpr ndarray<Tensor<1, dim>, 5, 2> table = {
+                {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+                 {{Point<dim>(1, 0, 0), Point<dim>(0, 1, 0)}},
+                 {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
+                 {{Point<dim>(-numbers::SQRT1_2, +numbers::SQRT1_2, 0),
+                   Point<dim>(0, 0, 1)}},
+                 {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}}}};
 
-            return table[face_no][i];
-          }
-        else
-          DEAL_II_ASSERT_UNREACHABLE();
-      default:
-        DEAL_II_NOT_IMPLEMENTED();
+              return table[face_no][i];
+            }
+        }
     }
 
-
+  DEAL_II_NOT_IMPLEMENTED();
   return {};
 }
 


### PR DESCRIPTION
This follows  #20116 and #20179 and #20186. It addresses the point raised in #20185: `ReferenceCell::face_tangent_vector()` out of *convenience* returns something in 1d when I think it should not because there is no meaningful way to define a tangent vector to the face (vertex) of a 1d cell (line). This patch does the same `if constexpr` transformations as  #20116 and #20179 and #20186 *and also* changes the 1d case to error out.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
