### PR TITLE
Optimize set bounding objects

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -4703,15 +4703,14 @@ namespace internal
                               // now we have to copy
                               // all information of the
                               // two quads
-                              const int switch_1_lines[4] = {
-                                static_cast<signed int>(
-                                  switch_1->line_index(0)),
-                                static_cast<signed int>(
-                                  switch_1->line_index(1)),
-                                static_cast<signed int>(
-                                  switch_1->line_index(2)),
-                                static_cast<signed int>(
-                                  switch_1->line_index(3))};
+                              int switch_1_lines[4], switch_2_lines[4];
+                              for (int i = 0; i < 4; ++i)
+                                {
+                                  switch_1_lines[i] =
+                                    switch_1->line(i)->index();
+                                  switch_2_lines[i] =
+                                    switch_2->line(i)->index();
+                                }
                               const types::geometric_orientation
                                 switch_1_line_orientations[4] = {
                                   switch_1->line_orientation(0),
@@ -4726,10 +4725,10 @@ namespace internal
                                 switch_1->user_flag_set();
 
                               switch_1->set_bounding_object_indices(
-                                {switch_2->line_index(0),
-                                 switch_2->line_index(1),
-                                 switch_2->line_index(2),
-                                 switch_2->line_index(3)});
+                                {switch_2_lines[0],
+                                 switch_2_lines[1],
+                                 switch_2_lines[2],
+                                 switch_2_lines[3]});
                               switch_1->set_line_orientation(
                                 0, switch_2->line_orientation(0));
                               switch_1->set_line_orientation(
@@ -7432,12 +7431,9 @@ namespace internal
                     // ReferenceCell, update it there).
 
                     std::array<raw_line_iterator, max_relevant_lines>
-                      relevant_lines;
-                    std::array<unsigned int, max_relevant_lines>
-                      relevant_line_indices;
-
+                                                        relevant_lines;
+                    std::array<int, max_relevant_lines> relevant_line_indices;
                     unsigned int relevant_lines_counter = 0;
-
                     // 1. Get relevant lines from quads
                     for (auto f : cell_reference_cell.face_indices_by_type(
                            ReferenceCells::Quadrilateral))
@@ -8788,11 +8784,12 @@ namespace internal
                                   }
                             // now we have to copy all information of
                             // the two quads
-                            const unsigned int switch_1_lines[4] = {
-                              switch_1->line_index(0),
-                              switch_1->line_index(1),
-                              switch_1->line_index(2),
-                              switch_1->line_index(3)};
+                            int switch_1_lines[4], switch_2_lines[4];
+                            for (int i = 0; i < 4; ++i)
+                              {
+                                switch_1_lines[i] = switch_1->line(i)->index();
+                                switch_2_lines[i] = switch_2->line(i)->index();
+                              }
                             const types::geometric_orientation
                               switch_1_line_orientations[4] = {
                                 switch_1->line_orientation(0),
@@ -8819,10 +8816,10 @@ namespace internal
                                  -1);
 
                             switch_1->set_bounding_object_indices(
-                              {switch_2->line_index(0),
-                               switch_2->line_index(1),
-                               switch_2->line_index(2),
-                               switch_2->line_index(3)});
+                              {switch_2_lines[0],
+                               switch_2_lines[1],
+                               switch_2_lines[2],
+                               switch_2_lines[3]});
                             switch_1->set_line_orientation(
                               0, switch_2->line_orientation(0));
                             switch_1->set_line_orientation(
@@ -9601,7 +9598,7 @@ namespace internal
                                   3) // 3
                             };
 
-                          unsigned int line_indices[4];
+                          int line_indices[4];
                           for (unsigned int i = 0; i < 4; ++i)
                             line_indices[i] = lines[i]->index();
 
@@ -9829,7 +9826,7 @@ namespace internal
                                   3) // 3
                             };
 
-                          unsigned int line_indices[4];
+                          int line_indices[4];
                           for (unsigned int i = 0; i < 4; ++i)
                             line_indices[i] = lines[i]->index();
 
@@ -10059,7 +10056,7 @@ namespace internal
                                   3) // 3
                             };
 
-                          unsigned int line_indices[4];
+                          int line_indices[4];
                           for (unsigned int i = 0; i < 4; ++i)
                             line_indices[i] = lines[i]->index();
 
@@ -10374,7 +10371,7 @@ namespace internal
                             new_lines[0] // 12
                           };
 
-                          unsigned int line_indices[13];
+                          int line_indices[13];
                           for (unsigned int i = 0; i < 13; ++i)
                             line_indices[i] = lines[i]->index();
 
@@ -10812,7 +10809,7 @@ namespace internal
                             new_lines[0] // 12
                           };
 
-                          unsigned int line_indices[13];
+                          int line_indices[13];
                           for (unsigned int i = 0; i < 13; ++i)
                             line_indices[i] = lines[i]->index();
 
@@ -11264,8 +11261,7 @@ namespace internal
                             new_lines[0] // 12
                           };
 
-                          unsigned int line_indices[13];
-
+                          int line_indices[13];
                           for (unsigned int i = 0; i < 13; ++i)
                             line_indices[i] = lines[i]->index();
 
@@ -11858,7 +11854,7 @@ namespace internal
                             new_lines[5]  // 29
                           };
 
-                          unsigned int line_indices[30];
+                          int line_indices[30];
                           for (unsigned int i = 0; i < 30; ++i)
                             line_indices[i] = lines[i]->index();
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1456,17 +1456,17 @@ void
 TriaAccessor<structdim, dim, spacedim>::set_bounding_object_indices(
   const std::initializer_list<int> &new_indices) const
 {
-  const ArrayView<int> bounding_object_index_ref =
+  ArrayView<int> bounding_object_index_ref =
     this->objects().get_bounding_object_indices(this->present_index);
 
-  AssertIndexRange(new_indices.size(), bounding_object_index_ref.size() + 1);
+  if constexpr (running_in_debug_mode())
+    for (const auto &v : new_indices)
+      Assert(v >= 0, ExcInternalError());
 
-  unsigned int i = 0;
-  for (const auto &new_index : new_indices)
-    {
-      bounding_object_index_ref[i] = new_index;
-      ++i;
-    }
+  AssertIndexRange(new_indices.size(), bounding_object_index_ref.size() + 1);
+  std::copy(new_indices.begin(),
+            new_indices.end(),
+            bounding_object_index_ref.begin());
 }
 
 
@@ -1480,13 +1480,9 @@ TriaAccessor<structdim, dim, spacedim>::set_bounding_object_indices(
     this->objects().get_bounding_object_indices(this->present_index);
 
   AssertIndexRange(new_indices.size(), bounding_object_index_ref.size() + 1);
-
-  unsigned int i = 0;
-  for (const auto &new_index : new_indices)
-    {
-      bounding_object_index_ref[i] = new_index;
-      ++i;
-    }
+  std::copy(new_indices.begin(),
+            new_indices.end(),
+            bounding_object_index_ref.begin());
 }
 
 


### PR DESCRIPTION
I was surprised to see that `set_bounding_object_indices` was one of the more expensive functions called by `execute_refinement_isotropic` (it occupies positions 2-5 when measured via callgrind). Optimizing it a little makes refinement about 1.7% faster.

It doesn't make a measurable performance difference, but while I was here I cleaned up some index arrays to avoid extra back-and-forth between `int` and `unsigned int`.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
