### PR TITLE
Optimize a lambda by breaking a loop early.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -4628,9 +4628,13 @@ ReferenceCell<dim>::get_combined_orientation(
       {
         bool match = true;
         for (unsigned int j = 0; j < n_vertices; ++j)
-          match = (match && vertices_0[j] == vertices_1[table[o][j]]);
+          {
+            match &= (vertices_0[j] == vertices_1[table[o][j]]);
+            if (match == false)
+              break;
+          }
 
-        if (match)
+        if (match == true)
           return o;
       }
 


### PR DESCRIPTION
Cleanup number 2 for the sequence #20116 and #20179 and #20186 and #20187 and #20198 and #20201.

Here, we're trying to match an array and a permutation of another array. If the two don't match, we need not continue comparing -- we can break early.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
