### PR TITLE
Make code easier to read.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -4676,34 +4676,37 @@ ReferenceCell<dim>::permute_by_combined_orientation(
 {
   Assert(*this != ReferenceCells::Invalid<dim>, ExcNotImplemented());
   AssertDimension(vertices.size(), n_vertices());
-  boost::container::small_vector<T, 8> result(n_vertices());
 
-  const auto permute = [&](const auto &table, unsigned int n_vertices) {
-    AssertIndexRange(orientation, table.size());
-    for (unsigned int j = 0; j < n_vertices; ++j)
-      result[j] = vertices[table[orientation][j]];
-  };
+  const auto permute =
+    [this, &vertices](const auto                        &table,
+                      const types::geometric_orientation orientation) {
+      AssertIndexRange(orientation, table.size());
+
+      boost::container::small_vector<T, 8> result(this->n_vertices());
+      for (unsigned int j = 0; j < result.size(); ++j)
+        result[j] = vertices[table[orientation][j]];
+      return result;
+    };
 
   if constexpr (dim == 0)
-    permute(vertex_vertex_permutations, 1);
+    return permute(vertex_vertex_permutations, orientation);
   else if constexpr (dim == 1)
-    permute(line_vertex_permutations, 2);
+    return permute(line_vertex_permutations, orientation);
   else if constexpr (dim == 2)
     {
       switch (this->kind)
         {
           case ReferenceCells::Triangle:
-            permute(triangle_vertex_permutations, 3);
-            break;
+            return permute(triangle_vertex_permutations, orientation);
           case ReferenceCells::Quadrilateral:
-            permute(quadrilateral_vertex_permutations, 4);
-            break;
+            return permute(quadrilateral_vertex_permutations, orientation);
         }
     }
   else if constexpr (dim == 3)
     DEAL_II_NOT_IMPLEMENTED();
 
-  return result;
+  DEAL_II_NOT_IMPLEMENTED();
+  return {};
 }
 
 


### PR DESCRIPTION
Cleanup number 1 for the sequence #20116 and #20179 and #20186 and #20187 and #20198 and #20201.

Here, we had a lambda function that computes something that it puts into a variable outside the lambda, and then later we return that variable. With return-value-optimization, I think it's easier to read to just let the lambda return what it computes, and then return the lambda's returned value right away.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
