### PR TITLE
Add cell type optimizations for affine/Cartesian cells to Portable::MatrixFree and Portable::FEEvaluation

### DIFF
--- a/include/deal.II/matrix_free/portable_fe_evaluation.h
+++ b/include/deal.II/matrix_free/portable_fe_evaluation.h
@@ -287,6 +287,52 @@ namespace Portable
     const typename MatrixFree<dim, Number>::PrecomputedData *precomputed_data;
     SharedData<dim, Number>                                 *shared_data;
     int                                                      cell_id;
+
+
+    /**
+     * Geometry classification of the current cell, loaded once at
+     * construction so that the per-quadrature-point accessors do not read it
+     * from global memory repeatedly.
+     */
+    ::dealii::internal::MatrixFreeFunctions::GeometryType cell_type;
+
+    /**
+     * Index of the first entry of the current cell in the compressed
+     * inv_jacobian and JxW storage, loaded once at construction.
+     */
+    unsigned int mapping_data_offset;
+
+    /**
+     * For Cartesian and affine cells, the (constant) Jacobian determinant of
+     * the current cell, loaded once at construction; JxW values are
+     * reconstructed as cell_determinant * q_weights(q_point).
+     */
+    Number cell_determinant;
+
+    /**
+     * Return the index of the given quadrature point of the current cell in
+     * the compressed inv_jacobian storage.
+     */
+    DEAL_II_HOST_DEVICE unsigned int
+    inv_jacobian_index(const int q_point) const
+    {
+      return mapping_data_offset +
+             ((cell_type == ::dealii::internal::MatrixFreeFunctions::general) ?
+                q_point :
+                0);
+    }
+
+    /**
+     * Return the mapped quadrature weight (JxW) at the given quadrature
+     * point of the current cell.
+     */
+    DEAL_II_HOST_DEVICE Number
+    JxW_value(const int q_point) const
+    {
+      return (cell_type == ::dealii::internal::MatrixFreeFunctions::general) ?
+               precomputed_data->JxW(mapping_data_offset + q_point) :
+               cell_determinant * precomputed_data->q_weights(q_point);
+    }
   };
 
 
@@ -304,6 +350,13 @@ namespace Portable
     , precomputed_data(&data->precomputed_data[dof_handler_index])
     , shared_data(&data->shared_data[dof_handler_index])
     , cell_id(data->team_member.league_rank())
+    , cell_type(precomputed_data->cell_type(cell_id))
+    , mapping_data_offset(precomputed_data->data_index_offsets(cell_id))
+    , cell_determinant(
+        (cell_type != ::dealii::internal::MatrixFreeFunctions::general &&
+         precomputed_data->JxW.size() > 0) ?
+          precomputed_data->JxW(mapping_data_offset) :
+          Number())
   {
     AssertIndexRange(dof_handler_index, data->n_dof_handler);
 
@@ -601,16 +654,15 @@ namespace Portable
     AssertIndexRange(q_point, n_q_points);
     Assert(precomputed_data->JxW.size() > 0,
            ExcMessage("submit_value() requires precomputed JxW"));
+    const Number JxW = JxW_value(q_point);
     if constexpr (n_components_ == 1)
       {
-        shared_data->values(q_point, 0) =
-          value * precomputed_data->JxW(q_point, cell_id);
+        shared_data->values(q_point, 0) = value * JxW;
       }
     else
       {
         for (unsigned int c = 0; c < n_components; ++c)
-          shared_data->values(q_point, c) =
-            value[c] * precomputed_data->JxW(q_point, cell_id);
+          shared_data->values(q_point, c) = value[c] * JxW;
       }
   }
 
@@ -657,15 +709,31 @@ namespace Portable
            ExcMessage("get_gradient() requires precomputed inv_jacobian"));
     gradient_type grad;
 
-    if constexpr (n_components_ == 1)
+    const unsigned int inv_jac_idx = inv_jacobian_index(q_point);
+    if (cell_type == ::dealii::internal::MatrixFreeFunctions::cartesian)
+      {
+        if constexpr (n_components_ == 1)
+          {
+            for (unsigned int d = 0; d < dim; ++d)
+              grad[d] = precomputed_data->inv_jacobian(inv_jac_idx, d, d) *
+                        shared_data->gradients(q_point, d, 0);
+          }
+        else
+          {
+            for (unsigned int c = 0; c < n_components; ++c)
+              for (unsigned int d = 0; d < dim; ++d)
+                grad[c][d] = precomputed_data->inv_jacobian(inv_jac_idx, d, d) *
+                             shared_data->gradients(q_point, d, c);
+          }
+      }
+    else if constexpr (n_components_ == 1)
       {
         for (unsigned int d_1 = 0; d_1 < dim; ++d_1)
           {
             Number tmp = 0.;
             for (unsigned int d_2 = 0; d_2 < dim; ++d_2)
-              tmp +=
-                precomputed_data->inv_jacobian(q_point, cell_id, d_2, d_1) *
-                shared_data->gradients(q_point, d_2, 0);
+              tmp += precomputed_data->inv_jacobian(inv_jac_idx, d_2, d_1) *
+                     shared_data->gradients(q_point, d_2, 0);
             grad[d_1] = tmp;
           }
       }
@@ -676,9 +744,8 @@ namespace Portable
             {
               Number tmp = 0.;
               for (unsigned int d_2 = 0; d_2 < dim; ++d_2)
-                tmp +=
-                  precomputed_data->inv_jacobian(q_point, cell_id, d_2, d_1) *
-                  shared_data->gradients(q_point, d_2, c);
+                tmp += precomputed_data->inv_jacobian(inv_jac_idx, d_2, d_1) *
+                       shared_data->gradients(q_point, d_2, c);
               grad[c][d_1] = tmp;
             }
       }
@@ -703,17 +770,35 @@ namespace Portable
     Assert(precomputed_data->JxW.size() > 0,
            ExcMessage("submit_gradient() requires precomputed JxW"));
 
-    if constexpr (n_components_ == 1)
+    const unsigned int inv_jac_idx = inv_jacobian_index(q_point);
+    const Number       JxW         = JxW_value(q_point);
+    if (cell_type == ::dealii::internal::MatrixFreeFunctions::cartesian)
+      {
+        if constexpr (n_components_ == 1)
+          {
+            for (unsigned int d = 0; d < dim; ++d)
+              shared_data->gradients(q_point, d, 0) =
+                precomputed_data->inv_jacobian(inv_jac_idx, d, d) *
+                gradient[d] * JxW;
+          }
+        else
+          {
+            for (unsigned int c = 0; c < n_components; ++c)
+              for (unsigned int d = 0; d < dim; ++d)
+                shared_data->gradients(q_point, d, c) =
+                  precomputed_data->inv_jacobian(inv_jac_idx, d, d) *
+                  gradient[c][d] * JxW;
+          }
+      }
+    else if constexpr (n_components_ == 1)
       {
         for (unsigned int d_1 = 0; d_1 < dim; ++d_1)
           {
             Number tmp = 0.;
             for (unsigned int d_2 = 0; d_2 < dim; ++d_2)
-              tmp +=
-                precomputed_data->inv_jacobian(q_point, cell_id, d_1, d_2) *
-                gradient[d_2];
-            shared_data->gradients(q_point, d_1, 0) =
-              tmp * precomputed_data->JxW(q_point, cell_id);
+              tmp += precomputed_data->inv_jacobian(inv_jac_idx, d_1, d_2) *
+                     gradient[d_2];
+            shared_data->gradients(q_point, d_1, 0) = tmp * JxW;
           }
       }
     else
@@ -723,11 +808,9 @@ namespace Portable
             {
               Number tmp = 0.;
               for (unsigned int d_2 = 0; d_2 < dim; ++d_2)
-                tmp +=
-                  precomputed_data->inv_jacobian(q_point, cell_id, d_1, d_2) *
-                  gradient[c][d_2];
-              shared_data->gradients(q_point, d_1, c) =
-                tmp * precomputed_data->JxW(q_point, cell_id);
+                tmp += precomputed_data->inv_jacobian(inv_jac_idx, d_1, d_2) *
+                       gradient[c][d_2];
+              shared_data->gradients(q_point, d_1, c) = tmp * JxW;
             }
       }
   }
@@ -771,10 +854,11 @@ namespace Portable
     Assert(precomputed_data->inv_jacobian.size() > 0,
            ExcMessage("get_divergence() requires precomputed inv_jacobian"));
 
-    Number divergence = 0.;
+    const unsigned int inv_jac_idx = inv_jacobian_index(q_point);
+    Number             divergence  = 0.;
     for (unsigned int c = 0; c < dim; ++c)
       for (unsigned int d = 0; d < dim; ++d)
-        divergence += precomputed_data->inv_jacobian(q_point, cell_id, d, c) *
+        divergence += precomputed_data->inv_jacobian(inv_jac_idx, d, c) *
                       shared_data->gradients(q_point, d, c);
     return divergence;
   }
@@ -800,11 +884,12 @@ namespace Portable
     Assert(precomputed_data->JxW.size() > 0,
            ExcMessage("submit_divergence() requires precomputed JxW"));
 
+    const unsigned int inv_jac_idx = inv_jacobian_index(q_point);
+    const Number       JxW         = JxW_value(q_point);
     for (unsigned int c = 0; c < dim; ++c)
       for (unsigned int d_1 = 0; d_1 < dim; ++d_1)
         shared_data->gradients(q_point, d_1, c) =
-          precomputed_data->inv_jacobian(q_point, cell_id, d_1, c) * div_in *
-          precomputed_data->JxW(q_point, cell_id);
+          precomputed_data->inv_jacobian(inv_jac_idx, d_1, c) * div_in * JxW;
   }
 
 
@@ -830,15 +915,16 @@ namespace Portable
     Assert(precomputed_data->JxW.size() > 0,
            ExcMessage("submit_symmetric_gradient() requires precomputed JxW"));
 
+    const unsigned int inv_jac_idx = inv_jacobian_index(q_point);
+    const Number       JxW         = JxW_value(q_point);
     for (unsigned int c = 0; c < dim; ++c)
       for (unsigned int d_1 = 0; d_1 < dim; ++d_1)
         {
           Number tmp = 0.;
           for (unsigned int d_2 = 0; d_2 < dim; ++d_2)
-            tmp += precomputed_data->inv_jacobian(q_point, cell_id, d_1, d_2) *
+            tmp += precomputed_data->inv_jacobian(inv_jac_idx, d_1, d_2) *
                    sym_grad[c][d_2];
-          shared_data->gradients(q_point, d_1, c) =
-            tmp * precomputed_data->JxW(q_point, cell_id);
+          shared_data->gradients(q_point, d_1, c) = tmp * JxW;
         }
   }
 

--- a/include/deal.II/matrix_free/portable_matrix_free.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.h
@@ -34,6 +34,7 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
+#include <deal.II/matrix_free/mapping_info_storage.h>
 #include <deal.II/matrix_free/shape_info.h>
 
 #include <Kokkos_Array.hpp>
@@ -288,15 +289,46 @@ namespace Portable
         local_to_global;
 
       /**
-       * Kokkos::View of the inverse Jacobian.
+       * Kokkos::View of the inverse Jacobian, stored in compressed form: for
+       * a cell classified as Cartesian or affine only a single inverse
+       * Jacobian is stored (at index data_index_offsets(cell)), while for a
+       * general cell one inverse Jacobian per quadrature point is stored
+       * (starting at index data_index_offsets(cell)).
        */
-      Kokkos::View<Number **[dim][dim], MemorySpace::Default::kokkos_space>
+      Kokkos::View<Number *[dim][dim], MemorySpace::Default::kokkos_space>
         inv_jacobian;
 
       /**
-       * Kokkos::View of the Jacobian times the weights.
+       * Kokkos::View of the determinant of the mapping Jacobian times
+       * quadrature weights, stored in compressed form: for a cell classified as
+       * Cartesian or affine only the (constant) Jacobian determinant is stored
+       * (at index data_index_offsets(cell)), which must be multiplied by the
+       * quadrature weight of the respective quadrature point to obtain JxW,
+       * while for a general cell the JxW values of all quadrature points are
+       * stored (starting at index data_index_offsets(cell)). Use JxW_value() to
+       * access the data.
        */
-      Kokkos::View<Number **, MemorySpace::Default::kokkos_space> JxW;
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space> JxW;
+
+      /**
+       * Geometric classification (Cartesian, affine, or general) of each cell.
+       */
+      Kokkos::View<::dealii::internal::MatrixFreeFunctions::GeometryType *,
+                   MemorySpace::Default::kokkos_space>
+        cell_type;
+
+      /**
+       * Index of the first entry of each cell within the compressed
+       * inv_jacobian and JxW storage.
+       */
+      Kokkos::View<unsigned int *, MemorySpace::Default::kokkos_space>
+        data_index_offsets;
+
+      /**
+       * Quadrature weights of the reference cell, used to compute JxW on
+       * Cartesian and affine cells from the stored Jacobian determinant.
+       */
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space> q_weights;
 
       /**
        * Mask deciding where constraints are set on a given cell.
@@ -365,6 +397,34 @@ namespace Portable
        * Size of the scratch pad for temporary storage in shared memory.
        */
       unsigned int scratch_pad_size;
+
+      /**
+       * Return the index into the compressed inv_jacobian storage for the
+       * given cell and quadrature point.
+       */
+      DEAL_II_HOST_DEVICE unsigned int
+      inv_jacobian_index(const int cell, const int q_point) const
+      {
+        return data_index_offsets(cell) +
+               ((cell_type(cell) ==
+                 ::dealii::internal::MatrixFreeFunctions::general) ?
+                  q_point :
+                  0);
+      }
+
+      /**
+       * Return the mapped JxW for the given cell and
+       * quadrature point, taking the compressed storage into account.
+       */
+      DEAL_II_HOST_DEVICE Number
+      JxW_value(const int cell, const int q_point) const
+      {
+        const unsigned int offset = data_index_offsets(cell);
+        return (cell_type(cell) ==
+                ::dealii::internal::MatrixFreeFunctions::general) ?
+                 JxW(offset + q_point) :
+                 JxW(offset) * q_weights(q_point);
+      }
     };
 
 
@@ -824,19 +884,42 @@ namespace Portable
         q_points;
 
       /**
-       * Vector of Kokkos::View of the inverse Jacobian associated with the
-       * cells of each color.
+       * Vector of Kokkos::View of the compressed (see PrecomputedData) inverse
+       * Jacobian associated with the cells of each color.
        */
       std::vector<
-        Kokkos::View<Number **[dim][dim], MemorySpace::Default::kokkos_space>>
+        Kokkos::View<Number *[dim][dim], MemorySpace::Default::kokkos_space>>
         inv_jacobian;
 
       /**
-       * Vector of Kokkos::View to the Jacobian times the weights associated
-       * with the cells of each color.
+       * Vector of Kokkos::View to the compressed (see PrecomputedData) Jacobian
+       * times the weights associated with the cells of each color.
        */
-      std::vector<Kokkos::View<Number **, MemorySpace::Default::kokkos_space>>
+      std::vector<Kokkos::View<Number *, MemorySpace::Default::kokkos_space>>
         JxW;
+
+      /**
+       * Vector of Kokkos::View to the geometry types associated with the cells
+       * of each color.
+       */
+      std::vector<
+        Kokkos::View<::dealii::internal::MatrixFreeFunctions::GeometryType *,
+                     MemorySpace::Default::kokkos_space>>
+        cell_type;
+
+      /**
+       * Vector of Kokkos::View to the corresponding index of the first entry
+       * for each cell within the compressed JxW and inv_jacobian storages for
+       * each color.
+       */
+      std::vector<
+        Kokkos::View<unsigned int *, MemorySpace::Default::kokkos_space>>
+        data_index_offsets;
+
+      /**
+       * Quadrature weights of the reference cell.
+       */
+      Kokkos::View<Number *, MemorySpace::Default::kokkos_space> q_weights;
     };
 
     /**
@@ -1079,18 +1162,43 @@ namespace Portable
       local_to_global;
 
     /**
-     * Kokkos::View of inverse Jacobians on the host.
+     * Kokkos::View of inverse Jacobians on the host in compressed (see
+     * PrecomputedData) form.
      */
-    typename Kokkos::View<Number **[dim][dim],
+    typename Kokkos::View<Number *[dim][dim],
                           MemorySpace::Default::kokkos_space>::host_mirror_type
       inv_jacobian;
 
     /**
-     * Kokkos::View of Jacobian times the weights on the host.
+     * Kokkos::View of Jacobian times the weights on the host in compressed (see
+     * PrecomputedData) form.
      */
-    typename Kokkos::View<Number **,
+    typename Kokkos::View<Number *,
                           MemorySpace::Default::kokkos_space>::host_mirror_type
       JxW;
+
+    /**
+     * Geometric classification (Cartesian, affine, or general) of each cell
+     * on the host.
+     */
+    typename Kokkos::View<
+      ::dealii::internal::MatrixFreeFunctions::GeometryType *,
+      MemorySpace::Default::kokkos_space>::host_mirror_type cell_type;
+
+    /**
+     * Index of the first entry of each cell within the compressed
+     * inv_jacobian and JxW storage on the host.
+     */
+    typename Kokkos::View<unsigned int *,
+                          MemorySpace::Default::kokkos_space>::host_mirror_type
+      data_index_offsets;
+
+    /**
+     * Quadrature weights of the reference cell on the host.
+     */
+    typename Kokkos::View<Number *,
+                          MemorySpace::Default::kokkos_space>::host_mirror_type
+      q_weights;
 
     /**
      * Number of cells.
@@ -1144,6 +1252,34 @@ namespace Portable
     {
       return q_points(q_point, cell);
     }
+
+    /**
+     * This function is the host version of
+     * PrecomputedData::inv_jacobian_index().
+     */
+    unsigned int
+    inv_jacobian_index(const unsigned int cell,
+                       const unsigned int q_point) const
+    {
+      return data_index_offsets(cell) +
+             ((cell_type(cell) ==
+               ::dealii::internal::MatrixFreeFunctions::general) ?
+                q_point :
+                0);
+    }
+
+    /**
+     * This function is the host version of PrecomputedData::JxW_value().
+     */
+    Number
+    JxW_value(const unsigned int cell, const unsigned int q_point) const
+    {
+      const unsigned int offset = data_index_offsets(cell);
+      return (cell_type(cell) ==
+              ::dealii::internal::MatrixFreeFunctions::general) ?
+               JxW(offset + q_point) :
+               JxW(offset) * q_weights(q_point);
+    }
   };
 
 
@@ -1168,29 +1304,56 @@ namespace Portable
     data_host.row_start      = data.row_start;
     data_host.use_coloring   = data.use_coloring;
 
+    const auto create_mirror_without_initializing = [](const auto &view) {
+#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
+      return Kokkos::create_mirror(Kokkos::WithoutInitializing, view);
+#else
+      return Kokkos::create_mirror(view);
+#endif
+    };
+
+    MemorySpace::Default::kokkos_space::execution_space exec;
+
     if (update_flags & update_quadrature_points)
       {
-        data_host.q_points = Kokkos::create_mirror(data.q_points);
-        Kokkos::deep_copy(data_host.q_points, data.q_points);
+        data_host.q_points = create_mirror_without_initializing(data.q_points);
+        Kokkos::deep_copy(exec, data_host.q_points, data.q_points);
       }
 
-    data_host.local_to_global = Kokkos::create_mirror(data.local_to_global);
-    Kokkos::deep_copy(data_host.local_to_global, data.local_to_global);
+    data_host.local_to_global =
+      create_mirror_without_initializing(data.local_to_global);
+    Kokkos::deep_copy(exec, data_host.local_to_global, data.local_to_global);
 
     if (update_flags & update_gradients)
       {
-        data_host.inv_jacobian = Kokkos::create_mirror(data.inv_jacobian);
-        Kokkos::deep_copy(data_host.inv_jacobian, data.inv_jacobian);
+        data_host.inv_jacobian =
+          create_mirror_without_initializing(data.inv_jacobian);
+        Kokkos::deep_copy(exec, data_host.inv_jacobian, data.inv_jacobian);
       }
 
     if (update_flags & update_JxW_values)
       {
-        data_host.JxW = Kokkos::create_mirror(data.JxW);
-        Kokkos::deep_copy(data_host.JxW, data.JxW);
+        data_host.JxW = create_mirror_without_initializing(data.JxW);
+        Kokkos::deep_copy(exec, data_host.JxW, data.JxW);
       }
 
-    data_host.constraint_mask = Kokkos::create_mirror(data.constraint_mask);
-    Kokkos::deep_copy(data_host.constraint_mask, data.constraint_mask);
+    data_host.cell_type = create_mirror_without_initializing(data.cell_type);
+    Kokkos::deep_copy(exec, data_host.cell_type, data.cell_type);
+
+    data_host.data_index_offsets =
+      create_mirror_without_initializing(data.data_index_offsets);
+    Kokkos::deep_copy(exec,
+                      data_host.data_index_offsets,
+                      data.data_index_offsets);
+
+    data_host.q_weights = create_mirror_without_initializing(data.q_weights);
+    Kokkos::deep_copy(exec, data_host.q_weights, data.q_weights);
+
+    data_host.constraint_mask =
+      create_mirror_without_initializing(data.constraint_mask);
+    Kokkos::deep_copy(exec, data_host.constraint_mask, data.constraint_mask);
+
+    exec.fence();
 
     return data_host;
   }

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -90,10 +90,83 @@ namespace Portable
       const unsigned int               q_points_per_cell;
       const UpdateFlags               &update_flags;
       const unsigned int               padding_length;
+      const double                     jacobian_size;
       dealii::internal::MatrixFreeFunctions::HangingNodes<dim> hanging_nodes;
     };
 
+    template <int dim>
+    double
+    get_jacobian_size(const dealii::Triangulation<dim> &tria)
+    {
+      if (tria.n_cells() == 0)
+        return 1.;
+      else
+        return tria.begin()->diameter();
+    }
 
+    template <int dim>
+    ::dealii::internal::MatrixFreeFunctions::GeometryType
+    classify_cell_geometry(const FEValues<dim> &fe_values,
+                           const unsigned int   q_points_per_cell,
+                           const double         jacobian_size)
+    {
+      const DerivativeForm<1, dim, dim> jac_0 = fe_values.jacobian(0);
+
+      // Check whether the Jacobian is constant across the quadrature
+      // points.
+      bool jacobian_constant = true;
+      for (unsigned int q = 1; q < q_points_per_cell; ++q)
+        {
+          const DerivativeForm<1, dim, dim> jac = fe_values.jacobian(q);
+          for (unsigned int d = 0; d < dim; ++d)
+            for (unsigned int e = 0; e < dim; ++e)
+              if (std::abs(jac_0[d][e] - jac[d][e]) > jacobian_size * 1e-12)
+                jacobian_constant = false;
+          if (jacobian_constant == false)
+            break;
+        }
+
+      // Check whether the Jacobian is diagonal to machine accuracy. A
+      // Cartesian cell additionally requires a constant Jacobian.
+      bool cell_cartesian = jacobian_constant;
+      for (unsigned int d = 0; d < dim && cell_cartesian; ++d)
+        for (unsigned int e = 0; e < dim; ++e)
+          if (d != e)
+            if (std::abs(jac_0[d][e]) > jacobian_size * 1e-12)
+              {
+                cell_cartesian = false;
+                break;
+              }
+
+      // With only a single quadrature point, a non-constant Jacobian
+      // cannot be detected by comparing quadrature points. In that case
+      // inspect the gradient of the Jacobian (second derivatives)
+      // instead.
+      if (cell_cartesian == false && q_points_per_cell == 1 &&
+          (fe_values.get_update_flags() & update_jacobian_grads))
+        {
+          const DerivativeForm<2, dim, dim> jacobian_grad =
+            fe_values.jacobian_grad(0);
+          for (unsigned int d = 0; d < dim; ++d)
+            for (unsigned int e = 0; e < dim; ++e)
+              for (unsigned int f = 0; f < dim; ++f)
+                {
+                  double jac_grad_comp = jac_0[f][0] * jacobian_grad[d][e][0];
+                  for (unsigned int g = 1; g < dim; ++g)
+                    jac_grad_comp += jac_0[f][g] * jacobian_grad[d][e][g];
+                  if (std::abs(jac_grad_comp) > jacobian_size * 1e-12)
+                    jacobian_constant = false;
+                }
+        }
+
+      // Return the cell type, defaulting to the more general classification.
+      if (cell_cartesian == true)
+        return dealii::internal::MatrixFreeFunctions::cartesian;
+      else if (jacobian_constant == true)
+        return dealii::internal::MatrixFreeFunctions::affine;
+      else
+        return dealii::internal::MatrixFreeFunctions::general;
+    }
 
     template <int dim, typename Number>
     ReinitHelper<dim, Number>::ReinitHelper(
@@ -122,6 +195,7 @@ namespace Portable
       , q_points_per_cell(data->q_points_per_cell)
       , update_flags(update_flags)
       , padding_length(data->get_padding_length())
+      , jacobian_size(get_jacobian_size(dof_handler.get_triangulation()))
       , hanging_nodes(dof_handler.get_triangulation())
     {
       fe_values.always_allow_check_for_cell_similarity(true);
@@ -158,6 +232,110 @@ namespace Portable
       typename MatrixFree<dim, Number>::MappingInfo &mapping_info =
         data->mapping_info[0];
 
+      struct ScratchData
+      {
+        FEValues<dim>                        fe_values;
+        std::vector<types::global_dof_index> local_dof_indices;
+        std::vector<types::global_dof_index> lexicographic_dof_indices;
+
+        explicit ScratchData(const FEValues<dim> &fe_values)
+          : fe_values(fe_values.get_mapping(),
+                      fe_values.get_fe(),
+                      fe_values.get_quadrature(),
+                      fe_values.get_update_flags())
+          , local_dof_indices(fe_values.dofs_per_cell)
+          , lexicographic_dof_indices(fe_values.dofs_per_cell)
+        {}
+
+
+        ScratchData(const ScratchData &scratch)
+          : fe_values(scratch.fe_values.get_mapping(),
+                      scratch.fe_values.get_fe(),
+                      scratch.fe_values.get_quadrature(),
+                      scratch.fe_values.get_update_flags())
+          , local_dof_indices(scratch.local_dof_indices.size())
+          , lexicographic_dof_indices(scratch.lexicographic_dof_indices.size())
+        {}
+      };
+
+      // Classify the geometry of all cells. We need to know this before we
+      // create the compressed JxW and inv_jacobian views.
+      typename std::remove_reference_t<
+        decltype(mapping_info.cell_type[color])>::host_mirror_type
+        cell_type_host;
+      typename std::remove_reference_t<
+        decltype(mapping_info.data_index_offsets[color])>::host_mirror_type
+                   data_index_offsets_host;
+      unsigned int n_mapping_entries = 0;
+
+      if (dof_handler_index == 0)
+        {
+          mapping_info.cell_type[color] = Kokkos::View<
+            ::dealii::internal::MatrixFreeFunctions::GeometryType *,
+            MemorySpace::Default::kokkos_space>(
+            Kokkos::view_alloc("cell_type_" + std::to_string(color),
+                               Kokkos::WithoutInitializing),
+            n_cells);
+          mapping_info.data_index_offsets[color] =
+            Kokkos::View<unsigned int *, MemorySpace::Default::kokkos_space>(
+              Kokkos::view_alloc("data_index_offsets_" + std::to_string(color),
+                                 Kokkos::WithoutInitializing),
+              n_cells);
+#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
+          cell_type_host =
+            Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
+                                       mapping_info.cell_type[color]);
+          data_index_offsets_host =
+            Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
+                                       mapping_info.data_index_offsets[color]);
+#else
+          cell_type_host =
+            Kokkos::create_mirror_view(mapping_info.cell_type[color]);
+          data_index_offsets_host =
+            Kokkos::create_mirror_view(mapping_info.data_index_offsets[color]);
+#endif
+
+          auto classification_worker = [&](const unsigned int cell_id,
+                                           ScratchData       &scratch_data,
+                                           int & /*copy_data*/) {
+            const auto &triacell = graph[cell_id];
+            typename Triangulation<dim>::cell_iterator cell(
+              &(dof_data.dof_handler->get_triangulation()),
+              triacell->level(),
+              triacell->index());
+
+            scratch_data.fe_values.reinit(cell);
+            cell_type_host(cell_id) =
+              classify_cell_geometry(scratch_data.fe_values,
+                                     q_points_per_cell,
+                                     jacobian_size);
+          };
+
+          FEValues<dim> fe_values_classify(fe_values.get_mapping(),
+                                           fe_values.get_fe(),
+                                           fe_values.get_quadrature(),
+                                           update_jacobians |
+                                             (q_points_per_cell == 1 ?
+                                                update_jacobian_grads :
+                                                update_default));
+
+          WorkStream::run(0,
+                          graph.size(),
+                          classification_worker,
+                          std::function<void(const int)>(),
+                          ScratchData(fe_values_classify),
+                          0);
+
+          for (unsigned int cell = 0; cell < n_cells; ++cell)
+            {
+              data_index_offsets_host(cell) = n_mapping_entries;
+              n_mapping_entries +=
+                (cell_type_host(cell) ==
+                 dealii::internal::MatrixFreeFunctions::general) ?
+                  q_points_per_cell :
+                  1;
+            }
+        }
 
 
       // Create the Views
@@ -180,19 +358,17 @@ namespace Portable
 
       if ((update_flags & update_JxW_values) && dof_handler_index == 0)
         mapping_info.JxW[color] =
-          Kokkos::View<Number **, MemorySpace::Default::kokkos_space>(
+          Kokkos::View<Number *, MemorySpace::Default::kokkos_space>(
             Kokkos::view_alloc("JxW_" + std::to_string(color),
                                Kokkos::WithoutInitializing),
-            q_points_per_cell,
-            n_cells);
+            n_mapping_entries);
 
       if ((update_flags & update_gradients) && dof_handler_index == 0)
         mapping_info.inv_jacobian[color] =
-          Kokkos::View<Number **[dim][dim], MemorySpace::Default::kokkos_space>(
+          Kokkos::View<Number *[dim][dim], MemorySpace::Default::kokkos_space>(
             Kokkos::view_alloc("inv_jacobian_" + std::to_string(color),
                                Kokkos::WithoutInitializing),
-            q_points_per_cell,
-            n_cells);
+            n_mapping_entries);
 
       // Initialize to zero, i.e., unconstrained cell
       dof_data.constraint_mask[color] =
@@ -238,31 +414,7 @@ namespace Portable
         inv_jacobian_host =
           Kokkos::create_mirror_view(mapping_info.inv_jacobian[color]);
 #endif
-      struct ScratchData
-      {
-        FEValues<dim>                        fe_values;
-        std::vector<types::global_dof_index> local_dof_indices;
-        std::vector<types::global_dof_index> lexicographic_dof_indices;
-
-        explicit ScratchData(const FEValues<dim> &fe_values)
-          : fe_values(fe_values.get_mapping(),
-                      fe_values.get_fe(),
-                      fe_values.get_quadrature(),
-                      fe_values.get_update_flags())
-          , local_dof_indices(fe_values.dofs_per_cell)
-          , lexicographic_dof_indices(fe_values.dofs_per_cell)
-        {}
-
-
-        ScratchData(const ScratchData &scratch)
-          : fe_values(scratch.fe_values.get_mapping(),
-                      scratch.fe_values.get_fe(),
-                      scratch.fe_values.get_quadrature(),
-                      scratch.fe_values.get_update_flags())
-          , local_dof_indices(scratch.local_dof_indices.size())
-          , lexicographic_dof_indices(scratch.lexicographic_dof_indices.size())
-        {}
-      };
+      const double first_q_weight = fe_values.get_quadrature().get_weights()[0];
 
       auto worker = [&](const unsigned int cell_id,
                         ScratchData       &scratch_data,
@@ -323,16 +475,30 @@ namespace Portable
 
         if ((update_flags & update_JxW_values) && dof_handler_index == 0)
           {
-            for (unsigned int i = 0; i < q_points_per_cell; ++i)
-              JxW_host(i, cell_id) = fe_values.JxW(i);
+            const unsigned int offset = data_index_offsets_host(cell_id);
+            if (cell_type_host(cell_id) ==
+                dealii::internal::MatrixFreeFunctions::general)
+              for (unsigned int i = 0; i < q_points_per_cell; ++i)
+                JxW_host(offset + i) = fe_values.JxW(i);
+            else
+              // For Cartesian and affine cells store the Jacobian
+              // determinant; JxW is recovered by multiplying with the
+              // quadrature weight of the respective quadrature point.
+              JxW_host(offset) = fe_values.JxW(0) / first_q_weight;
           }
 
         if ((update_flags & update_gradients) && dof_handler_index == 0)
           {
-            for (unsigned int i = 0; i < q_points_per_cell; ++i)
+            const unsigned int offset = data_index_offsets_host(cell_id);
+            const unsigned int n_stored_q_points =
+              (cell_type_host(cell_id) ==
+               dealii::internal::MatrixFreeFunctions::general) ?
+                q_points_per_cell :
+                1;
+            for (unsigned int i = 0; i < n_stored_q_points; ++i)
               for (unsigned int d = 0; d < dim; ++d)
                 for (unsigned int e = 0; e < dim; ++e)
-                  inv_jacobian_host(i, cell_id, d, e) =
+                  inv_jacobian_host(offset + i, d, e) =
                     fe_values.inverse_jacobian(i)[d][e];
           }
       };
@@ -362,6 +528,15 @@ namespace Portable
         Kokkos::deep_copy(exec_space,
                           mapping_info.inv_jacobian[color],
                           inv_jacobian_host);
+      if (dof_handler_index == 0)
+        {
+          Kokkos::deep_copy(exec_space,
+                            mapping_info.cell_type[color],
+                            cell_type_host);
+          Kokkos::deep_copy(exec_space,
+                            mapping_info.data_index_offsets[color],
+                            data_index_offsets_host);
+        }
     }
 
 
@@ -685,6 +860,12 @@ namespace Portable
       data_copy.inv_jacobian = mapping_info[mapping_index].inv_jacobian[color];
     if (mapping_info[mapping_index].JxW.size() > 0)
       data_copy.JxW = mapping_info[mapping_index].JxW[color];
+    if (mapping_info[mapping_index].cell_type.size() > 0)
+      data_copy.cell_type = mapping_info[mapping_index].cell_type[color];
+    if (mapping_info[mapping_index].data_index_offsets.size() > 0)
+      data_copy.data_index_offsets =
+        mapping_info[mapping_index].data_index_offsets[color];
+    data_copy.q_weights = mapping_info[mapping_index].q_weights;
 
     data_copy.local_to_global    = data.local_to_global[color];
     data_copy.constraint_mask    = data.constraint_mask[color];
@@ -946,12 +1127,22 @@ namespace Portable
                         MemoryConsumption::memory_consumption(level_graph);
 
     for (const auto &mapping_info : mapping_info)
-      for (unsigned int color = 0; color < n_colors; ++color)
-        {
-          bytes += mem(mapping_info.q_points[color]) +
-                   mem(mapping_info.inv_jacobian[color]) +
-                   mem(mapping_info.JxW[color]);
-        }
+      {
+        // The per-color vectors are only resized when the corresponding
+        // update flag was requested; guard against indexing empty vectors.
+        for (unsigned int color = 0; color < n_colors; ++color)
+          {
+            if (mapping_info.q_points.size() > 0)
+              bytes += mem(mapping_info.q_points[color]);
+            if (mapping_info.inv_jacobian.size() > 0)
+              bytes += mem(mapping_info.inv_jacobian[color]);
+            if (mapping_info.JxW.size() > 0)
+              bytes += mem(mapping_info.JxW[color]);
+            bytes += mem(mapping_info.cell_type[color]) +
+                     mem(mapping_info.data_index_offsets[color]);
+          }
+        bytes += mem(mapping_info.q_weights);
+      }
 
     for (const DoFInfo &pdhd : dof_handler_data)
       {
@@ -1202,6 +1393,25 @@ namespace Portable
         mapping_info[0].JxW.resize(n_colors);
       if (update_flags & update_gradients)
         mapping_info[0].inv_jacobian.resize(n_colors);
+      mapping_info[0].cell_type.resize(n_colors);
+      mapping_info[0].data_index_offsets.resize(n_colors);
+
+      // Quadrature weights of the reference cell, needed on the device to
+      // compute JxW from the Jacobian determinant stored for Cartesian and
+      // affine cells.
+      {
+        const Quadrature<dim>      quad_dim(quad);
+        const std::vector<double> &weights = quad_dim.get_weights();
+        mapping_info[0].q_weights =
+          Kokkos::View<Number *, MemorySpace::Default::kokkos_space>(
+            Kokkos::view_alloc("q_weights", Kokkos::WithoutInitializing),
+            weights.size());
+        auto q_weights_host =
+          Kokkos::create_mirror_view(mapping_info[0].q_weights);
+        for (unsigned int q = 0; q < weights.size(); ++q)
+          q_weights_host(q) = weights[q];
+        Kokkos::deep_copy(mapping_info[0].q_weights, q_weights_host);
+      }
     }
 
 

--- a/tests/matrix_free_kokkos/cell_classification_01.cc
+++ b/tests/matrix_free_kokkos/cell_classification_01.cc
@@ -1,0 +1,200 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Test the geometry classification of cells (Cartesian, affine, general) in
+// Portable::MatrixFree and the consistency of the associated compressed
+// mapping-data storage.
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+
+#include <deal.II/matrix_free/portable_matrix_free.h>
+
+#include "../tests.h"
+
+#include "Kokkos_Core.hpp"
+
+
+template <int dim, int fe_degree>
+void
+test(const Triangulation<dim> &tria, const std::string &mesh_name)
+{
+  const MappingQ1<dim> mapping;
+  const FE_Q<dim>      fe(fe_degree);
+  DoFHandler<dim>      dof_handler(tria);
+  dof_handler.distribute_dofs(fe);
+
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  Portable::MatrixFree<dim, double>                          mf_data;
+  typename Portable::MatrixFree<dim, double>::AdditionalData additional_data;
+  additional_data.mapping_update_flags =
+    update_values | update_gradients | update_JxW_values;
+  mf_data.reinit(mapping,
+                 dof_handler,
+                 constraints,
+                 QGauss<1>(fe_degree + 1),
+                 additional_data);
+
+  const QGauss<dim>  quadrature(fe_degree + 1);
+  const unsigned int n_q_points_per_cell = quadrature.size();
+  FEValues<dim>      fe_values(mapping, fe, quadrature, update_JxW_values);
+
+  unsigned int n_cartesian = 0;
+  unsigned int n_affine    = 0;
+  unsigned int n_general   = 0;
+
+  const auto        &graph    = mf_data.get_colored_graph();
+  const unsigned int n_colors = graph.size();
+  for (unsigned int color = 0; color < n_colors; ++color)
+    {
+      const typename Portable::MatrixFree<dim, double>::PrecomputedData
+                 gpu_data  = mf_data.get_data(color);
+      const auto host_data = Portable::copy_mf_data_to_host<dim, double>(
+        gpu_data, additional_data.mapping_update_flags);
+
+      unsigned int expected_offset = 0;
+      for (unsigned int cell = 0; cell < host_data.n_cells; ++cell)
+        {
+          // The data index offsets must match those generated from the process
+          // below.
+          AssertThrow(host_data.data_index_offsets(cell) == expected_offset,
+                      ExcInternalError());
+
+          const auto cell_type = host_data.cell_type(cell);
+          if (cell_type == dealii::internal::MatrixFreeFunctions::cartesian)
+            {
+              ++n_cartesian;
+              expected_offset += 1;
+            }
+          else if (cell_type == dealii::internal::MatrixFreeFunctions::affine)
+            {
+              ++n_affine;
+              expected_offset += 1;
+            }
+          else if (cell_type == dealii::internal::MatrixFreeFunctions::general)
+            {
+              ++n_general;
+              expected_offset += n_q_points_per_cell;
+            }
+          else
+            DEAL_II_ASSERT_UNREACHABLE();
+
+          // The JxW values reconstructed from the compressed storage must
+          // match the ones computed by FEValues on the same cell.
+          fe_values.reinit(graph[color][cell]);
+          for (unsigned int q = 0; q < n_q_points_per_cell; ++q)
+            AssertThrow(std::abs(host_data.JxW_value(cell, q) -
+                                 fe_values.JxW(q)) <
+                          1e-12 * std::abs(fe_values.JxW(q)) + 1e-30,
+                        ExcInternalError());
+        }
+
+      // The compressed storage must have exactly the size determined by the
+      // cell types.
+      AssertThrow(host_data.JxW.extent(0) == expected_offset,
+                  ExcInternalError());
+      AssertThrow(host_data.inv_jacobian.extent(0) == expected_offset,
+                  ExcInternalError());
+    }
+
+  // All cells must be classified into one of the three types.
+  AssertThrow(n_cartesian + n_affine + n_general == tria.n_active_cells(),
+              ExcInternalError());
+
+  // The cells should be classified in the predicted pattern.
+  deallog << mesh_name << ": cartesian=" << n_cartesian
+          << " affine=" << n_affine << " general=" << n_general << std::endl;
+}
+
+
+template <int dim, int fe_degree>
+void
+run()
+{
+  deallog << "dim=" << dim << " degree=" << fe_degree << std::endl;
+
+  // All cells are Cartesian.
+  {
+    Triangulation<dim> tria;
+    GridGenerator::hyper_cube(tria);
+    tria.refine_global(4 - dim);
+    test<dim, fe_degree>(tria, "hyper_cube");
+  }
+
+  // All cells are affine.
+  {
+    Triangulation<dim> tria;
+    GridGenerator::hyper_cube(tria);
+    tria.refine_global(4 - dim);
+    GridTools::transform(
+      [](const Point<dim> &p) {
+        Point<dim> q = p;
+        q[0] += 0.5 * p[dim - 1];
+        return q;
+      },
+      tria);
+    test<dim, fe_degree>(tria, "sheared");
+  }
+
+  // All cells are general.
+  {
+    Triangulation<dim> tria;
+    GridGenerator::hyper_cube(tria);
+    tria.refine_global(4 - dim);
+    GridTools::transform(
+      [](const Point<dim> &p) {
+        Point<dim> q = p;
+        q[0] += 0.1 * p[0] * p[dim - 1];
+        return q;
+      },
+      tria);
+    test<dim, fe_degree>(tria, "warped");
+  }
+
+  // Ball: Cartesian center cell, curved general cells at the boundary
+  {
+    Triangulation<dim> tria;
+    GridGenerator::hyper_ball(tria);
+    test<dim, fe_degree>(tria, "hyper_ball");
+  }
+}
+
+
+int
+main()
+{
+  initlog();
+  Kokkos::initialize();
+
+  run<2, 1>();
+  run<2, 2>();
+  run<3, 1>();
+  run<3, 2>();
+
+  deallog << "OK" << std::endl;
+  Kokkos::finalize();
+  return 0;
+}

--- a/tests/matrix_free_kokkos/cell_classification_01.output
+++ b/tests/matrix_free_kokkos/cell_classification_01.output
@@ -1,0 +1,22 @@
+
+DEAL::dim=2 degree=1
+DEAL::hyper_cube: cartesian=16 affine=0 general=0
+DEAL::sheared: cartesian=0 affine=16 general=0
+DEAL::warped: cartesian=0 affine=0 general=16
+DEAL::hyper_ball: cartesian=1 affine=0 general=4
+DEAL::dim=2 degree=2
+DEAL::hyper_cube: cartesian=16 affine=0 general=0
+DEAL::sheared: cartesian=0 affine=16 general=0
+DEAL::warped: cartesian=0 affine=0 general=16
+DEAL::hyper_ball: cartesian=1 affine=0 general=4
+DEAL::dim=3 degree=1
+DEAL::hyper_cube: cartesian=8 affine=0 general=0
+DEAL::sheared: cartesian=0 affine=8 general=0
+DEAL::warped: cartesian=0 affine=0 general=8
+DEAL::hyper_ball: cartesian=1 affine=0 general=6
+DEAL::dim=3 degree=2
+DEAL::hyper_cube: cartesian=8 affine=0 general=0
+DEAL::sheared: cartesian=0 affine=8 general=0
+DEAL::warped: cartesian=0 affine=0 general=8
+DEAL::hyper_ball: cartesian=1 affine=0 general=6
+DEAL::OK


### PR DESCRIPTION
This PR changes the JxW and inv_jacobian to a compressed row storage format based on cell type and includes changes and optimizations to the Portable::FEEvaluation to take advantage of this new format.

On my device on step-104 this configuration beat the current configuration in speed at every testing fe degree (Q1-Q6) and {0,0.25,0.5,0.75,1} fraction Cartesian with only a single case of regression of 1% in the worst case scenario (fully general mesh at Q3). Best results were a 11% speedup.

The real savings here are in terms of memory. At Q1 with a fully Cartesian mesh total MatrixFree memory dropped by 51% and in the Q6 case by 62%. The worst case memory increase (in the case of a fully general mesh) was 5%. In general, if even a small fraction of the mesh is Cartesian, memory will be saved.

The next logical step to take advantage of the lessened memory would be to batch process cells, but I see that is already on the cards in #20160. Further reading that issue, these changes might step on the toes of the optimizations already made there, so @iprusak I would appreciate you giving this a lookover to screen for compatibility or let me know if similar optimizations already exist in your framework.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
