### PR TITLE
Retire jammy testers. Update CUDA testers to noble.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,8 +49,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ubuntu_version: jammy
-            os: ubuntu-22.04
           - ubuntu_version: noble
             os: ubuntu-24.04
           - ubuntu_version: resolute
@@ -106,13 +104,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble, resolute]
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        ubuntu_version: [noble, resolute]
+        os: [ubuntu-26.04, ubuntu-26.04-arm]
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-26.04
             architecture: amd64
             flags:
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-26.04-arm
             architecture: arm64
             flags: -mno-outline-atomics
 
@@ -180,7 +178,7 @@ jobs:
     # simple parallel debug build using g++ and trilinos+tpetra
 
     name: ${{ matrix.ubuntu_version }} debug parallel tpetra
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     #
     # The following condition only runs the workflow on 'push' or if the
@@ -193,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble, resolute]
+        ubuntu_version: [noble, resolute]
 
     container:
       image: dealii/dependencies:${{ matrix.ubuntu_version }}-v9.7.1
@@ -244,10 +242,10 @@ jobs:
     # Based on https://github.com/oneapi-src/oneapi-ci
     # For a list of Intel packages see https://oneapi-src.github.io/oneapi-ci/#linux-apt
 
-    name: jammy debug intel oneapi
-    runs-on: [ubuntu-22.04]
+    name: resolute debug intel oneapi
+    runs-on: ubuntu-26.04
     container:
-      image: intel/oneapi:2026.1.0-devel-ubuntu22.04
+      image: intel/oneapi:2026.1.0-devel-ubuntu26.04
 
     #
     # The following condition only runs the workflow on 'push' or if the
@@ -512,8 +510,8 @@ jobs:
   clang-22-modules:
     # simple build testing C++20 modules
 
-    name: noble clang-22 modules
-    runs-on: [ubuntu-latest]
+    name: resolute clang-22 modules
+    runs-on: ubuntu-26.04
     container:
       image: dealii/dependencies:noble-v9.7.1
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -300,8 +300,8 @@ jobs:
   debug-cuda-12:
     # simple parallel debug build using cuda-12
 
-    name: jammy debug cuda-12
-    runs-on: [ubuntu-22.04]
+    name: noble debug cuda-12
+    runs-on: ubuntu-24.04
 
     #
     # The following condition only runs the workflow on 'push' or if the
@@ -318,21 +318,19 @@ jobs:
     - uses: actions/checkout@v7
     - name: modules
       run: |
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
-        sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
-        sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+        sudo dpkg -i cuda-keyring_1.1-1_all.deb
         sudo apt-get install -y software-properties-common
-        sudo add-apt-repository ppa:ginggs/deal.ii-9.6.0-backports
+        sudo add-apt-repository ppa:ginggs/deal.ii-9.7.1-backports
         sudo apt-get update
         sudo apt-get install -yq --no-install-recommends \
-            cuda-toolkit-12-3 \
+            cuda-toolkit-12-8 \
             libp4est-dev \
             libopenmpi-dev \
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+    # https://github.com/apache/flink/blob/master/tools/ci/free_disk_space.sh
     - name: remove unused large packages
       run : |
         echo "=============================================================================="
@@ -354,9 +352,9 @@ jobs:
         # deleting 15GB
         rm -rf /usr/share/dotnet/
         df -h
-    - uses: lukka/get-cmake@v4.3.2
+    - uses: lukka/get-cmake@v4.4.2
       with:
-        cmakeVersion: 3.27.9
+        cmakeVersion: 3.28.3
     - name: info
       run: |
         mpicc -v
@@ -414,8 +412,8 @@ jobs:
   debug-cuda-12-clang:
     # simple parallel debug build using cuda-12 and clang
 
-    name: jammy debug cuda-12 clang
-    runs-on: [ubuntu-22.04]
+    name: noble debug cuda-12 clang
+    runs-on: ubuntu-24.04
 
     #
     # The following condition only runs the workflow on 'push' or if the
@@ -434,28 +432,26 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 19
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
-        sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
-        sudo add-apt-repository "deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /"
+        sudo ./llvm.sh 22
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+        sudo dpkg -i cuda-keyring_1.1-1_all.deb
         sudo apt-get install -y software-properties-common
-        sudo add-apt-repository ppa:ginggs/deal.ii-9.6.0-backports
+        sudo add-apt-repository ppa:ginggs/deal.ii-9.7.1-backports
         sudo apt-get update
         sudo apt-get install -yq --no-install-recommends \
-            cuda-toolkit-12-3 \
+            cuda-toolkit-12-8 \
             libp4est-dev \
             libopenmpi-dev \
             numdiff \
             openmpi-bin \
             libboost-all-dev
-    - uses: lukka/get-cmake@v4.3.2
+    - uses: lukka/get-cmake@v4.4.2
       with:
-        cmakeVersion: 3.27.9
+        cmakeVersion: 3.28.3
     - name: info
       run: |
         mpicc -v
-        clang++-19 -v
+        clang++-22 -v
         cmake --version
     - uses: actions/checkout@v7
       with:
@@ -468,7 +464,7 @@ jobs:
         mkdir build
         cd build
         cmake -D BUILD_SHARED_LIBS=ON \
-              -D CMAKE_CXX_COMPILER=clang++-19 \
+              -D CMAKE_CXX_COMPILER=clang++-22 \
               -D CMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/../kokkos-install \
               -D Kokkos_ENABLE_CUDA=ON \
               -D Kokkos_ARCH_NATIVE=ON \
@@ -480,9 +476,8 @@ jobs:
         mkdir build
         cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
-              -D CMAKE_CXX_COMPILER=clang++-19 \
+              -D CMAKE_CXX_COMPILER=clang++-22 \
               -D DEAL_II_FORCE_BUNDLED_BOOST=ON \
-              -D DEAL_II_CXX_FLAGS="-std=c++17" \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
               -D DEAL_II_WITH_KOKKOS="ON" \
               -D KOKKOS_DIR=${GITHUB_WORKSPACE}/../kokkos-install \


### PR DESCRIPTION
The 22.04/jammy images will be deprecated starting September 17th, 2026 and will be fully unsupported on April 17th, 2027[^1].

Our configuration already covers 24.04/noble and 26.04/resolute, so I think it is fair to let go of the 22.04/jammy jobs. This patch retires the jammy images and upgrades to resolute where possible.

The CUDA testers currently run on jammy. They require the backports repository which is not available on resolute (yet), so I updated the testers to noble instead in a separate commit. I also updated to clang 22 and CUDA 12.8, which is the latest fully supported version for clang 22[^3]. I followed nvidia's instructions for network installations[^2]. I also had to update Kokkos and picked the same version number we bundle with, which seemed to work. @masterleinad, @tjhei -- Please have a look!

The recently released clang 23 fully supports CUDA 13.2[^5]. We could also make this configuration work with an update to Kokkos 5[^4] in the future. I suggest to stick to clang 22 for the moment.

Part of #19184.

[^1]: https://github.com/actions/runner-images/issues/14254
[^2]: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#network-repo-installation-for-ubuntu
[^3]: https://github.com/llvm/llvm-project/blob/release/22.x/clang/include/clang/Basic/Cuda.h
[^4]: https://github.com/kokkos/kokkos/pull/8298
[^5]: https://github.com/llvm/llvm-project/blob/release/23.x/clang/include/clang/Basic/Cuda.h