### PR TITLE
Mapping::get_bounding_box: Small documentation update

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -410,7 +410,8 @@ public:
    * locations, this function simply returns the value also produced by
    * `cell->bounding_box()`. However, there are also mappings that add
    * displacements or choose completely different locations, e.g.,
-   * MappingQEulerian, MappingQ1Eulerian, or MappingFEField.
+   * MappingFEField, MappingQEulerian or MappingQCache. Accordingly, this
+   * function differs by taking those displacements into account.
    *
    * For linear mappings, this function returns the bounding box containing all
    * the vertices of the cell, as returned by the get_vertices() method. For
@@ -418,7 +419,7 @@ public:
    * only guaranteed to contain all the support points, and it is, in general,
    * only an approximation of the true bounding box, which may be larger.
    *
-   * @param[in] cell The cell for which you want to compute the bounding box
+   * @param[in] cell The cell for which you want to compute the bounding box.
    */
   virtual BoundingBox<spacedim>
   get_bounding_box(


### PR DESCRIPTION
Slightly extend the documentation, and add some other mappings that are more representative to what users might use today as compared to `MappingQ1Eulerian` (which is `MappingQEulerian`).

### Important License and other information

As a contributor to this project, you agree that all of your contributions to deal.II will
 - be governed by the [<b>Developer Certificate of Origin version 1.1</b>](https://developercertificate.org/), and
 - be made available to the project under the terms of the [<b>Apache License 2.0</b>](https://spdx.org/licenses/Apache-2.0.html) with [<b>LLVM Exception</b>](https://spdx.org/licenses/LLVM-exception.html), and
 - separately under the terms of the [<b>GNU Lesser General Public License v2.1 or later</b>](https://spdx.org/licenses/LGPL-2.1-or-later.html).
See the [deal.II license file](https://github.com/dealii/dealii/blob/master/LICENSE.md) for details.

 Furthermore, by submitting this pull request, you confirm that:
- You have read and agree to abide by the [Code of Conduct](https://github.com/dealii/dealii/blob/master/CODE_OF_CONDUCT.md).
- You have read the [contributing guidelines](https://github.com/dealii/dealii/blob/master/CONTRIBUTING.md). 
