### PR TITLE
Fix a wrong dimension.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1498,7 +1498,7 @@ ReferenceCell<dim>::faces_for_given_vertex(const unsigned int vertex) const
   if constexpr (dim == 0)
     DEAL_II_NOT_IMPLEMENTED();
   else if constexpr (dim == 1)
-    return {&GeometryInfo<2>::vertex_to_face[vertex][0], 1};
+    return {&GeometryInfo<1>::vertex_to_face[vertex][0], 1};
   else if constexpr (dim == 2)
     {
       switch (this->kind)


### PR DESCRIPTION
This is clearly an oversight: In 1d code, we reference `GeometryInfo<2>`. As explained in #20163, this by chance results in the same outcome, but we should fix it regardless.

Fixes #20163.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
