### PR TITLE
PreconditionChebyshev: Avoid an unnecessary MPI sum

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -3574,13 +3574,10 @@ namespace internal
       void
       apply_to_subrange(const std::size_t begin, const std::size_t end) const
       {
-        // To circumvent a bug in gcc
-        // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63945), we create
-        // copies of the variables factor1 and factor2 and do not check based on
-        // factor1.
-        const double factor1        = this->factor1;
-        const double factor1_plus_1 = 1. + this->factor1;
-        const double factor2        = this->factor2;
+        // Create local copies to help the aliasing detection.
+        const Number factor1        = this->factor1;
+        const Number factor1_plus_1 = 1. + this->factor1;
+        const Number factor2        = this->factor2;
         if (compute_residual_norm)
           {
             VectorizedArray<Number> local_sum = 0;

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -3400,37 +3400,42 @@ namespace internal
               }
           };
           if (compute_residual_norm)
-            preconditioner.vmult(
-              temp_vector2,
-              temp_vector1,
-              [&](const auto begin, const auto end) {
-                if (end > begin)
-                  std::memset(temp_vector2_ptr + begin,
-                              0,
-                              sizeof(Number) * (end - begin));
+            {
+              preconditioner.vmult(
+                temp_vector2,
+                temp_vector1,
+                [&](const auto begin, const auto end) {
+                  if (end > begin)
+                    std::memset(temp_vector2_ptr + begin,
+                                0,
+                                sizeof(Number) * (end - begin));
 
-                VectorizedArray<Number> local_sum = 0;
-                constexpr unsigned int  n_lanes =
-                  VectorizedArray<Number>::size();
-                const unsigned int end_regular = end / n_lanes * n_lanes;
-                for (unsigned int i = begin; i < end_regular; i += n_lanes)
-                  {
-                    VectorizedArray<Number> rhs_i, tmp_i;
-                    rhs_i.load(rhs_ptr + i);
-                    tmp_i.load(temp_vector1_ptr + i);
-                    const VectorizedArray<Number> residual_i = rhs_i - tmp_i;
-                    residual_i.store(temp_vector1_ptr + i);
-                    local_sum += residual_i * residual_i;
-                  }
-                for (unsigned int i = end_regular; i < end; ++i)
-                  {
-                    temp_vector1_ptr[i] = rhs_ptr[i] - temp_vector1_ptr[i];
-                    local_sum[i - end_regular] +=
-                      temp_vector1_ptr[i] * temp_vector1_ptr[i];
-                  }
-                sum += local_sum;
-              },
-              post_update);
+                  VectorizedArray<Number> local_sum = 0;
+                  constexpr unsigned int  n_lanes =
+                    VectorizedArray<Number>::size();
+                  const unsigned int end_regular = end / n_lanes * n_lanes;
+                  for (unsigned int i = begin; i < end_regular; i += n_lanes)
+                    {
+                      VectorizedArray<Number> rhs_i, tmp_i;
+                      rhs_i.load(rhs_ptr + i);
+                      tmp_i.load(temp_vector1_ptr + i);
+                      const VectorizedArray<Number> residual_i = rhs_i - tmp_i;
+                      residual_i.store(temp_vector1_ptr + i);
+                      local_sum += residual_i * residual_i;
+                    }
+                  for (unsigned int i = end_regular; i < end; ++i)
+                    {
+                      temp_vector1_ptr[i] = rhs_ptr[i] - temp_vector1_ptr[i];
+                      local_sum[i - end_regular] +=
+                        temp_vector1_ptr[i] * temp_vector1_ptr[i];
+                    }
+                  sum += local_sum;
+                },
+                post_update);
+              residual_norm = std::sqrt(
+                Utilities::MPI::sum(sum.sum(),
+                                    solution_old.get_mpi_communicator()));
+            }
           else
             preconditioner.vmult(
               temp_vector2,
@@ -3445,9 +3450,6 @@ namespace internal
                   temp_vector1_ptr[i] = rhs_ptr[i] - temp_vector1_ptr[i];
               },
               post_update);
-          residual_norm =
-            std::sqrt(Utilities::MPI::sum(sum.sum(),
-                                          solution_old.get_mpi_communicator()));
         }
 
       solution_old.swap(temp_vector2);
@@ -4022,8 +4024,9 @@ namespace internal
                 }
             });
 
-          residual_norm = std::sqrt(
-            Utilities::MPI::sum(sum.sum(), solution.get_mpi_communicator()));
+          if (compute_residual_norm)
+            residual_norm = std::sqrt(
+              Utilities::MPI::sum(sum.sum(), solution.get_mpi_communicator()));
         }
       solution.swap(temp_vector2);
       solution_old.swap(temp_vector2);
@@ -4085,8 +4088,11 @@ namespace internal
       solution.swap(temp_vector1);
       solution_old.swap(temp_vector1);
 
-      return std::sqrt(Utilities::MPI::sum(updater.sum_accumulator.sum(),
-                                           solution.get_mpi_communicator()));
+      if (compute_residual_norm)
+        return std::sqrt(Utilities::MPI::sum(updater.sum_accumulator.sum(),
+                                             solution.get_mpi_communicator()));
+      else
+        return 0;
     }
 
     template <typename MatrixType, typename PreconditionerType>


### PR DESCRIPTION
In #19871, I added support for computing a residual norm. However, I forgot to add some `if` statements around the `MPI::sum()` calls that accumulates the locally computed L2 norms. This, unsurprisingly, leads to some slowdown in cases that do not use that feature, as visible in the performance tester, where a ~3% slowdown is reported https://dealii.org/performance_tests/graphs//whistler-bullseye-gcc-10/ba1c1a903df0a146bdcf9dfaba5be2e65929fd82-timing-step_37.average.png at 21 commits back.

This PR fixes this mistake. And while there, I also made some local variables have the correct type `Number` rather than `double`.

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
