### PR TITLE
execute_refinement_isotropic(): avoid calling n_lines().

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -6713,6 +6713,7 @@ namespace internal
                 continue;
 
               const auto reference_face_type = face->reference_cell();
+              const auto n_lines_per_face    = reference_face_type.n_lines();
 
               // 1) Create new lines (property is set later).
               // Maximum of 4 new lines (4 quadrilateral, 3 triangle).
@@ -6787,8 +6788,8 @@ namespace internal
               for (const auto i : face->vertex_indices())
                 vertex_indices[k++] = face->vertex_index(i);
 
-              for (const auto i : face->line_indices())
-                vertex_indices[k++] = face->line(i)->child(0)->vertex_index(1);
+              for (unsigned int l = 0; l < n_lines_per_face; ++l)
+                vertex_indices[k++] = face->line(l)->child(0)->vertex_index(1);
 
               if (reference_face_type == ReferenceCells::Quadrilateral)
                 {
@@ -6806,12 +6807,12 @@ namespace internal
               // created in step 3).
               std::array<raw_line_iterator, 12> lines;
               unsigned int                      n_lines = 0;
-              for (unsigned int l = 0; l < face->n_lines(); ++l)
+              for (unsigned int l = 0; l < n_lines_per_face; ++l)
                 for (unsigned int c = 0; c < 2; ++c)
                   lines[n_lines++] = face->line(l)->child(
                     child_line_index(c, face->line_orientation(l)));
 
-              for (unsigned int l = 0; l < face->n_lines(); ++l)
+              for (unsigned int l = 0; l < n_lines_per_face; ++l)
                 lines[n_lines++] = new_lines[l];
 
               std::array<int, 12> line_indices;
@@ -6896,8 +6897,8 @@ namespace internal
               // The first 2*face->n_lines() lines are already created by
               // refining the original lines on the face. Therefore, only the
               // subsequent face->n_lines() lines need to be processed now.
-              for (unsigned int i = 0, j = 2 * face->n_lines();
-                   i < face->n_lines();
+              for (unsigned int i = 0, j = 2 * n_lines_per_face;
+                   i < n_lines_per_face;
                    ++i, ++j)
                 {
                   auto &new_line = new_lines[i];


### PR DESCRIPTION
This isn't inlined (which is a little surprising since it is just a switch statement in 2d) so it ends up called many, many times (enough to be 2% of the total runtime of this function).

<!-- replace this text with a summary of your PR. Make sure you understand and complete the text below -->

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
