### PR TITLE
TpetraWrappers::Vector: implement lp_norm()

### DIFF
--- a/doc/news/changes/minor/20260831AlvaroBorras
+++ b/doc/news/changes/minor/20260831AlvaroBorras
@@ -1,0 +1,5 @@
+Added: LinearAlgebra::TpetraWrappers::Vector now provides the lp_norm()
+function, bringing it in line with the other distributed vector
+implementations.
+<br>
+(Álvaro Borrás, 2026/08/31)

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -754,6 +754,13 @@ namespace LinearAlgebra
       l2_norm() const;
 
       /**
+       * $l_p$-norm of the vector. The pth root of the sum of the pth powers of
+       * the absolute values of the elements.
+       */
+      real_type
+      lp_norm(const real_type p) const;
+
+      /**
        * Return the maximum norm of the vector (i.e., the maximum absolute value
        * among all entries and among all processors).
        */

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -1216,6 +1216,32 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpace>
     typename Vector<Number, MemorySpace>::real_type
+    Vector<Number, MemorySpace>::lp_norm(const real_type p) const
+    {
+      if (p == 1.)
+        return l1_norm();
+      else if (p == 2.)
+        return l2_norm();
+
+      Assert(!has_ghost_elements(), ExcGhostsPresent());
+
+      vector_1d_view.reset();
+      const auto local_view = vector->template getLocalView<Kokkos::HostSpace>(
+        Tpetra::Access::ReadOnlyStruct{});
+
+      using std::abs;
+      real_type local_sum = 0.;
+      for (size_type i = 0; i < vector->getLocalLength(); ++i)
+        local_sum += std::pow(abs(local_view(i, 0)), p);
+
+      return std::pow(Utilities::MPI::sum(local_sum, get_mpi_communicator()),
+                      static_cast<real_type>(1. / p));
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    typename Vector<Number, MemorySpace>::real_type
     Vector<Number, MemorySpace>::linfty_norm() const
     {
       Assert(!has_ghost_elements(), ExcGhostsPresent());

--- a/tests/trilinos/tpetra_vector_02.cc
+++ b/tests/trilinos/tpetra_vector_02.cc
@@ -15,6 +15,7 @@
 
 #include <deal.II/lac/read_write_vector.h>
 #include <deal.II/lac/trilinos_tpetra_vector.h>
+#include <deal.II/lac/vector.h>
 
 #include <iostream>
 #include <vector>
@@ -201,6 +202,23 @@ test()
   a.import_elements(read_write_1, VectorOperation::insert);
   const Number val = a.add_and_dot(2., a, b);
   AssertThrow(val == Number(1530.), ExcMessage("Problem in add_and_dot"));
+
+  Vector<Number> reference(a.size());
+  for (unsigned int i = 0; i < reference.size(); ++i)
+    {
+      reference[i] = i % 2 == 0 ? Number(i + 1) : -Number(i + 1);
+      if (read_write_index_set.is_element(i))
+        read_write_1[i] = reference[i];
+    }
+  a.import_elements(read_write_1, VectorOperation::insert);
+
+  for (const double p : {1., 2., 3., 4., 2.5})
+    {
+      const double reference_norm = reference.lp_norm(p);
+      AssertThrow(std::fabs(a.lp_norm(p) - reference_norm) <
+                    eps * reference_norm,
+                  ExcMessage("Problem in lp_norm."));
+    }
 }
 
 


### PR DESCRIPTION
`TpetraWrappers::Vector` lacks `lp_norm()`, which breaks backend-neutral code such as `tests/trilinos/33.cc` when instantiated with Tpetra.

This adds API parity with deal.II's other vector implementations. The cases `p=1` and `p=2` use the existing optimized norm functions; general powers accumulate absolute values locally and perform one MPI sum. Ghosted vectors retain the same restriction as the existing Tpetra norm functions.

The distributed `tpetra_vector_02` test now compares Tpetra results against `Vector` for `p=1`, `2`, `3`, `4`, and `2.5`, using alternating-sign values.

Fixes #20043.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md).