### PR TITLE
Remove code for Kokkos versions we no longer support.

### DIFF
--- a/include/deal.II/base/exception_macros.h
+++ b/include/deal.II/base/exception_macros.h
@@ -517,32 +517,10 @@
  * @ingroup Exceptions
  */
 #ifdef DEBUG
-#  if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
-#    define Assert(cond, exc)                                                \
-      do                                                                     \
-        {                                                                    \
-          KOKKOS_IF_ON_HOST(({                                               \
-            if (DEAL_II_BUILTIN_EXPECT(!(cond), false))                      \
-              ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-                ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
-                  abort_or_throw_on_exception,                               \
-                __FILE__,                                                    \
-                __LINE__,                                                    \
-                __PRETTY_FUNCTION__,                                         \
-                #cond,                                                       \
-                #exc,                                                        \
-                exc);                                                        \
-          }))                                                                \
-          KOKKOS_IF_ON_DEVICE(({                                             \
-            if (!(cond))                                                     \
-              Kokkos::abort(#cond);                                          \
-          }))                                                                \
-        }                                                                    \
-      while (false)
-#  else /*if DEAL_II_KOKKOS_VERSION_GTE(3,6,0), no device support: */
-#    define Assert(cond, exc)                                              \
-      do                                                                   \
-        {                                                                  \
+#  define Assert(cond, exc)                                                \
+    do                                                                     \
+      {                                                                    \
+        KOKKOS_IF_ON_HOST(({                                               \
           if (DEAL_II_BUILTIN_EXPECT(!(cond), false))                      \
             ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
               ::dealii::deal_II_exceptions::internals::ExceptionHandling:: \
@@ -553,10 +531,14 @@
               #cond,                                                       \
               #exc,                                                        \
               exc);                                                        \
-        }                                                                  \
-      while (false)
-#  endif /*DEAL_II_KOKKOS_VERSION_GTE(3,6,0)*/
-#else    /*ifdef DEBUG*/
+        }))                                                                \
+        KOKKOS_IF_ON_DEVICE(({                                             \
+          if (!(cond))                                                     \
+            Kokkos::abort(#cond);                                          \
+        }))                                                                \
+      }                                                                    \
+    while (false)
+#else /*ifdef DEBUG*/
 #  define Assert(cond, exc) \
     do                      \
       {                     \

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1127,7 +1127,6 @@ namespace deal_II_exceptions
                    const char *function,
                    const char *msg)
     {
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
       (void)file;
       (void)line;
       (void)function;
@@ -1142,18 +1141,6 @@ namespace deal_II_exceptions
                              nullptr,
                              ::dealii::StandardExceptions::ExcMessage(msg));
       }))
-#else
-      // KOKKOS_IF_ON_DEVICE is only supported in 3.6 or newer. We require 3.7
-      // on device though, so this means we won't be on device here:
-      issue_error_noreturn(::dealii::deal_II_exceptions::internals::
-                             ExceptionHandling::abort_or_throw_on_exception,
-                           file,
-                           line,
-                           function,
-                           nullptr,
-                           nullptr,
-                           ::dealii::StandardExceptions::ExcMessage(msg));
-#endif
       // This workaround is necessary, otherwise nvcc will complain that we
       // might return from this function, even though we will never get here (we
       // will throw or abort above).
@@ -1171,7 +1158,6 @@ namespace deal_II_exceptions
     [[noreturn]] DEAL_II_HOST_DEVICE inline void
     do_not_implemented(const char *file, int line, const char *function)
     {
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
       (void)file;
       (void)line;
       (void)function;
@@ -1187,18 +1173,6 @@ namespace deal_II_exceptions
                              nullptr,
                              ::dealii::StandardExceptions::ExcNotImplemented());
       }))
-#else
-      // KOKKOS_IF_ON_DEVICE is only supported in 3.6 or newer. We require 3.7
-      // on device though, so this means we won't be on device here:
-      issue_error_noreturn(::dealii::deal_II_exceptions::internals::
-                             ExceptionHandling::abort_or_throw_on_exception,
-                           file,
-                           line,
-                           function,
-                           nullptr,
-                           nullptr,
-                           ::dealii::StandardExceptions::ExcNotImplemented());
-#endif
       // This workaround is necessary, otherwise nvcc will complain that we
       // might return from this function, even though we will never get here (we
       // will throw or abort above).

--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -60,11 +60,7 @@ namespace MemorySpace
      * Kokkos View owning a host buffer used for MPI communication.
      */
     // FIXME Should we move this somewhere else?
-#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
     Kokkos::View<T *, Kokkos::SharedHostPinnedSpace> values_host_buffer;
-#else
-    Kokkos::View<T *, Kokkos::HostSpace> values_host_buffer;
-#endif
 
     /**
      * Kokkos View owning the data on the @ref GlossDevice "device" (unless @p values_sm_ptr is used).
@@ -106,12 +102,8 @@ namespace MemorySpace
   MemorySpaceData<T, MemorySpace>::MemorySpaceData()
     : values_host_buffer(
         (dealii::internal::ensure_kokkos_initialized(),
-#  if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
          Kokkos::View<T *, Kokkos::SharedHostPinnedSpace>("host pinned buffer",
                                                           0)))
-#  else
-         Kokkos::View<T *, Kokkos::HostSpace>("host buffer", 0)))
-#  endif
     , values(Kokkos::View<T *, typename MemorySpace::kokkos_space>(
         "memoryspace data",
         0))

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -561,7 +561,6 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
   {
     // Make things work with AD types and device code
 
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
     if constexpr (std::is_same_v<number, double> ||
                   std::is_same_v<number, float>)
       {
@@ -569,7 +568,6 @@ DEAL_II_NAMESPACE_OPEN // Do not convert for module purposes
         // with SYCL.
         return Kokkos::abs(x);
       }
-#endif
 
     using std::abs;
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -838,15 +838,9 @@ private:
    * a rank-1 tensor, then we simply need an array of scalars.
    * Otherwise, it is an array of tensors one rank lower.
    */
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
   std::conditional_t<rank_ == 1,
                      Kokkos::Array<Number, dim>,
                      Kokkos::Array<Tensor<rank_ - 1, dim, Number>, dim>>
-#else
-  std::conditional_t<rank_ == 1,
-                     std::array<Number, dim>,
-                     std::array<Tensor<rank_ - 1, dim, Number>, dim>>
-#endif
     values;
 
   /**
@@ -1103,7 +1097,6 @@ namespace internal
     constexpr DEAL_II_HOST_DEVICE_ALWAYS_INLINE void
     multiply_assign_scalar(std::complex<Number> &val, const OtherNumber &s)
     {
-#  if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
       KOKKOS_IF_ON_HOST((val *= s;))
       KOKKOS_IF_ON_DEVICE(({
         (void)val;
@@ -1111,10 +1104,6 @@ namespace internal
         Kokkos::abort(
           "This function is not implemented for std::complex<Number>!\n");
       }))
-#  else
-      // We do not support device code for Kokkos < 3.7:
-      val *= s;
-#  endif
     }
   } // namespace ComplexWorkaround
 } // namespace internal
@@ -1321,11 +1310,7 @@ namespace internal
   namespace TensorInitialization
   {
     template <int rank, int dim, typename Number, std::size_t... I>
-#    if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
     constexpr Kokkos::Array<typename Tensor<rank, dim, Number>::value_type, dim>
-#    else
-    constexpr std::array<typename Tensor<rank, dim, Number>::value_type, dim>
-#    endif
     make_zero_array(const std::index_sequence<I...> &)
     {
       static_assert(sizeof...(I) == dim, "This is bad.");

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -140,13 +140,9 @@ namespace LinearAlgebra
         {
           if (comm_shared == MPI_COMM_SELF)
             {
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
               Kokkos::resize(Kokkos::WithoutInitializing,
                              data.values,
                              new_alloc_size);
-#else
-              Kokkos::resize(data.values, new_alloc_size);
-#endif
 
               allocated_size = new_alloc_size;
 
@@ -365,13 +361,9 @@ namespace LinearAlgebra
                       data.values.size() == 0),
                      ExcInternalError());
 
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
               Kokkos::resize(Kokkos::WithoutInitializing,
                              data.values,
                              new_alloc_size);
-#else
-              Kokkos::resize(data.values, new_alloc_size);
-#endif
 
               allocated_size = new_alloc_size;
             }
@@ -508,12 +500,7 @@ namespace LinearAlgebra
               ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
               exec, 0, size),
             KOKKOS_LAMBDA(size_type i, RealType & update) {
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
               update = Kokkos::fmax(update, Kokkos::abs(data.values(i)));
-#else
-              update = Kokkos::Experimental::fmax(
-                update, Kokkos::Experimental::fabs(data.values(i)));
-#endif
             },
             Kokkos::Max<RealType, Kokkos::HostSpace>(result));
         }
@@ -1045,27 +1032,17 @@ namespace LinearAlgebra
           if (std::is_same_v<MemorySpaceType, dealii::MemorySpace::Default>)
             {
               if (import_data.values_host_buffer.size() == 0)
-#    if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
                 Kokkos::resize(Kokkos::WithoutInitializing,
                                import_data.values_host_buffer,
                                partitioner->n_import_indices());
-#    else
-                Kokkos::resize(import_data.values_host_buffer,
-                               partitioner->n_import_indices());
-#    endif
             }
           else
 #  endif
             {
               if (import_data.values.size() == 0)
-#  if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
                 Kokkos::resize(Kokkos::WithoutInitializing,
                                import_data.values,
                                partitioner->n_import_indices());
-#  else
-              Kokkos::resize(import_data.values,
-                             partitioner->n_import_indices());
-#  endif
             }
         }
 
@@ -1076,13 +1053,9 @@ namespace LinearAlgebra
           // device. We use values to store the elements because the function
           // uses a view of the array and thus we need the data on the host to
           // outlive the scope of the function.
-#    if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
           Kokkos::resize(Kokkos::WithoutInitializing,
                          data.values_host_buffer,
                          data.values.size());
-#    else
-          Kokkos::resize(data.values_host_buffer, data.values.size());
-#    endif
           Kokkos::deep_copy(data.values_host_buffer, data.values);
 
           partitioner->import_from_ghosted_array_start(
@@ -1206,27 +1179,17 @@ namespace LinearAlgebra
           if (std::is_same_v<MemorySpaceType, MemorySpace::Default>)
             {
               if (import_data.values_host_buffer.size() == 0)
-#    if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
                 Kokkos::resize(Kokkos::WithoutInitializing,
                                import_data.values_host_buffer,
                                partitioner->n_import_indices());
-#    else
-                Kokkos::resize(import_data.values_host_buffer,
-                               partitioner->n_import_indices());
-#    endif
             }
           else
 #  endif
             {
               if (import_data.values.size() == 0)
-#  if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
                 Kokkos::resize(Kokkos::WithoutInitializing,
                                import_data.values,
                                partitioner->n_import_indices());
-#  else
-              Kokkos::resize(import_data.values,
-                             partitioner->n_import_indices());
-#  endif
             }
         }
 
@@ -1237,13 +1200,9 @@ namespace LinearAlgebra
           // device. We use values to store the elements because the function
           // uses a view of the array and thus we need the data on the host to
           // outlive the scope of the function.
-#    if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
           Kokkos::resize(Kokkos::WithoutInitializing,
                          data.values_host_buffer,
                          data.values.size());
-#    else
-          Kokkos::resize(data.values_host_buffer, data.values.size());
-#    endif
           Kokkos::deep_copy(data.values_host_buffer, data.values);
 
           partitioner->export_to_ghosted_array_start<Number, MemorySpace::Host>(

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2549,11 +2549,7 @@ namespace internal
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, optional_offset, optional_offset + size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
             update += Kokkos::abs(data.values(i));
-#else
-            update += Kokkos::Experimental::fabs(data.values(i));
-#endif
           },
           sum);
       }
@@ -2577,12 +2573,7 @@ namespace internal
             ::dealii::MemorySpace::Default::kokkos_space::execution_space>(
             exec, 0, size),
           KOKKOS_LAMBDA(size_type i, Number & update) {
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
             update += Kokkos::pow(Kokkos::abs(data.values(i)), exp);
-#else
-            update += Kokkos::Experimental::pow(
-              Kokkos::Experimental::fabs(data.values(i)), exp);
-#endif
           },
           sum);
       }

--- a/include/deal.II/matrix_free/portable_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/portable_matrix_free.templates.h
@@ -281,19 +281,12 @@ namespace Portable
               Kokkos::view_alloc("data_index_offsets_" + std::to_string(color),
                                  Kokkos::WithoutInitializing),
               n_cells);
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
           cell_type_host =
             Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
                                        mapping_info.cell_type[color]);
           data_index_offsets_host =
             Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
                                        mapping_info.data_index_offsets[color]);
-#else
-          cell_type_host =
-            Kokkos::create_mirror_view(mapping_info.cell_type[color]);
-          data_index_offsets_host =
-            Kokkos::create_mirror_view(mapping_info.data_index_offsets[color]);
-#endif
 
           auto classification_worker = [&](const unsigned int cell_id,
                                            ScratchData       &scratch_data,
@@ -386,8 +379,7 @@ namespace Portable
         decltype(mapping_info.JxW[color])>::host_mirror_type JxW_host;
       typename std::remove_reference_t<
         decltype(mapping_info.inv_jacobian[color])>::host_mirror_type
-        inv_jacobian_host;
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
+           inv_jacobian_host;
       auto local_to_global_host =
         Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
                                    dof_data.local_to_global[color]);
@@ -402,18 +394,6 @@ namespace Portable
         inv_jacobian_host =
           Kokkos::create_mirror_view(Kokkos::WithoutInitializing,
                                      mapping_info.inv_jacobian[color]);
-#else
-      auto local_to_global_host =
-        Kokkos::create_mirror_view(dof_data.local_to_global[color]);
-      if (update_flags & update_quadrature_points && dof_handler_index == 0)
-        q_points_host =
-          Kokkos::create_mirror_view(mapping_info.q_points[color]);
-      if ((update_flags & update_JxW_values) && dof_handler_index == 0)
-        JxW_host = Kokkos::create_mirror_view(mapping_info.JxW[color]);
-      if ((update_flags & update_gradients) && dof_handler_index == 0)
-        inv_jacobian_host =
-          Kokkos::create_mirror_view(mapping_info.inv_jacobian[color]);
-#endif
       const double first_q_weight = fe_values.get_quadrature().get_weights()[0];
 
       auto worker = [&](const unsigned int cell_id,
@@ -1635,11 +1615,7 @@ namespace Portable
           }
       }
 
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 6, 0)
     exec_space.fence("MatrixFree::internal_reinit(): end");
-#else
-    exec_space.fence();
-#endif
   }
 
 

--- a/include/deal.II/matrix_free/portable_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/portable_tensor_product_kernels.h
@@ -72,7 +72,6 @@ namespace Portable
 
 
 
-#if DEAL_II_KOKKOS_VERSION_GTE(4, 0, 0)
     /**
      * Helper function for apply() in 1D
      */
@@ -282,7 +281,6 @@ namespace Portable
 
       team_member.team_barrier();
     }
-#endif
 
 
 

--- a/source/base/init_finalize.cc
+++ b/source/base/init_finalize.cc
@@ -340,11 +340,7 @@ InitFinalize::InitFinalize([[maybe_unused]] int    &argc,
           argv_new.push_back(arg);
 
       std::stringstream threads_flag;
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
       threads_flag << "--kokkos-num-threads=" << MultithreadInfo::n_threads();
-#else
-      threads_flag << "--kokkos-threads=" << MultithreadInfo::n_threads();
-#endif
       const std::string threads_flag_string = threads_flag.str();
       argv_new.push_back(const_cast<char *>(threads_flag_string.c_str()));
       argv_new.push_back(nullptr);

--- a/source/base/kokkos.cc
+++ b/source/base/kokkos.cc
@@ -27,22 +27,14 @@ namespace internal
   void
   ensure_kokkos_initialized()
   {
-    if (!Kokkos::is_initialized()
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
-        && !Kokkos::is_finalized()
-#endif
-    )
+    if (!Kokkos::is_initialized() && !Kokkos::is_finalized())
       {
         // only execute once
         static bool dummy = []() {
           dealii_initialized_kokkos = true;
-#if DEAL_II_KOKKOS_VERSION_GTE(3, 7, 0)
           const auto settings =
             Kokkos::InitializationSettings().set_num_threads(
               MultithreadInfo::n_threads());
-#else
-          const Kokkos::InitArguments settings(MultithreadInfo::n_threads());
-#endif
           Kokkos::initialize(settings);
           std::atexit(Kokkos::finalize);
           return true;


### PR DESCRIPTION
We require Kokkos 4.0 since #18845. This patch removes code for older versions of Kokkos.