### PR TITLE
Skip artificial cell when sorting particles

### DIFF
--- a/doc/news/changes/minor/20260831Blais
+++ b/doc/news/changes/minor/20260831Blais
@@ -4,6 +4,7 @@ particle found in such a cell was then scheduled to be sent to
 numbers::artificial_subdomain_id, which triggered an assertion in debug mode
 and silently deleted the particle in release mode without emitting the
 particle_lost signal. Artificial cells are now skipped, so that these
-particles are correctly reported as lost.
+particles are correctly reported as lost. This behavior is checked by the new
+test particles/particle_handler_sort_03.
 <br>
 (Bruno Blais, 2026/08/31)

--- a/doc/news/changes/minor/20260831Blais
+++ b/doc/news/changes/minor/20260831Blais
@@ -1,0 +1,9 @@
+Fixed: Particles::ParticleHandler::sort_particles_into_subdomains_and_cells()
+also searched artificial cells when looking for the new cell of a particle. A
+particle found in such a cell was then scheduled to be sent to
+numbers::artificial_subdomain_id, which triggered an assertion in debug mode
+and silently deleted the particle in release mode without emitting the
+particle_lost signal. Artificial cells are now skipped, so that these
+particles are correctly reported as lost.
+<br>
+(Bruno Blais, 2026/08/31)

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -467,8 +467,8 @@ namespace Particles
         else
           {
             const typename particle_container::iterator
-                                                  particles_in_current_cell =
-                                                    cells_to_particle_cache[active_cell_index];
+              particles_in_current_cell =
+                cells_to_particle_cache[active_cell_index];
             typename particle_container::iterator particles_in_next_cell =
               particles_in_current_cell;
             ++particles_in_next_cell;

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -467,8 +467,8 @@ namespace Particles
         else
           {
             const typename particle_container::iterator
-              particles_in_current_cell =
-                cells_to_particle_cache[active_cell_index];
+                                                  particles_in_current_cell =
+                                                    cells_to_particle_cache[active_cell_index];
             typename particle_container::iterator particles_in_next_cell =
               particles_in_current_cell;
             ++particles_in_next_cell;
@@ -1467,6 +1467,14 @@ namespace Particles
                 const_iterator candidate_cell = candidate_cells.begin();
 
               std::advance(candidate_cell, scratch.search_order[i]);
+
+              // We can not use artificial cells as a target since we
+              // can only send particles to owned or ghost cells.
+              // Skip them here so that the particle
+              // is reported as lost instead of being silently dropped later.
+              if ((*candidate_cell)->is_artificial())
+                continue;
+
               mapping->transform_points_real_to_unit_cell(
                 *candidate_cell,
                 scratch.real_locations,
@@ -1517,6 +1525,11 @@ namespace Particles
               for (const auto &cell :
                    vertex_to_cells[closest_vertex_index_in_domain])
                 {
+                  // See the comment above: artificial cells are not valid
+                  // targets for a particle. We skip them.
+                  if (cell->is_artificial())
+                    continue;
+
                   mapping->transform_points_real_to_unit_cell(
                     cell, scratch.real_locations, scratch.reference_locations);
 

--- a/tests/particles/particle_handler_sort_03.cc
+++ b/tests/particles/particle_handler_sort_03.cc
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------------
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR LGPL-2.1-or-later
+// Copyright (C) 2026 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// Detailed license information governing the source code and contributions
+// can be found in LICENSE.md and CONTRIBUTING.md at the top level directory.
+//
+// -----------------------------------------------------------------------------
+
+
+// Test that ParticleHandler::sort_particles_into_subdomains_and_cells() does
+// not silently drop a particle that moves into a cell that is artificial on
+// the process that owns the particle. Such a particle used to be scheduled to
+// be sent to numbers::artificial_subdomain_id, which is not a real rank: in
+// debug mode this triggered an assertion, in release mode the particle
+// disappeared without the particle_lost signal ever being emitted. Artificial
+// cells are no valid target, so the particle has to be reported as lost.
+//
+// The setup is two coarse cells merged into [-1,1]x[0,1] and refined once,
+// i.e. eight cells. On two processes rank 0 owns the four cells with x < 0
+// and its ghost layer only covers 0 < x < 0.5, so that the two cells with
+// x > 0.5 are artificial on rank 0. A single particle owned by rank 0 is
+// moved from (-0.75, 0.25) into one of those artificial cells in one step.
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q1.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  const unsigned int dim = 2;
+
+  const MPI_Comm     comm    = MPI_COMM_WORLD;
+  const unsigned int my_rank = Utilities::MPI::this_mpi_process(comm);
+
+  const Point<dim> start_location(-0.75, 0.25);
+  const Point<dim> end_location(0.75, 0.25);
+
+  parallel::distributed::Triangulation<dim> tria(comm);
+  GridGenerator::subdivided_hyper_rectangle(
+    tria, {2, 1}, Point<dim>(-1., 0.), Point<dim>(1., 1.), true);
+  tria.refine_global(1);
+
+  const MappingQ1<dim>            mapping;
+  Particles::ParticleHandler<dim> particle_handler(tria, mapping);
+
+  // Count how often the library tells us that a particle got lost. Before the
+  // fix this counter stayed at zero even though the particle disappeared.
+  unsigned int n_lost_particles = 0;
+  particle_handler.signals.particle_lost.connect(
+    [&n_lost_particles](
+      const typename Particles::ParticleIterator<dim>         &particle,
+      const typename Triangulation<dim>::active_cell_iterator &cell) {
+      ++n_lost_particles;
+      deallog << "Particle <" << particle->get_id() << "> lost in cell "
+              << cell->id() << std::endl;
+    });
+
+  // Insert the one and only particle, owned by rank 0.
+  const auto my_bounding_box = GridTools::compute_mesh_predicate_bounding_box(
+    tria, IteratorFilters::LocallyOwnedCell());
+  const auto global_bounding_boxes =
+    Utilities::MPI::all_gather(comm, my_bounding_box);
+
+  std::vector<Point<dim>> positions;
+  if (my_rank == 0)
+    positions.push_back(start_location);
+  particle_handler.insert_global_particles(positions, global_bounding_boxes);
+
+  deallog << "Particles before sort: " << particle_handler.n_global_particles()
+          << std::endl;
+
+  // The single displacement of the single particle. Its new location lies in
+  // a cell that is artificial on rank 0.
+  for (auto &particle : particle_handler)
+    particle.get_location() = end_location;
+
+  particle_handler.sort_particles_into_subdomains_and_cells();
+
+  deallog << "Particles after sort:  " << particle_handler.n_global_particles()
+          << std::endl;
+  deallog << "Lost particles:        "
+          << Utilities::MPI::sum(n_lost_particles, comm) << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  test();
+}

--- a/tests/particles/particle_handler_sort_03.with_p4est=true.mpirun=2.output
+++ b/tests/particles/particle_handler_sort_03.with_p4est=true.mpirun=2.output
@@ -1,0 +1,10 @@
+
+DEAL:0::Particles before sort: 1
+DEAL:0::Particle <0> lost in cell 0_1:0
+DEAL:0::Particles after sort:  0
+DEAL:0::Lost particles:        1
+
+DEAL:1::Particles before sort: 1
+DEAL:1::Particles after sort:  0
+DEAL:1::Lost particles:        1
+


### PR DESCRIPTION
This is a very simple PR, but it is related to a bug we have encountered
Right now we are working with mortar methods (with @brunaccampos and @peterrum ) and we are gluing cells together by merging meshes but not merging the vertices.
So this creates very weird triangulations, but anyway.

We are currently coupling this to particles. I found an issue where a particle would be located into an artificial cell and it would try to send that particle to the artificial cell (thus leading to an assertion thrown in debug). What would be the "better" behaviour in this case is to consider that particles sent to artificial cells should be considered as "lost" and then the user can decide what to do with them. In our case this means inserting them on the other side of the mortar interface or at least doing some manual particle management by leveraging the "lost particles" signal.

This is a very weird edge case, but I think the current behaviour is ill-defined. We should treat particles "sorted" into artificial cells as lost particles instead of trying to send them nowhere and losing them without using the right signal.


### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
